### PR TITLE
CSS to let song table wrap and reduced repetitive code

### DIFF
--- a/apps/web/app/components/song/songs-columns.tsx
+++ b/apps/web/app/components/song/songs-columns.tsx
@@ -106,7 +106,7 @@ export const songsColumns: ColumnDef<SongWithShows>[] = [
     cell: ({ row }) => {
       const plays = row.original.timesPlayed;
       return plays > 0 ? (
-        <span className="text-content-text-primary font-semibold whitespace-normal break-words">{plays}</span>
+        <span className={cn("text-content-text-primary font-semibold", cellWrapClass)}>{plays}</span>
       ) : (
         <span className={cellTertiaryClass}>Never performed</span>
       );


### PR DESCRIPTION
I instructed the LLM to let the text wrap and then to refactor repetitive code. 


<img width="1110" height="661" alt="Screenshot 2025-11-22 at 3 16 28 PM" src="https://github.com/user-attachments/assets/4b00273e-616a-4758-a284-fe33e51a0d78" />
