### PR TITLE
Fix Ratings Counts

### DIFF
--- a/packages/core/src/_shared/prisma/migrations/20251107141329_fix_rating_counts/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20251107141329_fix_rating_counts/migration.sql
@@ -1,0 +1,41 @@
+-- Update any track that has an average rating but no ratings_count to have its rating_count set
+with rating_aggregates as (
+  select
+    rateable_id,
+    avg(value) as average_rating,
+    count(id) as ratings_count
+  from ratings
+  where
+    rateable_type = 'Track'
+  group by
+    rateable_id
+)
+update tracks
+set
+average_rating = rating_aggregates.average_rating,
+ratings_count = rating_aggregates.ratings_count,
+updated_at = now()
+from rating_aggregates
+where
+tracks.average_rating != 0 and tracks.ratings_count = 0
+and rating_aggregates.rateable_id = tracks.id;
+
+-- Reset a tracks average_rating to 0 if there are no corresponding ratings in the rating table. There were between 100-200 of these.
+update tracks
+set
+average_rating = 0,
+ratings_count = 0,
+updated_at = now()
+where
+tracks.average_rating != 0
+and not exists (select 1 from ratings where ratings.rateable_type = 'Track' and ratings.rateable_id = tracks.id);
+
+-- Reset a shows average_rating to 0 if there are no corresponding ratings in the rating table. There was 1 instance of this.
+update shows
+set
+average_rating = 0,
+ratings_count = 0,
+updated_at = now()
+where
+shows.average_rating != 0
+and not exists (select 1 from ratings where ratings.rateable_type = 'Show' and ratings.rateable_id = shows.id);


### PR DESCRIPTION
There are some tracks that have an average rating but no rating count. I think this was due to the ratings count being added in more recently and not having a backfill. This migration fills in that data.

The queries in this migraton have been run locally and tested, but the migration iteself has not been tested as I have been unable to get migrations to work on my computer without telling me that things are out of sync.

Before migration:
<img width="1084" height="669" alt="Screenshot 2025-11-07 at 11 31 31 AM" src="https://github.com/user-attachments/assets/f7d50cee-5a0d-41c4-bc6e-5d62f1dd03a4" />

After migration:
<img width="1075" height="661" alt="Screenshot 2025-11-07 at 11 30 48 AM" src="https://github.com/user-attachments/assets/5a3c1c7d-7a44-40b2-9c53-5e3625f100a9" />
