### PR TITLE
Have VSCode auto recommend used extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["biomejs.biome"]
+}


### PR DESCRIPTION
`biomejs.biome` is used in `.vscode/settings.json` so set it in the list of vscode recommended extensions so new users can be prompted to install it.