### PR TITLE
Fix user ratings not displaying on all-timers page

### DIFF
--- a/apps/web/app/components/performance/performance-table.tsx
+++ b/apps/web/app/components/performance/performance-table.tsx
@@ -10,7 +10,9 @@ import {
 } from "@tanstack/react-table";
 import { ArrowDownIcon, ArrowUpIcon, Flame } from "lucide-react";
 import { useMemo, useState } from "react";
+import { useSession } from "~/hooks/use-session";
 import { useShowUserData } from "~/hooks/use-show-user-data";
+import { useTrackUserRatings } from "~/hooks/use-track-user-ratings";
 import { ATTENDED_ROW_CLASS } from "~/lib/utils";
 import { CombinedNotes } from "./combined-notes";
 import { TrackRatingCell } from "./track-rating-cell";
@@ -28,6 +30,8 @@ export function PerformanceTable({
   showSongColumn = false,
   showAllTimerColumn = false,
 }: PerformanceTableProps) {
+  const { user } = useSession();
+  const isAuthenticated = !!user;
   const [sorting, setSorting] = useState<SortingState>([{ id: "date", desc: true }]);
   const [activeFilters, setActiveFilters] = useState<Set<string>>(new Set());
 
@@ -37,6 +41,13 @@ export function PerformanceTable({
     [initialPerformances],
   );
   const { attendanceMap } = useShowUserData(showIds);
+
+  // Fetch user's track ratings for gold highlight
+  const trackIds = useMemo(
+    () => initialPerformances.map((p) => p.trackId),
+    [initialPerformances],
+  );
+  const { userRatingMap } = useTrackUserRatings(trackIds);
 
   const handleSortingChange = (updaterOrValue: SortingState | ((old: SortingState) => SortingState)) => {
     setSorting(updaterOrValue);
@@ -303,12 +314,15 @@ export function PerformanceTable({
           const ratingsCount = info.row.original.ratingsCount;
           const trackId = info.row.original.trackId;
           const showSlug = info.row.original.show.slug;
+          const userRating = userRatingMap.get(trackId) ?? null;
           return (
             <TrackRatingCell
               trackId={trackId}
               showSlug={showSlug}
               initialRating={rating || null}
               ratingsCount={ratingsCount || null}
+              userRating={userRating}
+              isAuthenticated={isAuthenticated}
             />
           );
         },
@@ -316,7 +330,7 @@ export function PerformanceTable({
     );
 
     return cols;
-  }, [showSongColumn, showAllTimerColumn, songTitle, columnHelper]);
+  }, [showSongColumn, showAllTimerColumn, songTitle, columnHelper, userRatingMap, isAuthenticated]);
 
   const table = useReactTable({
     data: filteredPerformances,

--- a/apps/web/app/components/performance/track-rating-cell.tsx
+++ b/apps/web/app/components/performance/track-rating-cell.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from "react";
 import { RatingComponent } from "~/components/rating";
 import { LoginPromptPopover } from "~/components/ui/login-prompt-popover";
 import { StarRating } from "~/components/ui/star-rating";
-import { useSession } from "~/hooks/use-session";
 import { cn } from "~/lib/utils";
 
 export function TrackRatingCell({
@@ -10,18 +9,27 @@ export function TrackRatingCell({
   showSlug,
   initialRating,
   ratingsCount,
+  userRating,
+  isAuthenticated,
 }: {
   trackId: string;
   showSlug: string;
   initialRating: number | null;
   ratingsCount: number | null;
+  userRating?: number | null;
+  isAuthenticated: boolean;
 }) {
-  const { user } = useSession();
   const [isExpanded, setIsExpanded] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
   const [displayedRating, setDisplayedRating] = useState(initialRating ?? 0);
   const [displayedCount, setDisplayedCount] = useState(ratingsCount ?? 0);
+  const [localHasRated, setLocalHasRated] = useState(userRating != null);
   const animationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Sync localHasRated when userRating prop arrives from async fetch
+  useEffect(() => {
+    if (userRating != null) setLocalHasRated(true);
+  }, [userRating]);
 
   // Cleanup timeout on unmount
   useEffect(() => {
@@ -32,6 +40,7 @@ export function TrackRatingCell({
 
   const handleRatingChange = (average: number, count: number) => {
     setIsAnimating(true);
+    setLocalHasRated(true);
     setDisplayedRating(average);
     setDisplayedCount(count);
     setIsExpanded(false);
@@ -44,16 +53,18 @@ export function TrackRatingCell({
     <button
       type="button"
       onClick={(e) => {
-        if (!user) return;
+        if (!isAuthenticated) return;
         e.stopPropagation();
         setIsExpanded(!isExpanded);
       }}
       className={cn(
         "inline-flex items-center justify-center gap-1 px-2 py-1 rounded-md",
         "origin-center",
-        "glass-secondary border border-dashed border-glass-border",
-        user && "hover:brightness-110 cursor-pointer hover:border-amber-500/30",
-        !user && "cursor-pointer hover:border-amber-500/30",
+        localHasRated
+          ? "bg-amber-500/10 border border-amber-500/50 shadow-[0_0_8px_rgba(245,158,11,0.2)]"
+          : "glass-secondary border border-dashed border-glass-border",
+        isAuthenticated && "hover:brightness-110 cursor-pointer hover:border-amber-500/30",
+        !isAuthenticated && "cursor-pointer hover:border-amber-500/30",
         isAnimating && "animate-[avg-rating-update_0.5s_ease-out]"
       )}
     >
@@ -62,6 +73,7 @@ export function TrackRatingCell({
           rateableId={trackId}
           rateableType="Track"
           showSlug={showSlug}
+          initialRating={userRating}
           onAverageRatingChange={handleRatingChange}
           skipRevalidation
         />
@@ -71,7 +83,7 @@ export function TrackRatingCell({
     </button>
   );
 
-  if (!user) {
+  if (!isAuthenticated) {
     return (
       <div className="w-[140px]">
         <LoginPromptPopover message="Sign in to rate">

--- a/apps/web/app/components/ui/star-rating.tsx
+++ b/apps/web/app/components/ui/star-rating.tsx
@@ -41,7 +41,7 @@ export function StarRating({
   const [isAnimating, setIsAnimating] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [rating, setRating] = useState<RatingResponse | null>(
-    initialRating !== undefined ? { userRating: initialRating, averageRating: null } : null
+    initialRating != null ? { userRating: initialRating, averageRating: null } : null
   );
   const { user, loading: isSessionLoading } = useSession();
   const revalidator = useRevalidator();
@@ -59,7 +59,7 @@ export function StarRating({
 
   // Fetch rating if needed (only when user is logged in and no initial rating provided)
   useEffect(() => {
-    if (!user || isSessionLoading || initialRating !== undefined || hasFetchedRef.current) {
+    if (!user || isSessionLoading || initialRating != null || hasFetchedRef.current) {
       return;
     }
 

--- a/apps/web/app/hooks/use-show-user-data.ts
+++ b/apps/web/app/hooks/use-show-user-data.ts
@@ -1,6 +1,7 @@
 import type { Attendance } from "@bip/domain";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
+import { batchedPostFetch } from "~/lib/batched-fetch";
 import type { ShowUserDataResponse } from "~/routes/api/shows/user-data";
 
 interface UseShowUserDataResult {
@@ -11,37 +12,7 @@ interface UseShowUserDataResult {
   error: Error | null;
 }
 
-const BATCH_SIZE = 200;
-
-async function fetchShowUserDataBatch(showIds: string[]): Promise<ShowUserDataResponse> {
-  const response = await fetch("/api/shows/user-data", {
-    method: "POST",
-    credentials: "include",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ showIds }),
-  });
-
-  if (!response.ok) {
-    throw new Error("Failed to fetch show user data");
-  }
-
-  return response.json();
-}
-
-async function fetchShowUserData(showIds: string[]): Promise<ShowUserDataResponse> {
-  if (showIds.length <= BATCH_SIZE) {
-    return fetchShowUserDataBatch(showIds);
-  }
-
-  // Split into batches and fetch in parallel
-  const batches: string[][] = [];
-  for (let i = 0; i < showIds.length; i += BATCH_SIZE) {
-    batches.push(showIds.slice(i, i + BATCH_SIZE));
-  }
-
-  const results = await Promise.all(batches.map(fetchShowUserDataBatch));
-
-  // Merge all batch results
+function mergeShowUserData(results: ShowUserDataResponse[]): ShowUserDataResponse {
   const merged: ShowUserDataResponse = {
     attendances: {},
     userRatings: {},
@@ -63,7 +34,8 @@ export function useShowUserData(showIds: string[]): UseShowUserDataResult {
 
   const { data, isLoading, error } = useQuery({
     queryKey,
-    queryFn: () => fetchShowUserData(showIds),
+    queryFn: () =>
+      batchedPostFetch<ShowUserDataResponse>("/api/shows/user-data", showIds, "showIds", 200, mergeShowUserData),
     enabled: showIds.length > 0,
     staleTime: 30_000, // 30 seconds
   });

--- a/apps/web/app/hooks/use-track-user-ratings.ts
+++ b/apps/web/app/hooks/use-track-user-ratings.ts
@@ -1,0 +1,44 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { batchedPostFetch } from "~/lib/batched-fetch";
+import type { TrackUserRatingsResponse } from "~/routes/api/tracks/user-ratings";
+
+function mergeTrackUserRatings(results: TrackUserRatingsResponse[]): TrackUserRatingsResponse {
+  const merged: TrackUserRatingsResponse = { userRatings: {} };
+  for (const result of results) {
+    Object.assign(merged.userRatings, result.userRatings);
+  }
+  return merged;
+}
+
+export function useTrackUserRatings(trackIds: string[]) {
+  const queryKey = useMemo(() => ["tracks", "user-ratings", [...trackIds].sort().join(",")], [trackIds]);
+
+  const { data, isLoading } = useQuery({
+    queryKey,
+    queryFn: () =>
+      batchedPostFetch<TrackUserRatingsResponse>(
+        "/api/tracks/user-ratings",
+        trackIds,
+        "trackIds",
+        400,
+        mergeTrackUserRatings,
+      ),
+    enabled: trackIds.length > 0,
+    staleTime: 30_000,
+  });
+
+  const userRatingMap = useMemo(() => {
+    const map = new Map<string, number>();
+    if (data?.userRatings) {
+      for (const [trackId, rating] of Object.entries(data.userRatings)) {
+        if (rating !== null) {
+          map.set(trackId, rating);
+        }
+      }
+    }
+    return map;
+  }, [data?.userRatings]);
+
+  return { userRatingMap, isLoading };
+}

--- a/apps/web/app/lib/batched-fetch.ts
+++ b/apps/web/app/lib/batched-fetch.ts
@@ -1,0 +1,43 @@
+/**
+ * Fetches data from a POST endpoint in batches, merging results.
+ *
+ * @param url - The endpoint URL
+ * @param ids - Array of IDs to fetch
+ * @param bodyKey - The key name for the IDs array in the request body (e.g. "showIds", "trackIds")
+ * @param batchSize - Max IDs per request
+ * @param merge - Function to merge multiple responses into one
+ */
+export async function batchedPostFetch<T>(
+  url: string,
+  ids: string[],
+  bodyKey: string,
+  batchSize: number,
+  merge: (results: T[]) => T,
+): Promise<T> {
+  const fetchBatch = async (batchIds: string[]): Promise<T> => {
+    const response = await fetch(url, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ [bodyKey]: batchIds }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch from ${url}`);
+    }
+
+    return response.json();
+  };
+
+  if (ids.length <= batchSize) {
+    return fetchBatch(ids);
+  }
+
+  const batches: string[][] = [];
+  for (let i = 0; i < ids.length; i += batchSize) {
+    batches.push(ids.slice(i, i + batchSize));
+  }
+
+  const results = await Promise.all(batches.map(fetchBatch));
+  return merge(results);
+}

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -114,6 +114,7 @@ export default [
     route("songs/:id", "routes/api/songs/$id.tsx"),
     route("tracks", "routes/api/tracks.tsx"),
     route("tracks/reorder", "routes/api/tracks/reorder.tsx"),
+    route("tracks/user-ratings", "routes/api/tracks/user-ratings.tsx"),
     route("search", "routes/api/search.tsx"),
     route("search/feedback", "routes/api/search/feedback.tsx"),
     route("users", "routes/api/users.tsx"),

--- a/apps/web/app/routes/api/ratings.tsx
+++ b/apps/web/app/routes/api/ratings.tsx
@@ -23,7 +23,10 @@ export const loader = publicLoader(async ({ request, context }) => {
   const userRating = rating?.value ?? null;
   const averageRating = await services.ratings.getAverageForRateable(rateableId, rateableType);
 
-  return { userRating, averageRating };
+  return new Response(JSON.stringify({ userRating, averageRating }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
 });
 
 export const action = protectedAction(async ({ request, context }) => {

--- a/apps/web/app/routes/api/tracks/$trackId.tsx
+++ b/apps/web/app/routes/api/tracks/$trackId.tsx
@@ -33,17 +33,23 @@ export const loader = publicLoader(async ({ params, context }) => {
   const averageRating = track.averageRating || 0;
   const ratingsCount = track.ratingsCount || 0;
 
-  return {
-    track: {
-      id: track.id,
-      songTitle: track.song?.title || "",
-      averageRating,
-      ratingsCount,
-      likesCount: track.likesCount || 0,
-      note: track.note,
+  return new Response(
+    JSON.stringify({
+      track: {
+        id: track.id,
+        songTitle: track.song?.title || "",
+        averageRating,
+        ratingsCount,
+        likesCount: track.likesCount || 0,
+        note: track.note,
+      },
+      userRating: userRating?.value || null,
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
     },
-    userRating: userRating?.value || null,
-  };
+  );
 });
 
 export const action = protectedAction(async ({ request, params }) => {

--- a/apps/web/app/routes/api/tracks/user-ratings.tsx
+++ b/apps/web/app/routes/api/tracks/user-ratings.tsx
@@ -1,0 +1,56 @@
+import { publicAction } from "~/lib/base-loaders";
+import { badRequest } from "~/lib/errors";
+import { logger } from "~/lib/logger";
+import { services } from "~/server/services";
+
+export interface TrackUserRatingsResponse {
+  userRatings: Record<string, number | null>;
+}
+
+export const action = publicAction(async ({ request, context }) => {
+  let trackIds: string[];
+  try {
+    const body = await request.json();
+    trackIds = body.trackIds;
+  } catch {
+    return badRequest();
+  }
+
+  if (!Array.isArray(trackIds) || trackIds.length === 0) {
+    return badRequest();
+  }
+
+  if (trackIds.length > 500) {
+    return new Response(JSON.stringify({ error: "Too many track IDs (max 500)" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const response: TrackUserRatingsResponse = {
+    userRatings: {},
+  };
+
+  try {
+    if (context.currentUser) {
+      const user = await services.users.findByEmail(context.currentUser.email);
+      if (user) {
+        const ratings = await services.ratings.findManyByUserIdAndRateableIds(user.id, trackIds, "Track");
+        for (const rating of ratings) {
+          response.userRatings[rating.rateableId] = rating.value;
+        }
+      }
+    }
+
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    logger.error("Error fetching track user ratings", { error, trackIds: trackIds.length });
+    return new Response(JSON.stringify({ error: "Failed to fetch track ratings" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+});

--- a/apps/web/app/routes/resources/chemical-warfare-brigade.tsx
+++ b/apps/web/app/routes/resources/chemical-warfare-brigade.tsx
@@ -537,8 +537,10 @@ function SongCard({ song, index }: { song: (typeof songs)[number]; index: number
           <blockquote className="border-l-4 border-purple-500/30 pl-4 italic text-content-text-secondary">
             {song.lyrics.map((line, i) =>
               line === "" ? (
+                // biome-ignore lint/suspicious/noArrayIndexKey: static lyrics
                 <br key={i} />
               ) : (
+                // biome-ignore lint/suspicious/noArrayIndexKey: static lyrics
                 <span key={i}>
                   {line}
                   <br />

--- a/apps/web/app/routes/resources/hot-air-balloon.tsx
+++ b/apps/web/app/routes/resources/hot-air-balloon.tsx
@@ -397,8 +397,10 @@ function renderLyrics(lyrics: string) {
   if (!lyrics.trim()) return null;
   const stanzas = lyrics.split("\n\n");
   return stanzas.map((stanza, i) => (
+    // biome-ignore lint/suspicious/noArrayIndexKey: static lyrics
     <p key={i}>
       {stanza.split("\n").map((line, j, arr) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static lyrics
         <span key={j}>
           {line}
           {j < arr.length - 1 && <br />}

--- a/apps/web/app/routes/resources/revolution-in-motion.tsx
+++ b/apps/web/app/routes/resources/revolution-in-motion.tsx
@@ -234,7 +234,7 @@ const listenLinks = [
 
 function SpotifyIcon({ className }: { className?: string }) {
   return (
-    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} role="img" aria-label="Spotify">
       <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
     </svg>
   );
@@ -242,7 +242,7 @@ function SpotifyIcon({ className }: { className?: string }) {
 
 function YouTubeIcon({ className }: { className?: string }) {
   return (
-    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} role="img" aria-label="YouTube">
       <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
     </svg>
   );
@@ -322,6 +322,7 @@ function StoryCard({ part, index }: { part: (typeof storyParts)[number]; index: 
           {/* Content */}
           <div className="space-y-3 text-content-text-secondary leading-relaxed text-base md:text-lg">
             {part.content.map((paragraph, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: static content
               <p key={i}>{paragraph}</p>
             ))}
           </div>

--- a/apps/web/app/routes/shows/$slug.tsx
+++ b/apps/web/app/routes/shows/$slug.tsx
@@ -13,6 +13,7 @@ import { ShowPhotos } from "~/components/show/show-photos";
 import { Button } from "~/components/ui/button";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { useSession } from "~/hooks/use-session";
+import { useShowUserData } from "~/hooks/use-show-user-data";
 import { type Context, publicLoader } from "~/lib/base-loaders";
 import { notFound } from "~/lib/errors";
 import { getShowMeta, getShowStructuredData } from "~/lib/seo";
@@ -164,6 +165,8 @@ export default function Show() {
   } = useSerializedLoaderData<ShowLoaderData>();
   const { user } = useSession();
   const revalidator = useRevalidator();
+  const { userRatingMap } = useShowUserData([setlist.show.id]);
+  const userRating = userRatingMap.get(setlist.show.id) ?? null;
 
   // Get the internal user ID from Supabase metadata
   const internalUserId = user?.user_metadata?.internal_user_id;
@@ -311,7 +314,7 @@ export default function Show() {
             key={setlist.show.id}
             setlist={setlist}
             userAttendance={userAttendance}
-            userRating={null}
+            userRating={userRating}
             showRating={setlist.show.averageRating}
           />
 


### PR DESCRIPTION
## Summary
- **Bug**: Clicking a track rating on the all-timers page (and song detail pages) never showed the user's existing rating, even though it was visible on their profile page
- **Root cause**: API route loaders returned plain objects which React Router v7 serializes via turbo-stream. Direct fetch() calls expected JSON, so response.json() silently failed
- **Fix**: Return explicit JSON Response objects from /api/ratings and /api/tracks/:trackId loaders
- **Gold highlight**: Added gold amber border to TrackRatingCell (matching existing SetlistCard pattern) when the user has rated a track — visible on all-timers, song detail, and show detail pages
- **Auth fix**: Lifted useSession() from individual TrackRatingCell instances to PerformanceTable parent to avoid 50+ concurrent Supabase client instances failing to resolve auth
- **Refactoring**: Extracted shared batchedPostFetch utility used by both useShowUserData and new useTrackUserRatings hooks
- **Show detail fix**: Show page was hardcoding userRating={null} — now fetches actual user rating via useShowUserData
- **Lint**: Fixed pre-existing lint errors in resource pages

## New files
- `apps/web/app/lib/batched-fetch.ts` — generic batched POST fetch utility
- `apps/web/app/hooks/use-track-user-ratings.ts` — hook to batch-fetch user track ratings
- `apps/web/app/routes/api/tracks/user-ratings.tsx` — batch endpoint for user track ratings

## Test plan
- [x] /songs/all-timers — tracks you have rated show gold border, clicking shows your stars pre-filled
- [x] /songs/:slug — same gold border + stars on performance table
- [x] /shows/:slug — show rating has gold border if you have rated it
- [x] /shows/year/:year — setlist card ratings still have gold highlight
- [x] Submit a new rating via star UI — gold border appears, rating persists on reload
- [x] Logged out — all pages show Sign in to rate popover, no gold borders, no errors

Generated with [Claude Code](https://claude.com/claude-code)