### PR TITLE
Remove React Query to fix server-side memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ tmp/
 *.DS_Store
 .vscode/chrome-debug-profile
 apps/web/.react-router/*
+.beads
+.gitattributes

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,8 +33,6 @@
     "@react-router/serve": "^7.7.1",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.87.1",
-    "@tanstack/react-query": "^5.83.0",
-    "@tanstack/react-query-devtools": "^5.83.0",
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/bun.lock
+++ b/bun.lock
@@ -55,8 +55,6 @@
         "@react-router/serve": "^7.7.1",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.87.1",
-        "@tanstack/react-query": "^5.83.0",
-        "@tanstack/react-query-devtools": "^5.83.0",
         "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -622,14 +620,6 @@
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.1.11", "", { "os": "win32", "cpu": "x64" }, "sha512-YfHoggn1j0LK7wR82TOucWc5LDCguHnoS879idHekmmiR7g9HUtMw9MI0NHatS28u/Xlkfi9w5RJWgz2Dl+5Qg=="],
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.11", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.1.11", "@tailwindcss/oxide": "4.1.11", "postcss": "^8.4.41", "tailwindcss": "4.1.11" } }, "sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA=="],
-
-    "@tanstack/query-core": ["@tanstack/query-core@5.83.0", "", {}, "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA=="],
-
-    "@tanstack/query-devtools": ["@tanstack/query-devtools@5.81.2", "", {}, "sha512-jCeJcDCwKfoyyBXjXe9+Lo8aTkavygHHsUHAlxQKKaDeyT0qyQNLKl7+UyqYH2dDF6UN/14873IPBHchcsU+Zg=="],
-
-    "@tanstack/react-query": ["@tanstack/react-query@5.83.0", "", { "dependencies": { "@tanstack/query-core": "5.83.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ=="],
-
-    "@tanstack/react-query-devtools": ["@tanstack/react-query-devtools@5.83.0", "", { "dependencies": { "@tanstack/query-devtools": "5.81.2" }, "peerDependencies": { "@tanstack/react-query": "^5.83.0", "react": "^18 || ^19" } }, "sha512-yfp8Uqd3I1jgx8gl0lxbSSESu5y4MO2ThOPBnGNTYs0P+ZFu+E9g5IdOngyUGuo6Uz6Qa7p9TLdZEX3ntik2fQ=="],
 
     "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
 


### PR DESCRIPTION
## Summary

- Completely removed React Query (`@tanstack/react-query`) from the codebase
- React Query's QueryClient instances were not being garbage collected on the server, causing memory to grow over time (~70MB per year page request)
- Replaced all useQuery/useMutation with native React patterns (useState + useEffect + fetch)
- Uses React Router v7's useRevalidator for cache invalidation after mutations

## Changes

**Routes:**
- `routes/shows/year/$year.tsx` - Removed unused rateMutation
- `routes/venues/$slug.tsx` - Removed unused _rateMutation
- `routes/shows/$slug.tsx` - Replaced React Query with useRevalidator for reviews

**Components:**
- `components/ui/star-rating.tsx` - Replaced useQuery/useMutation with fetch + useEffect
- `components/setlist/attendance.tsx` - Replaced useMutation with async functions
- `components/setlist/track-rating-overlay.tsx` - Replaced useQuery with useState/useEffect
- `components/track/track-manager.tsx` - Replaced 4 useMutation hooks with async functions

**Root:**
- `root.tsx` - Removed QueryClientProvider, makeQueryClient, serverQueryClients tracking

**Dependencies:**
- Removed `@tanstack/react-query` and `@tanstack/react-query-devtools`

## Test plan

- [ ] Verify rating submissions work on show pages
- [ ] Verify attendance toggle works
- [ ] Verify track hover ratings work
- [ ] Verify track manager CRUD operations work
- [ ] Monitor memory usage in production to confirm leak is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)