### PR TITLE
Fix show date in html header which is off by -1

### DIFF
--- a/apps/web/app/lib/seo.ts
+++ b/apps/web/app/lib/seo.ts
@@ -71,11 +71,19 @@ export function getHomeMeta() {
 // Generate meta tags for a show page
 export function getShowMeta(setlist: Setlist) {
   const show = setlist.show;
-  const date = new Date(show.date).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
+  // Parse date manually to avoid timezone offset issues
+  const dateParts = show.date.split("T")[0].split("-");
+  const date =
+    dateParts.length === 3
+      ? (() => {
+          const [year, month, day] = dateParts;
+          const monthName = new Date(Number(year), Number(month) - 1, Number(day)).toLocaleString("default", {
+            month: "long",
+          });
+          return `${monthName} ${day}, ${year}`;
+        })()
+      : show.date;
+
   const venue = show.venue?.name || "Unknown Venue";
   const location = show.venue ? `${show.venue.city}, ${show.venue.state}` : "";
 


### PR DESCRIPTION
The show's text date in the `<head><title>` field is currently off by -1 so 1998-11-02 displayed as 'November 1, 1998". I had some LLM fix this bug. 

Before PR:
<img width="568" height="431" alt="Screenshot 2025-11-02 at 10 58 28 PM" src="https://github.com/user-attachments/assets/f81254e8-7679-4dcb-9d26-a0eb922bc366" />

After PR:
<img width="564" height="431" alt="Screenshot 2025-11-02 at 10 59 19 PM" src="https://github.com/user-attachments/assets/9691fe8f-919a-464d-93ff-22c936d1e544" />
