### PR TITLE
Don't throw an error when trying to save a 0.5 star rating

### DIFF
--- a/apps/web/app/routes/api/ratings.tsx
+++ b/apps/web/app/routes/api/ratings.tsx
@@ -33,7 +33,7 @@ export const action = protectedAction(async ({ request, context }) => {
       const body = await request.json();
       const { rateableId, rateableType, value } = body;
 
-      if (!rateableId || !rateableType || !value || value < 1 || value > 5) {
+      if (!rateableId || !rateableType || !value || value < 0.5 || value > 5) {
         return badRequest();
       }
 


### PR DESCRIPTION
This fixes https://github.com/biscuits-internet-project/bip-turbo/issues/32