### PR TITLE
add shows with photos page

### DIFF
--- a/apps/web/app/components/filter-nav.tsx
+++ b/apps/web/app/components/filter-nav.tsx
@@ -39,20 +39,30 @@ export function FilterNav({
 
   const subtitleCSS = cn(
     "text-xs font-normal text-content-text-tertiary",
-    "bg-content-bg-secondary px-2 py-1 rounded-full",
+    "bg-content-bg-secondary px-2 py-0.5 rounded-full",
   );
   const itemCSS = cn(
-    "px-3 py-2 text-sm font-medium rounded-lg",
-    "transition-all duration-300 text-center relative shadow-sm",
+    "px-2 py-1.5 text-sm font-medium rounded-md",
+    "transition-all duration-200 text-center",
   );
   const highlightedItemCSS = cn(
     "text-white bg-gradient-to-r from-brand-primary to-brand-secondary",
-    "border-2 border-brand-primary/50 shadow-lg shadow-brand-primary/30",
-    "scale-110 font-bold ring-2 ring-brand-primary/20",
+    "font-semibold",
   );
   const nonHighlightedItemCSS = cn(
     "text-content-text-secondary bg-content-bg-secondary",
-    "hover:bg-content-bg-tertiary hover:text-white hover:scale-105 hover:shadow-md",
+    "hover:bg-content-bg-tertiary hover:text-white",
+  );
+  const toggleCSS = cn(
+    "px-3 py-1.5 text-sm font-medium rounded-md",
+    "transition-all duration-200 flex items-center gap-2",
+  );
+  const toggleActiveCSS = cn(
+    "text-white bg-content-bg-tertiary border border-brand-primary/50",
+  );
+  const toggleInactiveCSS = cn(
+    "text-content-text-secondary bg-content-bg-secondary",
+    "hover:bg-content-bg-tertiary hover:text-white",
   );
   const columnCSS = cn({
     "grid-cols-4 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8": widerItems,
@@ -65,12 +75,12 @@ export function FilterNav({
 
   return (
     <div className="card-premium rounded-lg overflow-hidden">
-      <div className="p-6 border-b border-content-bg-secondary">
+      <div className="px-4 py-3">
         {canBeCollapsed ? (
           <button
             type="button"
             className={cn(
-              "w-full flex items-center gap-2 text-base font-semibold text-white mb-4 cursor-pointer select-none transition-colors",
+              "w-full flex items-center gap-2 text-sm font-semibold text-white mb-3 cursor-pointer select-none transition-colors",
               {
                 "hover:text-brand-primary": expanded,
                 "hover:text-brand-secondary": !expanded,
@@ -94,7 +104,7 @@ export function FilterNav({
             </span>
           </button>
         ) : (
-          <h2 className="text-base font-semibold text-white mb-4 flex items-center gap-2">
+          <h2 className="text-sm font-semibold text-white mb-3 flex items-center gap-2">
             {title}
             {subtitle && <span className={subtitleCSS}>{subtitle}</span>}
             {additionalText && <span className={subtitleCSS}>{additionalText}</span>}
@@ -106,7 +116,7 @@ export function FilterNav({
             "max-h-0 opacity-0 pointer-events-none": !expanded && canBeCollapsed,
           })}
         >
-          <div className={cn("grid gap-2", columnCSS)}>
+          <div className={cn("grid gap-1.5", columnCSS)}>
             {filters.map((filter) => {
               const link = getLink(filter, basePath, currentURLParameters);
               return (
@@ -130,8 +140,12 @@ export function FilterNav({
                 All
               </Link>
             )}
-            {!allSelected &&
-              parameters.map((parameter) => {
+          </div>
+          {/* Parameter toggles rendered separately below the grid */}
+          {!allSelected && parameters.length > 0 && (
+            <div className="flex flex-wrap gap-2 mt-3 pt-3 border-t border-content-bg-secondary">
+              <span className="text-xs text-content-text-tertiary self-center">Filters:</span>
+              {parameters.map((parameter) => {
                 const newParams = new URLSearchParams(currentURLParameters.toString());
                 const hasParam = currentURLParameters.has(parameter);
                 if (hasParam) {
@@ -144,16 +158,20 @@ export function FilterNav({
                   <Link
                     key={parameter}
                     to={link}
-                    className={cn(itemCSS, {
-                      [highlightedItemCSS]: hasParam,
-                      [nonHighlightedItemCSS]: !hasParam,
-                    })}
+                    className={cn(toggleCSS, hasParam ? toggleActiveCSS : toggleInactiveCSS)}
                   >
+                    <span className={cn(
+                      "w-3.5 h-3.5 rounded-sm border flex items-center justify-center text-[10px]",
+                      hasParam ? "bg-brand-primary border-brand-primary text-white" : "border-content-text-tertiary"
+                    )}>
+                      {hasParam && "✓"}
+                    </span>
                     {parameter}
                   </Link>
                 );
               })}
-          </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -1,5 +1,5 @@
 import type { Attendance, Rating, Setlist, SetlistLight } from "@bip/domain";
-import { Check, Flame, Star } from "lucide-react";
+import { Camera, Check, Flame, Star } from "lucide-react";
 import { memo, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { RatingComponent } from "~/components/rating";
@@ -314,6 +314,15 @@ function SetlistCardComponent({
             </div>
           ) : (
             <div />
+          )}
+          {setlist.show.showPhotosCount > 0 && (
+            <Link
+              to={`/shows/${setlist.show.slug}#photos`}
+              className="flex items-center gap-1.5 text-content-text-tertiary hover:text-content-text-secondary transition-colors"
+            >
+              <Camera className="h-5 w-5" />
+              <span className="text-sm">{setlist.show.showPhotosCount}</span>
+            </Link>
           )}
         </div>
       </CardContent>

--- a/apps/web/app/components/year-filter-nav.tsx
+++ b/apps/web/app/components/year-filter-nav.tsx
@@ -9,9 +9,18 @@ interface YearFilterNavProps {
   basePath: string;
   showAllButton?: boolean;
   additionalText?: string;
+  parameters?: string[];
+  currentURLParameters?: URLSearchParams;
 }
 
-export function YearFilterNav({ currentYear, basePath, showAllButton, additionalText }: YearFilterNavProps) {
+export function YearFilterNav({
+  currentYear,
+  basePath,
+  showAllButton,
+  additionalText,
+  parameters,
+  currentURLParameters,
+}: YearFilterNavProps) {
   return (
     <FilterNav
       title="Filter by Year"
@@ -21,6 +30,8 @@ export function YearFilterNav({ currentYear, basePath, showAllButton, additional
       showAllButton={showAllButton}
       subtitle={`${years.length} years`}
       additionalText={additionalText}
+      parameters={parameters}
+      currentURLParameters={currentURLParameters}
     />
   );
 }

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -78,6 +78,7 @@ export default [
     ...prefix("shows", [
       index("routes/shows/_index.tsx"),
       route("year/:year", "routes/shows/year/$year.tsx"),
+      route("with-photos", "routes/shows/with-photos.tsx"),
       route(":slug", "routes/shows/$slug.tsx"),
       route("top-rated", "routes/shows/top-rated.tsx"),
       route("top-rated/:year", "routes/shows/top-rated/$year.tsx"),

--- a/apps/web/app/routes/shows/with-photos.tsx
+++ b/apps/web/app/routes/shows/with-photos.tsx
@@ -1,0 +1,159 @@
+import { type SetlistLight } from "@bip/domain";
+import { ArrowUp, Camera } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ClientLoaderFunctionArgs } from "react-router";
+import { SetlistCard } from "~/components/setlist/setlist-card";
+import { Button } from "~/components/ui/button";
+import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
+import { useShowUserData } from "~/hooks/use-show-user-data";
+import { publicLoader } from "~/lib/base-loaders";
+import { cn } from "~/lib/utils";
+import { services } from "~/server/services";
+
+interface LoaderData {
+  setlists: SetlistLight[];
+}
+
+export const loader = publicLoader(async (): Promise<LoaderData> => {
+  const setlists = await services.setlists.findManyLight({
+    filters: {
+      hasPhotos: true,
+    },
+    sort: [{ field: "date", direction: "desc" }],
+  });
+
+  return { setlists };
+});
+
+export function meta() {
+  return [
+    { title: "Shows with Photos | biscuits.info" },
+    { name: "description", content: "Disco Biscuits shows with photos" },
+  ];
+}
+
+export const clientLoader = async ({ serverLoader }: ClientLoaderFunctionArgs) => {
+  return serverLoader();
+};
+clientLoader.hydrate = true;
+
+export default function ShowsWithPhotos() {
+  const { setlists } = useSerializedLoaderData<LoaderData>();
+  const [showBackToTop, setShowBackToTop] = useState(false);
+
+  const showIds = useMemo(() => setlists.map((setlist) => setlist.show.id), [setlists]);
+  const { attendanceMap, userRatingMap, averageRatingMap } = useShowUserData(showIds);
+
+  // Group by year
+  const setlistsByYear = useMemo(() => {
+    return setlists.reduce(
+      (acc, setlist) => {
+        const year = new Date(setlist.show.date).getFullYear();
+        if (!acc[year]) {
+          acc[year] = [];
+        }
+        acc[year].push(setlist);
+        return acc;
+      },
+      {} as Record<number, SetlistLight[]>,
+    );
+  }, [setlists]);
+
+  const years = useMemo(() => {
+    return Object.keys(setlistsByYear)
+      .map(Number)
+      .sort((a, b) => b - a);
+  }, [setlistsByYear]);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setShowBackToTop(window.scrollY > window.innerHeight * 0.5);
+    };
+    handleScroll();
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  const scrollToTop = useCallback(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, []);
+
+  return (
+    <div className="relative">
+      <div className="space-y-6 md:space-y-8">
+        {/* Header */}
+        <div className="relative">
+          <h1 className="page-heading">SHOWS WITH PHOTOS</h1>
+          <div className="flex items-center justify-center gap-2 -mt-4 text-content-text-secondary">
+            <Camera className="h-5 w-5" />
+            <span className="text-xl font-medium">{setlists.length} shows</span>
+          </div>
+        </div>
+
+        {/* Year jump nav */}
+        <div className="card-premium rounded-lg overflow-hidden">
+          <div className="px-4 py-3">
+            <h2 className="text-sm font-semibold text-white mb-3">Jump to Year</h2>
+            <div className="flex flex-wrap gap-1.5">
+              {years.map((year) => (
+                <a
+                  key={year}
+                  href={`#year-${year}`}
+                  className="px-2 py-1.5 text-sm font-medium rounded-md text-content-text-secondary bg-content-bg-secondary hover:bg-content-bg-tertiary hover:text-white transition-all"
+                >
+                  {year}
+                  <span className="ml-1 text-xs text-content-text-tertiary">
+                    ({setlistsByYear[year].length})
+                  </span>
+                </a>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Shows grouped by year */}
+        <div className="space-y-8">
+          {years.map((year) => (
+            <div key={year} className="space-y-4">
+              <div id={`year-${year}`} className="scroll-mt-20">
+                <h2 className="text-xl font-semibold text-white border-b border-glass-border/30 pb-2">
+                  {year}
+                  <span className="ml-2 text-sm font-normal text-content-text-tertiary">
+                    ({setlistsByYear[year].length} shows)
+                  </span>
+                </h2>
+              </div>
+              {setlistsByYear[year].map((setlist) => (
+                <SetlistCard
+                  key={setlist.show.id}
+                  setlist={setlist}
+                  userAttendance={attendanceMap.get(setlist.show.id) ?? null}
+                  userRating={userRatingMap.get(setlist.show.id) ?? null}
+                  showRating={averageRatingMap.get(setlist.show.id)?.average ?? setlist.show.averageRating}
+                  className="transition-all duration-300 transform hover:scale-[1.01]"
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Back to Top */}
+      <div
+        className={cn(
+          "fixed bottom-6 right-6 transition-all duration-300 z-50",
+          showBackToTop ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10 pointer-events-none",
+        )}
+      >
+        <Button
+          onClick={scrollToTop}
+          size="icon"
+          className="h-14 w-14 rounded-full bg-brand-primary hover:bg-brand-secondary shadow-xl border-2 border-white/20"
+          aria-label="Back to top"
+        >
+          <ArrowUp className="h-6 w-6 text-white" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/routes/shows/year/$year.tsx
+++ b/apps/web/app/routes/shows/year/$year.tsx
@@ -1,5 +1,5 @@
 import { CacheKeys, type SetlistLight } from "@bip/domain";
-import { ArrowUp, Plus } from "lucide-react";
+import { ArrowUp, Camera, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, type LoaderFunctionArgs } from "react-router-dom";
 import type { ClientLoaderFunctionArgs } from "react-router";
@@ -180,7 +180,13 @@ export default function ShowsByYear() {
         {/* Header Section */}
         <div className="relative">
           <h1 className="page-heading">SHOWS</h1>
-          <div className="absolute top-0 right-0">
+          <div className="absolute top-0 right-0 flex items-center gap-2">
+            <Button variant="outline" size="sm" asChild>
+              <Link to="/shows/with-photos" className="flex items-center gap-1">
+                <Camera className="h-4 w-4" />
+                <span className="hidden sm:inline">Photos</span>
+              </Link>
+            </Button>
             <AdminOnly>
               <Button variant="outline" size="sm" asChild>
                 <Link to="/shows/new" className="flex items-center gap-1">
@@ -204,22 +210,22 @@ export default function ShowsByYear() {
             <YearFilterNav currentYear={year} basePath="/shows/year/" />
             <div className="card-premium rounded-lg overflow-hidden">
               {/* Month navigation */}
-              <div className="p-6">
-                <h2 className="text-base font-semibold text-white mb-4 flex items-center gap-2">
+              <div className="px-4 py-3">
+                <h2 className="text-sm font-semibold text-white mb-3 flex items-center gap-2">
                   Jump to Month
-                  <span className="text-xs font-normal text-content-text-tertiary bg-content-bg-secondary px-2 py-1 rounded-full">
+                  <span className="text-xs font-normal text-content-text-tertiary bg-content-bg-secondary px-2 py-0.5 rounded-full">
                     {monthsWithShows.length} active
                   </span>
                 </h2>
-                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-12 gap-2">
+                <div className="grid grid-cols-6 sm:grid-cols-12 gap-1.5">
                   {months.map((month, index) => (
                     <a
                       key={month}
                       href={monthsWithShows.includes(index) ? `#month-${index}` : undefined}
                       className={cn(
-                        "px-3 py-2 text-xs font-medium rounded-lg transition-all duration-200 text-center",
+                        "px-2 py-1.5 text-xs font-medium rounded-md transition-all duration-200 text-center",
                         monthsWithShows.includes(index)
-                          ? "text-content-text-secondary bg-content-bg-secondary hover:bg-accent/20 hover:text-white cursor-pointer hover:scale-105"
+                          ? "text-content-text-secondary bg-content-bg-secondary hover:bg-content-bg-tertiary hover:text-white cursor-pointer"
                           : "text-content-text-tertiary bg-transparent cursor-not-allowed opacity-40",
                       )}
                     >

--- a/packages/core/src/setlists/setlist-repository.ts
+++ b/packages/core/src/setlists/setlist-repository.ts
@@ -253,6 +253,7 @@ export class SetlistRepository {
   }): Promise<Setlist[]> {
     const year = options?.filters?.year;
     const venueId = options?.filters?.venueId;
+    const hasPhotos = options?.filters?.hasPhotos;
 
     const orderBy = buildOrderByClause(options?.sort, { date: "asc" });
     const skip =
@@ -270,6 +271,7 @@ export class SetlistRepository {
               lt: `${year + 1}-01-01`,
             }
           : undefined,
+        showPhotosCount: hasPhotos ? { gt: 0 } : undefined,
       },
       orderBy,
       skip,
@@ -310,6 +312,7 @@ export class SetlistRepository {
   }): Promise<SetlistLight[]> {
     const year = options?.filters?.year;
     const venueId = options?.filters?.venueId;
+    const hasPhotos = options?.filters?.hasPhotos;
 
     const orderBy = buildOrderByClause(options?.sort, { date: "asc" });
     const skip =
@@ -327,6 +330,7 @@ export class SetlistRepository {
               lt: `${year + 1}-01-01`,
             }
           : undefined,
+        showPhotosCount: hasPhotos ? { gt: 0 } : undefined,
       },
       orderBy,
       skip,

--- a/packages/core/src/setlists/setlist-service.ts
+++ b/packages/core/src/setlists/setlist-service.ts
@@ -5,6 +5,7 @@ import type { SetlistRepository } from "./setlist-repository";
 export type SetlistFilter = {
   year?: number;
   venueId?: string;
+  hasPhotos?: boolean;
 };
 
 export class SetlistService {


### PR DESCRIPTION
## Summary
- New `/shows/with-photos` page showing all shows with photos, grouped by year
- Camera icon with photo count on setlist cards (links to show's photos section)
- Tightened up filter nav styling (smaller padding, cleaner toggles)
- Photos link button in shows page header

## Test plan
- [ ] Visit `/shows/with-photos` - should show all shows with photos grouped by year
- [ ] Check setlist cards show camera icon + count for shows with photos
- [ ] Click camera icon to verify it links to show page #photos anchor
- [ ] Verify "Photos" button in shows page header links to with-photos page

🤖 Generated with [Claude Code](https://claude.com/claude-code)