### PR TITLE
Add Cloudflare CDN cache purging

### DIFF
--- a/apps/web/app/components/layout/user-dropdown.tsx
+++ b/apps/web/app/components/layout/user-dropdown.tsx
@@ -1,5 +1,6 @@
-import { Edit, Eye, LogOut } from "lucide-react";
+import { Edit, Eye, LogOut, Settings } from "lucide-react";
 import { Link } from "react-router-dom";
+import { AdminOnly } from "~/components/admin/admin-only";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Button } from "~/components/ui/button";
 import {
@@ -125,6 +126,28 @@ export function UserDropdown({ user, className }: UserDropdownProps) {
             </div>
           </Link>
         </DropdownMenuItem>
+
+        <AdminOnly>
+          <DropdownMenuItem
+            asChild
+            className={cn(
+              "cursor-pointer rounded-lg p-3 transition-all duration-200",
+              "hover:bg-amber-500/10 hover:text-amber-400",
+              "focus:bg-amber-500/10 focus:text-amber-400",
+              "group",
+            )}
+          >
+            <Link to="/admin/cache" className="flex items-center space-x-3">
+              <div className="flex h-8 w-8 items-center justify-center rounded-md bg-amber-500/10 group-hover:bg-amber-500/20 transition-colors">
+                <Settings className="h-4 w-4 text-amber-400" />
+              </div>
+              <div className="flex flex-col">
+                <span className="text-sm font-medium">Admin</span>
+                <span className="text-xs text-content-text-secondary">Cache management</span>
+              </div>
+            </Link>
+          </DropdownMenuItem>
+        </AdminOnly>
 
         <DropdownMenuSeparator className="my-2 bg-brand-primary/20" />
 

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -117,7 +117,11 @@ export default [
     route("contact", "routes/api/contact.tsx"),
     route("cron/:action", "routes/api/cron/$action.tsx"),
     route("images/upload", "routes/api/images/upload.tsx"),
+    route("admin/cache", "routes/api/admin/cache.tsx"),
   ]),
+
+  // Admin routes
+  ...prefix("admin", [route("cache", "routes/admin/cache.tsx")]),
 
   // MCP JSON-RPC endpoint (all tools exposed via JSON-RPC protocol)
   route("mcp", "routes/mcp/index.tsx"),

--- a/apps/web/app/routes/admin/cache.tsx
+++ b/apps/web/app/routes/admin/cache.tsx
@@ -1,0 +1,86 @@
+import { RefreshCw, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { Button } from "~/components/ui/button";
+import { adminLoader } from "~/lib/base-loaders";
+
+export const loader = adminLoader(async () => {
+  return { timestamp: new Date().toISOString() };
+});
+
+export function meta() {
+  return [{ title: "Cache Management | Admin" }];
+}
+
+export default function AdminCache() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [result, setResult] = useState<{ success: boolean; message: string } | null>(null);
+
+  const handlePurgeCache = async () => {
+    setIsLoading(true);
+    setResult(null);
+
+    try {
+      const response = await fetch("/api/admin/cache", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ action: "purge" }),
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        setResult({ success: true, message: data.message || "Cache purged successfully" });
+      } else {
+        setResult({ success: false, message: data.error || "Failed to purge cache" });
+      }
+    } catch (error) {
+      setResult({ success: false, message: "Network error occurred" });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="container max-w-2xl py-8">
+      <h1 className="page-heading mb-8">Cache Management</h1>
+
+      <div className="card-premium p-6 space-y-6">
+        <div>
+          <h2 className="text-lg font-semibold text-white mb-2">Cloudflare CDN Cache</h2>
+          <p className="text-content-text-secondary text-sm mb-4">
+            Purge the Cloudflare CDN cache for year listing pages. Use this when content isn't updating as expected.
+          </p>
+
+          <Button onClick={handlePurgeCache} disabled={isLoading} variant="destructive" className="gap-2">
+            {isLoading ? (
+              <>
+                <RefreshCw className="h-4 w-4 animate-spin" />
+                Purging...
+              </>
+            ) : (
+              <>
+                <Trash2 className="h-4 w-4" />
+                Purge CDN Cache
+              </>
+            )}
+          </Button>
+        </div>
+
+        {result && (
+          <div
+            className={`p-4 rounded-lg ${
+              result.success
+                ? "bg-green-500/10 border border-green-500/20 text-green-400"
+                : "bg-red-500/10 border border-red-500/20 text-red-400"
+            }`}
+          >
+            {result.message}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/routes/api/admin/cache.tsx
+++ b/apps/web/app/routes/api/admin/cache.tsx
@@ -1,0 +1,35 @@
+import { adminAction } from "~/lib/base-loaders";
+import { badRequest, methodNotAllowed } from "~/lib/errors";
+import { logger } from "~/lib/logger";
+import { services } from "~/server/services";
+
+export const action = adminAction(async ({ request }) => {
+  if (request.method !== "POST") {
+    return methodNotAllowed();
+  }
+
+  try {
+    const body = await request.json();
+    const { action } = body;
+
+    if (action === "purge") {
+      logger.info("Admin initiated CDN cache purge");
+
+      // Purge all year listings from Cloudflare
+      await services.cloudflareCache.purgeAll();
+
+      return new Response(JSON.stringify({ success: true, message: "CDN cache purged successfully" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return badRequest();
+  } catch (error) {
+    logger.error("Error purging cache", { error });
+    return new Response(JSON.stringify({ error: "Failed to purge cache" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+});

--- a/apps/web/app/server/env.ts
+++ b/apps/web/app/server/env.ts
@@ -15,6 +15,8 @@ export const envSchema = z.object({
   APP_ENV: z.enum(["development", "staging", "production"]),
   CLOUDFLARE_ACCOUNT_ID: z.string(),
   CLOUDFLARE_IMAGES_API_TOKEN: z.string(),
+  CLOUDFLARE_ZONE_ID: z.string(),
+  CLOUDFLARE_CACHE_PURGE_TOKEN: z.string(),
 });
 
 export const env = envSchema.parse(process.env);

--- a/packages/core/src/_shared/cache/cache-invalidation-service.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.ts
@@ -1,10 +1,12 @@
 import { CacheKeys, type Logger } from "@bip/domain";
 import type { CacheService } from "./cache-service";
+import type { CloudflareCacheService } from "./cloudflare-cache-service";
 
 export class CacheInvalidationService {
   constructor(
     private readonly cache: CacheService,
     private readonly logger: Logger,
+    private readonly cloudflareCache?: CloudflareCacheService,
   ) {}
 
   /**
@@ -48,6 +50,7 @@ export class CacheInvalidationService {
     await Promise.all([
       this.cache.delPattern(CacheKeys.shows.allLists()),
       this.cache.delPattern("home:*"), // Invalidate all home page caches
+      this.cloudflareCache?.purgeYearListings(),
     ]);
   }
 

--- a/packages/core/src/_shared/cache/cloudflare-cache-service.ts
+++ b/packages/core/src/_shared/cache/cloudflare-cache-service.ts
@@ -1,0 +1,101 @@
+import type { Logger } from "@bip/domain";
+
+export interface CloudflareCacheConfig {
+  zoneId: string;
+  apiToken: string;
+}
+
+export class CloudflareCacheService {
+  private readonly baseUrl: string;
+
+  constructor(
+    private readonly config: CloudflareCacheConfig,
+    private readonly logger: Logger,
+  ) {
+    this.baseUrl = `https://api.cloudflare.com/client/v4/zones/${config.zoneId}/purge_cache`;
+  }
+
+  /**
+   * Purge cache by tags. Cloudflare will purge all cached responses
+   * that have any of the specified Cache-Tag headers.
+   */
+  async purgeByTags(tags: string[]): Promise<void> {
+    if (tags.length === 0) return;
+
+    this.logger.info("Purging Cloudflare cache by tags", { tags });
+
+    try {
+      const response = await fetch(this.baseUrl, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.config.apiToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ tags }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        this.logger.error("Cloudflare cache purge failed", {
+          status: response.status,
+          error: errorText,
+        });
+        // Don't throw - cache purge failures shouldn't break the app
+        return;
+      }
+
+      const data = (await response.json()) as { success: boolean; errors?: Array<{ message: string }> };
+
+      if (!data.success) {
+        const errorMessage = data.errors?.map((e) => e.message).join(", ") ?? "Unknown error";
+        this.logger.error("Cloudflare cache purge failed", { error: errorMessage });
+        return;
+      }
+
+      this.logger.info("Cloudflare cache purged successfully", { tags });
+    } catch (error) {
+      this.logger.error("Cloudflare cache purge error", { error });
+      // Don't throw - cache purge failures shouldn't break the app
+    }
+  }
+
+  /**
+   * Purge cache for year listing pages
+   */
+  async purgeYearListings(years?: number[]): Promise<void> {
+    const currentYear = new Date().getFullYear();
+    const tagsToInvalidate = years?.map((y) => `year-${y}`) ?? [`year-${currentYear}`];
+    await this.purgeByTags(tagsToInvalidate);
+  }
+
+  /**
+   * Purge all cached content (use sparingly)
+   */
+  async purgeAll(): Promise<void> {
+    this.logger.info("Purging all Cloudflare cache");
+
+    try {
+      const response = await fetch(this.baseUrl, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.config.apiToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ purge_everything: true }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        this.logger.error("Cloudflare cache purge all failed", {
+          status: response.status,
+          error: errorText,
+        });
+        return;
+      }
+
+      this.logger.info("Cloudflare cache purged completely");
+    } catch (error) {
+      this.logger.error("Cloudflare cache purge all error", { error });
+    }
+  }
+}

--- a/packages/core/src/_shared/cache/index.ts
+++ b/packages/core/src/_shared/cache/index.ts
@@ -1,2 +1,3 @@
 export * from "./cache-service";
 export * from "./cache-invalidation-service";
+export * from "./cloudflare-cache-service";

--- a/packages/core/src/_shared/env.ts
+++ b/packages/core/src/_shared/env.ts
@@ -4,6 +4,8 @@ export const envSchema = z.object({
   REDIS_URL: z.string().url(),
   CLOUDFLARE_ACCOUNT_ID: z.string(),
   CLOUDFLARE_IMAGES_API_TOKEN: z.string(),
+  CLOUDFLARE_ZONE_ID: z.string(),
+  CLOUDFLARE_CACHE_PURGE_TOKEN: z.string(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/packages/core/src/_shared/services.ts
+++ b/packages/core/src/_shared/services.ts
@@ -15,7 +15,7 @@ import { SongService } from "../songs/song-service";
 import { TrackService } from "../tracks/track-service";
 import { UserService } from "../users/user-service";
 import { VenueService } from "../venues/venue-service";
-import type { CacheService } from "./cache";
+import type { CacheService, CloudflareCacheService } from "./cache";
 import type { ServiceContainer } from "./container";
 import type { RedisService } from "./redis";
 
@@ -37,6 +37,7 @@ export interface Services {
   postgresSearch: PostgresSearchService;
   redis: RedisService;
   cache: CacheService;
+  cloudflareCache: CloudflareCacheService;
   logger: Logger;
 }
 
@@ -69,6 +70,7 @@ export function createServices(container: ServiceContainer): Services {
     postgresSearch: postgresSearchService,
     redis: container.redis,
     cache: container.cache,
+    cloudflareCache: container.cloudflareCache,
     logger: container.logger,
   };
 }


### PR DESCRIPTION
## Summary

- Add `CloudflareCacheService` to purge Cloudflare CDN cache by tag
- Integrate automatic cache purging into `CacheInvalidationService` - when shows are updated, the year listing pages are purged from CDN
- Add admin cache management page at `/admin/cache` with manual purge button
- Add "Admin" link to user dropdown menu (visible only to admins)

## New Environment Variables

Added to Doppler (dev and prd):
- `CLOUDFLARE_ZONE_ID` - Cloudflare zone ID for discobiscuits.net
- `CLOUDFLARE_CACHE_PURGE_TOKEN` - API token with cache purge permissions

## Test plan

- [ ] Verify admin can access `/admin/cache` page
- [ ] Verify non-admins are redirected from `/admin/cache`
- [ ] Test manual cache purge button works
- [ ] Verify show updates trigger automatic CDN cache invalidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)