### PR TITLE
RatingComponent added to one last location

### DIFF
--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -843,7 +843,7 @@ export default function SongPage() {
                             <th className="p-3">Date</th>
                             <th className="p-3">Venue</th>
                             <th className="p-3">Location</th>
-                            <th className="p-3 text-right">Rating</th>
+                            <th className="p-3">Rating</th>
                           </tr>
                         </thead>
                         <tbody>
@@ -869,11 +869,7 @@ export default function SongPage() {
                                 {p.venue?.city && `${p.venue.city}, ${p.venue.state}`}
                               </td>
                               <td className="p-3 text-right">
-                                {p.rating && p.rating > 0 ? (
-                                  <span className="text-yellow-500">{`★ ${p.rating.toFixed(1)}`}</span>
-                                ) : (
-                                  <span className="text-content-text-tertiary">—</span>
-                                )}
+                                <RatingComponent rating={p.rating || null} ratingsCount={p.ratingsCount} />
                               </td>
                             </tr>
                           ))}


### PR DESCRIPTION
https://github.com/biscuits-internet-project/bip-turbo/issues/33 

Added one more location for the RatingComponent on the list of all-timers song table view

Before PR
<img width="1132" height="338" alt="Screenshot 2025-11-05 at 5 50 59 PM" src="https://github.com/user-attachments/assets/b3a28833-2c6b-4a14-8e0f-cc6f68e68fa3" />


After PR
<img width="1113" height="302" alt="Screenshot 2025-11-05 at 5 54 53 PM" src="https://github.com/user-attachments/assets/9447dbc1-8c04-4e30-9fd2-1adb53505bc1" />
