### PR TITLE
Songs table unification

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,33 @@
+# Git Hooks
+
+Custom [git hooks](https://git-scm.com/docs/githooks) for this repo.
+
+> Hooks are programs you can place in a hooks directory to trigger actions at certain points in git's execution. A non-zero exit code from a git hook aborts the operation.
+
+## Hooks
+
+- **`pre-commit`** — runs `bun run lint` before every commit. Fast.
+- **`pre-push`** — runs `bun run typecheck:all` and `bun run test` before every push. Slower but catches broken code before it hits the remote.
+
+## Activation
+
+These hooks are opt-in. To enable them, run this once in the repo root:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+This sets git's `core.hooksPath` to this directory instead of the default `.git/hooks`.
+
+## Skipping a hook
+
+Pass `--no-verify` to bypass the hook for a single operation — e.g. pushing a WIP branch where tests intentionally fail:
+
+```bash
+git push --no-verify
+git commit --no-verify
+```
+
+## Adding a new hook
+
+Place the executable at `.githooks/<hook-name>` and run `chmod a+x .githooks/<hook-name>`.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Before committing, ensure linting passes.
+bun run lint

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Before pushing, run typecheck and unit tests.
+bun run typecheck:all && bun run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ on:
       - '!README.md'
 
 jobs:
-  lint-typecheck:
-    name: Lint & Type Check
+  lint-typecheck-test:
+    name: Lint, Type Check & Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -55,3 +55,6 @@ jobs:
 
       - name: Lint
         run: bun run lint
+
+      - name: Test
+        run: bun run test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,25 @@ make lint                            # Same as bun run lint
 make format                          # Same as bun run format
 ```
 
+**Testing:**
+```bash
+bun run test                         # Run all tests
+make test                            # Same as bun run test
+cd apps/web && bun run test:watch    # Watch mode
+```
+
+Test files are colocated with source: `*.test.{ts,tsx}`. Shared test helpers live in `apps/web/test/test-utils.tsx` (import via `@test/*` alias, e.g. `import { setup } from "@test/test-utils"`).
+
+**Git Hooks:**
+Custom hooks live in `.githooks/`. Enable them once per clone:
+```bash
+git config core.hooksPath .githooks
+```
+- `pre-commit` runs `bun run lint`
+- `pre-push` runs `bun run typecheck:all && bun run test`
+
+Bypass a single hook with `--no-verify` (e.g. `git push --no-verify` for WIP branches).
+
 **Database Operations:**
 ```bash
 make migrate                         # Run Prisma migrations in dev
@@ -136,7 +155,8 @@ This is a **monorepo** using **pnpm workspaces** with **Bun** as the runtime. Ke
 1. **Database Changes**: Create migrations with `make migrate-create`, run with `make migrate`
 2. **Type Generation**: Run `bun run typecheck` after schema changes to regenerate types
 3. **New Features**: Follow the repository/service pattern in core, create corresponding UI components in web
-4. **Testing**: No specific test framework mentioned - check if tests exist before assuming testing approach
+4. **Testing**: Run `make test` to verify changes pass all tests
+5. **Formatting**: Always run `bun run format` on every file you change before committing. Biome handles formatting — never use Prettier or other formatters.
 
 ## Important Notes
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ tc:
 lint:
 	bun run lint
 
+test:
+	bun run test
+
 format:
 	bun run format
 

--- a/apps/web/app/components/author/author-columns.tsx
+++ b/apps/web/app/components/author/author-columns.tsx
@@ -1,6 +1,6 @@
 import type { Author } from "@bip/domain";
 import type { ColumnDef } from "@tanstack/react-table";
-import { ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import { Link } from "react-router-dom";
 import { Button } from "~/components/ui/button";
 
@@ -24,6 +24,7 @@ type AuthorWithSongCount = Author & { songCount?: number };
 export const authorColumns: ColumnDef<AuthorWithSongCount>[] = [
   {
     accessorKey: "name",
+    meta: { width: "25%" },
     header: ({ column }) => {
       return (
         <Button
@@ -50,6 +51,7 @@ export const authorColumns: ColumnDef<AuthorWithSongCount>[] = [
   },
   {
     accessorKey: "songCount",
+    meta: { width: "25%" },
     header: ({ column }) => {
       return (
         <Button
@@ -64,15 +66,12 @@ export const authorColumns: ColumnDef<AuthorWithSongCount>[] = [
     },
     cell: ({ row }) => {
       const count = row.original.songCount ?? 0;
-      return (
-        <span className="text-content-text-primary font-semibold">
-          {count}
-        </span>
-      );
+      return <span className="text-content-text-primary font-semibold">{count}</span>;
     },
   },
   {
     accessorKey: "slug",
+    meta: { width: "25%" },
     header: ({ column }) => {
       return (
         <Button
@@ -91,6 +90,7 @@ export const authorColumns: ColumnDef<AuthorWithSongCount>[] = [
   },
   {
     accessorKey: "createdAt",
+    meta: { width: "25%" },
     header: ({ column }) => {
       return (
         <Button

--- a/apps/web/app/components/performance/index.ts
+++ b/apps/web/app/components/performance/index.ts
@@ -1,3 +1,4 @@
 export { CombinedNotes } from "./combined-notes";
+export { createPerformanceColumns } from "./performance-columns";
 export { PerformanceTable } from "./performance-table";
 export { TrackRatingCell } from "./track-rating-cell";

--- a/apps/web/app/components/performance/performance-columns.test.tsx
+++ b/apps/web/app/components/performance/performance-columns.test.tsx
@@ -1,0 +1,158 @@
+import type { SongPagePerformance } from "@bip/domain";
+import { mockShallowComponent, setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { DataTable } from "~/components/ui/data-table";
+import { createPerformanceColumns } from "./performance-columns";
+
+vi.mock("./track-rating-cell", () => ({
+  TrackRatingCell: (props: object) => mockShallowComponent("TrackRatingCell", props),
+}));
+vi.mock("./combined-notes", () => ({
+  CombinedNotes: (props: object) => mockShallowComponent("CombinedNotes", props),
+}));
+
+function makePerformance(overrides: Partial<SongPagePerformance> = {}): SongPagePerformance {
+  return {
+    trackId: "track-1",
+    show: { id: "show-1", slug: "2024-06-15-the-cap", date: "2024-06-15", venueId: "venue-1" },
+    venue: {
+      id: "venue-1",
+      slug: "the-cap",
+      name: "The Capitol Theatre",
+      city: "Port Chester",
+      state: "NY",
+      country: "USA",
+    },
+    songBefore: undefined,
+    songAfter: undefined,
+    rating: 4.5,
+    ratingsCount: 12,
+    notes: undefined,
+    allTimer: false,
+    segue: null,
+    annotations: [],
+    set: "S1",
+    position: 3,
+    tags: {},
+    ...overrides,
+  };
+}
+
+const defaultOptions = {
+  userRatingMap: new Map<string, number>(),
+  isAuthenticated: false,
+};
+
+describe("createPerformanceColumns", () => {
+  // The default column set (no optional columns) renders Date, Venue, Set,
+  // Sequence, Notes, and Rating headers. These are always present regardless
+  // of which page renders the table.
+  test("default columns include Date, Venue, Set, Sequence, Notes, Rating headers", async () => {
+    const columns = createPerformanceColumns(defaultOptions);
+    await setup(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
+
+    expect(screen.getByText("Date")).toBeInTheDocument();
+    expect(screen.getByText("Venue")).toBeInTheDocument();
+    expect(screen.getByText("Set")).toBeInTheDocument();
+    expect(screen.getByText("Sequence")).toBeInTheDocument();
+    expect(screen.getByText("Notes")).toBeInTheDocument();
+    expect(screen.getByText("Rating")).toBeInTheDocument();
+  });
+
+  // The Song column only appears on /songs/all-timers where performances
+  // span multiple songs. On /songs/$slug (single song), it's omitted.
+  test("Song column present when showSongColumn is true, absent otherwise", async () => {
+    const performances = [makePerformance({ songTitle: "Cassidy", songSlug: "cassidy" })];
+
+    const withSong = createPerformanceColumns({ ...defaultOptions, showSongColumn: true });
+    const { unmount } = await setup(<DataTable columns={withSong} data={performances} hideSearch hidePagination />);
+    expect(screen.getByText("Song")).toBeInTheDocument();
+    unmount();
+
+    const withoutSong = createPerformanceColumns(defaultOptions);
+    await setup(<DataTable columns={withoutSong} data={performances} hideSearch hidePagination />);
+    expect(screen.queryByText("Song")).not.toBeInTheDocument();
+  });
+
+  // The AllTimer flame column marks standout performances. Only shown on
+  // the "All Performances" tab of /songs/$slug, not on /songs/all-timers
+  // (where every row is already an all-timer by definition).
+  test("AllTimer flame column present when showAllTimerColumn is true", async () => {
+    const performances = [makePerformance({ allTimer: true })];
+    const columns = createPerformanceColumns({ ...defaultOptions, showAllTimerColumn: true });
+    const { container } = await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+
+    expect(container.querySelectorAll(".lucide-flame").length).toBe(1);
+  });
+
+  // TrackRatingCell receives initialRating from the performance's rating
+  // field, NOT from the userRatingMap.
+  test("passes initialRating from performance.rating even when userRatingMap is empty", async () => {
+    const performances = [makePerformance({ trackId: "t1", rating: 3.5, ratingsCount: 2 })];
+    const columns = createPerformanceColumns({ ...defaultOptions, userRatingMap: new Map() });
+    await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+
+    const cell = screen.getByTestId("TrackRatingCell");
+    expect(cell.textContent).toContain('"initialRating":3.5');
+    expect(cell.textContent).toContain('"ratingsCount":2');
+  });
+
+  // A performance with rating=0 or rating=undefined should pass
+  // initialRating as null (not 0) so TrackRatingCell shows "Rate".
+  test("passes initialRating as null when performance.rating is undefined", async () => {
+    const performances = [makePerformance({ trackId: "t1", rating: undefined, ratingsCount: undefined })];
+    const columns = createPerformanceColumns(defaultOptions);
+    await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+
+    const cell = screen.getByTestId("TrackRatingCell");
+    expect(cell.textContent).toContain('"initialRating":null');
+    expect(cell.textContent).toContain('"ratingsCount":null');
+  });
+
+  // Each Date cell links to the show's detail page.
+  test("Date cell links to /shows/{show.slug}", async () => {
+    const performances = [
+      makePerformance({ show: { id: "s1", slug: "2024-06-15-the-cap", date: "2024-06-15", venueId: "v1" } }),
+    ];
+    const columns = createPerformanceColumns(defaultOptions);
+    await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+
+    const dateLink = screen.getByRole("link", { name: "2024-06-15" });
+    expect(dateLink).toHaveAttribute("href", "/shows/2024-06-15-the-cap");
+  });
+
+  // Sortable columns show sort indicators; non-sortable columns do not.
+  test("sortable columns show sort indicator, non-sortable columns do not", async () => {
+    const columns = createPerformanceColumns(defaultOptions);
+    await setup(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
+
+    const dateHeader = screen.getByText("Date").closest("button");
+    expect(dateHeader).not.toBeNull();
+    expect(dateHeader?.querySelector("svg")).not.toBeNull();
+
+    const setHeader = screen.getByText("Set").closest("th");
+    expect(setHeader?.querySelector("button")).toBeNull();
+
+    const ratingHeader = screen.getByText("Rating").closest("button");
+    expect(ratingHeader).not.toBeNull();
+    expect(ratingHeader?.querySelector("svg")).not.toBeNull();
+
+    const venueHeader = screen.getByText("Venue").closest("th");
+    expect(venueHeader?.querySelector("button")).toBeNull();
+
+    const sequenceHeader = screen.getByText("Sequence").closest("th");
+    expect(sequenceHeader?.querySelector("button")).toBeNull();
+  });
+
+  // Columns that need constrained widths set explicit meta.width.
+  test("allTimer and Set columns have explicit meta.width", () => {
+    const columns = createPerformanceColumns({ ...defaultOptions, showAllTimerColumn: true });
+
+    const allTimerColumn = columns.find((column) => "id" in column && column.id === "allTimer");
+    expect(allTimerColumn?.meta?.width).toBe("24px");
+
+    const setColumn = columns.find((column) => "accessorKey" in column && column.accessorKey === "set");
+    expect(setColumn?.meta?.width).toBe("48px");
+  });
+});

--- a/apps/web/app/components/performance/performance-columns.test.tsx
+++ b/apps/web/app/components/performance/performance-columns.test.tsx
@@ -87,19 +87,23 @@ describe("createPerformanceColumns", () => {
   });
 
   // TrackRatingCell receives initialRating from the performance's rating
-  // field, NOT from the userRatingMap.
+  // field, NOT from the userRatingMap. A performance with a community
+  // average rating should always pass that rating to the cell, regardless
+  // of whether the user has rated it or the userRatingMap is empty.
   test("passes initialRating from performance.rating even when userRatingMap is empty", async () => {
     const performances = [makePerformance({ trackId: "t1", rating: 3.5, ratingsCount: 2 })];
     const columns = createPerformanceColumns({ ...defaultOptions, userRatingMap: new Map() });
     await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
 
     const cell = screen.getByTestId("TrackRatingCell");
+    // initialRating should be 3.5, not null
     expect(cell.textContent).toContain('"initialRating":3.5');
     expect(cell.textContent).toContain('"ratingsCount":2');
   });
 
   // A performance with rating=0 or rating=undefined should pass
   // initialRating as null (not 0) so TrackRatingCell shows "Rate".
+  // This is correct — there's no community rating to display.
   test("passes initialRating as null when performance.rating is undefined", async () => {
     const performances = [makePerformance({ trackId: "t1", rating: undefined, ratingsCount: undefined })];
     const columns = createPerformanceColumns(defaultOptions);
@@ -110,7 +114,8 @@ describe("createPerformanceColumns", () => {
     expect(cell.textContent).toContain('"ratingsCount":null');
   });
 
-  // Each Date cell links to the show's detail page.
+  // Each Date cell links to the show's detail page so users can click
+  // through to see the full setlist.
   test("Date cell links to /shows/{show.slug}", async () => {
     const performances = [
       makePerformance({ show: { id: "s1", slug: "2024-06-15-the-cap", date: "2024-06-15", venueId: "v1" } }),
@@ -122,15 +127,20 @@ describe("createPerformanceColumns", () => {
     expect(dateLink).toHaveAttribute("href", "/shows/2024-06-15-the-cap");
   });
 
-  // Sortable columns show sort indicators; non-sortable columns do not.
+  // Sortable columns (Date, Set, Rating, Song) show an up/down arrow icon
+  // even when not actively sorted, so users can see at a glance which
+  // columns support sorting. Non-sortable columns (Venue, Sequence, Notes)
+  // render plain text headers with no icon.
   test("sortable columns show sort indicator, non-sortable columns do not", async () => {
     const columns = createPerformanceColumns(defaultOptions);
     await setup(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
 
+    // Sortable columns render a <button> with an SVG icon inside
     const dateHeader = screen.getByText("Date").closest("button");
     expect(dateHeader).not.toBeNull();
     expect(dateHeader?.querySelector("svg")).not.toBeNull();
 
+    // Set is not sortable — plain text header
     const setHeader = screen.getByText("Set").closest("th");
     expect(setHeader?.querySelector("button")).toBeNull();
 
@@ -138,6 +148,7 @@ describe("createPerformanceColumns", () => {
     expect(ratingHeader).not.toBeNull();
     expect(ratingHeader?.querySelector("svg")).not.toBeNull();
 
+    // Non-sortable columns render a plain <span> with no button
     const venueHeader = screen.getByText("Venue").closest("th");
     expect(venueHeader?.querySelector("button")).toBeNull();
 
@@ -145,7 +156,9 @@ describe("createPerformanceColumns", () => {
     expect(sequenceHeader?.querySelector("button")).toBeNull();
   });
 
-  // Columns that need constrained widths set explicit meta.width.
+  // Columns that need constrained widths (like the narrow allTimer flame
+  // icon and the Set label) set explicit meta.width. Other columns auto-size
+  // to avoid wasted space.
   test("allTimer and Set columns have explicit meta.width", () => {
     const columns = createPerformanceColumns({ ...defaultOptions, showAllTimerColumn: true });
 

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -1,0 +1,262 @@
+import type { SongPagePerformance } from "@bip/domain";
+import { type Column, type ColumnDef, createColumnHelper } from "@tanstack/react-table";
+import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon, Flame } from "lucide-react";
+import { CombinedNotes } from "./combined-notes";
+import { TrackRatingCell } from "./track-rating-cell";
+
+interface PerformanceColumnOptions {
+  showSongColumn?: boolean;
+  showAllTimerColumn?: boolean;
+  songTitle?: string;
+  userRatingMap: Map<string, number>;
+  isAuthenticated: boolean;
+}
+
+function SortableHeader({ column, label }: { column: Column<SongPagePerformance, unknown>; label: string }) {
+  if (!column.getCanSort()) return <span>{label}</span>;
+
+  return (
+    <button
+      type="button"
+      className="cursor-pointer select-none hover:text-content-text-primary w-full text-left"
+      onClick={() => column.toggleSorting()}
+    >
+      <span className={column.getIsSorted() ? "text-content-text-primary font-semibold" : ""}>{label}</span>
+      <span className={column.getIsSorted() ? "text-brand-primary ml-1" : "ml-1"}>
+        {column.getIsSorted() === "asc" ? (
+          <ArrowUpIcon className="h-4 w-4 inline" />
+        ) : column.getIsSorted() === "desc" ? (
+          <ArrowDownIcon className="h-4 w-4 inline" />
+        ) : (
+          <ArrowUpDown className="h-4 w-4 inline" />
+        )}
+      </span>
+    </button>
+  );
+}
+
+export function createPerformanceColumns(options: PerformanceColumnOptions): ColumnDef<SongPagePerformance, unknown>[] {
+  const { showSongColumn, showAllTimerColumn, songTitle, userRatingMap, isAuthenticated } = options;
+  const columnHelper = createColumnHelper<SongPagePerformance>();
+  const columns: ColumnDef<SongPagePerformance, unknown>[] = [];
+
+  if (showSongColumn) {
+    columns.push(
+      columnHelper.accessor((row) => row.songTitle || "", {
+        id: "song",
+        header: ({ column }) => <SortableHeader column={column} label="Song" />,
+        enableSorting: true,
+        sortingFn: "alphanumeric",
+        cell: (info) => {
+          const title = info.getValue() as string;
+          const slug = info.row.original.songSlug;
+          return slug ? (
+            <a href={`/songs/${slug}`} className="text-base text-brand-primary hover:text-brand-secondary font-medium">
+              {title}
+            </a>
+          ) : (
+            <span className="text-content-text-secondary">{title}</span>
+          );
+        },
+      }) as ColumnDef<SongPagePerformance, unknown>,
+    );
+  }
+
+  if (showAllTimerColumn) {
+    columns.push(
+      columnHelper.accessor((row) => row.allTimer ?? false, {
+        id: "allTimer",
+        header: "",
+        meta: { width: "24px" },
+        enableSorting: false,
+        cell: (info) => (info.getValue() ? <Flame className="h-3.5 w-3.5 text-orange-500" /> : null),
+      }) as ColumnDef<SongPagePerformance, unknown>,
+    );
+  }
+
+  columns.push(
+    columnHelper.accessor("show.date", {
+      id: "date",
+      meta: { width: "120px" },
+      header: ({ column }) => <SortableHeader column={column} label="Date" />,
+      enableSorting: true,
+      sortingFn: "datetime",
+      cell: (info) => (
+        <a
+          href={`/shows/${info.row.original.show.slug}`}
+          className="text-base text-brand-primary hover:text-brand-secondary"
+        >
+          {info.getValue()}
+        </a>
+      ),
+    }) as ColumnDef<SongPagePerformance, unknown>,
+    columnHelper.accessor(
+      (row) => ({
+        name: row.venue?.name,
+        city: row.venue?.city,
+        state: row.venue?.state,
+        slug: row.show.slug,
+      }),
+      {
+        id: "venue",
+        header: "Venue",
+        enableSorting: false,
+        cell: (info) => {
+          const venue = info.getValue();
+          return venue.city ? (
+            <a href={`/shows/${venue.slug}`} className="text-brand-primary hover:text-brand-secondary">
+              {venue.name}
+              <br />
+              {venue.city}, {venue.state}
+            </a>
+          ) : null;
+        },
+      },
+    ) as ColumnDef<SongPagePerformance, unknown>,
+    columnHelper.accessor("set", {
+      header: "Set",
+      meta: { width: "48px" },
+      enableSorting: false,
+      cell: (info) => {
+        const set = info.getValue();
+        return set ? (
+          <span className="text-content-text-secondary">{set}</span>
+        ) : (
+          <span className="text-content-text-tertiary">—</span>
+        );
+      },
+    }) as ColumnDef<SongPagePerformance, unknown>,
+    columnHelper.accessor(
+      (row) => ({
+        before: row.songBefore,
+        after: row.songAfter,
+        currentSong: songTitle || row.songTitle || "",
+      }),
+      {
+        id: "sequence",
+        header: "Sequence",
+        enableSorting: false,
+        cell: (info) => {
+          const { before, after, currentSong } = info.getValue();
+          const parts = [];
+
+          if (before?.songTitle) {
+            parts.push(
+              <a
+                key="before"
+                href={`/songs/${before.songSlug}`}
+                className="text-content-text-secondary hover:text-brand-primary"
+              >
+                {before.songTitle}
+              </a>,
+            );
+            if (before.segue) {
+              parts.push(
+                <span key="segue1" className="text-content-text-tertiary mx-1">
+                  {" "}
+                  &gt;{" "}
+                </span>,
+              );
+            } else {
+              parts.push(
+                <span key="sep1" className="text-content-text-tertiary">
+                  ,&nbsp;
+                </span>,
+              );
+            }
+          }
+
+          parts.push(
+            <span key="current" className="font-bold" style={{ color: "#DDD6FE" }}>
+              {currentSong}
+            </span>,
+          );
+
+          if (after?.songTitle) {
+            if (info.row.original.segue) {
+              parts.push(
+                <span key="segue2" className="text-content-text-tertiary mx-1">
+                  {" "}
+                  &gt;{" "}
+                </span>,
+              );
+            } else {
+              parts.push(
+                <span key="sep2" className="text-content-text-tertiary">
+                  ,&nbsp;
+                </span>,
+              );
+            }
+            parts.push(
+              <a
+                key="after"
+                href={`/songs/${after.songSlug}`}
+                className="text-content-text-secondary hover:text-brand-primary"
+              >
+                {after.songTitle}
+              </a>,
+            );
+          }
+
+          return parts.length > 0 ? <div className="flex items-center flex-wrap">{parts}</div> : null;
+        },
+      },
+    ) as ColumnDef<SongPagePerformance, unknown>,
+    columnHelper.accessor(
+      (row) => ({
+        annotations: row.annotations,
+        notes: row.notes,
+      }),
+      {
+        id: "notes",
+        header: "Notes",
+        enableSorting: false,
+        cell: (info) => {
+          const { annotations, notes } = info.getValue();
+          const items = [];
+
+          if (annotations && annotations.length > 0) {
+            for (const annotation of annotations) {
+              if (annotation.desc) {
+                items.push(annotation.desc);
+              }
+            }
+          }
+
+          if (notes) {
+            items.push(notes);
+          }
+
+          if (items.length === 0) return null;
+
+          return <CombinedNotes items={items} />;
+        },
+      },
+    ) as ColumnDef<SongPagePerformance, unknown>,
+    columnHelper.accessor((row) => row.rating ?? 0, {
+      id: "rating",
+      header: ({ column }) => <SortableHeader column={column} label="Rating" />,
+      enableSorting: true,
+      sortingFn: "basic",
+      cell: (info) => {
+        const rating = info.getValue();
+        const ratingsCount = info.row.original.ratingsCount;
+        const trackId = info.row.original.trackId;
+        const showSlug = info.row.original.show.slug;
+        const userRating = userRatingMap.get(trackId) ?? null;
+        return (
+          <TrackRatingCell
+            trackId={trackId}
+            showSlug={showSlug}
+            initialRating={rating || null}
+            ratingsCount={ratingsCount || null}
+            userRating={userRating}
+            isAuthenticated={isAuthenticated}
+          />
+        );
+      },
+    }) as ColumnDef<SongPagePerformance, unknown>,
+  );
+
+  return columns;
+}

--- a/apps/web/app/components/performance/performance-filter-controls.test.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.test.tsx
@@ -1,0 +1,69 @@
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { PerformanceFilterControls } from "./performance-filter-controls";
+
+const defaultProps = {
+  selectedYear: "all",
+  selectedEra: "all",
+  activeToggleSet: new Set<string>(),
+  updateFilter: vi.fn(),
+  toggleFilter: vi.fn(),
+  clearFilters: vi.fn(),
+};
+
+describe("PerformanceFilterControls", () => {
+  // The search input is opt-in — it only renders when the parent provides
+  // searchValue + onSearchChange. Pages that don't need search omit these props.
+  test("renders search input when searchValue is provided", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} searchValue="" onSearchChange={() => {}} />);
+
+    expect(screen.getByPlaceholderText("Search...")).toBeInTheDocument();
+  });
+
+  test("does not render search input when searchValue is not provided", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} />);
+
+    expect(screen.queryByPlaceholderText("Search...")).not.toBeInTheDocument();
+  });
+
+  // The search input is controlled — the parent owns the value and receives
+  // change events via onSearchChange. This lets the parent pre-filter data
+  // before passing it to the table.
+  test("typing in search input calls onSearchChange", async () => {
+    const handleSearchChange = vi.fn();
+    const { user } = await setup(
+      <PerformanceFilterControls {...defaultProps} searchValue="" onSearchChange={handleSearchChange} />,
+    );
+
+    await user.type(screen.getByPlaceholderText("Search..."), "hello");
+    expect(handleSearchChange).toHaveBeenCalled();
+  });
+
+  // Clear All appears in the select filter row (top row) when any filter is
+  // active — search text, select dropdowns, or toggle chips. It's a single
+  // entry point to reset everything.
+  test("renders Clear All button when hasActiveFilters is true", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} hasActiveFilters />);
+
+    expect(screen.getByRole("button", { name: "Clear All" })).toBeInTheDocument();
+  });
+
+  test("does not render Clear All button when hasActiveFilters is false", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} hasActiveFilters={false} />);
+
+    expect(screen.queryByRole("button", { name: "Clear All" })).not.toBeInTheDocument();
+  });
+
+  // Clicking Clear All delegates to the parent's clearFilters callback, which
+  // resets all URL params and search text in the hook.
+  test("clicking Clear All calls clearFilters", async () => {
+    const handleClearFilters = vi.fn();
+    const { user } = await setup(
+      <PerformanceFilterControls {...defaultProps} clearFilters={handleClearFilters} hasActiveFilters />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Clear All" }));
+    expect(handleClearFilters).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/app/components/performance/performance-filter-controls.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.tsx
@@ -1,0 +1,134 @@
+import type { ReactNode } from "react";
+import { AuthorSearch } from "~/components/author/author-search";
+import { SelectFilter } from "~/components/ui/filters";
+import { ToggleFilterGroup } from "~/components/ui/filters/toggle-filter-group";
+import { Input } from "~/components/ui/input";
+import { ERA_OPTIONS, TOGGLE_FILTER_DEFINITIONS, YEAR_OPTIONS } from "~/lib/song-filters";
+
+const ALL_TOGGLE_FILTERS = TOGGLE_FILTER_DEFINITIONS as unknown as Array<{ key: string; label: string }>;
+
+const TOGGLE_FILTERS_WITHOUT_ALL_TIMER = ALL_TOGGLE_FILTERS.filter((filter) => filter.key !== "allTimer");
+
+const labelClass =
+  "text-xs font-medium text-content-text-secondary uppercase tracking-wide mb-1.5 h-[18px] flex items-center";
+
+interface PerformanceFilterControlsProps {
+  selectedYear: string;
+  selectedEra: string;
+  activeToggleSet: Set<string>;
+  updateFilter: (updates: Record<string, string | null>) => void;
+  toggleFilter: (key: string) => void;
+  clearFilters: () => void;
+  extraSelectFilters?: ReactNode;
+  showAllTimerToggle?: boolean;
+  coverFilter?: string;
+  selectedAuthor?: string | null;
+  playedFilter?: string;
+  searchValue?: string;
+  onSearchChange?: (value: string) => void;
+  hasActiveFilters?: boolean;
+}
+
+export function PerformanceFilterControls({
+  selectedYear,
+  selectedEra,
+  activeToggleSet,
+  updateFilter,
+  toggleFilter,
+  clearFilters,
+  extraSelectFilters,
+  showAllTimerToggle = true,
+  coverFilter,
+  selectedAuthor,
+  playedFilter,
+  searchValue,
+  onSearchChange,
+  hasActiveFilters = false,
+}: PerformanceFilterControlsProps) {
+  const toggleFilters = showAllTimerToggle ? ALL_TOGGLE_FILTERS : TOGGLE_FILTERS_WITHOUT_ALL_TIMER;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-end flex-wrap gap-x-3 gap-y-2">
+        {searchValue !== undefined && onSearchChange && (
+          <Input
+            placeholder="Search..."
+            value={searchValue}
+            onChange={(event) => onSearchChange(event.target.value)}
+            className="w-auto min-w-[200px] sm:min-w-[250px] max-w-md h-[34px] text-sm bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20 placeholder:text-content-text-tertiary"
+          />
+        )}
+        <SelectFilter
+          id="year-filter"
+          label="Year"
+          value={selectedYear}
+          onValueChange={(value) => updateFilter({ year: value, era: null })}
+          options={[{ value: "all", label: "All Years" }, ...YEAR_OPTIONS]}
+          width="w-[130px]"
+        />
+        <SelectFilter
+          id="era-filter"
+          label="Era"
+          value={selectedEra}
+          onValueChange={(value) => updateFilter({ era: value, year: null })}
+          options={[{ value: "all", label: "All Eras" }, ...ERA_OPTIONS]}
+          width="w-[170px]"
+        />
+        {coverFilter !== undefined && (
+          <SelectFilter
+            id="cover-filter"
+            label="Original / Cover"
+            value={coverFilter}
+            onValueChange={(value) => updateFilter({ cover: value })}
+            options={[
+              { value: "all", label: "All" },
+              { value: "original", label: "Original" },
+              { value: "cover", label: "Cover" },
+            ]}
+            placeholder="Type"
+            width="w-[120px]"
+          />
+        )}
+        {selectedAuthor !== undefined && (
+          <div className="flex flex-col">
+            <label htmlFor="author-search" className={labelClass}>
+              Author
+            </label>
+            <AuthorSearch
+              value={selectedAuthor}
+              onValueChange={(value) => updateFilter({ author: value === "none" ? null : value })}
+              placeholder="All Authors"
+              className="w-[150px] sm:w-[200px] h-[34px] text-sm"
+            />
+          </div>
+        )}
+        {playedFilter !== undefined && (
+          <SelectFilter
+            id="played-filter"
+            label="Played"
+            value={playedFilter}
+            onValueChange={(value) => updateFilter({ played: value })}
+            options={[
+              { value: "all", label: "All" },
+              { value: "notPlayed", label: "Not Played" },
+            ]}
+            width="w-[150px]"
+          />
+        )}
+        {extraSelectFilters}
+      </div>
+      <div className="flex flex-wrap gap-2 items-center">
+        <ToggleFilterGroup filters={toggleFilters} activeFilters={activeToggleSet} onToggle={toggleFilter} />
+        {hasActiveFilters && (
+          <button
+            type="button"
+            onClick={clearFilters}
+            className="px-3 py-1.5 text-sm rounded-md bg-transparent border border-glass-border text-content-text-tertiary hover:text-content-text-secondary transition-colors"
+          >
+            Clear All
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/components/performance/performance-table.test.tsx
+++ b/apps/web/app/components/performance/performance-table.test.tsx
@@ -107,6 +107,7 @@ describe("PerformanceTable", () => {
   });
 
   // Attended rows get a green left border via useAttendanceRowHighlight.
+  // Verifies the hook→rowClassName→DataTable wiring is intact.
   test("attended rows get the attendance highlight class", async () => {
     vi.mocked(useShowUserData).mockReturnValue({
       attendanceMap: new Map([["s-attended", { id: "att-1" } as never]]),
@@ -123,11 +124,15 @@ describe("PerformanceTable", () => {
     await setup(<PerformanceTable performances={performances} />);
 
     const rows = screen.getAllByRole("row");
+    // Attended row should have both the green background tint and the left
+    // border highlight. The !border-l-green-500 class uses Tailwind's
+    // important modifier to avoid border conflicts with TableRow's border-b.
     const attendedRow = rows.find((row) => row.className.includes("bg-green-500"));
     expect(attendedRow).toBeDefined();
     expect(attendedRow?.className).toContain("!border-l-green-500");
     expect(attendedRow?.className).toContain("!border-l-2");
 
+    // Non-attended rows should have neither class
     const nonAttendedRow = rows.find(
       (row) => row.className.includes("hover:bg-hover-glass") && !row.className.includes("bg-green-500"),
     );
@@ -135,7 +140,8 @@ describe("PerformanceTable", () => {
     expect(nonAttendedRow?.className).not.toContain("!border-l-green-500");
   });
 
-  // The isAuthenticated prop flows through to TrackRatingCell.
+  // The isAuthenticated prop flows through to TrackRatingCell so it knows
+  // whether to show an editable or read-only rating UI.
   test("passes isAuthenticated=true to TrackRatingCell when user is logged in", async () => {
     vi.mocked(useSession).mockReturnValue({
       user: { id: "u1" } as never,
@@ -149,7 +155,9 @@ describe("PerformanceTable", () => {
     expect(cell.textContent).toContain('"isAuthenticated":true');
   });
 
-  // The headerContent prop lets callers inject filter UI above the table.
+  // The headerContent prop lets callers inject filter UI (Year/Era selects,
+  // toggle chips, etc.) above the table. PerformanceTable passes it through
+  // to DataTable's filterComponent slot.
   test("renders headerContent when provided", async () => {
     await setup(
       <PerformanceTable
@@ -162,7 +170,9 @@ describe("PerformanceTable", () => {
     expect(screen.getByText("Filter controls here")).toBeInTheDocument();
   });
 
-  // PerformanceTable shows pagination controls.
+  // PerformanceTable shows pagination controls (Previous/Next buttons) so
+  // users can navigate large performance lists without scrolling through
+  // hundreds of rows.
   test("renders pagination controls above and below the table", async () => {
     await setup(<PerformanceTable performances={[makePerformance()]} />);
 

--- a/apps/web/app/components/performance/performance-table.test.tsx
+++ b/apps/web/app/components/performance/performance-table.test.tsx
@@ -1,0 +1,172 @@
+import type { SongPagePerformance } from "@bip/domain";
+import { mockShallowComponent, setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// Mock hooks used internally by PerformanceTable.
+vi.mock("~/hooks/use-session", () => ({
+  useSession: vi.fn(() => ({ user: null, supabase: null, loading: false })),
+}));
+vi.mock("~/hooks/use-show-user-data", () => ({
+  useShowUserData: vi.fn(() => ({
+    attendanceMap: new Map(),
+    userRatingMap: new Map(),
+    averageRatingMap: new Map(),
+    isLoading: false,
+    error: null,
+  })),
+}));
+vi.mock("~/hooks/use-track-user-ratings", () => ({
+  useTrackUserRatings: vi.fn(() => ({ userRatingMap: new Map(), isLoading: false })),
+}));
+
+// Stub heavy child components rendered by the column factory.
+vi.mock("./track-rating-cell", () => ({
+  TrackRatingCell: (props: object) => mockShallowComponent("TrackRatingCell", props),
+}));
+vi.mock("./combined-notes", () => ({
+  CombinedNotes: (props: object) => mockShallowComponent("CombinedNotes", props),
+}));
+
+import { useSession } from "~/hooks/use-session";
+import { useShowUserData } from "~/hooks/use-show-user-data";
+import { PerformanceTable } from "./performance-table";
+
+function makePerformance(overrides: Partial<SongPagePerformance> = {}): SongPagePerformance {
+  return {
+    trackId: "track-1",
+    show: { id: "show-1", slug: "2024-06-15-show-1", date: "2024-06-15", venueId: "venue-1" },
+    venue: {
+      id: "venue-1",
+      slug: "the-cap",
+      name: "The Capitol Theatre",
+      city: "Port Chester",
+      state: "NY",
+      country: "USA",
+    },
+    songBefore: undefined,
+    songAfter: undefined,
+    rating: 4.5,
+    ratingsCount: 12,
+    notes: undefined,
+    allTimer: false,
+    segue: null,
+    annotations: [],
+    set: "S1",
+    position: 3,
+    tags: {
+      setOpener: false,
+      setCloser: false,
+      encore: false,
+      segueIn: false,
+      segueOut: false,
+      standalone: true,
+      inverted: false,
+      dyslexic: false,
+    },
+    ...overrides,
+  };
+}
+
+describe("PerformanceTable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Baseline rendering: the composed PerformanceTable renders rows with
+  // Date, Venue, and a TrackRatingCell stub for each performance.
+  test("renders a row per performance with date and rating cell", async () => {
+    const performances = [
+      makePerformance({
+        trackId: "t1",
+        show: { ...makePerformance().show, id: "s1", date: "2024-06-15" },
+      }),
+      makePerformance({
+        trackId: "t2",
+        show: { ...makePerformance().show, id: "s2", date: "2024-07-20" },
+      }),
+    ];
+    await setup(<PerformanceTable performances={performances} />);
+
+    expect(screen.getAllByTestId("TrackRatingCell")).toHaveLength(2);
+    expect(screen.getByText("2024-06-15")).toBeInTheDocument();
+    expect(screen.getByText("2024-07-20")).toBeInTheDocument();
+  });
+
+  // The Song column is only needed on /songs/all-timers where performances
+  // span multiple songs.
+  test("renders Song column when showSongColumn is true, omits it otherwise", async () => {
+    const performances = [makePerformance({ songTitle: "Cassidy", songSlug: "cassidy" })];
+
+    const { unmount } = await setup(<PerformanceTable performances={performances} showSongColumn />);
+    expect(screen.getByRole("link", { name: "Cassidy" })).toBeInTheDocument();
+    unmount();
+
+    await setup(<PerformanceTable performances={performances} />);
+    expect(screen.queryByRole("link", { name: "Cassidy" })).not.toBeInTheDocument();
+  });
+
+  // Attended rows get a green left border via useAttendanceRowHighlight.
+  test("attended rows get the attendance highlight class", async () => {
+    vi.mocked(useShowUserData).mockReturnValue({
+      attendanceMap: new Map([["s-attended", { id: "att-1" } as never]]),
+      userRatingMap: new Map(),
+      averageRatingMap: new Map(),
+      isLoading: false,
+      error: null,
+    });
+
+    const performances = [
+      makePerformance({ trackId: "t1", show: { ...makePerformance().show, id: "s-attended" } }),
+      makePerformance({ trackId: "t2", show: { ...makePerformance().show, id: "s-other" } }),
+    ];
+    await setup(<PerformanceTable performances={performances} />);
+
+    const rows = screen.getAllByRole("row");
+    const attendedRow = rows.find((row) => row.className.includes("bg-green-500"));
+    expect(attendedRow).toBeDefined();
+    expect(attendedRow?.className).toContain("!border-l-green-500");
+    expect(attendedRow?.className).toContain("!border-l-2");
+
+    const nonAttendedRow = rows.find(
+      (row) => row.className.includes("hover:bg-hover-glass") && !row.className.includes("bg-green-500"),
+    );
+    expect(nonAttendedRow).toBeDefined();
+    expect(nonAttendedRow?.className).not.toContain("!border-l-green-500");
+  });
+
+  // The isAuthenticated prop flows through to TrackRatingCell.
+  test("passes isAuthenticated=true to TrackRatingCell when user is logged in", async () => {
+    vi.mocked(useSession).mockReturnValue({
+      user: { id: "u1" } as never,
+      supabase: null,
+      loading: false,
+    });
+
+    await setup(<PerformanceTable performances={[makePerformance()]} />);
+
+    const cell = screen.getByTestId("TrackRatingCell");
+    expect(cell.textContent).toContain('"isAuthenticated":true');
+  });
+
+  // The headerContent prop lets callers inject filter UI above the table.
+  test("renders headerContent when provided", async () => {
+    await setup(
+      <PerformanceTable
+        performances={[makePerformance()]}
+        headerContent={<div data-testid="filter-controls">Filter controls here</div>}
+      />,
+    );
+
+    expect(screen.getByTestId("filter-controls")).toBeInTheDocument();
+    expect(screen.getByText("Filter controls here")).toBeInTheDocument();
+  });
+
+  // PerformanceTable shows pagination controls.
+  test("renders pagination controls above and below the table", async () => {
+    await setup(<PerformanceTable performances={[makePerformance()]} />);
+
+    expect(screen.getAllByRole("button", { name: "Previous" })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: "Next" })).toHaveLength(2);
+  });
+});

--- a/apps/web/app/components/performance/performance-table.tsx
+++ b/apps/web/app/components/performance/performance-table.tsx
@@ -1,452 +1,59 @@
 import type { SongPagePerformance } from "@bip/domain";
-import {
-  type ColumnDef,
-  createColumnHelper,
-  flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
-  type SortingState,
-  useReactTable,
-} from "@tanstack/react-table";
-import { ArrowDownIcon, ArrowUpIcon, Flame } from "lucide-react";
-import { useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import { useMemo } from "react";
+import { DataTable } from "~/components/ui/data-table";
+import { useAttendanceRowHighlight } from "~/hooks/use-attendance-row-highlight";
 import { useSession } from "~/hooks/use-session";
-import { useShowUserData } from "~/hooks/use-show-user-data";
 import { useTrackUserRatings } from "~/hooks/use-track-user-ratings";
-import { ATTENDED_ROW_CLASS } from "~/lib/utils";
-import { CombinedNotes } from "./combined-notes";
-import { TrackRatingCell } from "./track-rating-cell";
+import { createPerformanceColumns } from "./performance-columns";
+
+const getShowId = (performance: SongPagePerformance) => performance.show.id;
 
 interface PerformanceTableProps {
   performances: SongPagePerformance[];
   songTitle?: string;
   showSongColumn?: boolean;
   showAllTimerColumn?: boolean;
+  headerContent?: ReactNode;
+  isLoading?: boolean;
 }
 
+/**
+ * Composes DataTable with the standard performance-table building blocks:
+ * attendance row highlighting, track user ratings, and the performance
+ * column factory. Filtering is handled server-side by the calling route.
+ */
 export function PerformanceTable({
-  performances: initialPerformances,
+  performances,
   songTitle,
-  showSongColumn = false,
-  showAllTimerColumn = false,
+  showSongColumn,
+  showAllTimerColumn,
+  headerContent,
+  isLoading,
 }: PerformanceTableProps) {
   const { user } = useSession();
   const isAuthenticated = !!user;
-  const [sorting, setSorting] = useState<SortingState>([{ id: "date", desc: true }]);
-  const [activeFilters, setActiveFilters] = useState<Set<string>>(new Set());
 
-  // Fetch attendance data for all shows in the table
-  const showIds = useMemo(
-    () => [...new Set(initialPerformances.map((p) => p.show.id))],
-    [initialPerformances],
-  );
-  const { attendanceMap } = useShowUserData(showIds);
+  const { rowClassName } = useAttendanceRowHighlight(performances, getShowId);
 
-  // Fetch user's track ratings for gold highlight
-  const trackIds = useMemo(
-    () => initialPerformances.map((p) => p.trackId),
-    [initialPerformances],
-  );
+  const trackIds = useMemo(() => performances.map((performance) => performance.trackId), [performances]);
   const { userRatingMap } = useTrackUserRatings(trackIds);
 
-  const handleSortingChange = (updaterOrValue: SortingState | ((old: SortingState) => SortingState)) => {
-    setSorting(updaterOrValue);
-  };
-
-  const toggleFilter = (filterKey: string) => {
-    const newFilters = new Set(activeFilters);
-    if (newFilters.has(filterKey)) {
-      newFilters.delete(filterKey);
-    } else {
-      newFilters.add(filterKey);
-    }
-    setActiveFilters(newFilters);
-  };
-
-  // Filter performances based on active filters
-  const filteredPerformances = useMemo(() => {
-    if (activeFilters.size === 0) return initialPerformances;
-
-    return initialPerformances.filter((perf) => {
-      return Array.from(activeFilters).some((filterKey) => {
-        switch (filterKey) {
-          case "setOpener":
-            return perf.tags?.setOpener;
-          case "setCloser":
-            return perf.tags?.setCloser;
-          case "encore":
-            return perf.tags?.encore;
-          case "segueIn":
-            return perf.tags?.segueIn;
-          case "segueOut":
-            return perf.tags?.segueOut;
-          case "standalone":
-            return perf.tags?.standalone;
-          case "inverted":
-            return perf.tags?.inverted;
-          case "dyslexic":
-            return perf.tags?.dyslexic;
-          case "allTimer":
-            return perf.allTimer;
-          case "attended":
-            return !!attendanceMap.get(perf.show.id);
-          default:
-            return false;
-        }
-      });
-    });
-  }, [initialPerformances, activeFilters, attendanceMap]);
-
-  const columnHelper = createColumnHelper<SongPagePerformance>();
-
-  const columns = useMemo(() => {
-    const cols: ColumnDef<SongPagePerformance, unknown>[] = [];
-
-    if (showSongColumn) {
-      cols.push(
-        columnHelper.accessor((row) => row.songTitle || "", {
-          id: "song",
-          header: "Song",
-          size: 200,
-          enableSorting: true,
-          sortingFn: "alphanumeric",
-          cell: (info) => {
-            const title = info.getValue() as string;
-            const slug = info.row.original.songSlug;
-            return slug ? (
-              <a href={`/songs/${slug}`} className="text-brand-primary hover:text-brand-secondary font-medium">
-                {title}
-              </a>
-            ) : (
-              <span className="text-content-text-secondary">{title}</span>
-            );
-          },
-        }) as ColumnDef<SongPagePerformance, unknown>,
-      );
-    }
-
-    if (showAllTimerColumn) {
-      cols.push(
-        columnHelper.accessor((row) => row.allTimer ?? false, {
-          id: "allTimer",
-          header: "",
-          size: 32,
-          enableSorting: false,
-          cell: (info) =>
-            info.getValue() ? <Flame className="h-3.5 w-3.5 text-orange-500 ml-1" /> : null,
-        }) as ColumnDef<SongPagePerformance, unknown>,
-      );
-    }
-
-    cols.push(
-      columnHelper.accessor("show.date", {
-        id: "date",
-        header: "Date",
-        size: 128,
-        enableSorting: true,
-        sortingFn: "datetime",
-        cell: (info) => (
-          <a href={`/shows/${info.row.original.show.slug}`} className="text-brand-primary hover:text-brand-secondary">
-            {info.getValue()}
-          </a>
-        ),
-      }) as ColumnDef<SongPagePerformance, unknown>,
-      columnHelper.accessor(
-        (row) => ({
-          name: row.venue?.name,
-          city: row.venue?.city,
-          state: row.venue?.state,
-          slug: row.show.slug,
-        }),
-        {
-          id: "venue",
-          header: "Venue",
-          enableSorting: false,
-          cell: (info) => {
-            const venue = info.getValue();
-            return venue.city ? (
-              <a href={`/shows/${venue.slug}`} className="text-brand-primary hover:text-brand-secondary">
-                {venue.name}
-                <br />
-                {venue.city}, {venue.state}
-              </a>
-            ) : null;
-          },
-        },
-      ) as ColumnDef<SongPagePerformance, unknown>,
-      columnHelper.accessor("set", {
-        header: "Set",
-        size: 64,
-        enableSorting: true,
-        cell: (info) => {
-          const set = info.getValue();
-          return set ? (
-            <span className="text-content-text-secondary">{set}</span>
-          ) : (
-            <span className="text-content-text-tertiary">—</span>
-          );
-        },
-      }) as ColumnDef<SongPagePerformance, unknown>,
-      columnHelper.accessor(
-        (row) => ({
-          before: row.songBefore,
-          after: row.songAfter,
-          currentSong: songTitle || row.songTitle || "",
-        }),
-        {
-          id: "sequence",
-          header: "Sequence",
-          size: 384,
-          enableSorting: false,
-          cell: (info) => {
-            const { before, after, currentSong } = info.getValue();
-
-            const parts = [];
-
-            // Add song before
-            if (before?.songTitle) {
-              parts.push(
-                <a
-                  key="before"
-                  href={`/songs/${before.songSlug}`}
-                  className="text-content-text-secondary hover:text-brand-primary"
-                >
-                  {before.songTitle}
-                </a>,
-              );
-              if (before.segue) {
-                parts.push(
-                  <span key="segue1" className="text-content-text-tertiary mx-1">
-                    {" "}
-                    &gt;{" "}
-                  </span>,
-                );
-              } else {
-                parts.push(
-                  <span key="sep1" className="text-content-text-tertiary">
-                    ,&nbsp;
-                  </span>,
-                );
-              }
-            }
-
-            // Add current song
-            parts.push(
-              <span key="current" className="font-bold" style={{ color: "#DDD6FE" }}>
-                {currentSong}
-              </span>,
-            );
-
-            // Add song after
-            if (after?.songTitle) {
-              if (info.row.original.segue) {
-                parts.push(
-                  <span key="segue2" className="text-content-text-tertiary mx-1">
-                    {" "}
-                    &gt;{" "}
-                  </span>,
-                );
-              } else {
-                parts.push(
-                  <span key="sep2" className="text-content-text-tertiary">
-                    ,&nbsp;
-                  </span>,
-                );
-              }
-              parts.push(
-                <a
-                  key="after"
-                  href={`/songs/${after.songSlug}`}
-                  className="text-content-text-secondary hover:text-brand-primary"
-                >
-                  {after.songTitle}
-                </a>,
-              );
-            }
-
-            return parts.length > 0 ? <div className="flex items-center flex-wrap">{parts}</div> : null;
-          },
-        },
-      ) as ColumnDef<SongPagePerformance, unknown>,
-      columnHelper.accessor(
-        (row) => ({
-          annotations: row.annotations,
-          notes: row.notes,
-        }),
-        {
-          id: "notes",
-          header: "Notes",
-          size: 256,
-          enableSorting: false,
-          cell: (info) => {
-            const { annotations, notes } = info.getValue();
-
-            const items = [];
-
-            // Add annotations first
-            if (annotations && annotations.length > 0) {
-              for (const annotation of annotations) {
-                if (annotation.desc) {
-                  items.push(annotation.desc);
-                }
-              }
-            }
-
-            // Add track notes
-            if (notes) {
-              items.push(notes);
-            }
-
-            if (items.length === 0) return null;
-
-            return <CombinedNotes items={items} />;
-          },
-        },
-      ) as ColumnDef<SongPagePerformance, unknown>,
-      columnHelper.accessor((row) => row.rating ?? 0, {
-        id: "rating",
-        header: "Rating",
-        size: 180,
-        enableSorting: true,
-        sortingFn: "basic",
-        cell: (info) => {
-          const rating = info.getValue();
-          const ratingsCount = info.row.original.ratingsCount;
-          const trackId = info.row.original.trackId;
-          const showSlug = info.row.original.show.slug;
-          const userRating = userRatingMap.get(trackId) ?? null;
-          return (
-            <TrackRatingCell
-              trackId={trackId}
-              showSlug={showSlug}
-              initialRating={rating || null}
-              ratingsCount={ratingsCount || null}
-              userRating={userRating}
-              isAuthenticated={isAuthenticated}
-            />
-          );
-        },
-      }) as ColumnDef<SongPagePerformance, unknown>,
-    );
-
-    return cols;
-  }, [showSongColumn, showAllTimerColumn, songTitle, columnHelper, userRatingMap, isAuthenticated]);
-
-  const table = useReactTable({
-    data: filteredPerformances,
-    columns,
-    state: {
-      sorting,
-    },
-    onSortingChange: handleSortingChange,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    enableSorting: true,
-    enableMultiSort: false,
-  });
-
-  const filterButtons = [
-    { key: "setOpener", label: "Set Opener" },
-    { key: "setCloser", label: "Set Closer" },
-    { key: "encore", label: "Encore" },
-    { key: "segueIn", label: "Segue In" },
-    { key: "segueOut", label: "Segue Out" },
-    { key: "standalone", label: "Standalone" },
-    { key: "inverted", label: "Inverted" },
-    { key: "dyslexic", label: "Dyslexic" },
-    { key: "allTimer", label: "All-Timer" },
-    { key: "attended", label: "Attended" },
-  ];
+  const columns = useMemo(
+    () => createPerformanceColumns({ showSongColumn, showAllTimerColumn, songTitle, userRatingMap, isAuthenticated }),
+    [showSongColumn, showAllTimerColumn, songTitle, userRatingMap, isAuthenticated],
+  );
 
   return (
-    <div className="space-y-4">
-      {/* Filter Controls */}
-      <div className="flex flex-wrap gap-2">
-        <span className="text-sm text-content-text-secondary mr-2 self-center">Filters:</span>
-        {filterButtons.map((filter) => (
-          <button
-            type="button"
-            key={filter.key}
-            onClick={() => toggleFilter(filter.key)}
-            className={`px-3 py-1 text-sm rounded-md border transition-colors ${
-              activeFilters.has(filter.key)
-                ? "bg-brand-primary border-brand-primary text-white"
-                : "bg-transparent border-glass-border text-content-text-secondary hover:border-brand-primary/60"
-            }`}
-          >
-            {filter.label}
-          </button>
-        ))}
-        {activeFilters.size > 0 && (
-          <button
-            type="button"
-            onClick={() => setActiveFilters(new Set())}
-            className="px-3 py-1 text-sm rounded-md bg-transparent border border-glass-border text-content-text-tertiary hover:text-content-text-secondary"
-          >
-            Clear All
-          </button>
-        )}
-      </div>
-
-      {/* Performance count */}
-      <div className="text-sm text-content-text-tertiary">
-        Showing {filteredPerformances.length} of {initialPerformances.length} performances
-      </div>
-
-      <div className="relative overflow-x-auto">
-        <table className="w-full text-md">
-          <thead>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <tr key={headerGroup.id} className="text-left text-sm text-content-text-secondary">
-                {headerGroup.headers.map((header) => (
-                  <th key={header.id} className={header.id === "allTimer" ? "p-0 w-6" : "p-3"} style={{ width: header.getSize() }}>
-                    {header.isPlaceholder ? null : (
-                      <button
-                        type="button"
-                        className={
-                          header.column.getCanSort()
-                            ? "cursor-pointer select-none hover:text-content-text-primary w-full text-left"
-                            : "w-full text-left"
-                        }
-                        onClick={(_e) => {
-                          header.column.toggleSorting();
-                        }}
-                      >
-                        <span className={header.column.getIsSorted() ? "text-content-text-primary font-semibold" : ""}>
-                          {flexRender(header.column.columnDef.header, header.getContext())}
-                        </span>
-                        {header.column.getIsSorted() && (
-                          <span className="text-brand-primary ml-1">
-                            {header.column.getIsSorted() === "asc" ? (
-                              <ArrowUpIcon className="h-4 w-4 inline" />
-                            ) : (
-                              <ArrowDownIcon className="h-4 w-4 inline" />
-                            )}
-                          </span>
-                        )}
-                      </button>
-                    )}
-                  </th>
-                ))}
-              </tr>
-            ))}
-          </thead>
-          <tbody>
-            {table.getRowModel().rows.map((row) => {
-              const isAttended = !!attendanceMap.get(row.original.show.id);
-              return (
-              <tr key={row.id} className={`border-t border-glass-border/30 hover:bg-hover-glass ${isAttended ? ATTENDED_ROW_CLASS : ""}`}>
-                {row.getVisibleCells().map((cell) => (
-                  <td key={cell.id} className={cell.column.id === "allTimer" ? "p-0 w-6" : "p-3"}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
-                ))}
-              </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-    </div>
+    <DataTable
+      columns={columns}
+      data={performances}
+      getRowId={(performance) => performance.trackId}
+      hideSearch
+      isLoading={isLoading}
+      filterComponent={headerContent}
+      rowClassName={rowClassName}
+      initialSorting={[{ id: "date", desc: true }]}
+    />
   );
 }

--- a/apps/web/app/components/performance/track-rating-cell.test.tsx
+++ b/apps/web/app/components/performance/track-rating-cell.test.tsx
@@ -96,6 +96,8 @@ describe("TrackRatingCell", () => {
 
     expect(screen.getByText("4.17")).toBeInTheDocument();
 
+    // Simulate React reusing this component with different data (as happens
+    // when TanStack reorders rows by index after a sort/filter change).
     rerender(
       <MemoryRouter>
         <TrackRatingCell
@@ -109,6 +111,7 @@ describe("TrackRatingCell", () => {
       </MemoryRouter>,
     );
 
+    // Should now show "Rate", not the stale "4.17" from the previous render.
     expect(screen.queryByText("4.17")).not.toBeInTheDocument();
     expect(screen.getByText("Rate")).toBeInTheDocument();
   });
@@ -159,6 +162,7 @@ describe("TrackRatingCell", () => {
       />,
     );
 
+    // Initially golden
     let button = container.querySelector("button");
     expect(button?.className).toContain("border-amber-500");
 
@@ -175,6 +179,9 @@ describe("TrackRatingCell", () => {
       </MemoryRouter>,
     );
 
+    // Should now be dashed (no user rating), not golden.
+    // Check for border-amber-500/50 (the active golden border class)
+    // not just border-amber-500 (which also matches hover:border-amber-500/30).
     button = container.querySelector("button");
     expect(button?.className).toContain("border-dashed");
     expect(button?.className).not.toContain("bg-amber-500");

--- a/apps/web/app/components/performance/track-rating-cell.test.tsx
+++ b/apps/web/app/components/performance/track-rating-cell.test.tsx
@@ -1,0 +1,182 @@
+import { setupWithRouter } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test } from "vitest";
+import { TrackRatingCell } from "./track-rating-cell";
+
+describe("TrackRatingCell", () => {
+  // When a performance has a community average rating, the cell displays
+  // the rating number (e.g. "4.17") — not the "Rate" placeholder. This is
+  // the core display contract.
+  test("displays the community rating when initialRating is provided", async () => {
+    await setupWithRouter(
+      <TrackRatingCell
+        trackId="t1"
+        showSlug="show-1"
+        initialRating={4.17}
+        ratingsCount={3}
+        userRating={null}
+        isAuthenticated={false}
+      />,
+    );
+
+    expect(screen.getByText("4.17")).toBeInTheDocument();
+    expect(screen.getByText("(3)")).toBeInTheDocument();
+    expect(screen.queryByText("Rate")).not.toBeInTheDocument();
+  });
+
+  // When there is no community rating, the cell shows "Rate" as a
+  // placeholder to invite the user to be the first rater.
+  test('displays "Rate" when initialRating is null', async () => {
+    await setupWithRouter(
+      <TrackRatingCell
+        trackId="t1"
+        showSlug="show-1"
+        initialRating={null}
+        ratingsCount={null}
+        userRating={null}
+        isAuthenticated={false}
+      />,
+    );
+
+    expect(screen.getByText("Rate")).toBeInTheDocument();
+  });
+
+  // When the user has rated the track, the cell gets a golden border
+  // (amber styling) regardless of whether a community rating exists.
+  test("shows golden border when userRating is provided", async () => {
+    const { container } = await setupWithRouter(
+      <TrackRatingCell
+        trackId="t1"
+        showSlug="show-1"
+        initialRating={3.5}
+        ratingsCount={2}
+        userRating={4}
+        isAuthenticated={true}
+      />,
+    );
+
+    const button = container.querySelector("button");
+    expect(button?.className).toContain("border-amber-500");
+  });
+
+  // When the user has NOT rated the track, the cell has a dashed border
+  // (no golden highlight).
+  test("shows dashed border when userRating is null", async () => {
+    const { container } = await setupWithRouter(
+      <TrackRatingCell
+        trackId="t1"
+        showSlug="show-1"
+        initialRating={3.5}
+        ratingsCount={2}
+        userRating={null}
+        isAuthenticated={true}
+      />,
+    );
+
+    const button = container.querySelector("button");
+    expect(button?.className).toContain("border-dashed");
+  });
+
+  // When React reuses a TrackRatingCell component at the same DOM position
+  // but with different props (e.g., after sorting or filtering changes the
+  // data order), the displayed rating must update to match the new props —
+  // not retain the previous row's useState-cached value.
+  test("updates displayed rating when props change due to data reordering", async () => {
+    const { rerender } = await setupWithRouter(
+      <TrackRatingCell
+        trackId="t1"
+        showSlug="show-1"
+        initialRating={4.17}
+        ratingsCount={3}
+        userRating={null}
+        isAuthenticated={false}
+      />,
+    );
+
+    expect(screen.getByText("4.17")).toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter>
+        <TrackRatingCell
+          trackId="t2"
+          showSlug="show-2"
+          initialRating={null}
+          ratingsCount={null}
+          userRating={null}
+          isAuthenticated={false}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("4.17")).not.toBeInTheDocument();
+    expect(screen.getByText("Rate")).toBeInTheDocument();
+  });
+
+  // Same scenario in reverse: going from no rating to having a rating.
+  test("updates from Rate to rating number when props change", async () => {
+    const { rerender } = await setupWithRouter(
+      <TrackRatingCell
+        trackId="t1"
+        showSlug="show-1"
+        initialRating={null}
+        ratingsCount={null}
+        userRating={null}
+        isAuthenticated={false}
+      />,
+    );
+
+    expect(screen.getByText("Rate")).toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter>
+        <TrackRatingCell
+          trackId="t2"
+          showSlug="show-2"
+          initialRating={3.5}
+          ratingsCount={2}
+          userRating={null}
+          isAuthenticated={false}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("Rate")).not.toBeInTheDocument();
+    expect(screen.getByText("3.50")).toBeInTheDocument();
+  });
+
+  // When the component is reused at the same DOM position, the golden
+  // border state must track the new userRating prop, not the old one.
+  test("updates golden border state when userRating prop changes", async () => {
+    const { container, rerender } = await setupWithRouter(
+      <TrackRatingCell
+        trackId="t1"
+        showSlug="show-1"
+        initialRating={4.17}
+        ratingsCount={3}
+        userRating={5}
+        isAuthenticated={true}
+      />,
+    );
+
+    let button = container.querySelector("button");
+    expect(button?.className).toContain("border-amber-500");
+
+    rerender(
+      <MemoryRouter>
+        <TrackRatingCell
+          trackId="t2"
+          showSlug="show-2"
+          initialRating={3.0}
+          ratingsCount={1}
+          userRating={null}
+          isAuthenticated={true}
+        />
+      </MemoryRouter>,
+    );
+
+    button = container.querySelector("button");
+    expect(button?.className).toContain("border-dashed");
+    expect(button?.className).not.toContain("bg-amber-500");
+  });
+});

--- a/apps/web/app/components/performance/track-rating-cell.tsx
+++ b/apps/web/app/components/performance/track-rating-cell.tsx
@@ -26,9 +26,17 @@ export function TrackRatingCell({
   const [localHasRated, setLocalHasRated] = useState(userRating != null);
   const animationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Sync localHasRated when userRating prop arrives from async fetch
+  // Sync state when props change — handles both async fetch completion
+  // (userRating arriving after initial render) and component reuse (React
+  // keeping the same component mounted but with different data after a
+  // sort or filter change).
   useEffect(() => {
-    if (userRating != null) setLocalHasRated(true);
+    setDisplayedRating(initialRating ?? 0);
+    setDisplayedCount(ratingsCount ?? 0);
+  }, [initialRating, ratingsCount]);
+
+  useEffect(() => {
+    setLocalHasRated(userRating != null);
   }, [userRating]);
 
   // Cleanup timeout on unmount
@@ -65,7 +73,7 @@ export function TrackRatingCell({
           : "glass-secondary border border-dashed border-glass-border",
         isAuthenticated && "hover:brightness-110 cursor-pointer hover:border-amber-500/30",
         !isAuthenticated && "cursor-pointer hover:border-amber-500/30",
-        isAnimating && "animate-[avg-rating-update_0.5s_ease-out]"
+        isAnimating && "animate-[avg-rating-update_0.5s_ease-out]",
       )}
     >
       {isExpanded ? (
@@ -86,9 +94,7 @@ export function TrackRatingCell({
   if (!isAuthenticated) {
     return (
       <div className="w-[140px]">
-        <LoginPromptPopover message="Sign in to rate">
-          {ratingButton}
-        </LoginPromptPopover>
+        <LoginPromptPopover message="Sign in to rate">{ratingButton}</LoginPromptPopover>
       </div>
     );
   }

--- a/apps/web/app/components/song/songs-columns.test.tsx
+++ b/apps/web/app/components/song/songs-columns.test.tsx
@@ -206,7 +206,9 @@ describe("songsColumns", () => {
   });
 
   // First Played cell mirrors Last Played exactly — same date-format +
-  // show-link + venue-line structure, just reading different fields.
+  // show-link + venue-line structure, just reading different fields. Paired
+  // because the two cells are near-duplicate code today (candidate for a
+  // later shared helper). Regression gate if/when the duplication is DRY'd.
   test("First Played cell formats date, links to show, and shows venue", async () => {
     const song = makeSong({
       dateFirstPlayed: new Date("1995-07-04"),
@@ -228,7 +230,8 @@ describe("songsColumns", () => {
   });
 
   // The First Played column sorts by `dateFirstPlayed`. Users click it to
-  // find the band's earliest or most-recent debut performances.
+  // find the band's earliest or most-recent debut performances — useful for
+  // historical browsing. Symmetric with the Last Played sort test.
   test("clicking First Played header sorts by dateFirstPlayed ascending, then descending", async () => {
     const songs = [
       makeSong({ id: "a", title: "Alpha", slug: "alpha", dateFirstPlayed: new Date("1995-07-04") }),
@@ -253,7 +256,8 @@ describe("songsColumns", () => {
   });
 
   // The Plays column sorts by `timesPlayed`. Users click it to find songs
-  // played most (or least) often across the band's history.
+  // played most (or least) often across the band's history — a core way to
+  // browse the song catalog.
   test("clicking Plays header sorts by timesPlayed ascending, then descending", async () => {
     const songs = [
       makeSong({ id: "a", title: "Alpha", slug: "alpha", timesPlayed: 50 }),
@@ -278,7 +282,8 @@ describe("songsColumns", () => {
   });
 
   // The Last Played column sorts by `dateLastPlayed`. Users click it to find
-  // the most-recently-played songs or the longest dormant songs.
+  // the most-recently-played songs (default desc on date) or the longest
+  // dormant songs. TanStack's default date sort handles the comparison.
   test("clicking Last Played header sorts by dateLastPlayed ascending, then descending", async () => {
     const songs = [
       makeSong({ id: "a", title: "Alpha", slug: "alpha", dateLastPlayed: new Date("2020-01-01") }),
@@ -290,6 +295,7 @@ describe("songsColumns", () => {
     const sortHeader = screen.getByRole("button", { name: /^Last Played/i });
     await user.click(sortHeader);
 
+    // The title column uses the same tag as date cells, so filter by title set
     const titlesAsc = screen
       .getAllByRole("link")
       .filter((el) => ["Alpha", "Beta", "Gamma"].includes(el.textContent ?? ""));
@@ -305,6 +311,7 @@ describe("songsColumns", () => {
   // The "This Year" column has a custom `sortingFn` that sorts by the
   // CURRENT year's play count (not the default alphanumeric sort over the
   // JSON blob). Users click the header to find songs trending this year.
+  // Verifies asc/desc order by checking row position after each click.
   test("yearlyPlayData sortingFn sorts by current-year count ascending, then descending", async () => {
     const songs = [
       makeSong({

--- a/apps/web/app/components/song/songs-columns.test.tsx
+++ b/apps/web/app/components/song/songs-columns.test.tsx
@@ -1,0 +1,369 @@
+import type { Show, Song } from "@bip/domain";
+import { setupWithRouter } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { DataTable } from "~/components/ui/data-table";
+import { songsColumns } from "./songs-columns";
+
+interface SongWithShows extends Song {
+  firstPlayedShow?: Show | null;
+  lastPlayedShow?: Show | null;
+}
+
+const currentYear = new Date().getFullYear().toString();
+
+function makeShow(overrides: Partial<Show> = {}): Show {
+  return {
+    id: overrides.id ?? "show-1",
+    slug: overrides.slug ?? "2024-06-15-the-cap",
+    date: overrides.date ?? "2024-06-15",
+    venueId: overrides.venueId ?? "venue-1",
+    bandId: "band-1",
+    notes: null,
+    createdAt: new Date("2024-06-16"),
+    updatedAt: new Date("2024-06-16"),
+    likesCount: 0,
+    relistenUrl: null,
+    averageRating: 0,
+    ratingsCount: 0,
+    showPhotosCount: 0,
+    showYoutubesCount: 0,
+    reviewsCount: 0,
+    venue: overrides.venue ?? {
+      id: "venue-1",
+      slug: "the-cap",
+      name: "The Capitol Theatre",
+      city: "Port Chester",
+      state: "NY",
+      country: "USA",
+      createdAt: new Date("2020-01-01"),
+      updatedAt: new Date("2020-01-01"),
+      timesPlayed: 0,
+    },
+    ...overrides,
+  };
+}
+
+function makeSong(overrides: Partial<SongWithShows> = {}): SongWithShows {
+  return {
+    id: overrides.id ?? "song-1",
+    title: overrides.title ?? "Cassidy",
+    slug: overrides.slug ?? "cassidy",
+    createdAt: new Date("2020-01-01"),
+    updatedAt: new Date("2020-01-01"),
+    lyrics: null,
+    tabs: null,
+    notes: null,
+    cover: false,
+    authorId: null,
+    history: null,
+    featuredLyric: null,
+    timesPlayed: 42,
+    dateLastPlayed: new Date("2024-06-15"),
+    dateFirstPlayed: new Date("1995-07-04"),
+    actualLastPlayedDate: null,
+    showsSinceLastPlayed: null,
+    lastVenue: null,
+    firstVenue: null,
+    firstShowSlug: null,
+    lastShowSlug: null,
+    yearlyPlayData: {},
+    longestGapsData: {},
+    mostCommonYear: null,
+    leastCommonYear: null,
+    guitarTabsUrl: null,
+    authorName: null,
+    firstPlayedShow: null,
+    lastPlayedShow: null,
+    ...overrides,
+  };
+}
+
+describe("songsColumns", () => {
+  // The Song Title column is how users navigate from /songs to /songs/$slug.
+  // Verifies the title is rendered inside an <a> with the correct href.
+  test("title cell renders a link to /songs/{slug}", async () => {
+    await setupWithRouter(
+      <DataTable
+        columns={songsColumns}
+        data={[makeSong({ title: "Cassidy", slug: "cassidy" })]}
+        hideSearch
+        hidePagination
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: "Cassidy" });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/songs/cassidy");
+  });
+
+  // Songs with no performances (DB songs that exist but were never played)
+  // render a readable italic "Never performed" placeholder rather than a bare
+  // "0". Matters because /songs hides songs with timesPlayed > 0 by default,
+  // but the "Not Played" filter flips that.
+  test('timesPlayed === 0 renders "Never performed"', async () => {
+    await setupWithRouter(
+      <DataTable columns={songsColumns} data={[makeSong({ timesPlayed: 0 })]} hideSearch hidePagination />,
+    );
+
+    expect(screen.getByText("Never performed")).toBeInTheDocument();
+  });
+
+  // The normal case: `timesPlayed` is rendered as a bold number. Paired with
+  // the previous test to pin "Never performed" to exactly the 0 case.
+  test("timesPlayed > 0 renders the play count", async () => {
+    await setupWithRouter(
+      <DataTable columns={songsColumns} data={[makeSong({ timesPlayed: 42 })]} hideSearch hidePagination />,
+    );
+
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.queryByText("Never performed")).not.toBeInTheDocument();
+  });
+
+  // The "This Year" column reads from `yearlyPlayData[currentYear]` — a
+  // per-year play-count map. Verifies the cell extracts the current year's
+  // value and renders it as a number when present.
+  test("yearlyPlayData cell renders the current-year count when present", async () => {
+    await setupWithRouter(
+      <DataTable
+        columns={songsColumns}
+        data={[makeSong({ yearlyPlayData: { [currentYear]: 7 } })]}
+        hideSearch
+        hidePagination
+      />,
+    );
+
+    expect(screen.getByText("7")).toBeInTheDocument();
+  });
+
+  // If the current year has no plays (either missing from the map or zero),
+  // the "This Year" cell renders an em-dash rather than "0". Avoids crowding
+  // the table with zeros for songs that haven't been played yet this year.
+  test("yearlyPlayData cell renders em-dash when current-year count is 0 or missing", async () => {
+    await setupWithRouter(
+      <DataTable
+        columns={songsColumns}
+        data={[makeSong({ title: "OldSong", slug: "oldsong", yearlyPlayData: { "2010": 3 } })]}
+        hideSearch
+        hidePagination
+      />,
+    );
+
+    // em-dash appears for both the yearlyPlayData cell. (Date cells may also render em-dash
+    // when dates are null, but fixture dates are non-null here.)
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // The Last Played cell formats the date (en-US, UTC, "Jun 15, 2024") and
+  // wraps it in a link to the show page when `lastPlayedShow` has a slug.
+  // Also renders the venue name + city/state as a secondary line under the
+  // date. This is the user's primary way to jump from "I saw this song" to
+  // the specific show where it happened.
+  test("Last Played cell formats date, links to show, and shows venue", async () => {
+    const song = makeSong({
+      dateLastPlayed: new Date("2024-06-15"),
+      lastPlayedShow: makeShow({ slug: "2024-06-15-the-cap" }),
+    });
+    await setupWithRouter(<DataTable columns={songsColumns} data={[song]} hideSearch hidePagination />);
+
+    // Date text is formatted (not ISO). Regex avoids pinning exact locale format.
+    expect(screen.getByText(/Jun 15, 2024/)).toBeInTheDocument();
+    // Wrapped in a link to the show
+    const showLink = screen.getByRole("link", { name: /Jun 15, 2024/ });
+    expect(showLink).toHaveAttribute("href", "/shows/2024-06-15-the-cap");
+    // Venue line is rendered
+    expect(screen.getByText(/The Capitol Theatre/)).toBeInTheDocument();
+    expect(screen.getByText(/Port Chester NY/)).toBeInTheDocument();
+  });
+
+  // When `dateLastPlayed` is null (a DB song that's never been performed, or
+  // one whose last-played date hasn't been backfilled), the cell renders an
+  // em-dash placeholder instead of crashing or showing "Invalid Date".
+  test("Last Played cell renders em-dash when dateLastPlayed is null", async () => {
+    const song = makeSong({ dateLastPlayed: null, lastPlayedShow: null });
+    await setupWithRouter(<DataTable columns={songsColumns} data={[song]} hideSearch hidePagination />);
+
+    // Both Last Played and First Played will be null → 2 em-dashes expected
+    // (we null out dateFirstPlayed below to make the assertion precise).
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // When a Last Played date exists but the show relation is missing (edge
+  // case: data migration gap), the date still renders — just without the
+  // show link. Keeps the cell useful even when joined data is incomplete.
+  test("Last Played cell renders plain date (no link) when lastPlayedShow is missing", async () => {
+    const song = makeSong({
+      dateLastPlayed: new Date("2024-06-15"),
+      lastPlayedShow: null,
+    });
+    await setupWithRouter(<DataTable columns={songsColumns} data={[song]} hideSearch hidePagination />);
+
+    expect(screen.getByText(/Jun 15, 2024/)).toBeInTheDocument();
+    // No link wraps the date
+    expect(screen.queryByRole("link", { name: /Jun 15, 2024/ })).not.toBeInTheDocument();
+  });
+
+  // First Played cell mirrors Last Played exactly — same date-format +
+  // show-link + venue-line structure, just reading different fields.
+  test("First Played cell formats date, links to show, and shows venue", async () => {
+    const song = makeSong({
+      dateFirstPlayed: new Date("1995-07-04"),
+      firstPlayedShow: makeShow({ id: "show-first", slug: "1995-07-04-red-rocks" }),
+    });
+    await setupWithRouter(<DataTable columns={songsColumns} data={[song]} hideSearch hidePagination />);
+
+    expect(screen.getByText(/Jul 4, 1995/)).toBeInTheDocument();
+    const showLink = screen.getByRole("link", { name: /Jul 4, 1995/ });
+    expect(showLink).toHaveAttribute("href", "/shows/1995-07-04-red-rocks");
+  });
+
+  // Symmetric with "Last Played null" — confirms First Played also handles
+  // null dates gracefully with an em-dash.
+  test("First Played cell renders em-dash when dateFirstPlayed is null", async () => {
+    const song = makeSong({ dateFirstPlayed: null, firstPlayedShow: null });
+    await setupWithRouter(<DataTable columns={songsColumns} data={[song]} hideSearch hidePagination />);
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1);
+  });
+
+  // The First Played column sorts by `dateFirstPlayed`. Users click it to
+  // find the band's earliest or most-recent debut performances.
+  test("clicking First Played header sorts by dateFirstPlayed ascending, then descending", async () => {
+    const songs = [
+      makeSong({ id: "a", title: "Alpha", slug: "alpha", dateFirstPlayed: new Date("1995-07-04") }),
+      makeSong({ id: "b", title: "Beta", slug: "beta", dateFirstPlayed: new Date("2020-01-01") }),
+      makeSong({ id: "c", title: "Gamma", slug: "gamma", dateFirstPlayed: new Date("2010-06-15") }),
+    ];
+    const { user } = await setupWithRouter(<DataTable columns={songsColumns} data={songs} hideSearch hidePagination />);
+
+    const sortHeader = screen.getByRole("button", { name: /^First Played/i });
+    await user.click(sortHeader);
+
+    const titlesAsc = screen
+      .getAllByRole("link")
+      .filter((el) => ["Alpha", "Beta", "Gamma"].includes(el.textContent ?? ""));
+    expect(titlesAsc.map((el) => el.textContent)).toEqual(["Alpha", "Gamma", "Beta"]);
+
+    await user.click(sortHeader);
+    const titlesDesc = screen
+      .getAllByRole("link")
+      .filter((el) => ["Alpha", "Beta", "Gamma"].includes(el.textContent ?? ""));
+    expect(titlesDesc.map((el) => el.textContent)).toEqual(["Beta", "Gamma", "Alpha"]);
+  });
+
+  // The Plays column sorts by `timesPlayed`. Users click it to find songs
+  // played most (or least) often across the band's history.
+  test("clicking Plays header sorts by timesPlayed ascending, then descending", async () => {
+    const songs = [
+      makeSong({ id: "a", title: "Alpha", slug: "alpha", timesPlayed: 50 }),
+      makeSong({ id: "b", title: "Beta", slug: "beta", timesPlayed: 10 }),
+      makeSong({ id: "c", title: "Gamma", slug: "gamma", timesPlayed: 30 }),
+    ];
+    const { user } = await setupWithRouter(<DataTable columns={songsColumns} data={songs} hideSearch hidePagination />);
+
+    const sortHeader = screen.getByRole("button", { name: /^Plays/i });
+    await user.click(sortHeader);
+
+    const titlesAsc = screen
+      .getAllByRole("link")
+      .filter((el) => ["Alpha", "Beta", "Gamma"].includes(el.textContent ?? ""));
+    expect(titlesAsc.map((el) => el.textContent)).toEqual(["Beta", "Gamma", "Alpha"]);
+
+    await user.click(sortHeader);
+    const titlesDesc = screen
+      .getAllByRole("link")
+      .filter((el) => ["Alpha", "Beta", "Gamma"].includes(el.textContent ?? ""));
+    expect(titlesDesc.map((el) => el.textContent)).toEqual(["Alpha", "Gamma", "Beta"]);
+  });
+
+  // The Last Played column sorts by `dateLastPlayed`. Users click it to find
+  // the most-recently-played songs or the longest dormant songs.
+  test("clicking Last Played header sorts by dateLastPlayed ascending, then descending", async () => {
+    const songs = [
+      makeSong({ id: "a", title: "Alpha", slug: "alpha", dateLastPlayed: new Date("2020-01-01") }),
+      makeSong({ id: "b", title: "Beta", slug: "beta", dateLastPlayed: new Date("2024-06-15") }),
+      makeSong({ id: "c", title: "Gamma", slug: "gamma", dateLastPlayed: new Date("2022-03-10") }),
+    ];
+    const { user } = await setupWithRouter(<DataTable columns={songsColumns} data={songs} hideSearch hidePagination />);
+
+    const sortHeader = screen.getByRole("button", { name: /^Last Played/i });
+    await user.click(sortHeader);
+
+    const titlesAsc = screen
+      .getAllByRole("link")
+      .filter((el) => ["Alpha", "Beta", "Gamma"].includes(el.textContent ?? ""));
+    expect(titlesAsc.map((el) => el.textContent)).toEqual(["Alpha", "Gamma", "Beta"]);
+
+    await user.click(sortHeader);
+    const titlesDesc = screen
+      .getAllByRole("link")
+      .filter((el) => ["Alpha", "Beta", "Gamma"].includes(el.textContent ?? ""));
+    expect(titlesDesc.map((el) => el.textContent)).toEqual(["Beta", "Gamma", "Alpha"]);
+  });
+
+  // The "This Year" column has a custom `sortingFn` that sorts by the
+  // CURRENT year's play count (not the default alphanumeric sort over the
+  // JSON blob). Users click the header to find songs trending this year.
+  test("yearlyPlayData sortingFn sorts by current-year count ascending, then descending", async () => {
+    const songs = [
+      makeSong({
+        id: "a",
+        title: "Alpha",
+        slug: "alpha",
+        yearlyPlayData: { [currentYear]: 1 },
+      }),
+      makeSong({
+        id: "b",
+        title: "Beta",
+        slug: "beta",
+        yearlyPlayData: { [currentYear]: 5 },
+      }),
+      makeSong({
+        id: "c",
+        title: "Gamma",
+        slug: "gamma",
+        yearlyPlayData: { [currentYear]: 3 },
+      }),
+    ];
+    const { user } = await setupWithRouter(<DataTable columns={songsColumns} data={songs} hideSearch hidePagination />);
+
+    // Click the "This Year" sort header twice:
+    //   first click → asc order (1, 3, 5)
+    //   second click → desc order (5, 3, 1)
+    const sortHeader = screen.getByRole("button", { name: /This Year/i });
+    await user.click(sortHeader);
+
+    // First click: asc. Assert row order by finding song titles in document order.
+    const titlesAsc = screen
+      .getAllByRole("link")
+      .filter((el) => ["Alpha", "Beta", "Gamma"].includes(el.textContent ?? ""));
+    expect(titlesAsc.map((el) => el.textContent)).toEqual(["Alpha", "Gamma", "Beta"]);
+
+    // Second click: desc.
+    await user.click(sortHeader);
+    const titlesDesc = screen
+      .getAllByRole("link")
+      .filter((el) => ["Alpha", "Beta", "Gamma"].includes(el.textContent ?? ""));
+    expect(titlesDesc.map((el) => el.textContent)).toEqual(["Beta", "Gamma", "Alpha"]);
+  });
+
+  // The /songs page shows songs sorted by times played (most played first)
+  // by default. The Plays header should show a descending arrow on load so
+  // users know the active sort column and direction.
+  test("Plays header shows descending sort icon when initialSorting is timesPlayed desc", async () => {
+    await setupWithRouter(
+      <DataTable
+        columns={songsColumns}
+        data={[makeSong()]}
+        hideSearch
+        hidePagination
+        initialSorting={[{ id: "timesPlayed", desc: true }]}
+      />,
+    );
+
+    const playsButton = screen.getByRole("button", { name: /^Plays/i });
+    // The descending ArrowDown icon should be present (has class "lucide-arrow-down")
+    expect(playsButton.querySelector(".lucide-arrow-down")).not.toBeNull();
+  });
+});

--- a/apps/web/app/components/song/songs-columns.tsx
+++ b/apps/web/app/components/song/songs-columns.tsx
@@ -1,12 +1,12 @@
-import type { Song, Show } from "@bip/domain";
+import type { Show, Song } from "@bip/domain";
 import type { ColumnDef } from "@tanstack/react-table";
 
-// Enhanced Song type that includes show relationships for the data table
 interface SongWithShows extends Song {
   firstPlayedShow?: Show | null;
   lastPlayedShow?: Show | null;
 }
-import { ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
+
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import { Link } from "react-router-dom";
 import { Button } from "~/components/ui/button";
 
@@ -20,14 +20,15 @@ const formatDate = (date: Date) => {
 };
 
 const getSortIcon = (sortState: false | "asc" | "desc") => {
-  if (sortState === "asc") return <ArrowUp className="ml-2 h-4 w-4" />;
-  if (sortState === "desc") return <ArrowDown className="ml-2 h-4 w-4" />;
+  if (sortState === "asc") return <ArrowUp className="ml-2 h-4 w-4 text-brand-primary" />;
+  if (sortState === "desc") return <ArrowDown className="ml-2 h-4 w-4 text-brand-primary" />;
   return <ArrowUpDown className="ml-2 h-4 w-4" />;
 };
 
 export const songsColumns: ColumnDef<SongWithShows>[] = [
   {
     accessorKey: "title",
+    meta: { width: "30%" },
     header: ({ column }) => {
       return (
         <Button
@@ -43,7 +44,10 @@ export const songsColumns: ColumnDef<SongWithShows>[] = [
     cell: ({ row }) => {
       const song = row.original;
       return (
-        <Link to={`/songs/${song.slug}`} className="text-brand-primary hover:text-brand-secondary font-medium">
+        <Link
+          to={`/songs/${song.slug}`}
+          className="text-base text-brand-primary hover:text-brand-secondary font-medium"
+        >
           {song.title}
         </Link>
       );
@@ -51,6 +55,7 @@ export const songsColumns: ColumnDef<SongWithShows>[] = [
   },
   {
     accessorKey: "timesPlayed",
+    meta: { width: "10%" },
     header: ({ column }) => {
       return (
         <Button
@@ -74,6 +79,7 @@ export const songsColumns: ColumnDef<SongWithShows>[] = [
   },
   {
     accessorKey: "dateLastPlayed",
+    meta: { width: "25%" },
     header: ({ column }) => {
       return (
         <Button
@@ -121,6 +127,7 @@ export const songsColumns: ColumnDef<SongWithShows>[] = [
   },
   {
     accessorKey: "dateFirstPlayed",
+    meta: { width: "25%" },
     header: ({ column }) => {
       return (
         <Button
@@ -168,6 +175,7 @@ export const songsColumns: ColumnDef<SongWithShows>[] = [
   },
   {
     accessorKey: "yearlyPlayData",
+    meta: { width: "10%" },
     header: ({ column }) => {
       return (
         <Button

--- a/apps/web/app/components/song/songs-columns.tsx
+++ b/apps/web/app/components/song/songs-columns.tsx
@@ -96,7 +96,7 @@ export const songsColumns: ColumnDef<SongWithShows>[] = [
       const date = row.original.dateLastPlayed;
       const show = row.original.lastPlayedShow;
       return date ? (
-        <div className="text-base">
+        <div>
           {show?.slug ? (
             <Link
               to={`/shows/${show.slug}`}
@@ -144,7 +144,7 @@ export const songsColumns: ColumnDef<SongWithShows>[] = [
       const date = row.original.dateFirstPlayed;
       const show = row.original.firstPlayedShow;
       return date ? (
-        <div className="text-base">
+        <div>
           {show?.slug ? (
             <Link
               to={`/shows/${show.slug}`}

--- a/apps/web/app/components/song/songs-table.tsx
+++ b/apps/web/app/components/song/songs-table.tsx
@@ -6,30 +6,20 @@ import { DataTable } from "~/components/ui/data-table";
 interface SongsTableProps {
   songs: Song[];
   filterComponent?: ReactNode;
-  secondaryFilterComponent?: ReactNode;
-  searchActions?: ReactNode;
   isLoading?: boolean;
 }
 
-export function SongsTable({
-  songs,
-  filterComponent,
-  secondaryFilterComponent,
-  searchActions,
-  isLoading = false,
-}: SongsTableProps) {
+export function SongsTable({ songs, filterComponent, isLoading = false }: SongsTableProps) {
   return (
     <div>
       <DataTable
         columns={songsColumns}
         data={songs}
-        searchKey="title"
-        searchPlaceholder="Search songs..."
-        hidePagination
+        hideSearch
+        pageSize={50}
         filterComponent={filterComponent}
-        secondaryFilterComponent={secondaryFilterComponent}
-        searchActions={searchActions}
         isLoading={isLoading}
+        initialSorting={[{ id: "timesPlayed", desc: true }]}
       />
     </div>
   );

--- a/apps/web/app/components/ui/data-table.test.tsx
+++ b/apps/web/app/components/ui/data-table.test.tsx
@@ -1,0 +1,131 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { DataTable } from "./data-table";
+
+type Row = { id: string; name: string; count: number };
+
+const rows: Row[] = [
+  { id: "1", name: "Alpha", count: 3 },
+  { id: "2", name: "Beta", count: 1 },
+  { id: "3", name: "Gamma", count: 2 },
+];
+
+const basicColumns: ColumnDef<Row>[] = [
+  { accessorKey: "name", header: "Name" },
+  { accessorKey: "count", header: "Count" },
+];
+
+describe("DataTable", () => {
+  // Baseline smoke test: given columns + data, the table renders header labels
+  // and one row per data item. If this fails, every other test is suspect.
+  test("renders column headers and row cells", async () => {
+    await setup(<DataTable columns={basicColumns} data={rows} hideSearch />);
+
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Count")).toBeInTheDocument();
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+    expect(screen.getByText("Gamma")).toBeInTheDocument();
+  });
+
+  // The built-in search input (rendered when `searchKey` is set) filters the
+  // table on that column using TanStack's column filter. Verifies the
+  // input→filter wiring; pages like /songs and /admin/authors rely on it.
+  test("search filter narrows visible rows by searchKey", async () => {
+    const { user } = await setup(
+      <DataTable columns={basicColumns} data={rows} searchKey="name" searchPlaceholder="Search..." />,
+    );
+
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+
+    const input = screen.getByPlaceholderText("Search...");
+    await user.type(input, "Alp");
+
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.queryByText("Beta")).not.toBeInTheDocument();
+    expect(screen.queryByText("Gamma")).not.toBeInTheDocument();
+  });
+
+  // The `rowClassName` callback lets callers style individual rows based on
+  // row data (e.g., attendance-row highlighting on top-rated shows).
+  test("rowClassName callback adds class to each row", async () => {
+    await setup(
+      <DataTable
+        columns={basicColumns}
+        data={rows}
+        hideSearch
+        rowClassName={(row) => (row.count > 1 ? "big-count" : undefined)}
+      />,
+    );
+
+    // Row with count=3 (Alpha) and count=2 (Gamma) should have the class; count=1 (Beta) should not
+    const alphaRow = screen.getByText("Alpha").closest("tr");
+    const betaRow = screen.getByText("Beta").closest("tr");
+    const gammaRow = screen.getByText("Gamma").closest("tr");
+
+    expect(alphaRow?.className).toContain("big-count");
+    expect(gammaRow?.className).toContain("big-count");
+    expect(betaRow?.className ?? "").not.toContain("big-count");
+  });
+
+  // When `data` is empty, the table shows a friendly empty-state message
+  // instead of a bare table body. Matters for filtered views where the user's
+  // query yields zero rows.
+  test("empty state renders 'No results found'", async () => {
+    await setup(<DataTable columns={basicColumns} data={[]} hideSearch />);
+
+    expect(screen.getByText("No results found")).toBeInTheDocument();
+  });
+
+  // When `isLoading=true`, rows are hidden and a loading indicator appears in
+  // their place. Used by /songs during filter-refetch to avoid showing stale
+  // data while the new API response is in flight.
+  test("isLoading state renders 'Loading...'", async () => {
+    await setup(<DataTable columns={basicColumns} data={rows} hideSearch isLoading />);
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    // When loading, rows should not render
+    expect(screen.queryByText("Alpha")).not.toBeInTheDocument();
+  });
+
+  // Callers that render all rows at once (like /songs, which has <1000 songs
+  // total) pass `hidePagination` to suppress the paginator. Confirms that the
+  // Previous/Next buttons don't render in that mode.
+  test("hidePagination removes Previous/Next buttons", async () => {
+    await setup(<DataTable columns={basicColumns} data={rows} hideSearch hidePagination />);
+
+    expect(screen.queryByRole("button", { name: "Previous" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
+  });
+
+  // The default/non-hidePagination mode shows Previous and Next buttons.
+  // Complement to the previous test — together they pin pagination visibility
+  // to the `hidePagination` prop exactly.
+  test("pagination buttons render when not hidden", async () => {
+    await setup(<DataTable columns={basicColumns} data={rows} hideSearch />);
+
+    expect(screen.getByRole("button", { name: "Previous" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument();
+  });
+
+  // A column's `meta.width` is applied as the header's CSS width. This
+  // replaced hardcoded ID-based widths, making DataTable truly generic —
+  // any consumer can specify their own widths via column def meta.
+  test("honors meta.width on column defs", async () => {
+    const columnsWithWidths: ColumnDef<Row>[] = [
+      { accessorKey: "name", header: "Name", meta: { width: "60%" } },
+      { accessorKey: "count", header: "Count", meta: { width: "40%" } },
+    ];
+
+    await setup(<DataTable columns={columnsWithWidths} data={rows} hideSearch />);
+
+    const nameHeader = screen.getByText("Name").closest("th");
+    const countHeader = screen.getByText("Count").closest("th");
+
+    expect(nameHeader?.style.width).toBe("60%");
+    expect(countHeader?.style.width).toBe("40%");
+  });
+});

--- a/apps/web/app/components/ui/data-table.test.tsx
+++ b/apps/web/app/components/ui/data-table.test.tsx
@@ -71,6 +71,17 @@ describe("DataTable", () => {
     expect(betaRow?.className ?? "").not.toContain("big-count");
   });
 
+  // When there are zero results, pagination controls should not render at
+  // all — Previous/Next buttons and "Page X of Y" are meaningless with no
+  // data to page through.
+  test("hides pagination controls when data is empty", async () => {
+    await setup(<DataTable columns={basicColumns} data={[]} hideSearch />);
+
+    expect(screen.queryByRole("button", { name: "Previous" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Page/)).not.toBeInTheDocument();
+  });
+
   // When `data` is empty, the table shows a friendly empty-state message
   // instead of a bare table body. Matters for filtered views where the user's
   // query yields zero rows.
@@ -101,19 +112,92 @@ describe("DataTable", () => {
     expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
   });
 
-  // The default/non-hidePagination mode shows Previous and Next buttons.
-  // Complement to the previous test — together they pin pagination visibility
-  // to the `hidePagination` prop exactly.
+  // The default/non-hidePagination mode shows Previous and Next buttons
+  // above and below the table. Complement to the previous test — together
+  // they pin pagination visibility to the `hidePagination` prop exactly.
   test("pagination buttons render when not hidden", async () => {
     await setup(<DataTable columns={basicColumns} data={rows} hideSearch />);
 
-    expect(screen.getByRole("button", { name: "Previous" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Previous" })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: "Next" })).toHaveLength(2);
   });
 
-  // A column's `meta.width` is applied as the header's CSS width. This
-  // replaced hardcoded ID-based widths, making DataTable truly generic —
-  // any consumer can specify their own widths via column def meta.
+  // The page input shows "Page [input] of N" between Previous and Next.
+  test("renders page input with current page and total", async () => {
+    const manyRows = Array.from({ length: 10 }, (_, i) => ({
+      id: String(i),
+      name: `Row ${i}`,
+      count: i,
+    }));
+
+    await setup(<DataTable columns={basicColumns} data={manyRows} hideSearch pageSize={3} />);
+
+    // 10 rows / 3 per page = 4 pages
+    const pageInputs = screen.getAllByRole("spinbutton");
+    expect(pageInputs.length).toBeGreaterThanOrEqual(2); // top + bottom
+    expect(pageInputs[0]).toHaveValue(1);
+    expect(screen.getAllByText(/of 4/).length).toBeGreaterThanOrEqual(2);
+  });
+
+  // Typing a page number into the input navigates to that page.
+  test("typing a page number in the input navigates to that page", async () => {
+    const manyRows = Array.from({ length: 6 }, (_, i) => ({
+      id: String(i),
+      name: `Row ${i}`,
+      count: i,
+    }));
+
+    const { user } = await setup(<DataTable columns={basicColumns} data={manyRows} hideSearch pageSize={3} />);
+
+    expect(screen.getByText("Row 0")).toBeInTheDocument();
+
+    // Clear the input and type "2", then press Enter
+    const pageInputs = screen.getAllByRole("spinbutton");
+    await user.clear(pageInputs[0]);
+    await user.type(pageInputs[0], "2{Enter}");
+
+    expect(screen.getByText("Row 3")).toBeInTheDocument();
+    expect(screen.queryByText("Row 0")).not.toBeInTheDocument();
+  });
+
+  // Out-of-range values are clamped: below 1 goes to page 1, above max goes to last page.
+  test("page input clamps out-of-range values", async () => {
+    const manyRows = Array.from({ length: 6 }, (_, i) => ({
+      id: String(i),
+      name: `Row ${i}`,
+      count: i,
+    }));
+
+    const { user } = await setup(<DataTable columns={basicColumns} data={manyRows} hideSearch pageSize={3} />);
+
+    const pageInputs = screen.getAllByRole("spinbutton");
+
+    // Type a number higher than max pages (2) — should clamp to last page
+    await user.clear(pageInputs[0]);
+    await user.type(pageInputs[0], "99{Enter}");
+
+    expect(screen.getByText("Row 3")).toBeInTheDocument(); // page 2
+    expect(screen.queryByText("Row 0")).not.toBeInTheDocument();
+  });
+
+  // Page input should not render when hidePagination is true.
+  test("page input hidden when hidePagination is true", async () => {
+    const manyRows = Array.from({ length: 10 }, (_, i) => ({
+      id: String(i),
+      name: `Row ${i}`,
+      count: i,
+    }));
+
+    await setup(<DataTable columns={basicColumns} data={manyRows} hideSearch hidePagination />);
+
+    expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
+  });
+
+  // Pending: DataTable currently hardcodes column widths by ID
+  // (header.id === "title" etc.), a leaky abstraction. This test pins the
+  // desired behavior — a column's `meta.width` is applied as the header's
+  // CSS width — and should be un-skipped once DataTable reads from
+  // `column.columnDef.meta?.width` instead.
   test("honors meta.width on column defs", async () => {
     const columnsWithWidths: ColumnDef<Row>[] = [
       { accessorKey: "name", header: "Name", meta: { width: "60%" } },

--- a/apps/web/app/components/ui/data-table.tsx
+++ b/apps/web/app/components/ui/data-table.tsx
@@ -19,7 +19,7 @@ declare module "@tanstack/react-table" {
   }
 }
 
-import { type ReactNode, useState } from "react";
+import { type KeyboardEvent, type ReactNode, useState } from "react";
 
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
@@ -28,6 +28,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
+  getRowId?: (row: TData) => string;
   searchKey?: string;
   searchPlaceholder?: string;
   pageSize?: number;
@@ -40,7 +41,6 @@ interface DataTableProps<TData, TValue> {
   isLoading?: boolean;
   rowClassName?: (data: TData, index: number) => string | undefined;
   initialSorting?: SortingState;
-  getRowId?: (row: TData) => string;
 }
 
 export function DataTable<TData, TValue>({
@@ -87,8 +87,71 @@ export function DataTable<TData, TValue>({
     },
   });
 
+  const hasResults = table.getFilteredRowModel().rows.length > 0;
+  const currentPage = table.getState().pagination.pageIndex + 1;
+  const totalPages = table.getPageCount();
+
+  function handlePageInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key !== "Enter") return;
+    const value = Number(event.currentTarget.value);
+    if (Number.isNaN(value)) return;
+    const clamped = Math.max(1, Math.min(totalPages, value));
+    table.setPageIndex(clamped - 1);
+    event.currentTarget.value = String(clamped);
+  }
+
+  const paginationBlock = !hasResults ? null : (
+    <div className="flex items-center justify-between px-2">
+      {!hidePaginationText ? (
+        <div className="text-sm text-content-text-secondary font-medium">
+          {table.getFilteredRowModel().rows.length === 0
+            ? "0 results"
+            : `Showing ${table.getState().pagination.pageIndex * table.getState().pagination.pageSize + 1} to ${Math.min(
+                (table.getState().pagination.pageIndex + 1) * table.getState().pagination.pageSize,
+                table.getFilteredRowModel().rows.length,
+              )} of ${table.getFilteredRowModel().rows.length} results`}
+        </div>
+      ) : (
+        <div />
+      )}
+      <div className="flex items-center space-x-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+          className="hover:bg-brand-primary/20 hover:border-brand-primary/40"
+        >
+          Previous
+        </Button>
+        <span className="flex items-center gap-1.5 text-sm text-content-text-secondary">
+          Page
+          <input
+            type="number"
+            min={1}
+            max={totalPages}
+            defaultValue={currentPage}
+            key={currentPage}
+            onKeyDown={handlePageInputKeyDown}
+            className="w-12 rounded border border-glass-border bg-glass-bg px-2 py-1 text-center text-sm text-white focus:outline-none focus:ring-1 focus:ring-ring/20 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          />
+          of {totalPages}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+          className="hover:bg-brand-primary/20 hover:border-brand-primary/40"
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+
   return (
-    <div className="space-y-6 w-full max-w-full overflow-hidden">
+    <div className="space-y-3 w-full max-w-full overflow-hidden">
       {searchKey && !hideSearch && (
         <div className="flex flex-col gap-3">
           <div className="flex items-end flex-wrap gap-x-6 gap-y-3">
@@ -109,17 +172,20 @@ export function DataTable<TData, TValue>({
           {secondaryFilterComponent}
         </div>
       )}
+      {!searchKey && filterComponent && <div>{filterComponent}</div>}
 
-      <div className="card-premium rounded-lg shadow-lg overflow-hidden w-full">
+      {!hidePagination && paginationBlock}
+
+      <div className="overflow-x-auto w-full">
         <Table className="w-full">
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id} className="border-glass-border/60 hover:bg-transparent bg-glass-bg/30">
+              <TableRow key={headerGroup.id} className="text-left text-sm text-content-text-secondary">
                 {headerGroup.headers.map((header) => {
                   return (
                     <TableHead
                       key={header.id}
-                      className="text-content-text-secondary font-semibold text-base uppercase tracking-wide py-5 px-4 sm:px-6 md:px-8 first:pl-4 sm:first:pl-6 md:first:pl-8 last:pr-4 sm:last:pr-6 md:last:pr-8"
+                      className="p-3 text-sm text-content-text-secondary"
                       style={{
                         width: header.column.columnDef.meta?.width,
                       }}
@@ -131,7 +197,7 @@ export function DataTable<TData, TValue>({
               </TableRow>
             ))}
           </TableHeader>
-          <TableBody className="bg-glass-bg/10">
+          <TableBody>
             {isLoading ? (
               <TableRow>
                 <TableCell
@@ -148,15 +214,10 @@ export function DataTable<TData, TValue>({
                 <TableRow
                   key={row.id}
                   data-state={row.getIsSelected() && "selected"}
-                  className={`border-glass-border/30 transition-all duration-200 hover:bg-hover-glass/80 ${
-                    index % 2 === 0 ? "bg-glass-bg/5" : "bg-glass-bg/15"
-                  } ${rowClassName?.(row.original, index) ?? ""}`}
+                  className={`border-t border-glass-border/30 hover:bg-hover-glass ${rowClassName?.(row.original, index) ?? ""}`}
                 >
                   {row.getVisibleCells().map((cell) => (
-                    <TableCell
-                      key={cell.id}
-                      className="py-5 px-4 sm:px-6 md:px-8 first:pl-4 sm:first:pl-6 md:first:pl-8 last:pr-4 sm:last:pr-6 md:last:pr-8 text-base"
-                    >
+                    <TableCell key={cell.id} className="p-3">
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </TableCell>
                   ))}
@@ -181,50 +242,7 @@ export function DataTable<TData, TValue>({
         </Table>
       </div>
 
-      {!hidePagination && (
-        <div className="flex items-center justify-between px-2">
-          {!hidePaginationText ? (
-            <div className="text-sm text-content-text-secondary font-medium">
-              Showing {table.getState().pagination.pageIndex * table.getState().pagination.pageSize + 1} to{" "}
-              {Math.min(
-                (table.getState().pagination.pageIndex + 1) * table.getState().pagination.pageSize,
-                table.getFilteredRowModel().rows.length,
-              )}{" "}
-              of {table.getFilteredRowModel().rows.length} results
-            </div>
-          ) : (
-            <div></div>
-          )}
-          <div className="flex items-center space-x-3">
-            <div className="flex items-center space-x-2 text-sm text-content-text-secondary">
-              <span>Page</span>
-              <span className="font-semibold text-content-text-primary">
-                {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
-              </span>
-            </div>
-            <div className="flex items-center space-x-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => table.previousPage()}
-                disabled={!table.getCanPreviousPage()}
-                className="hover:bg-brand-primary/20 hover:border-brand-primary/40"
-              >
-                Previous
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => table.nextPage()}
-                disabled={!table.getCanNextPage()}
-                className="hover:bg-brand-primary/20 hover:border-brand-primary/40"
-              >
-                Next
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
+      {!hidePagination && paginationBlock}
     </div>
   );
 }

--- a/apps/web/app/components/ui/data-table.tsx
+++ b/apps/web/app/components/ui/data-table.tsx
@@ -6,10 +6,19 @@ import {
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
+  type RowData,
   type SortingState,
   useReactTable,
   type VisibilityState,
 } from "@tanstack/react-table";
+
+declare module "@tanstack/react-table" {
+  // biome-ignore lint/correctness/noUnusedVariables: required by TanStack's module augmentation pattern
+  interface ColumnMeta<TData extends RowData, TValue> {
+    width?: string;
+  }
+}
+
 import { type ReactNode, useState } from "react";
 
 import { Button } from "~/components/ui/button";
@@ -30,6 +39,8 @@ interface DataTableProps<TData, TValue> {
   secondaryFilterComponent?: ReactNode;
   isLoading?: boolean;
   rowClassName?: (data: TData, index: number) => string | undefined;
+  initialSorting?: SortingState;
+  getRowId?: (row: TData) => string;
 }
 
 export function DataTable<TData, TValue>({
@@ -46,14 +57,17 @@ export function DataTable<TData, TValue>({
   secondaryFilterComponent,
   isLoading = false,
   rowClassName,
+  initialSorting,
+  getRowId,
 }: DataTableProps<TData, TValue>) {
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const [sorting, setSorting] = useState<SortingState>(initialSorting ?? []);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
 
   const table = useReactTable({
     data,
     columns,
+    ...(getRowId ? { getRowId } : {}),
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
@@ -107,14 +121,7 @@ export function DataTable<TData, TValue>({
                       key={header.id}
                       className="text-content-text-secondary font-semibold text-base uppercase tracking-wide py-5 px-4 sm:px-6 md:px-8 first:pl-4 sm:first:pl-6 md:first:pl-8 last:pr-4 sm:last:pr-6 md:last:pr-8"
                       style={{
-                        width:
-                          header.id === "title"
-                            ? "30%"
-                            : header.id === "timesPlayed"
-                              ? "10%"
-                              : header.id === "yearlyPlayData"
-                                ? "10%"
-                                : "25%",
+                        width: header.column.columnDef.meta?.width,
                       }}
                     >
                       {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}

--- a/apps/web/app/components/ui/filters/index.ts
+++ b/apps/web/app/components/ui/filters/index.ts
@@ -1,0 +1,2 @@
+export { SelectFilter } from "./select-filter";
+export { ToggleFilterGroup } from "./toggle-filter-group";

--- a/apps/web/app/components/ui/filters/select-filter.test.tsx
+++ b/apps/web/app/components/ui/filters/select-filter.test.tsx
@@ -1,0 +1,64 @@
+import { screen } from "@testing-library/react";
+import { setup } from "@test/test-utils";
+import { describe, expect, test, vi } from "vitest";
+import { SelectFilter } from "./select-filter";
+
+const options = [
+  { value: "all", label: "All" },
+  { value: "original", label: "Original" },
+  { value: "cover", label: "Cover" },
+];
+
+describe("SelectFilter", () => {
+  // The label sits above the select trigger and is associated via htmlFor/id.
+  // Confirms the component renders a visible label with the given text.
+  test("renders label text", async () => {
+    await setup(<SelectFilter id="test-filter" label="Type" value="all" onValueChange={() => {}} options={options} />);
+
+    expect(screen.getByText("Type")).toBeInTheDocument();
+  });
+
+  // The trigger shows the currently selected option's label. When value
+  // matches an option, its label is visible in the trigger.
+  test("displays the selected value in the trigger", async () => {
+    await setup(
+      <SelectFilter id="test-filter" label="Type" value="cover" onValueChange={() => {}} options={options} />,
+    );
+
+    expect(screen.getByText("Cover")).toBeInTheDocument();
+  });
+
+  // When the user picks a new option, onValueChange fires with the option's
+  // value string. This is the core contract between the filter and its parent.
+  test("calls onValueChange when an option is selected", async () => {
+    const handleChange = vi.fn();
+    const { user } = await setup(
+      <SelectFilter id="test-filter" label="Type" value="all" onValueChange={handleChange} options={options} />,
+    );
+
+    // Open the select dropdown
+    await user.click(screen.getByRole("combobox"));
+    // Select "Cover" option
+    await user.click(screen.getByRole("option", { name: "Cover" }));
+
+    expect(handleChange).toHaveBeenCalledWith("cover");
+  });
+
+  // The width prop lets callers control the trigger width to match the
+  // layout context (e.g. "w-[130px]" for Year vs "w-[170px]" for Era).
+  test("applies the width class to the trigger", async () => {
+    await setup(
+      <SelectFilter
+        id="test-filter"
+        label="Type"
+        value="all"
+        onValueChange={() => {}}
+        options={options}
+        width="w-[120px]"
+      />,
+    );
+
+    const trigger = screen.getByRole("combobox");
+    expect(trigger.className).toContain("w-[120px]");
+  });
+});

--- a/apps/web/app/components/ui/filters/select-filter.tsx
+++ b/apps/web/app/components/ui/filters/select-filter.tsx
@@ -1,0 +1,40 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
+
+const selectTriggerClass =
+  "h-[34px] text-sm bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20";
+const selectContentClass = "bg-glass-bg border-glass-border backdrop-blur-md";
+const selectItemClass = "text-content-text-primary hover:bg-hover-glass";
+const labelClass =
+  "text-xs font-medium text-content-text-secondary uppercase tracking-wide mb-1.5 h-[18px] flex items-center";
+
+interface SelectFilterProps {
+  id: string;
+  label: string;
+  value: string;
+  onValueChange: (value: string) => void;
+  options: Array<{ value: string; label: string }>;
+  placeholder?: string;
+  width?: string;
+}
+
+export function SelectFilter({ id, label, value, onValueChange, options, placeholder, width }: SelectFilterProps) {
+  return (
+    <div className="flex flex-col">
+      <label htmlFor={id} className={labelClass}>
+        {label}
+      </label>
+      <Select value={value} onValueChange={onValueChange}>
+        <SelectTrigger id={id} className={`${width ?? ""} ${selectTriggerClass}`}>
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent className={selectContentClass}>
+          {options.map((option) => (
+            <SelectItem key={option.value} value={option.value} className={selectItemClass}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/apps/web/app/components/ui/filters/toggle-filter-group.test.tsx
+++ b/apps/web/app/components/ui/filters/toggle-filter-group.test.tsx
@@ -1,0 +1,47 @@
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { ToggleFilterGroup } from "./toggle-filter-group";
+
+const filters = [
+  { key: "encore", label: "Encore" },
+  { key: "setOpener", label: "Set Opener" },
+  { key: "segueIn", label: "Segue In" },
+];
+
+describe("ToggleFilterGroup", () => {
+  // The group renders one button per filter definition. This is the baseline
+  // rendering test — if it fails, the component isn't producing visible output.
+  test("renders a button for each filter", async () => {
+    await setup(<ToggleFilterGroup filters={filters} activeFilters={new Set()} onToggle={() => {}} />);
+
+    expect(screen.getByRole("button", { name: "Encore" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Set Opener" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Segue In" })).toBeInTheDocument();
+  });
+
+  // Active chips get a filled background to visually distinguish them from
+  // inactive ones. The active class is the primary brand color.
+  test("active filter chip has active styling class", async () => {
+    await setup(<ToggleFilterGroup filters={filters} activeFilters={new Set(["encore"])} onToggle={() => {}} />);
+
+    const encoreButton = screen.getByRole("button", { name: "Encore" });
+    expect(encoreButton.className).toContain("bg-brand-primary");
+
+    const openerButton = screen.getByRole("button", { name: "Set Opener" });
+    expect(openerButton.className).not.toContain("bg-brand-primary");
+  });
+
+  // Clicking a chip fires onToggle with that chip's key so the parent can
+  // add/remove it from the active set. The component is controlled — it
+  // doesn't manage its own state.
+  test("clicking a chip calls onToggle with its key", async () => {
+    const handleToggle = vi.fn();
+    const { user } = await setup(
+      <ToggleFilterGroup filters={filters} activeFilters={new Set()} onToggle={handleToggle} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Segue In" }));
+    expect(handleToggle).toHaveBeenCalledWith("segueIn");
+  });
+});

--- a/apps/web/app/components/ui/filters/toggle-filter-group.tsx
+++ b/apps/web/app/components/ui/filters/toggle-filter-group.tsx
@@ -1,0 +1,26 @@
+interface ToggleFilterGroupProps {
+  filters: Array<{ key: string; label: string }>;
+  activeFilters: Set<string>;
+  onToggle: (key: string) => void;
+}
+
+export function ToggleFilterGroup({ filters, activeFilters, onToggle }: ToggleFilterGroupProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {filters.map((filter) => (
+        <button
+          type="button"
+          key={filter.key}
+          onClick={() => onToggle(filter.key)}
+          className={`px-3 py-1.5 text-sm rounded-md border transition-colors ${
+            activeFilters.has(filter.key)
+              ? "bg-brand-primary border-brand-primary text-white"
+              : "bg-transparent border-glass-border text-content-text-secondary hover:border-brand-primary/60"
+          }`}
+        >
+          {filter.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/app/hooks/use-attendance-row-highlight.test.ts
+++ b/apps/web/app/hooks/use-attendance-row-highlight.test.ts
@@ -1,0 +1,140 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("~/hooks/use-session", () => ({
+  useSession: vi.fn(() => ({ user: { id: "user-1" }, supabase: null, loading: false })),
+}));
+
+vi.mock("~/hooks/use-show-user-data", () => ({
+  useShowUserData: vi.fn(() => ({
+    attendanceMap: new Map(),
+    userRatingMap: new Map(),
+    averageRatingMap: new Map(),
+    isLoading: false,
+    error: null,
+  })),
+}));
+
+import { useSession } from "~/hooks/use-session";
+import { useShowUserData } from "~/hooks/use-show-user-data";
+import { ATTENDED_ROW_CLASS } from "~/lib/utils";
+import { useAttendanceRowHighlight } from "./use-attendance-row-highlight";
+
+type TestItem = { id: string; showId: string };
+const getShowId = (item: TestItem) => item.showId;
+
+describe("useAttendanceRowHighlight", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useSession).mockReturnValue({
+      user: { id: "user-1" } as never,
+      supabase: null,
+      loading: false,
+    });
+    vi.mocked(useShowUserData).mockReturnValue({
+      attendanceMap: new Map(),
+      userRatingMap: new Map(),
+      averageRatingMap: new Map(),
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  // rowClassName is the primary output — it's passed directly to DataTable's
+  // rowClassName prop. Returns the attended-row CSS class for shows the user
+  // attended, undefined otherwise.
+  test("rowClassName returns ATTENDED_ROW_CLASS for attended shows and undefined for others", () => {
+    vi.mocked(useShowUserData).mockReturnValue({
+      attendanceMap: new Map([["show-attended", { id: "att-1" } as never]]),
+      userRatingMap: new Map(),
+      averageRatingMap: new Map(),
+      isLoading: false,
+      error: null,
+    });
+
+    const items: TestItem[] = [
+      { id: "1", showId: "show-attended" },
+      { id: "2", showId: "show-other" },
+    ];
+
+    const { result } = renderHook(() => useAttendanceRowHighlight(items, getShowId));
+
+    expect(result.current.rowClassName(items[0])).toBe(ATTENDED_ROW_CLASS);
+    expect(result.current.rowClassName(items[1])).toBeUndefined();
+  });
+
+  // When the user is not authenticated, the hook should pass an empty array
+  // to useShowUserData so no attendance data is fetched. This prevents
+  // unnecessary API calls for logged-out users.
+  test("passes empty showIds to useShowUserData when user is not authenticated", () => {
+    vi.mocked(useSession).mockReturnValue({
+      user: null,
+      supabase: null,
+      loading: false,
+    });
+
+    const items: TestItem[] = [{ id: "1", showId: "show-1" }];
+    renderHook(() => useAttendanceRowHighlight(items, getShowId));
+
+    expect(vi.mocked(useShowUserData)).toHaveBeenCalledWith([]);
+  });
+
+  // isAttended is used by filter predicates (e.g., the "Attended" toggle
+  // chip on performance tables) to narrow rows to attended shows.
+  test("isAttended returns true for attended shows, false for others", () => {
+    vi.mocked(useShowUserData).mockReturnValue({
+      attendanceMap: new Map([["show-yes", { id: "att-1" } as never]]),
+      userRatingMap: new Map(),
+      averageRatingMap: new Map(),
+      isLoading: false,
+      error: null,
+    });
+
+    const items: TestItem[] = [
+      { id: "1", showId: "show-yes" },
+      { id: "2", showId: "show-no" },
+    ];
+
+    const { result } = renderHook(() => useAttendanceRowHighlight(items, getShowId));
+
+    expect(result.current.isAttended(items[0])).toBe(true);
+    expect(result.current.isAttended(items[1])).toBe(false);
+  });
+
+  // Multiple items can reference the same show (e.g., multiple performances
+  // at the same show). The hook should deduplicate IDs before passing to
+  // useShowUserData to avoid redundant API calls.
+  test("deduplicates show IDs before passing to useShowUserData", () => {
+    const items: TestItem[] = [
+      { id: "1", showId: "show-same" },
+      { id: "2", showId: "show-same" },
+      { id: "3", showId: "show-other" },
+    ];
+
+    renderHook(() => useAttendanceRowHighlight(items, getShowId));
+
+    const calledWithIds = vi.mocked(useShowUserData).mock.calls[0][0] as string[];
+    expect(calledWithIds).toHaveLength(2);
+    expect(new Set(calledWithIds)).toEqual(new Set(["show-same", "show-other"]));
+  });
+
+  // The hook passes through userRatingMap and averageRatingMap from
+  // useShowUserData so callers don't need a separate call for rating data.
+  test("passes through userRatingMap and averageRatingMap from useShowUserData", () => {
+    const mockUserRatingMap = new Map([["show-1", 4.5]]);
+    const mockAverageRatingMap = new Map([["show-1", { average: 4.2, count: 10 }]]);
+
+    vi.mocked(useShowUserData).mockReturnValue({
+      attendanceMap: new Map(),
+      userRatingMap: mockUserRatingMap,
+      averageRatingMap: mockAverageRatingMap,
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useAttendanceRowHighlight([{ id: "1", showId: "show-1" }], getShowId));
+
+    expect(result.current.userRatingMap).toBe(mockUserRatingMap);
+    expect(result.current.averageRatingMap).toBe(mockAverageRatingMap);
+  });
+});

--- a/apps/web/app/hooks/use-attendance-row-highlight.ts
+++ b/apps/web/app/hooks/use-attendance-row-highlight.ts
@@ -1,0 +1,29 @@
+import { useCallback, useMemo } from "react";
+import { useSession } from "~/hooks/use-session";
+import { useShowUserData } from "~/hooks/use-show-user-data";
+import { ATTENDED_ROW_CLASS } from "~/lib/utils";
+
+/**
+ * Encapsulates the auth-gated attendance highlighting pattern used across
+ * multiple DataTable consumers. Fetches attendance + rating data for the
+ * given items' shows, and returns ready-to-use rowClassName and isAttended
+ * functions plus the raw maps for callers that need to compose further.
+ *
+ * @param items - The data rows displayed in the table.
+ * @param getShowId - Extracts the show ID from a row. Callers should pass a
+ *   stable reference (module-level or useCallback) to avoid busting the
+ *   internal useMemo on every render.
+ */
+export function useAttendanceRowHighlight<T>(items: T[], getShowId: (item: T) => string) {
+  const { user } = useSession();
+
+  const showIds = useMemo(() => [...new Set(items.map(getShowId))], [items, getShowId]);
+
+  const { attendanceMap, userRatingMap, averageRatingMap, isLoading } = useShowUserData(user ? showIds : []);
+
+  const isAttended = useCallback((item: T) => !!attendanceMap.get(getShowId(item)), [attendanceMap, getShowId]);
+
+  const rowClassName = useCallback((item: T) => (isAttended(item) ? ATTENDED_ROW_CLASS : undefined), [isAttended]);
+
+  return { rowClassName, isAttended, attendanceMap, userRatingMap, averageRatingMap, isLoading };
+}

--- a/apps/web/app/hooks/use-performance-page-filters.test.ts
+++ b/apps/web/app/hooks/use-performance-page-filters.test.ts
@@ -1,0 +1,227 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const mockSetSearchParams = vi.fn();
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("react-router-dom", () => ({
+  useSearchParams: () => [mockSearchParams, mockSetSearchParams],
+}));
+
+import { usePerformancePageFilters } from "./use-performance-page-filters";
+
+// Stable reference prevents the useEffect (which has initialData in its
+// deps) from re-running on every render. An inline `[]` creates a new array
+// each render, causing an infinite fetch loop in tests.
+const EMPTY: never[] = [];
+
+describe("usePerformancePageFilters", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // The hook returns generic `data` and `filteredData` arrays so consumers
+  // can work with any type T, not just SongPagePerformance.
+  test("returns data and filteredData properties", () => {
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.filteredData).toEqual([]);
+  });
+
+  // isLoading tracks whether a fetch is in progress with a 200ms debounce
+  // to prevent flickering on fast responses.
+  test("isLoading is false when no filters are active", () => {
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  // Loading state is debounced by 200ms to avoid flicker on fast responses.
+  // Before the timeout fires, isLoading should remain false.
+  test("isLoading becomes true after debounce when filters trigger a fetch", async () => {
+    mockSearchParams = new URLSearchParams("year=2024");
+    // Never-resolving fetch so loading stays true
+    globalThis.fetch = vi.fn().mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    // Before debounce, still false
+    expect(result.current.isLoading).toBe(false);
+
+    // After 200ms debounce, becomes true
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  // Once the fetch resolves, loading state should clear — even if the
+  // debounce timeout already fired. Verifies the full loading lifecycle.
+  test("isLoading returns to false when fetch completes", async () => {
+    mockSearchParams = new URLSearchParams("year=2024");
+    let resolveResponse: (value: unknown) => void = () => {};
+    globalThis.fetch = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveResponse = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      resolveResponse({ ok: true, json: () => Promise.resolve([]) });
+    });
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  // hasFilters tracks whether any server-side URL param filter is active.
+  // Used to decide whether to fetch filtered data or use the initial dataset.
+  test("hasFilters is false when all params are default", () => {
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    expect(result.current.hasFilters).toBe(false);
+  });
+
+  test("hasFilters is true when year is set", () => {
+    mockSearchParams = new URLSearchParams("year=2024");
+
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    expect(result.current.hasFilters).toBe(true);
+  });
+
+  test("hasFilters is true when era is set", () => {
+    mockSearchParams = new URLSearchParams("era=1.0");
+
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    expect(result.current.hasFilters).toBe(true);
+  });
+
+  test("hasFilters is true when cover filter is set", () => {
+    mockSearchParams = new URLSearchParams("cover=cover");
+
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    expect(result.current.hasFilters).toBe(true);
+  });
+
+  test("hasFilters is true when author is set", () => {
+    mockSearchParams = new URLSearchParams("author=Trey");
+
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    expect(result.current.hasFilters).toBe(true);
+  });
+
+  test("hasFilters is true when toggle filters are set", () => {
+    mockSearchParams = new URLSearchParams("filters=encore,setOpener");
+
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    expect(result.current.hasFilters).toBe(true);
+  });
+
+  test("hasFilters is true when attended is set", () => {
+    mockSearchParams = new URLSearchParams("attended=attended");
+
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    expect(result.current.hasFilters).toBe(true);
+  });
+
+  // hasActiveFilters combines URL param filters AND client-side search text.
+  // Used to show/hide the "Clear All" button in PerformanceFilterControls.
+  test("hasActiveFilters is false when all params are default and searchText is empty", () => {
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    expect(result.current.hasActiveFilters).toBe(false);
+  });
+
+  test("hasActiveFilters is true when searchText is non-empty", () => {
+    globalThis.fetch = vi.fn().mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    act(() => {
+      result.current.setSearchText("test");
+    });
+    expect(result.current.hasActiveFilters).toBe(true);
+  });
+
+  test("hasActiveFilters is true when URL params are set even if searchText is empty", () => {
+    mockSearchParams = new URLSearchParams("year=2024");
+
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    expect(result.current.hasActiveFilters).toBe(true);
+    expect(result.current.searchText).toBe("");
+  });
+
+  // clearFilters is a single entry point to reset everything — both URL param
+  // filters (year, era, cover, author, toggles, attended) and client-side
+  // search text. This powers the "Clear All" button.
+  test("clearFilters also resets searchText", () => {
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    act(() => {
+      result.current.setSearchText("hello");
+    });
+    expect(result.current.searchText).toBe("hello");
+
+    act(() => {
+      result.current.clearFilters();
+    });
+    expect(result.current.searchText).toBe("");
+  });
+
+  // Verifies that the setSearchParams updater clears all seven URL param keys
+  // (year, era, cover, author, filters, attended, played). We call the updater
+  // manually because the mock doesn't trigger React state updates — we just
+  // need to confirm the function produces the right params.
+  test("clearFilters resets all params", () => {
+    mockSearchParams = new URLSearchParams(
+      "year=2024&era=1.0&cover=cover&author=Trey&filters=encore&attended=attended&played=notPlayed",
+    );
+
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    act(() => {
+      result.current.clearFilters();
+    });
+
+    expect(mockSetSearchParams).toHaveBeenCalledTimes(1);
+
+    const updaterFn = mockSetSearchParams.mock.calls[0][0];
+    const nextParams = updaterFn(
+      new URLSearchParams(
+        "year=2024&era=1.0&cover=cover&author=Trey&filters=encore&attended=attended&played=notPlayed",
+      ),
+    );
+
+    expect(nextParams.get("year")).toBeNull();
+    expect(nextParams.get("era")).toBeNull();
+    expect(nextParams.get("cover")).toBeNull();
+    expect(nextParams.get("author")).toBeNull();
+    expect(nextParams.get("filters")).toBeNull();
+    expect(nextParams.get("attended")).toBeNull();
+    expect(nextParams.get("played")).toBeNull();
+  });
+});

--- a/apps/web/app/hooks/use-performance-page-filters.ts
+++ b/apps/web/app/hooks/use-performance-page-filters.ts
@@ -1,0 +1,203 @@
+import type { SongPagePerformance } from "@bip/domain";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
+export const searchPerformance = (performance: SongPagePerformance, query: string) =>
+  performance.songTitle?.toLowerCase().includes(query) ||
+  performance.venue?.name?.toLowerCase().includes(query) ||
+  performance.venue?.city?.toLowerCase().includes(query) ||
+  performance.venue?.state?.toLowerCase().includes(query) ||
+  false;
+
+interface PageFiltersOptions<T> {
+  initialData: T[];
+  apiUrl: string;
+  extraParams?: Record<string, string>;
+  searchFilter?: (item: T, query: string) => boolean;
+}
+
+export function usePerformancePageFilters<T>({
+  initialData,
+  apiUrl,
+  extraParams,
+  searchFilter,
+}: PageFiltersOptions<T>) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const selectedYear = searchParams.get("year") || "all";
+  const selectedEra = searchParams.get("era") || "all";
+  const coverFilter = (searchParams.get("cover") as "all" | "cover" | "original") || "all";
+  const selectedAuthor = searchParams.get("author") || null;
+  const filtersParam = searchParams.get("filters") || "";
+  const attendedParam = searchParams.get("attended") || "";
+  const playedParam = searchParams.get("played") || "";
+
+  const activeToggles = useMemo(() => {
+    const toggles = filtersParam ? filtersParam.split(",").filter(Boolean) : [];
+    if (attendedParam) toggles.push("attended");
+    return toggles;
+  }, [filtersParam, attendedParam]);
+  const activeToggleSet = new Set(activeToggles);
+
+  const [data, setData] = useState<T[]>(initialData);
+  const [isLoading, setIsLoading] = useState(false);
+  const loadingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const hasFilters =
+    selectedYear !== "all" ||
+    selectedEra !== "all" ||
+    coverFilter !== "all" ||
+    !!selectedAuthor ||
+    filtersParam !== "" ||
+    attendedParam !== "" ||
+    playedParam !== "";
+
+  useEffect(() => {
+    if (!hasFilters) {
+      setData(initialData);
+      setIsLoading(false);
+      if (loadingTimeoutRef.current) {
+        clearTimeout(loadingTimeoutRef.current);
+        loadingTimeoutRef.current = null;
+      }
+      return undefined;
+    }
+
+    const controller = new AbortController();
+
+    loadingTimeoutRef.current = setTimeout(() => {
+      setIsLoading(true);
+    }, 200);
+
+    const params = new URLSearchParams();
+    if (selectedYear !== "all") params.set("year", selectedYear);
+    if (selectedEra !== "all") params.set("era", selectedEra);
+    if (coverFilter !== "all") params.set("cover", coverFilter);
+    if (selectedAuthor) params.set("author", selectedAuthor);
+    if (filtersParam) params.set("filters", filtersParam);
+    if (attendedParam) params.set("attended", attendedParam);
+    if (playedParam) params.set("played", playedParam);
+
+    if (extraParams) {
+      for (const [key, value] of Object.entries(extraParams)) {
+        params.set(key, value);
+      }
+    }
+
+    fetch(`${apiUrl}?${params.toString()}`, { signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+        return response.json();
+      })
+      .then((result: T[]) => {
+        setData(result);
+        if (loadingTimeoutRef.current) {
+          clearTimeout(loadingTimeoutRef.current);
+          loadingTimeoutRef.current = null;
+        }
+        setIsLoading(false);
+      })
+      .catch((error) => {
+        if (error.name === "AbortError") return;
+        setData([]);
+        if (loadingTimeoutRef.current) {
+          clearTimeout(loadingTimeoutRef.current);
+          loadingTimeoutRef.current = null;
+        }
+        setIsLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+      if (loadingTimeoutRef.current) {
+        clearTimeout(loadingTimeoutRef.current);
+        loadingTimeoutRef.current = null;
+      }
+    };
+  }, [
+    selectedYear,
+    selectedEra,
+    coverFilter,
+    selectedAuthor,
+    filtersParam,
+    attendedParam,
+    playedParam,
+    initialData,
+    hasFilters,
+    apiUrl,
+    extraParams,
+  ]);
+
+  const updateFilter = useCallback(
+    (updates: Record<string, string | null>) => {
+      setSearchParams(
+        (previous) => {
+          const next = new URLSearchParams(previous);
+          for (const [key, value] of Object.entries(updates)) {
+            if (value && value !== "all") {
+              next.set(key, value);
+            } else {
+              next.delete(key);
+            }
+          }
+          return next;
+        },
+        { replace: true, preventScrollReset: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const toggleFilter = useCallback(
+    (key: string) => {
+      if (key === "attended") {
+        updateFilter({ attended: attendedParam ? null : "attended" });
+        return;
+      }
+
+      const currentFilters = filtersParam ? filtersParam.split(",").filter(Boolean) : [];
+      const filterSet = new Set(currentFilters);
+      if (filterSet.has(key)) {
+        filterSet.delete(key);
+      } else {
+        filterSet.add(key);
+      }
+      updateFilter({ filters: [...filterSet].join(",") || null });
+    },
+    [filtersParam, attendedParam, updateFilter],
+  );
+
+  const [searchText, setSearchText] = useState("");
+
+  const filteredData = useMemo(() => {
+    if (!searchText || !searchFilter) return data;
+    const lower = searchText.toLowerCase();
+    return data.filter((item) => searchFilter(item, lower));
+  }, [data, searchText, searchFilter]);
+
+  const hasActiveFilters = hasFilters || searchText.length > 0;
+
+  const clearFilters = useCallback(() => {
+    updateFilter({ year: null, era: null, cover: null, author: null, filters: null, attended: null, played: null });
+    setSearchText("");
+  }, [updateFilter]);
+
+  return {
+    data,
+    filteredData,
+    isLoading,
+    selectedYear,
+    selectedEra,
+    coverFilter,
+    selectedAuthor,
+    playedFilter: playedParam || "all",
+    activeToggleSet,
+    hasFilters,
+    hasActiveFilters,
+    searchText,
+    setSearchText,
+    updateFilter,
+    toggleFilter,
+    clearFilters,
+  };
+}

--- a/apps/web/app/lib/performance-filter-params.ts
+++ b/apps/web/app/lib/performance-filter-params.ts
@@ -1,0 +1,101 @@
+import type { PerformanceFilterOptions } from "@bip/core/page-composers/song-page-composer";
+import { CacheKeys } from "@bip/domain/cache-keys";
+import type { PublicContext } from "~/lib/base-loaders";
+import { SONG_FILTERS } from "~/lib/song-filters";
+import { services } from "~/server/services";
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const VALID_FILTER_KEYS = new Set([
+  "encore",
+  "setOpener",
+  "setCloser",
+  "segueIn",
+  "segueOut",
+  "standalone",
+  "inverted",
+  "dyslexic",
+  "allTimer",
+]);
+
+/**
+ * Resolve the "attended" param to a user ID. Supports both:
+ * - attended=attended (uses logged-in user)
+ * - attended=<username> (looks up by username)
+ */
+export async function resolveAttendedUserId(
+  attendedParam: string | null,
+  context: PublicContext,
+): Promise<string | undefined> {
+  if (!attendedParam) return undefined;
+
+  if (attendedParam === "attended" && context.currentUser) {
+    const localUser = await services.users.findByEmail(context.currentUser.email);
+    return localUser?.id;
+  }
+
+  if (attendedParam !== "attended") {
+    const localUser = await services.users.findByUsername(attendedParam);
+    return localUser?.id;
+  }
+
+  return undefined;
+}
+
+/**
+ * Parse URL search params into PerformanceFilterOptions.
+ * Shared by /api/all-timers and /api/songs/performances.
+ */
+export async function parsePerformanceFilters(url: URL, context: PublicContext): Promise<PerformanceFilterOptions> {
+  const year = url.searchParams.get("year");
+  const era = url.searchParams.get("era");
+  const coverParam = url.searchParams.get("cover");
+  const authorParam = url.searchParams.get("author");
+  const filtersParam = url.searchParams.get("filters");
+  const attendedParam = url.searchParams.get("attended");
+
+  const dateRangeKey = year || era;
+  const dateRange = dateRangeKey && dateRangeKey in SONG_FILTERS ? SONG_FILTERS[dateRangeKey] : null;
+
+  const filters: PerformanceFilterOptions = {};
+
+  if (dateRange?.startDate) filters.startDate = dateRange.startDate;
+  if (dateRange?.endDate) filters.endDate = dateRange.endDate;
+  if (coverParam === "cover") filters.cover = true;
+  else if (coverParam === "original") filters.cover = false;
+  if (authorParam && UUID_REGEX.test(authorParam)) filters.authorId = authorParam;
+
+  const attendedUserId = await resolveAttendedUserId(attendedParam, context);
+  if (attendedUserId) filters.attendedUserId = attendedUserId;
+
+  if (filtersParam) {
+    for (const key of filtersParam.split(",")) {
+      if (VALID_FILTER_KEYS.has(key)) {
+        (filters as Record<string, boolean>)[key] = true;
+      }
+    }
+  }
+
+  return filters;
+}
+
+/**
+ * Build a cache key from URL search params for filtered performance queries.
+ */
+export function buildFilteredCacheKey(url: URL, scope: string, attendedUserId?: string): string {
+  const year = url.searchParams.get("year");
+  const era = url.searchParams.get("era");
+  const coverParam = url.searchParams.get("cover");
+  const authorParam = url.searchParams.get("author");
+  const filtersParam = url.searchParams.get("filters");
+
+  return CacheKeys.songs.filtered({
+    scope,
+    year: year || null,
+    era: era || null,
+    cover: coverParam || null,
+    author: authorParam || null,
+    filters: filtersParam || null,
+    attended: attendedUserId || null,
+  });
+}

--- a/apps/web/app/lib/song-filters.ts
+++ b/apps/web/app/lib/song-filters.ts
@@ -1,42 +1,60 @@
 export interface SongFilterConfig {
-	label: string;
-	startDate?: Date;
-	endDate?: Date;
+  label: string;
+  startDate?: Date;
+  endDate?: Date;
 }
 
 const START_YEAR = 1995;
 
 const yearFilters: Record<string, SongFilterConfig> = Object.fromEntries(
-	Array.from({ length: new Date().getFullYear() - START_YEAR + 1 }, (_, i) => {
-		const year = START_YEAR + i;
-		return [
-			String(year),
-			{
-				label: String(year),
-				startDate: new Date(`${year}-01-01`),
-				endDate: new Date(`${year}-12-31`),
-			},
-		];
-	}),
+  Array.from({ length: new Date().getFullYear() - START_YEAR + 1 }, (_, i) => {
+    const year = START_YEAR + i;
+    return [
+      String(year),
+      {
+        label: String(year),
+        startDate: new Date(`${year}-01-01`),
+        endDate: new Date(`${year}-12-31`),
+      },
+    ];
+  }),
 );
 
 const eraFilters: Record<string, SongFilterConfig> = {
-	sammy: { label: "Sammy Era", endDate: new Date("2005-08-27") },
-	allen: { label: "Allen Era", startDate: new Date("2005-12-28"), endDate: new Date("2025-09-07") },
-	marlon: { label: "Marlon Era", startDate: new Date("2025-10-31") },
-	triscuits: { label: "Triscuits", startDate: new Date("2000-03-11"), endDate: new Date("2000-07-12") },
+  sammy: { label: "Sammy Era", endDate: new Date("2005-08-27") },
+  allen: { label: "Allen Era", startDate: new Date("2005-12-28"), endDate: new Date("2025-09-07") },
+  marlon: { label: "Marlon Era", startDate: new Date("2025-10-31") },
+  triscuits: { label: "Triscuits", startDate: new Date("2000-03-11"), endDate: new Date("2000-07-12") },
 };
 
 export const SONG_FILTERS: Record<string, SongFilterConfig> = {
-	...yearFilters,
-	...eraFilters,
+  ...yearFilters,
+  ...eraFilters,
 };
 
 export const YEAR_OPTIONS = Object.entries(yearFilters)
-	.map(([value, config]) => ({ value, label: config.label }))
-	.reverse(); // Most recent first
+  .map(([value, config]) => ({ value, label: config.label }))
+  .reverse(); // Most recent first
 
 export const ERA_OPTIONS = Object.entries(eraFilters).map(([value, config]) => ({
-	value,
-	label: config.label,
+  value,
+  label: config.label,
 }));
+
+/**
+ * Tag filters shared between /songs, /songs/all-timers, and /songs/$slug.
+ * Used by PerformanceFilterControls for the toggle chip UI and by the
+ * server-side API endpoints for filtering.
+ */
+export const TOGGLE_FILTER_DEFINITIONS = [
+  { key: "setOpener", label: "Set Opener" },
+  { key: "setCloser", label: "Set Closer" },
+  { key: "encore", label: "Encore" },
+  { key: "segueIn", label: "Segue In" },
+  { key: "segueOut", label: "Segue Out" },
+  { key: "standalone", label: "Standalone" },
+  { key: "inverted", label: "Inverted" },
+  { key: "dyslexic", label: "Dyslexic" },
+  { key: "allTimer", label: "All-Timer" },
+  { key: "attended", label: "Attended" },
+] as const;

--- a/apps/web/app/lib/utils.ts
+++ b/apps/web/app/lib/utils.ts
@@ -22,7 +22,7 @@ export function getSafeRedirectUrl(url: string | null): string {
   return url;
 }
 
-export const ATTENDED_ROW_CLASS = "border-l-2 border-l-green-500 bg-green-500/5";
+export const ATTENDED_ROW_CLASS = "!border-l-2 !border-l-green-500 bg-green-500/5";
 
 export function formatDateShort(date: string): string {
   const dateParts = date.split("T")[0].split("-");

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -53,9 +53,7 @@ export default [
   ]),
 
   // OAuth routes
-  ...prefix("oauth", [
-    route("consent", "routes/oauth/consent.tsx"),
-  ]),
+  ...prefix("oauth", [route("consent", "routes/oauth/consent.tsx")]),
 
   // Profile routes
   ...prefix("profile", [route("edit", "routes/profile/edit.tsx")]),
@@ -110,7 +108,9 @@ export default [
     route("authors/:id", "routes/api/authors/$id.tsx"),
     route("venues", "routes/api/venues.tsx"),
     route("venues/:id", "routes/api/venues/$id.tsx"),
+    route("all-timers", "routes/api/all-timers.tsx"),
     route("songs", "routes/api/songs.tsx"),
+    route("songs/performances", "routes/api/songs/performances.tsx"),
     route("songs/:id", "routes/api/songs/$id.tsx"),
     route("tracks", "routes/api/tracks.tsx"),
     route("tracks/reorder", "routes/api/tracks/reorder.tsx"),

--- a/apps/web/app/routes/api/all-timers.tsx
+++ b/apps/web/app/routes/api/all-timers.tsx
@@ -1,0 +1,17 @@
+import { publicLoader } from "~/lib/base-loaders";
+import { buildFilteredCacheKey, parsePerformanceFilters } from "~/lib/performance-filter-params";
+import { services } from "~/server/services";
+
+export const loader = publicLoader(async ({ request, context }) => {
+  const url = new URL(request.url);
+  const filters = await parsePerformanceFilters(url, context);
+  const cacheKey = buildFilteredCacheKey(url, "all-timers", filters.attendedUserId);
+
+  const result = await services.cache.getOrSet(
+    cacheKey,
+    async () => services.songPageComposer.buildAllTimers(filters),
+    { ttl: 3600 },
+  );
+
+  return result.performances;
+});

--- a/apps/web/app/routes/api/attendances.tsx
+++ b/apps/web/app/routes/api/attendances.tsx
@@ -62,6 +62,8 @@ export const action = protectedAction(async ({ request, context }) => {
         showId,
       });
 
+      await services.cacheInvalidation.invalidateAttendanceCaches(user.id);
+
       return { attendance };
     } catch (error) {
       logger.error("Error creating attendance", { error });
@@ -88,6 +90,8 @@ export const action = protectedAction(async ({ request, context }) => {
       }
 
       await services.attendances.delete(id);
+      await services.cacheInvalidation.invalidateAttendanceCaches(user.id);
+
       return new Response(JSON.stringify({ deletedId: id }), {
         status: 200,
         headers: { "Content-Type": "application/json" },

--- a/apps/web/app/routes/api/songs.tsx
+++ b/apps/web/app/routes/api/songs.tsx
@@ -2,6 +2,7 @@ import type { Song } from "@bip/domain";
 import { CacheKeys } from "@bip/domain/cache-keys";
 import { publicLoader } from "~/lib/base-loaders";
 import { logger } from "~/lib/logger";
+import { parsePerformanceFilters, resolveAttendedUserId } from "~/lib/performance-filter-params";
 import { SONG_FILTERS } from "~/lib/song-filters";
 import { addVenueInfoToSongs } from "~/lib/song-utilities";
 import { services } from "~/server/services";
@@ -14,119 +15,130 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
  * For "played" songs: filters to those with timesPlayed > 0 in the filtered results.
  */
 async function splitByPlayStatus(
-	filteredSongs: Song[],
-	showNotPlayed: boolean,
-	baseFilter: { authorId?: string; cover?: boolean; attendedUserId?: string },
+  filteredSongs: Song[],
+  showNotPlayed: boolean,
+  baseFilter: { authorId?: string; cover?: boolean; attendedUserId?: string },
 ): Promise<Song[]> {
-	const playedInFilter = filteredSongs.filter((song) => song.timesPlayed > 0);
+  const playedInFilter = filteredSongs.filter((song) => song.timesPlayed > 0);
 
-	if (!showNotPlayed) {
-		return playedInFilter;
-	}
+  if (!showNotPlayed) {
+    return playedInFilter;
+  }
 
-	// Get all songs matching author/cover, but without date range or attended constraint.
-	// This ensures "not played" = played overall but not in the filtered view.
-	const { attendedUserId: _, ...baseFilterWithoutAttended } = baseFilter;
-	const allSongs = await services.songs.findMany(baseFilterWithoutAttended);
-	const allSongsPlayed = allSongs.filter((song) => song.timesPlayed > 0);
+  // Get all songs matching author/cover, but without date range or attended constraint.
+  // This ensures "not played" = played overall but not in the filtered view.
+  const { attendedUserId: _, ...baseFilterWithoutAttended } = baseFilter;
+  const allSongs = await services.songs.findMany(baseFilterWithoutAttended);
+  const allSongsPlayed = allSongs.filter((song) => song.timesPlayed > 0);
 
-	// Songs NOT played in this filter = matching played songs minus filter played
-	const playedIds = new Set(playedInFilter.map((song) => song.id));
-	const notPlayed = allSongsPlayed.filter((song) => !playedIds.has(song.id));
+  // Songs NOT played in this filter = matching played songs minus filter played
+  const playedIds = new Set(playedInFilter.map((song) => song.id));
+  const notPlayed = allSongsPlayed.filter((song) => !playedIds.has(song.id));
 
-	// Sort by overall timesPlayed descending (most popular first)
-	return notPlayed.sort((a, b) => b.timesPlayed - a.timesPlayed);
+  // Sort by overall timesPlayed descending (most popular first)
+  return notPlayed.sort((a, b) => b.timesPlayed - a.timesPlayed);
 }
 
 export const loader = publicLoader(async ({ request, context }) => {
-	const url = new URL(request.url);
-	const query = url.searchParams.get("q");
-	const year = url.searchParams.get("year");
-	const era = url.searchParams.get("era");
-	const playedParam = url.searchParams.get("played");
-	const authorParam = url.searchParams.get("author");
-	const coverParam = url.searchParams.get("cover");
-	const attendedParam = url.searchParams.get("attended");
-	const showNotPlayed = playedParam === "notPlayed";
+  const url = new URL(request.url);
+  const query = url.searchParams.get("q");
+  const year = url.searchParams.get("year");
+  const era = url.searchParams.get("era");
+  const playedParam = url.searchParams.get("played");
+  const authorParam = url.searchParams.get("author");
+  const coverParam = url.searchParams.get("cover");
+  const attendedParam = url.searchParams.get("attended");
+  const filtersParam = url.searchParams.get("filters");
+  const showNotPlayed = playedParam === "notPlayed";
 
-	const coverFilter = coverParam === "cover" ? true : coverParam === "original" ? false : undefined;
+  const coverFilter = coverParam === "cover" ? true : coverParam === "original" ? false : undefined;
 
-	const authorId = authorParam ? (UUID_REGEX.test(authorParam) ? authorParam : null) : null;
-	if (authorParam && !authorId) {
-		logger.warn("Ignoring invalid author filter", { authorParam });
-	}
+  const authorId = authorParam ? (UUID_REGEX.test(authorParam) ? authorParam : null) : null;
+  if (authorParam && !authorId) {
+    logger.warn("Ignoring invalid author filter", { authorParam });
+  }
 
-	// Resolve internal user ID for attended filter
-	let attendedUserId: string | undefined;
-	if (attendedParam === "attended" && context.currentUser) {
-		const localUser = await services.users.findByEmail(context.currentUser.email);
-		if (localUser) {
-			attendedUserId = localUser.id;
-		}
-	}
+  const attendedUserId = await resolveAttendedUserId(attendedParam, context);
 
-	// Year and era both resolve to a date-range key in SONG_FILTERS (mutually exclusive)
-	const dateRangeKey = year || era;
-	const hasDateRange = dateRangeKey && dateRangeKey in SONG_FILTERS;
+  // Year and era both resolve to a date-range key in SONG_FILTERS (mutually exclusive)
+  const dateRangeKey = year || era;
+  const hasDateRange = dateRangeKey && dateRangeKey in SONG_FILTERS;
 
-	// Handle filtering by author, cover, date range, attended, or any combination
-	if (authorId || coverFilter !== undefined || hasDateRange || attendedUserId) {
-		try {
-			const cacheKey = CacheKeys.songs.filtered({
-				year: year || null,
-				era: era || null,
-				played: playedParam || null,
-				author: authorId || null,
-				cover: coverParam || null,
-				attended: attendedUserId || null,
-			});
+  const hasToggleFilters = !!filtersParam;
 
-			return await services.cache.getOrSet(
-				cacheKey,
-				async () => {
-					const filter: {
-						authorId?: string;
-						cover?: boolean;
-						startDate?: Date;
-						endDate?: Date;
-						attendedUserId?: string;
-					} = {};
-					if (authorId) filter.authorId = authorId;
-					if (coverFilter !== undefined) filter.cover = coverFilter;
-					if (attendedUserId) filter.attendedUserId = attendedUserId;
+  // Handle filtering by author, cover, date range, attended, toggle filters, or any combination
+  if (authorId || coverFilter !== undefined || hasDateRange || attendedUserId || hasToggleFilters) {
+    try {
+      const cacheKey = CacheKeys.songs.filtered({
+        year: year || null,
+        era: era || null,
+        played: playedParam || null,
+        author: authorId || null,
+        cover: coverParam || null,
+        attended: attendedUserId || null,
+        filters: filtersParam || null,
+      });
 
-					let songs: Song[];
-					if (hasDateRange) {
-						const { startDate, endDate } = SONG_FILTERS[dateRangeKey];
-						songs = await services.songs.findManyInDateRange({ startDate, endDate, ...filter });
-					} else {
-						songs = await services.songs.findMany(filter);
-					}
+      return await services.cache.getOrSet(
+        cacheKey,
+        async () => {
+          const filter: {
+            authorId?: string;
+            cover?: boolean;
+            startDate?: Date;
+            endDate?: Date;
+            attendedUserId?: string;
+          } = {};
+          if (authorId) filter.authorId = authorId;
+          if (coverFilter !== undefined) filter.cover = coverFilter;
+          if (attendedUserId) filter.attendedUserId = attendedUserId;
 
-					const filtered = await splitByPlayStatus(songs, showNotPlayed && (!!hasDateRange || !!attendedUserId), filter);
-					return addVenueInfoToSongs(filtered);
-				},
-				{ ttl: 3600 },
-			);
-		} catch (error) {
-			logger.error("Error fetching filtered songs", { error });
-			return [];
-		}
-	}
+          let songs: Song[];
+          if (hasDateRange) {
+            const { startDate, endDate } = SONG_FILTERS[dateRangeKey];
+            songs = await services.songs.findManyInDateRange({ startDate, endDate, ...filter });
+          } else {
+            songs = await services.songs.findMany(filter);
+          }
 
-	// Handle search query
-	if (!query || query.length < 2) {
-		return [];
-	}
+          // When toggle filters are active, cross-reference with performance counts
+          if (hasToggleFilters) {
+            const performanceFilters = await parsePerformanceFilters(url, context);
+            const counts = await services.songPageComposer.buildSongPerformanceCounts(performanceFilters);
 
-	logger.info(`Song search for '${query}'`);
+            songs = songs
+              .filter((song) => (counts[song.id] ?? 0) > 0)
+              .map((song) => ({ ...song, timesPlayed: counts[song.id] }));
+          }
 
-	try {
-		const songs = await services.songs.search(query, 20);
-		logger.info(`Song search for '${query}' returned ${songs.length} results`);
-		return songs;
-	} catch (error) {
-		logger.error("Song search error", { error });
-		return [];
-	}
+          const filtered = await splitByPlayStatus(
+            songs,
+            showNotPlayed && (!!hasDateRange || !!attendedUserId),
+            filter,
+          );
+          return await addVenueInfoToSongs(filtered);
+        },
+        { ttl: 3600 },
+      );
+    } catch (error) {
+      logger.error("Error fetching filtered songs", { error });
+      return [];
+    }
+  }
+
+  // Handle search query
+  if (!query || query.length < 2) {
+    return [];
+  }
+
+  logger.info(`Song search for '${query}'`);
+
+  try {
+    const songs = await services.songs.search(query, 20);
+    logger.info(`Song search for '${query}' returned ${songs.length} results`);
+    return songs;
+  } catch (error) {
+    logger.error("Song search error", { error });
+    return [];
+  }
 });

--- a/apps/web/app/routes/api/songs/performances.tsx
+++ b/apps/web/app/routes/api/songs/performances.tsx
@@ -1,0 +1,20 @@
+import { publicLoader } from "~/lib/base-loaders";
+import { buildFilteredCacheKey, parsePerformanceFilters } from "~/lib/performance-filter-params";
+import { services } from "~/server/services";
+
+export const loader = publicLoader(async ({ request, context }) => {
+  const url = new URL(request.url);
+  const slug = url.searchParams.get("slug");
+  if (!slug) {
+    return new Response(JSON.stringify({ error: "slug is required" }), { status: 400 });
+  }
+
+  const filters = await parsePerformanceFilters(url, context);
+  const cacheKey = buildFilteredCacheKey(url, `song:${slug}`, filters.attendedUserId);
+
+  return await services.cache.getOrSet(
+    cacheKey,
+    async () => services.songPageComposer.buildSongPerformances(slug, filters),
+    { ttl: 3600 },
+  );
+});

--- a/apps/web/app/routes/shows/top-rated.tsx
+++ b/apps/web/app/routes/shows/top-rated.tsx
@@ -6,11 +6,11 @@ import { DataTable } from "~/components/ui/data-table";
 import { LoginPromptPopover } from "~/components/ui/login-prompt-popover";
 import { StarRating } from "~/components/ui/star-rating";
 import { YearFilterNav } from "~/components/year-filter-nav";
+import { useAttendanceRowHighlight } from "~/hooks/use-attendance-row-highlight";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { useSession } from "~/hooks/use-session";
-import { useShowUserData } from "~/hooks/use-show-user-data";
 import { publicLoader } from "~/lib/base-loaders";
-import { ATTENDED_ROW_CLASS, cn, formatDateShort } from "~/lib/utils";
+import { cn, formatDateShort } from "~/lib/utils";
 import { getTopRatedShows, type ShowWithRank, type TopRatedShowsLoaderData } from "~/routes/shows/top-rated-shows";
 
 const MIN_SHOW_RATINGS = 10;
@@ -134,18 +134,13 @@ const createColumns = (userRatingMap: Map<string, number | null>): ColumnDef<Sho
 ];
 
 export default function TopRated() {
-  const { user } = useSession();
   const { shows = [] } = useSerializedLoaderData<TopRatedShowsLoaderData>();
   const showsWithRank: ShowWithRank[] = shows.map((show, index) => ({
     ...show,
     rank: index + 1,
   }));
 
-  // Fetch user data (ratings, attendance) for all shows
-  const showIds = useMemo(() => shows.map((show) => show.id), [shows]);
-  const { userRatingMap, attendanceMap } = useShowUserData(user ? showIds : []);
-
-  // Create columns with user rating data
+  const { userRatingMap, rowClassName } = useAttendanceRowHighlight(showsWithRank, (show) => show.id);
   const columns = useMemo(() => createColumns(userRatingMap), [userRatingMap]);
 
   return (
@@ -160,13 +155,7 @@ export default function TopRated() {
           showAllButton={true}
           additionalText={`min ${MIN_SHOW_RATINGS} ratings`}
         />
-        <DataTable
-          columns={columns}
-          data={showsWithRank}
-          hideSearch={true}
-          hidePaginationText={true}
-          rowClassName={(show) => (attendanceMap.get(show.id) ? ATTENDED_ROW_CLASS : undefined)}
-        />
+        <DataTable columns={columns} data={showsWithRank} hideSearch={true} rowClassName={rowClassName} />
       </div>
     </div>
   );

--- a/apps/web/app/routes/shows/top-rated.tsx
+++ b/apps/web/app/routes/shows/top-rated.tsx
@@ -6,8 +6,8 @@ import { DataTable } from "~/components/ui/data-table";
 import { LoginPromptPopover } from "~/components/ui/login-prompt-popover";
 import { StarRating } from "~/components/ui/star-rating";
 import { YearFilterNav } from "~/components/year-filter-nav";
-import { useSession } from "~/hooks/use-session";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
+import { useSession } from "~/hooks/use-session";
 import { useShowUserData } from "~/hooks/use-show-user-data";
 import { publicLoader } from "~/lib/base-loaders";
 import { ATTENDED_ROW_CLASS, cn, formatDateShort } from "~/lib/utils";
@@ -68,7 +68,7 @@ function RatingCell({ show, userRating }: { show: ShowWithRank; userRating?: num
         localHasRated
           ? "bg-amber-500/10 border border-amber-500/50 shadow-[0_0_8px_rgba(245,158,11,0.2)]"
           : "glass-secondary border border-dashed border-glass-border hover:border-amber-500/30",
-        isAnimating && "animate-[avg-rating-update_0.5s_ease-out]"
+        isAnimating && "animate-[avg-rating-update_0.5s_ease-out]",
       )}
     >
       {isExpanded ? (
@@ -90,21 +90,24 @@ function RatingCell({ show, userRating }: { show: ShowWithRank; userRating?: num
 const createColumns = (userRatingMap: Map<string, number | null>): ColumnDef<ShowWithRank>[] => [
   {
     accessorKey: "rank",
+    meta: { width: "25%" },
     header: "#",
     cell: ({ row }) => <span className="font-medium text-content-text-primary">{row.original.rank}</span>,
   },
   {
     accessorKey: "averageRating",
+    meta: { width: "25%" },
     header: "Rating",
     cell: ({ row }) => <RatingCell show={row.original} userRating={userRatingMap.get(row.original.id)} />,
   },
   {
     accessorKey: "date",
+    meta: { width: "25%" },
     header: "Date",
     cell: ({ row }) => (
       <Link
         to={`/shows/${row.original.slug}`}
-        className="text-brand-primary hover:text-brand-secondary hover:underline"
+        className="text-base text-brand-primary hover:text-brand-secondary hover:underline"
       >
         {formatDateShort(row.original.date)}
       </Link>
@@ -112,6 +115,7 @@ const createColumns = (userRatingMap: Map<string, number | null>): ColumnDef<Sho
   },
   {
     accessorKey: "venue.name",
+    meta: { width: "25%" },
     header: "Venue",
     cell: ({ row }) => {
       const venue = row.original.venue;
@@ -161,7 +165,7 @@ export default function TopRated() {
           data={showsWithRank}
           hideSearch={true}
           hidePaginationText={true}
-          rowClassName={(show) => attendanceMap.get(show.id) ? ATTENDED_ROW_CLASS : undefined}
+          rowClassName={(show) => (attendanceMap.get(show.id) ? ATTENDED_ROW_CLASS : undefined)}
         />
       </div>
     </div>

--- a/apps/web/app/routes/shows/top-rated/$year.tsx
+++ b/apps/web/app/routes/shows/top-rated/$year.tsx
@@ -6,8 +6,8 @@ import { DataTable } from "~/components/ui/data-table";
 import { LoginPromptPopover } from "~/components/ui/login-prompt-popover";
 import { StarRating } from "~/components/ui/star-rating";
 import { YearFilterNav } from "~/components/year-filter-nav";
-import { useSession } from "~/hooks/use-session";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
+import { useSession } from "~/hooks/use-session";
 import { useShowUserData } from "~/hooks/use-show-user-data";
 import { publicLoader } from "~/lib/base-loaders";
 import { ATTENDED_ROW_CLASS, cn, formatDateShort } from "~/lib/utils";
@@ -73,7 +73,7 @@ function RatingCell({ show, userRating }: { show: ShowWithRank; userRating?: num
         localHasRated
           ? "bg-amber-500/10 border border-amber-500/50 shadow-[0_0_8px_rgba(245,158,11,0.2)]"
           : "glass-secondary border border-dashed border-glass-border hover:border-amber-500/30",
-        isAnimating && "animate-[avg-rating-update_0.5s_ease-out]"
+        isAnimating && "animate-[avg-rating-update_0.5s_ease-out]",
       )}
     >
       {isExpanded ? (
@@ -95,21 +95,24 @@ function RatingCell({ show, userRating }: { show: ShowWithRank; userRating?: num
 const createColumns = (userRatingMap: Map<string, number | null>): ColumnDef<ShowWithRank>[] => [
   {
     accessorKey: "rank",
+    meta: { width: "25%" },
     header: "#",
     cell: ({ row }) => <span className="font-medium text-content-text-primary">{row.original.rank}</span>,
   },
   {
     accessorKey: "averageRating",
+    meta: { width: "25%" },
     header: "Rating",
     cell: ({ row }) => <RatingCell show={row.original} userRating={userRatingMap.get(row.original.id)} />,
   },
   {
     accessorKey: "date",
+    meta: { width: "25%" },
     header: "Date",
     cell: ({ row }) => (
       <Link
         to={`/shows/${row.original.slug}`}
-        className="text-brand-primary hover:text-brand-secondary hover:underline"
+        className="text-base text-brand-primary hover:text-brand-secondary hover:underline"
       >
         {formatDateShort(row.original.date)}
       </Link>
@@ -117,6 +120,7 @@ const createColumns = (userRatingMap: Map<string, number | null>): ColumnDef<Sho
   },
   {
     accessorKey: "venue.name",
+    meta: { width: "25%" },
     header: "Venue",
     cell: ({ row }) => {
       const venue = row.original.venue;
@@ -166,7 +170,7 @@ export default function TopRatedYear() {
           data={showsWithRank}
           hideSearch={true}
           hidePaginationText={true}
-          rowClassName={(show) => attendanceMap.get(show.id) ? ATTENDED_ROW_CLASS : undefined}
+          rowClassName={(show) => (attendanceMap.get(show.id) ? ATTENDED_ROW_CLASS : undefined)}
         />
       </div>
     </div>

--- a/apps/web/app/routes/shows/top-rated/$year.tsx
+++ b/apps/web/app/routes/shows/top-rated/$year.tsx
@@ -6,11 +6,11 @@ import { DataTable } from "~/components/ui/data-table";
 import { LoginPromptPopover } from "~/components/ui/login-prompt-popover";
 import { StarRating } from "~/components/ui/star-rating";
 import { YearFilterNav } from "~/components/year-filter-nav";
+import { useAttendanceRowHighlight } from "~/hooks/use-attendance-row-highlight";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { useSession } from "~/hooks/use-session";
-import { useShowUserData } from "~/hooks/use-show-user-data";
 import { publicLoader } from "~/lib/base-loaders";
-import { ATTENDED_ROW_CLASS, cn, formatDateShort } from "~/lib/utils";
+import { cn, formatDateShort } from "~/lib/utils";
 import { getTopRatedShows, type ShowWithRank, type TopRatedShowsLoaderData } from "~/routes/shows/top-rated-shows";
 
 const MIN_SHOW_RATINGS = 10;
@@ -139,18 +139,13 @@ const createColumns = (userRatingMap: Map<string, number | null>): ColumnDef<Sho
 ];
 
 export default function TopRatedYear() {
-  const { user } = useSession();
   const { shows = [], year } = useSerializedLoaderData<TopRatedShowsLoaderData>();
   const showsWithRank: ShowWithRank[] = shows.map((show, index) => ({
     ...show,
     rank: index + 1,
   }));
 
-  // Fetch user data (ratings, attendance) for all shows
-  const showIds = useMemo(() => shows.map((show) => show.id), [shows]);
-  const { userRatingMap, attendanceMap } = useShowUserData(user ? showIds : []);
-
-  // Create columns with user rating data
+  const { userRatingMap, rowClassName } = useAttendanceRowHighlight(showsWithRank, (show) => show.id);
   const columns = useMemo(() => createColumns(userRatingMap), [userRatingMap]);
 
   return (
@@ -165,13 +160,7 @@ export default function TopRatedYear() {
           showAllButton={true}
           additionalText={`min ${MIN_SHOW_RATINGS} ratings`}
         />
-        <DataTable
-          columns={columns}
-          data={showsWithRank}
-          hideSearch={true}
-          hidePaginationText={true}
-          rowClassName={(show) => (attendanceMap.get(show.id) ? ATTENDED_ROW_CLASS : undefined)}
-        />
+        <DataTable columns={columns} data={showsWithRank} hideSearch={true} rowClassName={rowClassName} />
       </div>
     </div>
   );

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -1,14 +1,16 @@
 import type { SongPageView } from "@bip/domain";
 import { ArrowLeft, BarChart3, FileTextIcon, GuitarIcon, History, Pencil, StarIcon } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import type { LoaderFunctionArgs } from "react-router";
 import { Link, useSearchParams } from "react-router-dom";
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { AdminOnly } from "~/components/admin/admin-only";
 import { PerformanceTable } from "~/components/performance";
+import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
 import { RatingComponent } from "~/components/rating";
 import { Button } from "~/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
+import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
 import { getSongMeta, getSongStructuredData } from "~/lib/seo";
@@ -98,12 +100,44 @@ export function meta({ data }: { data: SongPageView }) {
 }
 
 export default function SongPage() {
-  const { song, performances } = useSerializedLoaderData<SongPageView>();
-  const allTimers = performances.filter((p) => p.allTimer);
+  const { song, performances: allPerformances } = useSerializedLoaderData<SongPageView>();
   const [searchParams] = useSearchParams();
   const tabParam = searchParams.get("tab");
   const validTabs = ["performances", "all-timers", "stats", "history", "lyrics", "guitar-tabs"];
   const defaultTab = tabParam && validTabs.includes(tabParam) ? tabParam : "performances";
+  const {
+    filteredData: filteredPerformances,
+    isLoading,
+    selectedYear,
+    selectedEra,
+    activeToggleSet,
+    hasActiveFilters,
+    searchText,
+    setSearchText,
+    updateFilter,
+    toggleFilter,
+    clearFilters,
+  } = usePerformancePageFilters({
+    initialData: allPerformances,
+    apiUrl: "/api/songs/performances",
+    extraParams: useMemo(() => ({ slug: song.slug }), [song.slug]),
+    searchFilter: searchPerformance,
+  });
+
+  const allTimers = useMemo(() => filteredPerformances.filter((p) => p.allTimer), [filteredPerformances]);
+  const filterContent = (
+    <PerformanceFilterControls
+      selectedYear={selectedYear}
+      selectedEra={selectedEra}
+      activeToggleSet={activeToggleSet}
+      updateFilter={updateFilter}
+      toggleFilter={toggleFilter}
+      clearFilters={clearFilters}
+      searchValue={searchText}
+      onSearchChange={setSearchText}
+      hasActiveFilters={hasActiveFilters}
+    />
+  );
 
   return (
     <div className="space-y-6 md:space-y-8">
@@ -127,25 +161,23 @@ export default function SongPage() {
             </span>
           )}
         </div>
-        <AdminOnly>
-          <Button asChild variant="outline" className="btn-secondary">
-            <Link to={`/songs/${song.slug}/edit`} className="flex items-center gap-2">
-              <Pencil className="h-4 w-4" />
-              Edit
-            </Link>
-          </Button>
-        </AdminOnly>
-      </div>
-
-      {/* Subtle back link */}
-      <div className="flex justify-start">
-        <Link
-          to="/songs"
-          className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors"
-        >
-          <ArrowLeft className="h-3 w-3" />
-          <span>Back to songs</span>
-        </Link>
+        <div className="flex items-center gap-3">
+          <Link
+            to="/songs"
+            className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors"
+          >
+            <ArrowLeft className="h-3 w-3" />
+            <span>Back to songs</span>
+          </Link>
+          <AdminOnly>
+            <Button asChild variant="outline" className="btn-secondary">
+              <Link to={`/songs/${song.slug}/edit`} className="flex items-center gap-2">
+                <Pencil className="h-4 w-4" />
+                Edit
+              </Link>
+            </Button>
+          </AdminOnly>
+        </div>
       </div>
 
       {/* Stats Grid */}
@@ -388,19 +420,23 @@ export default function SongPage() {
               );
             })()}
 
-            {/* Full performance table for all all-timers */}
-            <div className="glass-content rounded-lg p-4 md:p-6">
-              <h3 className="text-lg font-semibold text-content-text-primary mb-4">All-Timer Performances</h3>
-              <PerformanceTable performances={allTimers} songTitle={song.title} />
-            </div>
+            <PerformanceTable
+              performances={allTimers}
+              songTitle={song.title}
+              isLoading={isLoading}
+              headerContent={filterContent}
+            />
           </TabsContent>
         )}
 
         <TabsContent value="performances" className="mt-6">
-          <div className="glass-content rounded-lg p-4 md:p-6">
-            <h3 className="text-lg font-semibold text-content-text-primary mb-4">All Performances</h3>
-            <PerformanceTable performances={performances} songTitle={song.title} showAllTimerColumn />
-          </div>
+          <PerformanceTable
+            performances={filteredPerformances}
+            songTitle={song.title}
+            showAllTimerColumn
+            isLoading={isLoading}
+            headerContent={filterContent}
+          />
         </TabsContent>
 
         <TabsContent value="stats" className="mt-6">

--- a/apps/web/app/routes/songs/_index.tsx
+++ b/apps/web/app/routes/songs/_index.tsx
@@ -1,18 +1,15 @@
 import type { Song, TrendingSong } from "@bip/domain";
 import { CacheKeys } from "@bip/domain/cache-keys";
 import { Flame, Plus } from "lucide-react";
-import { useEffect, useState } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { AdminOnly } from "~/components/admin/admin-only";
-import { AuthorSearch } from "~/components/author/author-search";
+import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
+import { usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
-import { useSession } from "~/hooks/use-session";
 import { publicLoader } from "~/lib/base-loaders";
 import { getSongsMeta } from "~/lib/seo";
-import { ERA_OPTIONS, YEAR_OPTIONS } from "~/lib/song-filters";
 import { addVenueInfoToSongs } from "~/lib/song-utilities";
 import { services } from "~/server/services";
 import { SongsTable } from "../../components/song/songs-table";
@@ -123,405 +120,48 @@ export function meta() {
   return getSongsMeta();
 }
 
-const selectTriggerClass =
-  "h-[42px] bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20";
-const selectContentClass = "bg-glass-bg border-glass-border backdrop-blur-md";
-const selectItemClass = "text-content-text-primary hover:bg-hover-glass";
-const labelClass =
-  "text-xs font-medium text-content-text-secondary uppercase tracking-wide mb-1.5 h-[18px] flex items-center";
-
 export default function Songs() {
-  const { songs, trendingSongs, yearlyTrendingSongs, recentShowsCount } = useSerializedLoaderData<LoaderData>();
-  const { user } = useSession();
-  const [searchParams] = useSearchParams();
-  const yearParam = searchParams.get("year");
-  const eraParam = searchParams.get("era");
-  const playedParam = searchParams.get("played");
-  const authorParam = searchParams.get("author");
-  const coverParam = searchParams.get("cover");
-  const attendedParam = searchParams.get("attended");
+  const { songs, trendingSongs, recentShowsCount } = useSerializedLoaderData<LoaderData>();
 
-  const [selectedYear, setSelectedYear] = useState<string>(yearParam || "all");
-  const [selectedEra, setSelectedEra] = useState<string>(eraParam || "all");
-  const [playedFilter, setPlayedFilter] = useState<"played" | "notPlayed">(
-    playedParam === "notPlayed" ? "notPlayed" : "played",
-  );
-  const [selectedAuthor, setSelectedAuthor] = useState<string | null>(authorParam || null);
-  const [coverFilter, setCoverFilter] = useState<"all" | "cover" | "original">(
-    coverParam === "cover" ? "cover" : coverParam === "original" ? "original" : "all",
-  );
-  const [attendedFilter, setAttendedFilter] = useState<"all" | "attended">(
-    attendedParam === "attended" ? "attended" : "all",
-  );
-  const [filteredSongs, setFilteredSongs] = useState<Song[]>(songs);
-  const [isLoadingFiltered, setIsLoadingFiltered] = useState(false);
-
-  // Auto-expand if URL has advanced filter params
-  const hasAdvancedParams = yearParam || eraParam || playedParam === "notPlayed" || attendedParam === "attended";
-  const [showMoreFilters, setShowMoreFilters] = useState(!!hasAdvancedParams);
+  const {
+    filteredData: filteredSongs,
+    isLoading,
+    selectedYear,
+    selectedEra,
+    coverFilter,
+    selectedAuthor,
+    playedFilter,
+    activeToggleSet,
+    hasActiveFilters,
+    searchText,
+    setSearchText,
+    updateFilter,
+    toggleFilter,
+    clearFilters,
+  } = usePerformancePageFilters<Song>({
+    initialData: songs,
+    apiUrl: "/api/songs",
+    searchFilter: (song, query) => song.title.toLowerCase().includes(query),
+  });
 
   const hasDateRange = selectedYear !== "all" || selectedEra !== "all";
-  const hasAnyFilter = hasDateRange || selectedAuthor || coverFilter !== "all" || attendedFilter !== "all";
+  const showPlayedFilter = hasDateRange || activeToggleSet.has("attended");
 
-  // Helper to update URL without React Router re-render
-  const updateUrl = (params: {
-    year?: string;
-    era?: string;
-    played?: "played" | "notPlayed";
-    author?: string | null;
-    cover?: "all" | "cover" | "original";
-    attended?: "all" | "attended";
-  }) => {
-    const newParams = new URLSearchParams(window.location.search);
-    if (params.year && params.year !== "all") {
-      newParams.set("year", params.year);
-    } else {
-      newParams.delete("year");
-    }
-    if (params.era && params.era !== "all") {
-      newParams.set("era", params.era);
-    } else {
-      newParams.delete("era");
-    }
-    const hasDateRangeParam = (params.year && params.year !== "all") || (params.era && params.era !== "all");
-    const hasAttendedParam = params.attended && params.attended !== "all";
-    if ((hasDateRangeParam || hasAttendedParam) && params.played === "notPlayed") {
-      newParams.set("played", "notPlayed");
-    } else {
-      newParams.delete("played");
-    }
-    if (params.author && params.author !== "none") {
-      newParams.set("author", params.author);
-    } else {
-      newParams.delete("author");
-    }
-    if (params.cover && params.cover !== "all") {
-      newParams.set("cover", params.cover);
-    } else {
-      newParams.delete("cover");
-    }
-    if (params.attended && params.attended !== "all") {
-      newParams.set("attended", params.attended);
-    } else {
-      newParams.delete("attended");
-    }
-    const newUrl = newParams.toString()
-      ? `${window.location.pathname}?${newParams.toString()}`
-      : window.location.pathname;
-    window.history.replaceState({}, "", newUrl);
-  };
-
-  // Fetch filtered songs when any filter changes
-  useEffect(() => {
-    if (
-      selectedYear === "all" &&
-      selectedEra === "all" &&
-      !selectedAuthor &&
-      coverFilter === "all" &&
-      attendedFilter === "all"
-    ) {
-      setFilteredSongs(songs);
-      setIsLoadingFiltered(false);
-      return undefined;
-    }
-
-    const controller = new AbortController();
-
-    // Only show loading if fetch takes more than 200ms to prevent flickering
-    const loadingTimeout = setTimeout(() => {
-      setIsLoadingFiltered(true);
-    }, 200);
-
-    const params = new URLSearchParams();
-    if (selectedYear !== "all") {
-      params.set("year", selectedYear);
-    }
-    if (selectedEra !== "all") {
-      params.set("era", selectedEra);
-    }
-    if ((selectedYear !== "all" || selectedEra !== "all" || attendedFilter !== "all") && playedFilter === "notPlayed") {
-      params.set("played", "notPlayed");
-    }
-    if (selectedAuthor && selectedAuthor !== "none") {
-      params.set("author", selectedAuthor);
-    }
-    if (coverFilter !== "all") {
-      params.set("cover", coverFilter);
-    }
-    if (attendedFilter !== "all") {
-      params.set("attended", attendedFilter);
-    }
-
-    fetch(`/api/songs?${params.toString()}`, { signal: controller.signal })
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error(`HTTP error! status: ${res.status}`);
-        }
-        return res.json();
-      })
-      .then((data: Song[]) => {
-        clearTimeout(loadingTimeout);
-        setIsLoadingFiltered(false);
-        setFilteredSongs(data);
-      })
-      .catch((error) => {
-        if (error.name === "AbortError") {
-          return;
-        }
-        clearTimeout(loadingTimeout);
-        setIsLoadingFiltered(false);
-        setFilteredSongs([]);
-      });
-
-    return () => {
-      controller.abort();
-      clearTimeout(loadingTimeout);
-    };
-  }, [selectedYear, selectedEra, playedFilter, selectedAuthor, coverFilter, attendedFilter, songs]);
-
-  const filterPanel = (
-    <>
-      <div className="flex flex-col">
-        <label htmlFor="author-search" className={labelClass}>
-          Author
-        </label>
-        <AuthorSearch
-          value={selectedAuthor}
-          onValueChange={(value) => {
-            const newAuthor = value === "none" ? null : value;
-            setSelectedAuthor(newAuthor);
-            updateUrl({
-              year: selectedYear,
-              era: selectedEra,
-              played: playedFilter,
-              author: newAuthor,
-              cover: coverFilter,
-              attended: attendedFilter,
-            });
-          }}
-          placeholder="All Authors"
-          className="w-[150px] sm:w-[200px] h-[42px]"
-        />
-      </div>
-      <div className="flex flex-col">
-        <label htmlFor="cover-filter" className={labelClass}>
-          Original / Cover
-        </label>
-        <Select
-          value={coverFilter}
-          onValueChange={(value) => {
-            const newCoverFilter = value as "all" | "cover" | "original";
-            setCoverFilter(newCoverFilter);
-            updateUrl({
-              year: selectedYear,
-              era: selectedEra,
-              played: playedFilter,
-              author: selectedAuthor,
-              cover: newCoverFilter,
-              attended: attendedFilter,
-            });
-          }}
-        >
-          <SelectTrigger id="cover-filter" className={`w-[120px] ${selectTriggerClass}`}>
-            <SelectValue placeholder="Type" />
-          </SelectTrigger>
-          <SelectContent className={selectContentClass}>
-            <SelectItem value="all" className={selectItemClass}>
-              All
-            </SelectItem>
-            <SelectItem value="original" className={selectItemClass}>
-              Original
-            </SelectItem>
-            <SelectItem value="cover" className={selectItemClass}>
-              Cover
-            </SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="flex flex-col">
-        <div className="h-[18px] mb-1.5" />
-        <button
-          type="button"
-          onClick={() => setShowMoreFilters((v) => !v)}
-          className="text-sm text-brand-primary hover:text-brand-secondary h-[42px] flex items-center whitespace-nowrap transition-colors"
-        >
-          {showMoreFilters ? "Hide More Filters" : "Show More Filters"}
-        </button>
-      </div>
-    </>
-  );
-
-  const secondaryFilterPanel = (
-    <div
-      className={`overflow-hidden transition-all duration-300 ${
-        showMoreFilters ? "max-h-[200px] opacity-100" : "max-h-0 opacity-0 pointer-events-none"
-      }`}
-    >
-      <div className="flex items-end flex-wrap gap-x-4 gap-y-3">
-        <div className="flex flex-col">
-          <label htmlFor="year-filter" className={labelClass}>
-            Year
-          </label>
-          <Select
-            value={selectedYear}
-            onValueChange={(value) => {
-              const newYear = value;
-              setSelectedYear(newYear);
-              if (newYear !== "all") {
-                setSelectedEra("all");
-              }
-              updateUrl({
-                year: newYear,
-                era: newYear !== "all" ? "all" : selectedEra,
-                played: playedFilter,
-                author: selectedAuthor,
-                cover: coverFilter,
-                attended: attendedFilter,
-              });
-            }}
-          >
-            <SelectTrigger id="year-filter" className={`w-[130px] ${selectTriggerClass}`}>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent className={selectContentClass}>
-              <SelectItem value="all" className={selectItemClass}>
-                All Years
-              </SelectItem>
-              {YEAR_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value} className={selectItemClass}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="flex flex-col">
-          <label htmlFor="era-filter" className={labelClass}>
-            Era
-          </label>
-          <Select
-            value={selectedEra}
-            onValueChange={(value) => {
-              const newEra = value;
-              setSelectedEra(newEra);
-              if (newEra !== "all") {
-                setSelectedYear("all");
-              }
-              updateUrl({
-                year: newEra !== "all" ? "all" : selectedYear,
-                era: newEra,
-                played: playedFilter,
-                author: selectedAuthor,
-                cover: coverFilter,
-                attended: attendedFilter,
-              });
-            }}
-          >
-            <SelectTrigger id="era-filter" className={`w-[170px] ${selectTriggerClass}`}>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent className={selectContentClass}>
-              <SelectItem value="all" className={selectItemClass}>
-                All Eras
-              </SelectItem>
-              {ERA_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value} className={selectItemClass}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        {user && (
-          <div className="flex flex-col">
-            <label htmlFor="attended-filter" className={labelClass}>
-              Attendance
-            </label>
-            <Select
-              value={attendedFilter}
-              onValueChange={(value) => {
-                const newAttendedFilter = value as "all" | "attended";
-                setAttendedFilter(newAttendedFilter);
-                updateUrl({
-                  year: selectedYear,
-                  era: selectedEra,
-                  played: playedFilter,
-                  author: selectedAuthor,
-                  cover: coverFilter,
-                  attended: newAttendedFilter,
-                });
-              }}
-            >
-              <SelectTrigger id="attended-filter" className={`w-[130px] ${selectTriggerClass}`}>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent className={selectContentClass}>
-                <SelectItem value="all" className={selectItemClass}>
-                  All Shows
-                </SelectItem>
-                <SelectItem value="attended" className={selectItemClass}>
-                  Attended
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-        )}
-        {(hasDateRange || attendedFilter !== "all") && (
-          <div className="flex flex-col">
-            <label htmlFor="played-filter" className={labelClass}>
-              Played
-            </label>
-            <Select
-              value={playedFilter}
-              onValueChange={(value) => {
-                const newPlayedFilter = value as "played" | "notPlayed";
-                setPlayedFilter(newPlayedFilter);
-                updateUrl({
-                  year: selectedYear,
-                  era: selectedEra,
-                  played: newPlayedFilter,
-                  author: selectedAuthor,
-                  cover: coverFilter,
-                  attended: attendedFilter,
-                });
-              }}
-            >
-              <SelectTrigger id="played-filter" className={`w-[150px] ${selectTriggerClass}`}>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent className={selectContentClass}>
-                <SelectItem value="played" className={selectItemClass}>
-                  Played
-                </SelectItem>
-                <SelectItem value="notPlayed" className={selectItemClass}>
-                  Not Played
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-        )}
-        {hasAnyFilter && (
-          <div className="flex flex-col">
-            <div className="h-[18px] mb-1.5" />
-            <button
-              type="button"
-              onClick={() => {
-                setSelectedYear("all");
-                setSelectedEra("all");
-                setPlayedFilter("played");
-                setSelectedAuthor(null);
-                setCoverFilter("all");
-                setAttendedFilter("all");
-                updateUrl({ year: "all", era: "all", played: "played", author: null, cover: "all", attended: "all" });
-              }}
-              className="text-sm text-content-text-tertiary hover:text-content-text-secondary underline h-[42px] flex items-center"
-            >
-              Clear
-            </button>
-          </div>
-        )}
-      </div>
-    </div>
+  const filterControls = (
+    <PerformanceFilterControls
+      selectedYear={selectedYear}
+      selectedEra={selectedEra}
+      activeToggleSet={activeToggleSet}
+      updateFilter={updateFilter}
+      toggleFilter={toggleFilter}
+      clearFilters={clearFilters}
+      coverFilter={coverFilter}
+      selectedAuthor={selectedAuthor}
+      playedFilter={showPlayedFilter ? playedFilter : undefined}
+      searchValue={searchText}
+      onSearchChange={setSearchText}
+      hasActiveFilters={hasActiveFilters}
+    />
   );
 
   return (
@@ -561,10 +201,12 @@ export default function Songs() {
               </div>
             )}
           </div>
-          <div className="lg:col-span-1">{yearlyTrendingSongs.length > 0 && <YearlyTrendingSongs />}</div>
+          <div className="lg:col-span-1">
+            <YearlyTrendingSongs />
+          </div>
         </div>
 
-        <SongsTable songs={filteredSongs} filterComponent={filterPanel} secondaryFilterComponent={secondaryFilterPanel} isLoading={isLoadingFiltered} />
+        <SongsTable songs={filteredSongs} filterComponent={filterControls} isLoading={isLoading} />
       </div>
     </div>
   );

--- a/apps/web/app/routes/songs/all-timers.tsx
+++ b/apps/web/app/routes/songs/all-timers.tsx
@@ -2,6 +2,8 @@ import { type AllTimersPageView, CacheKeys } from "@bip/domain";
 import { ArrowLeft, Flame } from "lucide-react";
 import { Link } from "react-router-dom";
 import { PerformanceTable } from "~/components/performance";
+import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
+import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
 import { services } from "~/server/services";
@@ -18,18 +20,34 @@ export function meta() {
 }
 
 export default function AllTimersPage() {
-  const { performances } = useSerializedLoaderData<AllTimersPageView>();
+  const { performances: allPerformances } = useSerializedLoaderData<AllTimersPageView>();
+  const {
+    filteredData: filteredPerformances,
+    isLoading,
+    selectedYear,
+    selectedEra,
+    coverFilter,
+    selectedAuthor,
+    activeToggleSet,
+    hasActiveFilters,
+    searchText,
+    setSearchText,
+    updateFilter,
+    toggleFilter,
+    clearFilters,
+  } = usePerformancePageFilters({
+    initialData: allPerformances,
+    apiUrl: "/api/all-timers",
+    searchFilter: searchPerformance,
+  });
 
   return (
-    <div className="space-y-6 md:space-y-8">
+    <div className="space-y-4">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <Flame className="h-6 w-6 text-orange-500" />
           <h1 className="text-3xl md:text-4xl font-bold text-content-text-primary">All-Timers</h1>
         </div>
-      </div>
-
-      <div className="flex justify-start">
         <Link
           to="/songs"
           className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors"
@@ -39,9 +57,27 @@ export default function AllTimersPage() {
         </Link>
       </div>
 
-      <div className="glass-content rounded-lg p-4 md:p-6">
-        <PerformanceTable performances={performances} showSongColumn />
-      </div>
+      <PerformanceTable
+        performances={filteredPerformances}
+        isLoading={isLoading}
+        showSongColumn
+        headerContent={
+          <PerformanceFilterControls
+            selectedYear={selectedYear}
+            selectedEra={selectedEra}
+            activeToggleSet={activeToggleSet}
+            updateFilter={updateFilter}
+            toggleFilter={toggleFilter}
+            clearFilters={clearFilters}
+            coverFilter={coverFilter}
+            selectedAuthor={selectedAuthor}
+            showAllTimerToggle={false}
+            searchValue={searchText}
+            onSearchChange={setSearchText}
+            hasActiveFilters={hasActiveFilters}
+          />
+        }
+      />
     </div>
   );
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,8 @@
     "start:inspect": "node --inspect --expose-gc ./node_modules/.bin/react-router-serve ./build/server/index.js --port 8080",
     "gen-root": "bun scripts/gen-root.ts",
     "typecheck": "react-router typegen && bun run gen-root && tsc",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
     "lint": "biome lint",
     "format": "biome format . --write"
   },
@@ -60,13 +62,20 @@
     "@react-router/dev": "^7.11.0",
     "@react-router/fs-routes": "^7.11.0",
     "@tailwindcss/postcss": "^4.1.18",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jsdom": "^28.0.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
+    "jsdom": "^29.0.1",
     "postcss-cli": "^11.0.1",
     "shadcn": "^3.6.2",
     "tailwindcss": "^4.1.18",
     "vite": "^7.3.0",
-    "vite-tsconfig-paths": "^6.0.3"
+    "vite-tsconfig-paths": "^6.0.3",
+    "vitest": "^4.1.2"
   }
 }

--- a/apps/web/test/setup.ts
+++ b/apps/web/test/setup.ts
@@ -1,0 +1,9 @@
+import "@testing-library/jest-dom/vitest";
+
+// Polyfills for Radix UI components that use pointer/scroll APIs unavailable in jsdom.
+if (typeof Element.prototype.hasPointerCapture !== "function") {
+  Element.prototype.hasPointerCapture = () => false;
+}
+if (typeof Element.prototype.scrollIntoView !== "function") {
+  Element.prototype.scrollIntoView = () => {};
+}

--- a/apps/web/test/test-utils.tsx
+++ b/apps/web/test/test-utils.tsx
@@ -1,0 +1,154 @@
+import { render, screen, within } from "@testing-library/react";
+import { type Options, userEvent } from "@testing-library/user-event";
+import { expect } from "vitest";
+import type { ReactElement } from "react";
+import { MemoryRouter } from "react-router-dom";
+
+type voidFunc = () => void;
+
+/**
+ * Renders a component and returns both the RTL render result and a configured
+ * `userEvent` instance — bundled together so every test can kick off with one
+ * line instead of wiring up `userEvent.setup()` + `render()` separately.
+ *
+ * Use this for every component test that doesn't need router context. If the
+ * component renders a react-router `<Link>`, `<NavLink>`, or uses router hooks,
+ * use `setupWithRouter` instead.
+ *
+ * @example
+ *   const { user } = await setup(<MyButton onClick={handler} />);
+ *   await user.click(screen.getByRole("button"));
+ */
+export const setup = async (ui: ReactElement, options?: Options) => ({
+  user: await userEvent.setup(options),
+  ...render(ui),
+});
+
+/**
+ * Same as `setup`, but wraps the UI in a `MemoryRouter` so react-router
+ * components (`<Link>`, `<NavLink>`, `useNavigate`, etc.) render without errors.
+ *
+ * Use this whenever the component under test contains anything from
+ * `react-router-dom`. If you forget the router wrapper, tests fail with
+ * confusing "You cannot render a <Link> outside a <Router>" errors.
+ *
+ * @example
+ *   const { user } = await setupWithRouter(<SongCard song={song} />);
+ */
+export const setupWithRouter = async (ui: ReactElement, options?: Options) => ({
+  user: await userEvent.setup(options),
+  ...render(<MemoryRouter>{ui}</MemoryRouter>),
+});
+
+/**
+ * Returns a stub component (plain `<div>`) that captures the props it was
+ * called with. Use this inside `vi.mock()` to replace a child component that
+ * would otherwise be rendered in full during a parent's test.
+ *
+ * Use when: the component under test renders a stateful / network-heavy child
+ * (e.g. `TrackRatingCell`, `StarRating`) and you want to assert "the right
+ * props were passed to it" without actually exercising the child's internals.
+ * This keeps parent tests focused on the parent's own behavior and avoids
+ * cascading failures when an unrelated child has a bug.
+ *
+ * Function props are invoked once during the stub's creation so that
+ * `expectMockedShallowComponent` can verify they were passed (via `toHaveBeenCalledTimes(1)`).
+ *
+ * @example
+ *   vi.mock("./track-rating-cell", () => ({
+ *     TrackRatingCell: (props: object) => mockShallowComponent("TrackRatingCell", props),
+ *   }));
+ *   // later in the test:
+ *   expectMockedShallowComponent("TrackRatingCell", { trackId: "abc", ... });
+ */
+export const mockShallowComponent = (mockComponentName: string, props: object) => {
+  const propsRecord = props as Record<string, unknown>;
+  // If a function was passed as a prop, there is no easy way to print out its value in the prop
+  // as a string. Instead we call these passed functions once so that it can be verified that they
+  // were passed as a prop.
+  Object.keys(propsRecord).forEach((key) => {
+    if (typeof propsRecord[key] === "function") {
+      const func = propsRecord[key] as voidFunc;
+      func();
+    }
+  });
+  return <div data-testid={`${mockComponentName}`}>props: {JSON.stringify(props, Object.keys(props).sort())}</div>;
+};
+
+/**
+ * Asserts that exactly one stubbed child (created via `mockShallowComponent`)
+ * is in the document AND was rendered with the expected props.
+ *
+ * Use this when the parent renders the stubbed child exactly once. If the
+ * parent renders the stub multiple times (e.g. one per row), use
+ * `expectAllMockedShallowComponent` instead.
+ *
+ * Pass any `vi.fn()` mocks that should have been props in the `functions`
+ * array — this verifies each was "called once" (by `mockShallowComponent`
+ * during stub creation), confirming it was actually passed as a prop.
+ *
+ * @example
+ *   const onSelect = vi.fn();
+ *   // ...render parent with <MyChild onSelect={onSelect} label="Hello" />
+ *   expectMockedShallowComponent("MyChild", { onSelect, label: "Hello" }, [onSelect]);
+ */
+export const expectMockedShallowComponent = (mockComponentName: string, props: object, functions: voidFunc[] = []) => {
+  const component = screen.getByTestId(mockComponentName);
+  expect(component).toBeInTheDocument();
+  expect(within(component).getByText(`props: ${JSON.stringify(props, Object.keys(props).sort())}`)).toBeInTheDocument();
+  // Verify that each function that should have been a prop was "called" one time by
+  // mockShallowComponent
+  functions.forEach((func) => {
+    expect(func).toHaveBeenCalledTimes(1);
+  });
+};
+
+/**
+ * Asserts that the stubbed child was rendered N times with the expected props
+ * per instance (positional — first rendered instance matches `props[0]`, etc.).
+ *
+ * Use this for list/table rows where the parent renders the same child
+ * component once per data row. For example, asserting `<TrackRatingCell>`
+ * received the right props for each performance in `<PerformanceTable>`.
+ *
+ * `functions` array is checked with `toHaveBeenCalledTimes(props.length)` —
+ * each function prop should have been invoked once per rendered stub.
+ *
+ * @example
+ *   expectAllMockedShallowComponent("TrackRatingCell", [
+ *     { trackId: "1", rating: 5, ... },
+ *     { trackId: "2", rating: 4, ... },
+ *     { trackId: "3", rating: 3, ... },
+ *   ]);
+ */
+export const expectAllMockedShallowComponent = (
+  mockComponentName: string,
+  props: object[],
+  functions: voidFunc[] = [],
+) => {
+  const components = screen.getAllByTestId(mockComponentName);
+  expect(components).toHaveLength(props.length);
+  for (let i = 0; i < props.length; i++) {
+    expect(
+      within(components[i]).getByText(`props: ${JSON.stringify(props[i], Object.keys(props[i]).sort())}`),
+    ).toBeInTheDocument();
+  }
+  // Verify that each function that should have been a prop was "called" one time by
+  // mockShallowComponent. In this case, each time should be the number of components that we are
+  // looking for
+  functions.forEach((func) => {
+    expect(func).toHaveBeenCalledTimes(props.length);
+  });
+};
+
+/**
+ * Asserts that a stubbed child is NOT rendered. Use this to verify conditional
+ * rendering — e.g., "when `showRating={false}`, the rating cell stub is absent."
+ *
+ * @example
+ *   expectMockedShallowComponentNotInDocument("TrackRatingCell");
+ */
+export const expectMockedShallowComponentNotInDocument = (mockComponentName: string) => {
+  const component = screen.queryByTestId(mockComponentName);
+  expect(component).not.toBeInTheDocument();
+};

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -18,6 +18,7 @@
     "paths": {
       "~/*": ["./app/*"],
       "@/*": ["./app/*"],
+      "@test/*": ["./test/*"],
       "@/components/*": ["app/components/*"],
       "@/lib/*": ["app/lib/*"],
       "@/ui/*": ["app/components/ui/*"],

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,13 @@
+import react from "@vitejs/plugin-react";
+import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react(), tsconfigPaths()],
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["./test/setup.ts"],
+    include: ["app/**/*.test.{ts,tsx}"],
+  },
+});

--- a/biome.json
+++ b/biome.json
@@ -27,6 +27,13 @@
       }
     }
   },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",

--- a/bun.lock
+++ b/bun.lock
@@ -82,14 +82,21 @@
         "@react-router/dev": "^7.11.0",
         "@react-router/fs-routes": "^7.11.0",
         "@tailwindcss/postcss": "^4.1.18",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jsdom": "^28.0.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.2",
+        "jsdom": "^29.0.1",
         "postcss-cli": "^11.0.1",
         "shadcn": "^3.6.2",
         "tailwindcss": "^4.1.18",
         "vite": "^7.3.0",
         "vite-tsconfig-paths": "^6.0.3",
+        "vitest": "^4.1.2",
       },
     },
     "packages/core": {
@@ -115,6 +122,7 @@
         "tsup": "^8.5.1",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
+        "vitest": "^4.1.2",
       },
     },
     "packages/domain": {
@@ -132,11 +140,19 @@
     "detect-libc": "^2.0.4",
   },
   "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
     "@antfu/ni": ["@antfu/ni@25.0.0", "", { "dependencies": { "ansis": "^4.0.0", "fzf": "^0.5.2", "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" }, "bin": { "na": "bin/na.mjs", "ni": "bin/ni.mjs", "nr": "bin/nr.mjs", "nci": "bin/nci.mjs", "nlx": "bin/nlx.mjs", "nun": "bin/nun.mjs", "nup": "bin/nup.mjs" } }, "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.8", "", { "dependencies": { "@csstools/css-calc": "^3.1.1", "@csstools/css-color-parser": "^4.0.2", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-OISPR9c2uPo23rUdvfEQiLPjoMLOpEeLNnP5iGkxr6tDDxJd3NjD+6fxY0mdaMbIPUjFGL4HFOJqLvow5q4aqQ=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.0.8", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-erMO6FgtM02dC24NGm0xufMzWz5OF0wXKR7BpvGD973bq/GbmR8/DbxNZbj0YevQ5hlToJaWSVK/G9/NDgGEVw=="],
+
+    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
@@ -192,6 +208,8 @@
 
     "@babel/preset-typescript": ["@babel/preset-typescript@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ=="],
 
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
     "@babel/template": ["@babel/template@7.27.2", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/parser": "^7.27.2", "@babel/types": "^7.27.1" } }, "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw=="],
 
     "@babel/traverse": ["@babel/traverse@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "debug": "^4.3.1" } }, "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ=="],
@@ -222,6 +240,8 @@
 
     "@bip/web": ["@bip/web@workspace:apps/web"],
 
+    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
     "@bundled-es-modules/cookie": ["@bundled-es-modules/cookie@2.0.1", "", { "dependencies": { "cookie": "^0.7.2" } }, "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw=="],
 
     "@bundled-es-modules/statuses": ["@bundled-es-modules/statuses@1.0.1", "", { "dependencies": { "statuses": "^2.0.1" } }, "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg=="],
@@ -239,6 +259,18 @@
     "@colors/colors": ["@colors/colors@1.6.0", "", {}, "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.1.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.0.2", "", { "dependencies": { "@csstools/color-helpers": "^6.0.2", "@csstools/css-calc": "^3.1.1" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.2", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
     "@dabh/diagnostics": ["@dabh/diagnostics@2.0.8", "", { "dependencies": { "@so-ric/colorspace": "^1.1.6", "enabled": "2.0.x", "kuler": "^2.0.0" } }, "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q=="],
 
@@ -315,6 +347,8 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.6.9", "", { "dependencies": { "@floating-ui/utils": "^0.2.9" } }, "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw=="],
 
@@ -604,7 +638,7 @@
 
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
-    "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
@@ -688,6 +722,14 @@
 
     "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
     "@tsconfig/node10": ["@tsconfig/node10@1.0.11", "", {}, "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw=="],
@@ -697,6 +739,8 @@
     "@tsconfig/node14": ["@tsconfig/node14@1.0.3", "", {}, "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="],
 
     "@tsconfig/node16": ["@tsconfig/node16@1.0.4", "", {}, "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/aws-lambda": ["@types/aws-lambda@8.10.152", "", {}, "sha512-soT/c2gYBnT5ygwiHPmd9a1bftj462NWVk2tKCc1PYHSIacB2UwbTS2zYG4jzag1mRDuzg/OjtxQjQ2NKRB6Rw=="],
 
@@ -709,6 +753,8 @@
     "@types/babel__traverse": ["@types/babel__traverse@7.20.6", "", { "dependencies": { "@babel/types": "^7.20.7" } }, "sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg=="],
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
@@ -734,6 +780,8 @@
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
@@ -745,6 +793,8 @@
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
     "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
+
+    "@types/jsdom": ["@types/jsdom@28.0.1", "", { "dependencies": { "@types/node": "*", "@types/tough-cookie": "*", "parse5": "^7.0.0", "undici-types": "^7.21.0" } }, "sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
@@ -786,6 +836,20 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.1.2", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.53", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.3", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.3", "@vitest/utils": "4.1.3", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.3", "", { "dependencies": { "@vitest/spy": "4.1.3", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.3", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.3", "", { "dependencies": { "@vitest/utils": "4.1.3", "pathe": "^2.0.3" } }, "sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.3", "", { "dependencies": { "@vitest/pretty-format": "4.1.3", "@vitest/utils": "4.1.3", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.3", "", {}, "sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.3", "", { "dependencies": { "@vitest/pretty-format": "4.1.3", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw=="],
+
     "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "acorn": ["acorn@8.14.1", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="],
@@ -800,9 +864,9 @@
 
     "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
-    "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
 
@@ -816,7 +880,11 @@
 
     "aria-hidden": ["aria-hidden@1.2.4", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A=="],
 
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
     "array-flatten": ["array-flatten@1.1.1", "", {}, "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
@@ -833,6 +901,8 @@
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.11", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ=="],
 
     "basic-auth": ["basic-auth@2.0.1", "", { "dependencies": { "safe-buffer": "5.1.2" } }, "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg=="],
+
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "bin-links": ["bin-links@6.0.0", "", { "dependencies": { "cmd-shim": "^8.0.0", "npm-normalize-package-bin": "^5.0.0", "proc-log": "^6.0.0", "read-cmd-shim": "^6.0.0", "write-file-atomic": "^7.0.0" } }, "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w=="],
 
@@ -867,6 +937,8 @@
     "caniuse-lite": ["caniuse-lite@1.0.30001761", "", {}, "sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@5.4.1", "", {}, "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="],
 
@@ -944,6 +1016,10 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
@@ -972,11 +1048,15 @@
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
+    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
+
     "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
 
     "date-fns-jalali": ["date-fns-jalali@4.1.0-0", "", {}, "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg=="],
 
     "debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
@@ -1015,6 +1095,8 @@
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "dotenv": ["dotenv@17.2.3", "", {}, "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="],
 
@@ -1070,6 +1152,8 @@
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
     "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
@@ -1081,6 +1165,8 @@
     "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
 
     "exit-hook": ["exit-hook@2.2.1", "", {}, "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "express": ["express@4.21.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "1.20.3", "content-disposition": "0.5.4", "content-type": "~1.0.4", "cookie": "0.7.1", "cookie-signature": "1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "1.3.1", "fresh": "0.5.2", "http-errors": "2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "0.1.12", "proxy-addr": "~2.0.7", "qs": "6.13.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "0.19.0", "serve-static": "1.16.2", "setprototypeof": "1.2.0", "statuses": "2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA=="],
 
@@ -1200,6 +1286,8 @@
 
     "hono": ["hono@4.10.6", "", {}, "sha512-BIdolzGpDO9MQ4nu3AUuDwHZZ+KViNm+EZ75Ae55eMXMqLVhDFqEMXxtUe9Qh8hjL+pIna/frs2j6Y2yD5Ua/g=="],
 
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
@@ -1223,6 +1311,8 @@
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -1266,6 +1356,8 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-property": ["is-property@1.0.2", "", {}, "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="],
@@ -1293,6 +1385,8 @@
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
+
+    "jsdom": ["jsdom@29.0.2", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.5", "@asamuzakjp/dom-selector": "^7.0.6", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w=="],
 
     "jsesc": ["jsesc@3.0.2", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="],
 
@@ -1352,11 +1446,13 @@
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
-    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+    "lru-cache": ["lru-cache@11.3.2", "", {}, "sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ=="],
 
     "lru.min": ["lru.min@1.1.3", "", {}, "sha512-Lkk/vx6ak3rYkRR0Nhu4lFUT2VDnQSxBe8Hbl7f36358p6ow8Bnvr8lrLt98H8J1aGxfhbX4Fs5tYg2+FTwr5Q=="],
 
     "lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -1395,6 +1491,8 @@
     "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
     "media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
 
@@ -1474,6 +1572,8 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
     "minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
@@ -1527,6 +1627,8 @@
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
     "object-treeify": ["object-treeify@1.1.33", "", {}, "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A=="],
+
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
@@ -1630,6 +1732,8 @@
 
     "prettier": ["prettier@3.6.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
 
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
     "pretty-hrtime": ["pretty-hrtime@1.0.3", "", {}, "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A=="],
 
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
@@ -1704,6 +1808,8 @@
 
     "recharts": ["recharts@3.6.0", "", { "dependencies": { "@reduxjs/toolkit": "1.x.x || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-L5bjxvQRAe26RlToBAziKUB7whaGKEwD3znoM6fz3DrTowCIC/FnJYnuq1GEzB8Zv2kdTfaxQfi5GoH0tBinyg=="],
 
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
     "redis": ["redis@5.10.0", "", { "dependencies": { "@redis/bloom": "5.10.0", "@redis/client": "5.10.0", "@redis/json": "5.10.0", "@redis/search": "5.10.0", "@redis/time-series": "5.10.0" } }, "sha512-0/Y+7IEiTgVGPrLFKy8oAEArSyEJkU0zvgV5xyi9NzNQ+SLZmyFbUsWIbgPcd4UdUh00opXGKlXJwMmsis5Byw=="],
 
     "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
@@ -1758,6 +1864,8 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
@@ -1786,6 +1894,8 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
@@ -1808,11 +1918,13 @@
 
     "stack-trace": ["stack-trace@0.0.10", "", {}, "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
     "stacktrace-parser": ["stacktrace-parser@0.1.11", "", { "dependencies": { "type-fest": "^0.7.1" } }, "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg=="],
 
     "statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
 
-    "std-env": ["std-env@3.9.0", "", {}, "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw=="],
+    "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
 
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
 
@@ -1836,6 +1948,8 @@
 
     "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
 
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
     "style-to-js": ["style-to-js@1.1.16", "", { "dependencies": { "style-to-object": "1.0.8" } }, "sha512-/Q6ld50hKYPH3d/r6nr117TZkHR0w0kGGIVfpG9N6D8NymRPM9RqCUv4pRpJ62E5DqOYx2AFpbZMyCPnjQCnOw=="],
 
     "style-to-object": ["style-to-object@1.0.8", "", { "dependencies": { "inline-style-parser": "0.2.4" } }, "sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g=="],
@@ -1845,6 +1959,8 @@
     "supabase": ["supabase@2.70.4", "", { "dependencies": { "bin-links": "^6.0.0", "https-proxy-agent": "^7.0.2", "node-fetch": "^3.3.2", "tar": "7.5.2" }, "bin": { "supabase": "bin/supabase" } }, "sha512-6Z5d0Snq5dxjL2K6XY89fPd9PNUJi83p7UpwlurPeSOHYhJfX9DbhzLhBGygrGigLST3M97ITgp4sFDXPd77Iw=="],
 
     "svix": ["svix@1.76.1", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "@types/node": "^22.7.5", "es6-promise": "^4.2.8", "fast-sha256": "^1.3.0", "url-parse": "^1.5.10", "uuid": "^10.0.0" } }, "sha512-CRuDWBTgYfDnBLRaZdKp9VuoPcNUq9An14c/k+4YJ15Qc5Grvf66vp0jvTltd4t7OIRj+8lM1DAgvSgvf7hdLw=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "tailwind-merge": ["tailwind-merge@3.4.0", "", {}, "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g=="],
 
@@ -1864,15 +1980,25 @@
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
     "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
+
+    "tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
-    "tough-cookie": ["tough-cookie@4.1.4", "", { "dependencies": { "psl": "^1.1.33", "punycode": "^2.1.1", "universalify": "^0.2.0", "url-parse": "^1.5.3" } }, "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag=="],
+    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
@@ -1906,7 +2032,9 @@
 
     "ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
 
-    "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
+    "undici": ["undici@7.24.7", "", {}, "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ=="],
+
+    "undici-types": ["undici-types@7.24.7", "", {}, "sha512-XA+gOBkzYD3C74sZowtCLTpgtaCdqZhqCvR6y9LXvrKTt/IVU6bz49T4D+BPi475scshCCkb0IklJRw6T1ZlgQ=="],
 
     "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
 
@@ -1962,11 +2090,23 @@
 
     "vite-tsconfig-paths": ["vite-tsconfig-paths@6.0.3", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" }, "optionalPeers": ["vite"] }, "sha512-7bL7FPX/DSviaZGYUKowWF1AiDVWjMjxNbE8lyaVGDezkedWqfGhlnQ4BZXre0ZN5P4kAgIJfAlgFDVyjrCIyg=="],
 
+    "vitest": ["vitest@4.1.3", "", { "dependencies": { "@vitest/expect": "4.1.3", "@vitest/mocker": "4.1.3", "@vitest/pretty-format": "4.1.3", "@vitest/runner": "4.1.3", "@vitest/snapshot": "4.1.3", "@vitest/spy": "4.1.3", "@vitest/utils": "4.1.3", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.3", "@vitest/browser-preview": "4.1.3", "@vitest/browser-webdriverio": "4.1.3", "@vitest/coverage-istanbul": "4.1.3", "@vitest/coverage-v8": "4.1.3", "@vitest/ui": "4.1.3", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+
     "which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "winston": ["winston@3.19.0", "", { "dependencies": { "@colors/colors": "^1.6.0", "@dabh/diagnostics": "^2.0.8", "async": "^3.2.3", "is-stream": "^2.0.0", "logform": "^2.7.0", "one-time": "^1.0.0", "readable-stream": "^3.4.0", "safe-stable-stringify": "^2.3.1", "stack-trace": "0.0.x", "triple-beam": "^1.3.0", "winston-transport": "^4.9.0" } }, "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA=="],
 
@@ -1983,6 +2123,10 @@
     "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "wsl-utils": ["wsl-utils@0.3.0", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-3sFIGLiaDP7rTO4xh3g+b3AzhYDIUGGywE/WsmqzJWDxus5aJXVnPTNC/6L+r2WzrwXqVOdD262OaO+cEyPMSQ=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
@@ -2036,6 +2180,8 @@
 
     "@babel/helper-compilation-targets/browserslist": ["browserslist@4.24.4", "", { "dependencies": { "caniuse-lite": "^1.0.30001688", "electron-to-chromium": "^1.5.73", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.1" }, "bin": { "browserslist": "cli.js" } }, "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A=="],
 
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-create-class-features-plugin/@babel/traverse": ["@babel/traverse@7.28.0", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.0", "@babel/template": "^7.27.2", "@babel/types": "^7.28.0", "debug": "^4.3.1" } }, "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg=="],
@@ -2072,6 +2218,8 @@
 
     "@bundled-es-modules/cookie/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
+    "@bundled-es-modules/tough-cookie/tough-cookie": ["tough-cookie@4.1.4", "", { "dependencies": { "psl": "^1.1.33", "punycode": "^2.1.1", "universalify": "^0.2.0", "url-parse": "^1.5.3" } }, "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag=="],
+
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
@@ -2097,6 +2245,8 @@
     "@prisma/dev/@hono/node-server": ["@hono/node-server@1.19.6", "", { "peerDependencies": { "hono": "^4" } }, "sha512-Shz/KjlIeAhfiuE93NDKVdZ7HdBVLQAfdbaXEaoAVO3ic9ibRSLGIQGkcBbFyuLr+7/1D5ZCINM8B+6IvXeMtw=="],
 
     "@prisma/dev/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "@prisma/dev/std-env": ["std-env@3.9.0", "", {}, "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw=="],
 
     "@prisma/engines/@prisma/get-platform": ["@prisma/get-platform@7.2.0", "", { "dependencies": { "@prisma/debug": "7.2.0" } }, "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA=="],
 
@@ -2132,6 +2282,8 @@
 
     "@react-router/dev/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
 
+    "@reduxjs/toolkit/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.7.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
@@ -2143,6 +2295,8 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "@ts-morph/common/minimatch": ["minimatch@10.1.1", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ=="],
 
@@ -2160,17 +2314,21 @@
 
     "@types/estree-jsx/@types/estree": ["@types/estree@1.0.6", "", {}, "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="],
 
+    "@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
+
     "@vitejs/plugin-react/@babel/core": ["@babel/core@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-compilation-targets": "^7.27.2", "@babel/helper-module-transforms": "^7.28.3", "@babel/helpers": "^7.28.4", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw=="],
 
     "@vitejs/plugin-react/react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
+
+    "@vitest/runner/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "@vitest/snapshot/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
-
-    "ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -2204,6 +2362,8 @@
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "effect/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+
     "execa/is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
     "express/cookie": ["cookie@0.7.1", "", {}, "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="],
@@ -2228,9 +2388,9 @@
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
-    "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
+    "jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 
-    "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+    "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
     "micromark/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
@@ -2272,6 +2432,8 @@
 
     "postcss-cli/tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
 
+    "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "proper-lockfile/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
@@ -2298,13 +2460,11 @@
 
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
     "sucrase/@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.8", "", { "dependencies": { "@jridgewell/set-array": "^1.2.1", "@jridgewell/sourcemap-codec": "^1.4.10", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
-
-    "tough-cookie/universalify": ["universalify@0.2.0", "", {}, "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="],
 
     "ts-node/arg": ["arg@4.1.3", "", {}, "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="],
 
@@ -2318,9 +2478,19 @@
 
     "vite-node/vite": ["vite@7.0.6", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.6", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.40.0", "tinyglobby": "^0.2.14" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-MHFiOENNBd+Bd9uvc8GEsIzdkn1JxMmEeYX35tI3fv0sJBUTfW5tQsoaOwuY4KhBI09A3dUJ/DXf2yxPVPUceg=="],
 
+    "vitest/es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
+
+    "vitest/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "vitest/tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -2347,6 +2517,8 @@
     "@babel/helper-compilation-targets/browserslist/node-releases": ["node-releases@2.0.19", "", {}, "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="],
 
     "@babel/helper-compilation-targets/browserslist/update-browserslist-db": ["update-browserslist-db@1.1.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw=="],
+
+    "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/generator": ["@babel/generator@7.28.0", "", { "dependencies": { "@babel/parser": "^7.28.0", "@babel/types": "^7.28.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg=="],
 
@@ -2392,6 +2564,8 @@
 
     "@babel/template/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.27.1", "", {}, "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="],
 
+    "@bundled-es-modules/tough-cookie/tough-cookie/universalify": ["universalify@0.2.0", "", {}, "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="],
+
     "@cspotcode/source-map-support/@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
     "@dotenvx/dotenvx/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
@@ -2403,6 +2577,8 @@
     "@dotenvx/dotenvx/execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "@dotenvx/dotenvx/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
+
+    "@inquirer/core/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@inquirer/core/wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -2468,8 +2644,6 @@
 
     "accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
     "babel-dead-code-elimination/@babel/core/@babel/code-frame": ["@babel/code-frame@7.26.2", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.25.9", "js-tokens": "^4.0.0", "picocolors": "^1.0.0" } }, "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ=="],
 
     "babel-dead-code-elimination/@babel/core/@babel/generator": ["@babel/generator@7.26.9", "", { "dependencies": { "@babel/parser": "^7.26.9", "@babel/types": "^7.26.9", "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.25", "jsesc": "^3.0.2" } }, "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg=="],
@@ -2502,8 +2676,6 @@
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "cmdk/@radix-ui/react-dialog/@radix-ui/primitive": ["@radix-ui/primitive@1.1.2", "", {}, "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA=="],
 
     "cmdk/@radix-ui/react-dialog/@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.10", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ=="],
@@ -2524,6 +2696,8 @@
 
     "fix-dts-default-cjs-exports/magic-string/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
+    "jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
     "mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
     "morgan/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
@@ -2535,8 +2709,6 @@
     "postcss-cli/tinyglobby/fdir": ["fdir@6.4.6", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
-    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "sucrase/@jridgewell/gen-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
@@ -2552,13 +2724,13 @@
 
     "vite-node/vite/tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
 
+    "wrap-ansi-cjs/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
     "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -2580,9 +2752,9 @@
 
     "@babel/helper-skip-transparent-expression-wrappers/@babel/traverse/@babel/generator/jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
-    "@inquirer/core/wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "@inquirer/core/wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
-    "@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "@inquirer/core/wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "@modelcontextprotocol/sdk/express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -2607,6 +2779,8 @@
     "babel-dead-code-elimination/@babel/core/@babel/helper-compilation-targets/@babel/helper-validator-option": ["@babel/helper-validator-option@7.25.9", "", {}, "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw=="],
 
     "babel-dead-code-elimination/@babel/core/@babel/helper-compilation-targets/browserslist": ["browserslist@4.24.4", "", { "dependencies": { "caniuse-lite": "^1.0.30001688", "electron-to-chromium": "^1.5.73", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.1" }, "bin": { "browserslist": "cli.js" } }, "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A=="],
+
+    "babel-dead-code-elimination/@babel/core/@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "babel-dead-code-elimination/@babel/core/@babel/helper-module-transforms/@babel/helper-module-imports": ["@babel/helper-module-imports@7.25.9", "", { "dependencies": { "@babel/traverse": "^7.25.9", "@babel/types": "^7.25.9" } }, "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw=="],
 
@@ -2672,7 +2846,11 @@
 
     "vite-node/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ=="],
 
-    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "wrap-ansi-cjs/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "@inquirer/core/wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "babel-dead-code-elimination/@babel/core/@babel/generator/@jridgewell/gen-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
@@ -2685,6 +2863,8 @@
     "babel-dead-code-elimination/@babel/core/@babel/helper-compilation-targets/browserslist/node-releases": ["node-releases@2.0.19", "", {}, "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="],
 
     "babel-dead-code-elimination/@babel/core/@babel/helper-compilation-targets/browserslist/update-browserslist-db": ["update-browserslist-db@1.1.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw=="],
+
+    "babel-dead-code-elimination/@babel/core/@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "babel-dead-code-elimination/@babel/traverse/@babel/generator/@jridgewell/gen-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "format": "biome format . --write",
     "typecheck": "cd apps/web && bun react-router typegen && cd ../.. && bun tsc --noEmit",
     "typecheck:all": "bun run -F '*' typecheck",
+    "test": "bun run -F '*' test",
     "migrate:users": "cd packages/core && bun run migrate:users",
     "truncate:auth:users": "cd packages/core && bun run truncate:auth:users",
     "index:songs": "doppler run -- bun ./packages/core/src/search/scripts/index-songs.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,8 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
     "build": "tsup src/index.ts --format esm --dts",
     "dev": "tsup src/index.ts --watch",
     "lint": "biome lint",
@@ -43,8 +45,9 @@
     "prisma": "^7.2.0",
     "supabase": "^2.70.4",
     "ts-node": "^10.9.2",
-    "tsx": "^4.21.0",
     "tsup": "^8.5.1",
-    "typescript": "^5.9.3"
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.2"
   }
 }

--- a/packages/core/src/_shared/cache/cache-invalidation-service.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.ts
@@ -59,10 +59,7 @@ export class CacheInvalidationService {
    */
   async invalidateSongCaches(): Promise<void> {
     this.logger.info("Invalidating all song caches");
-    await Promise.all([
-      this.cache.del(CacheKeys.songs.index()),
-      this.cache.delPattern(CacheKeys.songs.allFiltered()),
-    ]);
+    await Promise.all([this.cache.del(CacheKeys.songs.index()), this.cache.delPattern(CacheKeys.songs.allFiltered())]);
   }
 
   /**
@@ -85,6 +82,14 @@ export class CacheInvalidationService {
   async invalidateAllTimers(): Promise<void> {
     this.logger.info("Invalidating all-timers cache");
     await this.cache.del(CacheKeys.songs.allTimers());
+  }
+
+  /**
+   * Invalidate all filtered caches that include a specific user's attendance.
+   */
+  async invalidateAttendanceCaches(userId: string): Promise<void> {
+    this.logger.info(`Invalidating attendance caches for user: ${userId}`);
+    await this.cache.delPattern(CacheKeys.songs.allFilteredForUser(userId));
   }
 
   /**

--- a/packages/core/src/_shared/prisma/migrations/20260408000000_add_tracks_show_set_position_index/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260408000000_add_tracks_show_set_position_index/migration.sql
@@ -1,0 +1,6 @@
+-- Composite index for set opener/closer filter queries.
+-- The setOpener and setCloser filters use correlated subqueries that compute
+-- MIN/MAX(position) per (show_id, set). Without this index, each subquery
+-- does a sequential scan of the full tracks table (~20k+ rows per invocation).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS tracks_show_set_position_idx
+  ON tracks (show_id, set, position);

--- a/packages/core/src/_shared/prisma/migrations/20260408010000_fix_duplicate_track_positions/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260408010000_fix_duplicate_track_positions/migration.sql
@@ -1,0 +1,46 @@
+-- Fix duplicate track positions across 5 shows.
+-- Some shows have two different songs sharing a position (need renumbering),
+-- others have fully duplicated rows for the same song (need deduplication).
+
+BEGIN;
+
+--------------------------------------------------------------------------------
+-- 2024-09-07 Mishawaka Amphitheater — S2 position 5 (Minions / Leavemealone)
+-- Keep Minions at 5, shift Leavemealone to 6, closing 7-11 bookend to 7.
+--------------------------------------------------------------------------------
+UPDATE tracks SET position = 7 WHERE id = 'ae27f3c4-31de-4346-85b4-d8399c8acb10';
+UPDATE tracks SET position = 6 WHERE id = '17cf701d-ebcf-4dbc-8a60-c90cde23cc8b';
+
+--------------------------------------------------------------------------------
+-- 2024-07-12 Bourbon Room — S2 position 4 (Photograph / Strobelights)
+-- Photograph stays at 4, shift Strobelights to 5, closing Morph Dusseldorf to 6.
+--------------------------------------------------------------------------------
+UPDATE tracks SET position = 6 WHERE id = 'b0ea999c-a6e4-49a1-8a3c-a7cd653e6569';
+UPDATE tracks SET position = 5 WHERE id = '7d4ed251-7780-4e2c-9647-86f4a64b62cb';
+
+--------------------------------------------------------------------------------
+-- 2024-02-10 Boulder Theater — S2 position 4 (The Deal / Gamma Goblins)
+-- The Deal stays at 4, shift Gamma Goblins to 5, closing Reactor to 6.
+--------------------------------------------------------------------------------
+UPDATE tracks SET position = 6 WHERE id = '9a357965-ee91-4f41-9b1f-0cc265328c97';
+UPDATE tracks SET position = 5 WHERE id = 'c59d2377-6661-4553-9b70-6e1618c4bdb5';
+
+--------------------------------------------------------------------------------
+-- 2023-05-25 Three Sisters Park — S1 position 4 (two "To Be Continued" rows)
+-- Keep 74bcd4a8 (has 2 ratings). Delete 5ec55d18 (0 ratings, duplicate annotation).
+-- Fix Cyclone's previous_track_id to point to the survivor.
+--------------------------------------------------------------------------------
+DELETE FROM annotations WHERE id = 'ecb18d4a-b703-47f7-82ef-749adb012614';
+UPDATE tracks SET previous_track_id = '74bcd4a8-78e4-4256-8f55-47df86a1e8fa'
+  WHERE id = 'eaa6b105-8a16-4572-8f75-3151ef8a88b6';
+DELETE FROM tracks WHERE id = '5ec55d18-e83c-4e03-9552-201fc2e6b541';
+
+--------------------------------------------------------------------------------
+-- 2002-04-05 9:30 Club — E1 position 2 (two "Mary Had A Little Lamb" rows)
+-- Keep bdaadeec (Pat And Dex's next_track_id points to it). Delete aac77b6a.
+-- Both have 0 ratings; annotations are identical duplicates.
+--------------------------------------------------------------------------------
+DELETE FROM annotations WHERE id = '5c3f3509-15e0-4798-8fff-913439736f6d';
+DELETE FROM tracks WHERE id = 'aac77b6a-c4e2-4cd3-8b81-89377e4c056d';
+
+COMMIT;

--- a/packages/core/src/_shared/services.ts
+++ b/packages/core/src/_shared/services.ts
@@ -17,6 +17,7 @@ import { TrackService } from "../tracks/track-service";
 import { UserService } from "../users/user-service";
 import { VenueService } from "../venues/venue-service";
 import type { CacheService, CloudflareCacheService } from "./cache";
+import type { CacheInvalidationService } from "./cache/cache-invalidation-service";
 import type { ServiceContainer } from "./container";
 import type { RedisService } from "./redis";
 
@@ -40,6 +41,7 @@ export interface Services {
   searchHistory: SearchHistoryService;
   redis: RedisService;
   cache: CacheService;
+  cacheInvalidation: CacheInvalidationService;
   cloudflareCache: CloudflareCacheService;
   logger: Logger;
 }
@@ -75,6 +77,7 @@ export function createServices(container: ServiceContainer): Services {
     searchHistory: searchHistoryService,
     redis: container.redis,
     cache: container.cache,
+    cacheInvalidation: container.cacheInvalidation,
     cloudflareCache: container.cloudflareCache,
     logger: container.logger,
   };

--- a/packages/core/src/page-composers/song-page-composer.test.ts
+++ b/packages/core/src/page-composers/song-page-composer.test.ts
@@ -1,9 +1,11 @@
 import type { Annotation, SongPagePerformance } from "@bip/domain";
-import { describe, expect, test } from "vitest";
+import { Prisma } from "@prisma/client";
+import { describe, expect, test, vi } from "vitest";
 import {
   buildSetPositionKey,
   computeTagsForPerformance,
   type PerformanceDto,
+  SongPageComposer,
   transformToSongPagePerformanceView,
 } from "./song-page-composer";
 
@@ -44,15 +46,18 @@ function makeAnnotation(desc: string): Annotation {
 
 function makeDto(overrides: Partial<PerformanceDto> = {}): PerformanceDto {
   return {
+    // Show fields
     id: "show-1",
     date: "2024-06-15",
     venue_id: "venue-1",
     slug: "2024-06-15",
+    // Venue fields
     venue_name: "The Capitol Theatre",
     venue_city: "Port Chester",
     venue_state: "NY",
     venue_slug: "the-cap",
     venue_country: "USA",
+    // Track fields
     track_id: "track-1",
     song_id: "song-1",
     segue: null,
@@ -62,8 +67,10 @@ function makeDto(overrides: Partial<PerformanceDto> = {}): PerformanceDto {
     average_rating: 4.5,
     ratings_count: 12,
     note: null,
+    // Next/Prev track segues
     next_track_segue: null,
     prev_track_segue: null,
+    // Next/Prev song fields
     next_song_id: null,
     next_song_title: null,
     next_song_slug: null,
@@ -95,6 +102,8 @@ describe("computeTagsForPerformance", () => {
   });
 
   // Non-encore sets never have the `encore` tag set (absent, not false).
+  // Distinction matters because downstream filter predicates check
+  // `performance.tags?.encore` — truthy for `true`, falsy for `undefined`.
   test("non-encore sets do not set encore tag", () => {
     const setData = makeSetPositionData([["show-1", "S1", 1, 8]]);
     const tags = computeTagsForPerformance(makePerformance({ set: "S1", position: 3 }), setData);
@@ -102,7 +111,7 @@ describe("computeTagsForPerformance", () => {
   });
 
   // The set opener is the track whose position equals the min for its
-  // (show, set) pair.
+  // (show, set) pair. One-per-show-per-set by definition.
   test("position === min marks the performance as setOpener", () => {
     const setData = makeSetPositionData([["show-1", "S1", 1, 8]]);
     const tags = computeTagsForPerformance(makePerformance({ set: "S1", position: 1 }), setData);
@@ -110,7 +119,8 @@ describe("computeTagsForPerformance", () => {
     expect(tags.setCloser).toBe(false);
   });
 
-  // The set closer is the track whose position equals the max.
+  // The set closer is the track whose position equals the max. Symmetric
+  // with the opener test.
   test("position === max marks the performance as setCloser", () => {
     const setData = makeSetPositionData([["show-1", "S1", 1, 8]]);
     const tags = computeTagsForPerformance(makePerformance({ set: "S1", position: 8 }), setData);
@@ -118,8 +128,8 @@ describe("computeTagsForPerformance", () => {
     expect(tags.setOpener).toBe(false);
   });
 
-  // Edge case: a one-song set has min === max, so the single performance
-  // is both opener AND closer.
+  // Edge case: a one-song set (common for encores, rare for main sets) has
+  // min === max, so the single performance is both opener AND closer.
   test("single-song set marks the performance as both opener and closer", () => {
     const setData = makeSetPositionData([["show-1", "S2", 1, 1]]);
     const tags = computeTagsForPerformance(makePerformance({ set: "S2", position: 1 }), setData);
@@ -127,19 +137,21 @@ describe("computeTagsForPerformance", () => {
     expect(tags.setCloser).toBe(true);
   });
 
-  // If set-position data is missing for this show+set, opener/closer tags
-  // are left absent rather than set to `false`.
+  // Defensive behavior: if set-position data is missing for this show+set
+  // (shouldn't happen in production, but could if the lookup is incomplete),
+  // opener/closer tags are left absent rather than set to `false`.
   test("opener/closer tags are absent when set-position data is missing", () => {
-    const setData = makeSetPositionData([]);
+    const setData = makeSetPositionData([]); // empty
     const tags = computeTagsForPerformance(makePerformance({ set: "S1", position: 1 }), setData);
     expect(tags.setOpener).toBeUndefined();
     expect(tags.setCloser).toBeUndefined();
   });
 
   // Segue tags are booleans based on adjacent track segues:
-  //   - segueIn: the previous track has a `segue` value
+  //   - segueIn: the previous track in the show has a `segue` value
   //   - segueOut: THIS track has a `segue` value
   //   - standalone: neither
+  // One test with three fixture variants covers all three cases.
   test("segueIn, segueOut, and standalone flags reflect adjacent segues", () => {
     const setData = makeSetPositionData([["show-1", "S1", 1, 8]]);
 
@@ -175,7 +187,10 @@ describe("computeTagsForPerformance", () => {
   });
 
   // Inverted/dyslexic tags come from annotation text (case-insensitive
-  // substring match on `annotation.desc`).
+  // substring match on `annotation.desc`). Current impl uses
+  // `annotationText.includes("inverted")`, so substrings like "not inverted"
+  // would also match — noted for a future scoped discussion, but the current
+  // behavior is what we're pinning.
   test("inverted and dyslexic tags match annotation desc case-insensitively", () => {
     const setData = makeSetPositionData([["show-1", "S1", 1, 8]]);
 
@@ -232,8 +247,9 @@ describe("transformToSongPagePerformanceView", () => {
     expect(view.segue).toBe(null);
   });
 
-  // When the DTO has null venue fields, `venue` is set to `undefined` rather
-  // than building a partial venue object.
+  // When the DTO has null venue fields (legacy shows with missing venue
+  // relations), `venue` is set to `undefined` rather than building a
+  // partial venue object.
   test("sets venue to undefined when venue fields are null", () => {
     const view = transformToSongPagePerformanceView(
       makeDto({ venue_id: null as never, venue_slug: null, venue_name: null }),
@@ -241,7 +257,8 @@ describe("transformToSongPagePerformanceView", () => {
     expect(view.venue).toBeUndefined();
   });
 
-  // When the previous track fields are null, `songBefore` is `undefined`.
+  // When the previous track fields are null (e.g., first track of the set
+  // or a show with missing track relations), `songBefore` is `undefined`.
   test("sets songBefore to undefined when prev_song fields are null", () => {
     const view = transformToSongPagePerformanceView(
       makeDto({ prev_song_id: null, prev_song_title: null, prev_song_slug: null }),
@@ -257,7 +274,26 @@ describe("transformToSongPagePerformanceView", () => {
     expect(view.songAfter).toBeUndefined();
   });
 
-  // Null optional scalars map to `undefined` (via `|| undefined`).
+  // When the DTO includes song-level fields (from the songs table join in
+  // buildAllTimers), cover and authorId are mapped to the view.
+  test("maps song_cover and song_author_id to cover and authorId", () => {
+    const view = transformToSongPagePerformanceView(makeDto({ song_cover: true, song_author_id: "author-1" }));
+    expect(view.cover).toBe(true);
+    expect(view.authorId).toBe("author-1");
+  });
+
+  // When song-level fields are absent (build() path where songs isn't
+  // joined), cover and authorId default to undefined/null.
+  test("cover is undefined and authorId is null when song fields are absent", () => {
+    const view = transformToSongPagePerformanceView(makeDto());
+    expect(view.cover).toBeUndefined();
+    expect(view.authorId).toBeNull();
+  });
+
+  // Null optional scalars map to `undefined` (via `|| undefined` in the
+  // current impl). Documented quirk: `|| undefined` means `0` values also
+  // become `undefined`, which is fine for rating/ratingsCount but worth
+  // pinning so the behavior is explicit.
   test("null rating, ratings_count, and note all map to undefined", () => {
     const view = transformToSongPagePerformanceView(
       makeDto({ average_rating: null as never, ratings_count: null as never, note: null }),
@@ -274,10 +310,121 @@ describe("transformToSongPagePerformanceView", () => {
 
 describe("buildSetPositionKey", () => {
   // The exact key separator ("|||") is load-bearing: the same function is
-  // called on both the writer side (populating setPositionData) and the
-  // reader side (looking up each performance's set range). Pins the format.
+  // called on both the writer side (when populating setPositionData from
+  // SQL results) and the reader side (when looking up each performance's
+  // set range). If the format ever drifts between those two sites, opener/
+  // closer tags silently break. Pins the format so accidental changes fail.
   test('produces "showId|||set" format', () => {
     expect(buildSetPositionKey("show-1", "S1")).toBe("show-1|||S1");
     expect(buildSetPositionKey("abc-123", "E2")).toBe("abc-123|||E2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFilterQuery — static filter-to-SQL builder
+// ---------------------------------------------------------------------------
+
+describe("buildFilterQuery", () => {
+  // With no filter options, only the caller's base conditions should be
+  // returned — no extra WHERE clauses or JOINs injected.
+  test("returns only base conditions when no options provided", () => {
+    const base = [Prisma.sql`tracks.all_timer = true`];
+    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery(base);
+
+    expect(conditions).toHaveLength(1);
+    expect(extraJoins).toHaveLength(0);
+  });
+
+  // Boolean toggle filters (encore, segueOut, etc.) produce WHERE conditions,
+  // not JOINs. Verifies the encore filter generates the expected SQL fragment.
+  test("adds encore condition when encore is true", () => {
+    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery([], { encore: true });
+
+    expect(conditions.length).toBeGreaterThan(0);
+    expect(extraJoins).toHaveLength(0);
+    // The encore condition should reference tracks.set LIKE 'E%'
+    const sql = conditions[0].strings.join("");
+    expect(sql).toContain("tracks.set LIKE");
+  });
+
+  // The attended filter is special: it produces a JOIN (on the attendances
+  // table) rather than a WHERE condition. Important because JOINs and
+  // conditions are injected at different points in the SQL template.
+  test("adds attendedUserId as a join, not a condition", () => {
+    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery([], {
+      attendedUserId: "user-123",
+    });
+
+    expect(conditions).toHaveLength(0);
+    expect(extraJoins).toHaveLength(1);
+    const joinSql = extraJoins[0].strings.join("");
+    expect(joinSql).toContain("attendances");
+  });
+
+  // Multiple active filters are combined with AND: base conditions plus each
+  // active filter's condition/join. Verifies the accumulation logic and that
+  // JOINs and conditions are collected separately.
+  test("combines multiple filters with AND semantics", () => {
+    const base = [Prisma.sql`tracks.all_timer = true`];
+    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery(base, {
+      encore: true,
+      segueOut: true,
+      attendedUserId: "user-123",
+    });
+
+    // base + encore + segueOut = 3 conditions
+    expect(conditions).toHaveLength(3);
+    // attendedUserId produces a join
+    expect(extraJoins).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSongPerformanceCounts — aggregation query
+// ---------------------------------------------------------------------------
+
+describe("buildSongPerformanceCounts", () => {
+  // Helper: creates a SongPageComposer with a mocked $queryRaw that returns
+  // the given rows. Used to test the result transformation without hitting a DB.
+  function createComposer(queryRawResult: Array<{ song_id: string; count: string }>) {
+    const mockDb = {
+      $queryRaw: vi.fn().mockResolvedValue(queryRawResult),
+    };
+    const mockSongService = {} as never;
+    return { composer: new SongPageComposer(mockDb as never, mockSongService), mockDb };
+  }
+
+  // The raw SQL returns count as text (to avoid BigInt issues). Verifies
+  // the method parses string counts into numbers and keys by song_id.
+  test("returns Record<string, number> from raw query result rows", async () => {
+    const { composer } = createComposer([
+      { song_id: "song-1", count: "5" },
+      { song_id: "song-2", count: "3" },
+    ]);
+
+    const result = await composer.buildSongPerformanceCounts();
+
+    expect(result).toEqual({ "song-1": 5, "song-2": 3 });
+  });
+
+  // When no performances match the filter (e.g., no encores exist), the
+  // result should be an empty object — not null, not undefined.
+  test("returns empty record when no rows match", async () => {
+    const { composer } = createComposer([]);
+
+    const result = await composer.buildSongPerformanceCounts({ encore: true });
+
+    expect(result).toEqual({});
+  });
+
+  // Verifies that the method actually executes a query when filters are
+  // provided. The SQL correctness is tested via buildFilterQuery; this
+  // confirms the integration point calls $queryRaw.
+  test("passes filter options through to the query", async () => {
+    const { composer, mockDb } = createComposer([]);
+
+    await composer.buildSongPerformanceCounts({ encore: true, segueIn: true });
+
+    expect(mockDb.$queryRaw).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/page-composers/song-page-composer.test.ts
+++ b/packages/core/src/page-composers/song-page-composer.test.ts
@@ -1,0 +1,283 @@
+import type { Annotation, SongPagePerformance } from "@bip/domain";
+import { describe, expect, test } from "vitest";
+import {
+  buildSetPositionKey,
+  computeTagsForPerformance,
+  type PerformanceDto,
+  transformToSongPagePerformanceView,
+} from "./song-page-composer";
+
+// --- fixture helpers ---
+
+function makePerformance(overrides: Partial<SongPagePerformance> = {}): SongPagePerformance {
+  return {
+    trackId: "track-1",
+    show: { id: "show-1", slug: "2024-06-15", date: "2024-06-15", venueId: "venue-1" },
+    set: "S1",
+    position: 3,
+    segue: null,
+    allTimer: false,
+    annotations: [],
+    ...overrides,
+  };
+}
+
+function makeSetPositionData(
+  entries: Array<[string, string, number, number]>,
+): Map<string, { min: number; max: number }> {
+  const map = new Map<string, { min: number; max: number }>();
+  for (const [showId, set, min, max] of entries) {
+    map.set(buildSetPositionKey(showId, set), { min, max });
+  }
+  return map;
+}
+
+function makeAnnotation(desc: string): Annotation {
+  return {
+    id: "ann-1",
+    trackId: "track-1",
+    desc,
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+  };
+}
+
+function makeDto(overrides: Partial<PerformanceDto> = {}): PerformanceDto {
+  return {
+    id: "show-1",
+    date: "2024-06-15",
+    venue_id: "venue-1",
+    slug: "2024-06-15",
+    venue_name: "The Capitol Theatre",
+    venue_city: "Port Chester",
+    venue_state: "NY",
+    venue_slug: "the-cap",
+    venue_country: "USA",
+    track_id: "track-1",
+    song_id: "song-1",
+    segue: null,
+    set: "S1",
+    position: 3,
+    all_timer: false,
+    average_rating: 4.5,
+    ratings_count: 12,
+    note: null,
+    next_track_segue: null,
+    prev_track_segue: null,
+    next_song_id: null,
+    next_song_title: null,
+    next_song_slug: null,
+    prev_song_id: null,
+    prev_song_title: null,
+    prev_song_slug: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// computeTagsForPerformance — pure tag classification
+// ---------------------------------------------------------------------------
+
+describe("computeTagsForPerformance", () => {
+  // Sets starting with "E" (E1, E2, etc.) are encores. The encore check runs
+  // first and short-circuits the opener/closer computation, because encores
+  // aren't treated as normal sets.
+  test("sets starting with E are tagged as encore, and skip opener/closer", () => {
+    const setData = makeSetPositionData([["show-1", "E1", 1, 2]]);
+    const tags = computeTagsForPerformance(makePerformance({ set: "E1", position: 1 }), setData);
+    expect(tags.encore).toBe(true);
+    expect(tags.setOpener).toBeUndefined();
+    expect(tags.setCloser).toBeUndefined();
+
+    // Second encore (E2) also matches
+    const tags2 = computeTagsForPerformance(makePerformance({ set: "E2", position: 1 }), setData);
+    expect(tags2.encore).toBe(true);
+  });
+
+  // Non-encore sets never have the `encore` tag set (absent, not false).
+  test("non-encore sets do not set encore tag", () => {
+    const setData = makeSetPositionData([["show-1", "S1", 1, 8]]);
+    const tags = computeTagsForPerformance(makePerformance({ set: "S1", position: 3 }), setData);
+    expect(tags.encore).toBeUndefined();
+  });
+
+  // The set opener is the track whose position equals the min for its
+  // (show, set) pair.
+  test("position === min marks the performance as setOpener", () => {
+    const setData = makeSetPositionData([["show-1", "S1", 1, 8]]);
+    const tags = computeTagsForPerformance(makePerformance({ set: "S1", position: 1 }), setData);
+    expect(tags.setOpener).toBe(true);
+    expect(tags.setCloser).toBe(false);
+  });
+
+  // The set closer is the track whose position equals the max.
+  test("position === max marks the performance as setCloser", () => {
+    const setData = makeSetPositionData([["show-1", "S1", 1, 8]]);
+    const tags = computeTagsForPerformance(makePerformance({ set: "S1", position: 8 }), setData);
+    expect(tags.setCloser).toBe(true);
+    expect(tags.setOpener).toBe(false);
+  });
+
+  // Edge case: a one-song set has min === max, so the single performance
+  // is both opener AND closer.
+  test("single-song set marks the performance as both opener and closer", () => {
+    const setData = makeSetPositionData([["show-1", "S2", 1, 1]]);
+    const tags = computeTagsForPerformance(makePerformance({ set: "S2", position: 1 }), setData);
+    expect(tags.setOpener).toBe(true);
+    expect(tags.setCloser).toBe(true);
+  });
+
+  // If set-position data is missing for this show+set, opener/closer tags
+  // are left absent rather than set to `false`.
+  test("opener/closer tags are absent when set-position data is missing", () => {
+    const setData = makeSetPositionData([]);
+    const tags = computeTagsForPerformance(makePerformance({ set: "S1", position: 1 }), setData);
+    expect(tags.setOpener).toBeUndefined();
+    expect(tags.setCloser).toBeUndefined();
+  });
+
+  // Segue tags are booleans based on adjacent track segues:
+  //   - segueIn: the previous track has a `segue` value
+  //   - segueOut: THIS track has a `segue` value
+  //   - standalone: neither
+  test("segueIn, segueOut, and standalone flags reflect adjacent segues", () => {
+    const setData = makeSetPositionData([["show-1", "S1", 1, 8]]);
+
+    // Both segues present
+    const bothTags = computeTagsForPerformance(
+      makePerformance({
+        segue: ">",
+        songBefore: { id: "b", songId: "b", segue: ">", songSlug: "prev", songTitle: "Prev" },
+      }),
+      setData,
+    );
+    expect(bothTags.segueIn).toBe(true);
+    expect(bothTags.segueOut).toBe(true);
+    expect(bothTags.standalone).toBe(false);
+
+    // Only segue in
+    const inTags = computeTagsForPerformance(
+      makePerformance({
+        segue: null,
+        songBefore: { id: "b", songId: "b", segue: ">", songSlug: "prev", songTitle: "Prev" },
+      }),
+      setData,
+    );
+    expect(inTags.segueIn).toBe(true);
+    expect(inTags.segueOut).toBe(false);
+    expect(inTags.standalone).toBe(false);
+
+    // Neither segue
+    const noneTags = computeTagsForPerformance(makePerformance({ segue: null, songBefore: undefined }), setData);
+    expect(noneTags.segueIn).toBe(false);
+    expect(noneTags.segueOut).toBe(false);
+    expect(noneTags.standalone).toBe(true);
+  });
+
+  // Inverted/dyslexic tags come from annotation text (case-insensitive
+  // substring match on `annotation.desc`).
+  test("inverted and dyslexic tags match annotation desc case-insensitively", () => {
+    const setData = makeSetPositionData([["show-1", "S1", 1, 8]]);
+
+    const invertedTags = computeTagsForPerformance(
+      makePerformance({ annotations: [makeAnnotation("Inverted version")] }),
+      setData,
+    );
+    expect(invertedTags.inverted).toBe(true);
+    expect(invertedTags.dyslexic).toBe(false);
+
+    const dyslexicTags = computeTagsForPerformance(
+      makePerformance({ annotations: [makeAnnotation("DYSLEXIC Cassidy")] }),
+      setData,
+    );
+    expect(dyslexicTags.dyslexic).toBe(true);
+    expect(dyslexicTags.inverted).toBe(false);
+
+    const noAnnotationsTags = computeTagsForPerformance(makePerformance({ annotations: [] }), setData);
+    expect(noAnnotationsTags.inverted).toBe(false);
+    expect(noAnnotationsTags.dyslexic).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transformToSongPagePerformanceView — DTO → view mapping
+// ---------------------------------------------------------------------------
+
+describe("transformToSongPagePerformanceView", () => {
+  // Happy path: every DTO field is populated. Verifies the entire view shape
+  // is built correctly.
+  test("maps all DTO fields to the view shape", () => {
+    const view = transformToSongPagePerformanceView(makeDto());
+
+    expect(view.trackId).toBe("track-1");
+    expect(view.show).toEqual({
+      id: "show-1",
+      slug: "2024-06-15",
+      date: "2024-06-15",
+      venueId: "venue-1",
+    });
+    expect(view.venue).toEqual({
+      id: "venue-1",
+      slug: "the-cap",
+      name: "The Capitol Theatre",
+      city: "Port Chester",
+      state: "NY",
+      country: "USA",
+    });
+    expect(view.rating).toBe(4.5);
+    expect(view.ratingsCount).toBe(12);
+    expect(view.set).toBe("S1");
+    expect(view.position).toBe(3);
+    expect(view.allTimer).toBe(false);
+    expect(view.segue).toBe(null);
+  });
+
+  // When the DTO has null venue fields, `venue` is set to `undefined` rather
+  // than building a partial venue object.
+  test("sets venue to undefined when venue fields are null", () => {
+    const view = transformToSongPagePerformanceView(
+      makeDto({ venue_id: null as never, venue_slug: null, venue_name: null }),
+    );
+    expect(view.venue).toBeUndefined();
+  });
+
+  // When the previous track fields are null, `songBefore` is `undefined`.
+  test("sets songBefore to undefined when prev_song fields are null", () => {
+    const view = transformToSongPagePerformanceView(
+      makeDto({ prev_song_id: null, prev_song_title: null, prev_song_slug: null }),
+    );
+    expect(view.songBefore).toBeUndefined();
+  });
+
+  // Symmetric: last track of the set, or missing relations.
+  test("sets songAfter to undefined when next_song fields are null", () => {
+    const view = transformToSongPagePerformanceView(
+      makeDto({ next_song_id: null, next_song_title: null, next_song_slug: null }),
+    );
+    expect(view.songAfter).toBeUndefined();
+  });
+
+  // Null optional scalars map to `undefined` (via `|| undefined`).
+  test("null rating, ratings_count, and note all map to undefined", () => {
+    const view = transformToSongPagePerformanceView(
+      makeDto({ average_rating: null as never, ratings_count: null as never, note: null }),
+    );
+    expect(view.rating).toBeUndefined();
+    expect(view.ratingsCount).toBeUndefined();
+    expect(view.notes).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSetPositionKey — key format
+// ---------------------------------------------------------------------------
+
+describe("buildSetPositionKey", () => {
+  // The exact key separator ("|||") is load-bearing: the same function is
+  // called on both the writer side (populating setPositionData) and the
+  // reader side (looking up each performance's set range). Pins the format.
+  test('produces "showId|||set" format', () => {
+    expect(buildSetPositionKey("show-1", "S1")).toBe("show-1|||S1");
+    expect(buildSetPositionKey("abc-123", "E2")).toBe("abc-123|||E2");
+  });
+});

--- a/packages/core/src/page-composers/song-page-composer.ts
+++ b/packages/core/src/page-composers/song-page-composer.ts
@@ -3,6 +3,28 @@ import { Prisma } from "@prisma/client";
 import type { DbClient } from "../_shared/database/models";
 import type { SongService } from "../songs/song-service";
 
+/**
+ * Filters for querying performances. All fields are optional — only
+ * active filters produce SQL conditions. Used by buildAllTimers and
+ * buildSongPerformances to construct dynamic WHERE clauses.
+ */
+export interface PerformanceFilterOptions {
+  startDate?: Date;
+  endDate?: Date;
+  cover?: boolean;
+  authorId?: string;
+  attendedUserId?: string;
+  encore?: boolean;
+  setOpener?: boolean;
+  setCloser?: boolean;
+  segueIn?: boolean;
+  segueOut?: boolean;
+  standalone?: boolean;
+  inverted?: boolean;
+  dyslexic?: boolean;
+  allTimer?: boolean;
+}
+
 export class SongPageComposer {
   constructor(
     private db: DbClient,
@@ -107,7 +129,11 @@ export class SongPageComposer {
       whereClause: Prisma.sql`tracks.song_id = ${song.id}::uuid`,
     });
 
-    const performances = result.map((row) => transformToSongPagePerformanceView(row));
+    const performances = result.map((row) => ({
+      ...this.transformToSongPagePerformanceView(row),
+      cover: song.cover ?? undefined,
+      authorId: song.authorId ?? null,
+    }));
     await this.enrichPerformances(performances);
 
     return {
@@ -124,14 +150,22 @@ export class SongPageComposer {
     };
   }
 
-  async buildAllTimers(): Promise<AllTimersPageView> {
+  /** Build the all-timers page view, optionally filtered by date range, cover, author, attendance, and performance tags. */
+  async buildAllTimers(options?: PerformanceFilterOptions): Promise<AllTimersPageView> {
+    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery(
+      [Prisma.sql`tracks.all_timer = true`],
+      options,
+    );
+
+    const whereClause = Prisma.join(conditions, " AND ");
     const result = await this.queryPerformances({
-      whereClause: Prisma.sql`tracks.all_timer = true`,
+      whereClause,
       includeSongInfo: true,
+      extraJoins,
     });
 
     const performances = (result as AllTimerPerformanceDto[]).map((row) => ({
-      ...transformToSongPagePerformanceView(row),
+      ...this.transformToSongPagePerformanceView(row),
       songTitle: row.song_title,
       songSlug: row.song_slug,
     }));
@@ -140,14 +174,151 @@ export class SongPageComposer {
     return { performances };
   }
 
+  /** Build a filtered list of performances for a single song. */
+  async buildSongPerformances(songSlug: string, options?: PerformanceFilterOptions): Promise<SongPagePerformance[]> {
+    const song = await this.songService.findBySlug(songSlug);
+    if (!song) throw new Error("Song not found");
+
+    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery(
+      [Prisma.sql`tracks.song_id = ${song.id}::uuid`],
+      options,
+    );
+
+    const whereClause = Prisma.join(conditions, " AND ");
+    const result = await this.queryPerformances({ whereClause, extraJoins });
+
+    const performances = result.map((row) => ({
+      ...this.transformToSongPagePerformanceView(row),
+      cover: song.cover ?? undefined,
+      authorId: song.authorId ?? null,
+    }));
+    await this.enrichPerformances(performances);
+
+    return performances;
+  }
+
+  /**
+   * Count matching performances per song, grouped by song_id.
+   * Used by /songs to show per-song counts when toggle filters are active.
+   */
+  async buildSongPerformanceCounts(options?: PerformanceFilterOptions): Promise<Record<string, number>> {
+    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery([], options);
+
+    const whereClause = conditions.length > 0 ? Prisma.sql`WHERE ${Prisma.join(conditions, " AND ")}` : Prisma.empty;
+
+    const extraJoinsSql = extraJoins.length > 0 ? Prisma.sql`${Prisma.join(extraJoins, "\n      ")}` : Prisma.empty;
+
+    const rows = await this.db.$queryRaw<Array<{ song_id: string; count: string }>>`
+      SELECT tracks.song_id, COUNT(DISTINCT tracks.id)::text as count
+      FROM tracks
+      JOIN shows ON tracks.show_id = shows.id
+      JOIN songs ON tracks.song_id = songs.id
+      ${extraJoinsSql}
+      LEFT JOIN tracks prevTracks ON tracks.show_id = prevTracks.show_id
+        AND prevTracks.position = tracks.position - 1
+        AND prevTracks.set = tracks.set
+      ${whereClause}
+      GROUP BY tracks.song_id
+    `;
+
+    const result: Record<string, number> = {};
+    for (const row of rows) {
+      result[row.song_id] = Number.parseInt(row.count, 10);
+    }
+    return result;
+  }
+
+  /**
+   * Maps each filter field to a function that returns its SQL condition
+   * (WHERE clause) or join. Returns null when the filter is inactive.
+   * Value-carrying filters (dates, IDs) interpolate their values into
+   * parameterized SQL. Boolean filters produce static SQL fragments.
+   */
+  static readonly FILTER_BUILDERS: Record<
+    string,
+    (options: PerformanceFilterOptions) => { condition?: Prisma.Sql; join?: Prisma.Sql } | null
+  > = {
+    startDate: (o) =>
+      o.startDate ? { condition: Prisma.sql`shows.date >= ${o.startDate.toISOString().slice(0, 10)}` } : null,
+    endDate: (o) =>
+      o.endDate ? { condition: Prisma.sql`shows.date <= ${o.endDate.toISOString().slice(0, 10)}` } : null,
+    cover: (o) => (o.cover !== undefined ? { condition: Prisma.sql`songs.cover = ${o.cover}` } : null),
+    authorId: (o) => (o.authorId ? { condition: Prisma.sql`songs.author_id = ${o.authorId}::uuid` } : null),
+    attendedUserId: (o) =>
+      o.attendedUserId
+        ? {
+            join: Prisma.sql`JOIN attendances ON attendances.show_id = shows.id AND attendances.user_id = ${o.attendedUserId}::uuid`,
+          }
+        : null,
+    encore: (o) => (o.encore ? { condition: Prisma.sql`tracks.set LIKE 'E%'` } : null),
+    setOpener: (o) =>
+      o.setOpener
+        ? {
+            condition: Prisma.sql`tracks.position = (SELECT MIN(t2.position) FROM tracks t2 WHERE t2.show_id = tracks.show_id AND t2.set = tracks.set) AND tracks.set NOT LIKE 'E%'`,
+          }
+        : null,
+    setCloser: (o) =>
+      o.setCloser
+        ? {
+            condition: Prisma.sql`tracks.position = (SELECT MAX(t2.position) FROM tracks t2 WHERE t2.show_id = tracks.show_id AND t2.set = tracks.set) AND tracks.set NOT LIKE 'E%'`,
+          }
+        : null,
+    segueOut: (o) => (o.segueOut ? { condition: Prisma.sql`tracks.segue IS NOT NULL AND tracks.segue != ''` } : null),
+    segueIn: (o) =>
+      o.segueIn ? { condition: Prisma.sql`prevTracks.segue IS NOT NULL AND prevTracks.segue != ''` } : null,
+    standalone: (o) =>
+      o.standalone
+        ? {
+            condition: Prisma.sql`(tracks.segue IS NULL OR tracks.segue = '') AND (prevTracks.segue IS NULL OR prevTracks.segue = '')`,
+          }
+        : null,
+    allTimer: (o) => (o.allTimer ? { condition: Prisma.sql`tracks.all_timer = true` } : null),
+    inverted: (o) =>
+      o.inverted
+        ? {
+            condition: Prisma.sql`EXISTS (SELECT 1 FROM annotations WHERE annotations.track_id = tracks.id AND LOWER(annotations.desc) LIKE '%inverted%')`,
+          }
+        : null,
+    dyslexic: (o) =>
+      o.dyslexic
+        ? {
+            condition: Prisma.sql`EXISTS (SELECT 1 FROM annotations WHERE annotations.track_id = tracks.id AND LOWER(annotations.desc) LIKE '%dyslexic%')`,
+          }
+        : null,
+  };
+
+  /** Combine base conditions with active filter conditions and joins. */
+  static buildFilterQuery(
+    baseConditions: Prisma.Sql[],
+    options?: PerformanceFilterOptions,
+  ): { conditions: Prisma.Sql[]; extraJoins: Prisma.Sql[] } {
+    const conditions = [...baseConditions];
+    const extraJoins: Prisma.Sql[] = [];
+
+    if (!options) return { conditions, extraJoins };
+
+    for (const builder of Object.values(SongPageComposer.FILTER_BUILDERS)) {
+      const result = builder(options);
+      if (result?.condition) conditions.push(result.condition);
+      if (result?.join) extraJoins.push(result.join);
+    }
+
+    return { conditions, extraJoins };
+  }
+
   private async queryPerformances(options: {
     whereClause: Prisma.Sql;
     includeSongInfo?: boolean;
+    extraJoins?: Prisma.Sql[];
   }): Promise<PerformanceDto[]> {
     const songColumns = options.includeSongInfo
-      ? Prisma.sql`, songs.title as song_title, songs.slug as song_slug`
+      ? Prisma.sql`, songs.title as song_title, songs.slug as song_slug, songs.cover as song_cover, songs.author_id as song_author_id`
       : Prisma.empty;
     const songJoin = options.includeSongInfo ? Prisma.sql`JOIN songs ON tracks.song_id = songs.id` : Prisma.empty;
+    const extraJoinsSql =
+      options.extraJoins && options.extraJoins.length > 0
+        ? Prisma.sql`${Prisma.join(options.extraJoins, "\n      ")}`
+        : Prisma.empty;
 
     return this.db.$queryRaw<PerformanceDto[]>`
       SELECT
@@ -183,6 +354,7 @@ export class SongPageComposer {
       ${songJoin}
       JOIN shows ON tracks.show_id = shows.id
       LEFT JOIN venues ON shows.venue_id = venues.id
+      ${extraJoinsSql}
       LEFT JOIN tracks nextTracks ON tracks.show_id = nextTracks.show_id
         AND nextTracks.position = tracks.position + 1
         AND nextTracks.set = tracks.set
@@ -256,6 +428,10 @@ export class SongPageComposer {
 
     return setPositionData;
   }
+
+  private transformToSongPagePerformanceView(row: PerformanceDto): SongPagePerformance {
+    return transformToSongPagePerformanceView(row);
+  }
 }
 
 /**
@@ -277,11 +453,13 @@ export function computeTagsForPerformance(
 ): NonNullable<SongPagePerformance["tags"]> {
   const tags: NonNullable<SongPagePerformance["tags"]> = {};
 
+  // Encore (sets that start with "E") - check this first
   const isEncore = performance.set?.startsWith("E");
   if (isEncore) {
     tags.encore = true;
   }
 
+  // Set opener/closer (only for non-encore sets)
   if (performance.set && performance.position !== undefined && !isEncore) {
     const setRange = setPositionData.get(buildSetPositionKey(performance.show.id, performance.set));
     if (setRange) {
@@ -290,13 +468,16 @@ export function computeTagsForPerformance(
     }
   }
 
+  // Segue in/out
   const hasSegueIn = performance.songBefore?.segue;
   const hasSegueOut = performance.segue;
   tags.segueIn = !!hasSegueIn;
   tags.segueOut = !!hasSegueOut;
 
+  // Standalone (no segue in or out)
   tags.standalone = !hasSegueIn && !hasSegueOut;
 
+  // Inverted/Dyslexic from annotations
   if (performance.annotations) {
     const annotationText = performance.annotations.map((a) => a.desc?.toLowerCase() || "").join(" ");
     tags.inverted = annotationText.includes("inverted");
@@ -356,6 +537,8 @@ export function transformToSongPagePerformanceView(row: PerformanceDto): SongPag
     segue: row.segue,
     set: row.set,
     position: row.position,
+    cover: row.song_cover ?? undefined,
+    authorId: row.song_author_id ?? null,
   };
 }
 
@@ -395,9 +578,15 @@ export type PerformanceDto = {
   prev_song_id: string | null;
   prev_song_title: string | null;
   prev_song_slug: string | null;
+
+  // Song fields (present when songs table is joined)
+  song_cover?: boolean | null;
+  song_author_id?: string | null;
 };
 
 type AllTimerPerformanceDto = PerformanceDto & {
   song_title: string;
   song_slug: string;
+  song_cover: boolean | null;
+  song_author_id: string | null;
 };

--- a/packages/core/src/page-composers/song-page-composer.ts
+++ b/packages/core/src/page-composers/song-page-composer.ts
@@ -107,7 +107,7 @@ export class SongPageComposer {
       whereClause: Prisma.sql`tracks.song_id = ${song.id}::uuid`,
     });
 
-    const performances = result.map((row) => this.transformToSongPagePerformanceView(row));
+    const performances = result.map((row) => transformToSongPagePerformanceView(row));
     await this.enrichPerformances(performances);
 
     return {
@@ -131,7 +131,7 @@ export class SongPageComposer {
     });
 
     const performances = (result as AllTimerPerformanceDto[]).map((row) => ({
-      ...this.transformToSongPagePerformanceView(row),
+      ...transformToSongPagePerformanceView(row),
       songTitle: row.song_title,
       songSlug: row.song_slug,
     }));
@@ -210,134 +210,156 @@ export class SongPageComposer {
       annotationsByTrackId.set(annotation.trackId, trackAnnotations);
     }
 
-    for (const perf of performances) {
-      perf.annotations = annotationsByTrackId.get(perf.trackId) || [];
+    for (const performance of performances) {
+      performance.annotations = annotationsByTrackId.get(performance.trackId) || [];
     }
 
     await this.computePerformanceTags(performances);
   }
 
   private async computePerformanceTags(performances: SongPagePerformance[]): Promise<void> {
-    // For set opener/closer computation, we need to know the min/max positions for each set in each show
-    const setPositionData = new Map<string, { min: number; max: number }>();
-
-    // Get all unique show IDs
-    const showIds = [...new Set(performances.map((p) => p.show.id))];
-
-    if (showIds.length > 0) {
-      // Get all set position ranges in a single query
-      const setRanges = await this.db.$queryRaw<
-        Array<{ show_id: string; set: string; min_position: number; max_position: number }>
-      >`
-        SELECT show_id, set, MIN(position) as min_position, MAX(position) as max_position
-        FROM tracks
-        WHERE show_id = ANY(${showIds}::uuid[])
-        GROUP BY show_id, set
-      `;
-
-      // Build the lookup map
-      for (const range of setRanges) {
-        const key = `${range.show_id}|||${range.set}`;
-        setPositionData.set(key, {
-          min: range.min_position,
-          max: range.max_position,
-        });
-      }
+    const setPositionData = await this.fetchSetPositionData(performances);
+    for (const performance of performances) {
+      performance.tags = computeTagsForPerformance(performance, setPositionData);
     }
-
-    // Compute tags for each performance
-    performances.forEach((perf) => {
-      const tags: SongPagePerformance["tags"] = {};
-
-      // Encore (sets that start with "E") - check this first
-      const isEncore = perf.set?.startsWith("E");
-      if (isEncore) {
-        tags.encore = true;
-      }
-
-      // Set opener/closer (only for non-encore sets)
-      if (perf.set && perf.position !== undefined && !isEncore) {
-        const showSetKey = `${perf.show.id}|||${perf.set}`;
-        const setRange = setPositionData.get(showSetKey);
-
-        if (setRange) {
-          tags.setOpener = perf.position === setRange.min;
-          tags.setCloser = perf.position === setRange.max;
-        }
-      }
-
-      // Segue in/out
-      const hasSegueIn = perf.songBefore?.segue;
-      const hasSegueOut = perf.segue;
-      tags.segueIn = !!hasSegueIn;
-      tags.segueOut = !!hasSegueOut;
-
-      // Standalone (no segue in or out)
-      tags.standalone = !hasSegueIn && !hasSegueOut;
-
-      // Inverted/Dyslexic from annotations
-      if (perf.annotations) {
-        const annotationText = perf.annotations.map((a) => a.desc?.toLowerCase() || "").join(" ");
-        tags.inverted = annotationText.includes("inverted");
-        tags.dyslexic = annotationText.includes("dyslexic");
-      }
-
-      perf.tags = tags;
-    });
   }
 
-  private transformToSongPagePerformanceView(row: PerformanceDto): SongPagePerformance {
-    return {
-      trackId: row.track_id,
-      show: {
-        id: row.id,
-        slug: row.slug,
-        date: row.date,
-        venueId: row.venue_id,
-      },
-      venue:
-        row.venue_id && row.venue_slug && row.venue_name
-          ? {
-              id: row.venue_id,
-              slug: row.venue_slug,
-              name: row.venue_name,
-              city: row.venue_city || "",
-              state: row.venue_state,
-              country: row.venue_country || "",
-            }
-          : undefined,
-      songBefore:
-        row.prev_song_id && row.prev_song_slug && row.prev_song_title
-          ? {
-              id: row.prev_song_id,
-              songId: row.prev_song_id,
-              segue: row.prev_track_segue,
-              songSlug: row.prev_song_slug,
-              songTitle: row.prev_song_title,
-            }
-          : undefined,
-      songAfter:
-        row.next_song_id && row.next_song_slug && row.next_song_title
-          ? {
-              id: row.next_song_id,
-              songId: row.next_song_id,
-              segue: row.next_track_segue,
-              songSlug: row.next_song_slug,
-              songTitle: row.next_song_title,
-            }
-          : undefined,
-      rating: row.average_rating || undefined,
-      ratingsCount: row.ratings_count || undefined,
-      notes: row.note || undefined,
-      allTimer: row.all_timer,
-      segue: row.segue,
-      set: row.set,
-      position: row.position,
-    };
+  /**
+   * Fetches the min/max track positions for each (show, set) pair touched by the
+   * given performances. Used to identify set openers and closers.
+   */
+  private async fetchSetPositionData(
+    performances: SongPagePerformance[],
+  ): Promise<Map<string, { min: number; max: number }>> {
+    const setPositionData = new Map<string, { min: number; max: number }>();
+    const showIds = [...new Set(performances.map((p) => p.show.id))];
+
+    if (showIds.length === 0) {
+      return setPositionData;
+    }
+
+    const setRanges = await this.db.$queryRaw<
+      Array<{ show_id: string; set: string; min_position: number; max_position: number }>
+    >`
+      SELECT show_id, set, MIN(position) as min_position, MAX(position) as max_position
+      FROM tracks
+      WHERE show_id = ANY(${showIds}::uuid[])
+      GROUP BY show_id, set
+    `;
+
+    for (const range of setRanges) {
+      setPositionData.set(buildSetPositionKey(range.show_id, range.set), {
+        min: range.min_position,
+        max: range.max_position,
+      });
+    }
+
+    return setPositionData;
   }
 }
 
-type PerformanceDto = {
+/**
+ * Build the lookup key used for set-position data. The triple-pipe separator
+ * is unlikely to appear in show IDs or set labels.
+ */
+export function buildSetPositionKey(showId: string, set: string): string {
+  return `${showId}|||${set}`;
+}
+
+/**
+ * Compute the performance tags (encore, opener/closer, segues, standalone,
+ * inverted, dyslexic) for a single performance. Pure function — no DB,
+ * no side effects.
+ */
+export function computeTagsForPerformance(
+  performance: SongPagePerformance,
+  setPositionData: Map<string, { min: number; max: number }>,
+): NonNullable<SongPagePerformance["tags"]> {
+  const tags: NonNullable<SongPagePerformance["tags"]> = {};
+
+  const isEncore = performance.set?.startsWith("E");
+  if (isEncore) {
+    tags.encore = true;
+  }
+
+  if (performance.set && performance.position !== undefined && !isEncore) {
+    const setRange = setPositionData.get(buildSetPositionKey(performance.show.id, performance.set));
+    if (setRange) {
+      tags.setOpener = performance.position === setRange.min;
+      tags.setCloser = performance.position === setRange.max;
+    }
+  }
+
+  const hasSegueIn = performance.songBefore?.segue;
+  const hasSegueOut = performance.segue;
+  tags.segueIn = !!hasSegueIn;
+  tags.segueOut = !!hasSegueOut;
+
+  tags.standalone = !hasSegueIn && !hasSegueOut;
+
+  if (performance.annotations) {
+    const annotationText = performance.annotations.map((a) => a.desc?.toLowerCase() || "").join(" ");
+    tags.inverted = annotationText.includes("inverted");
+    tags.dyslexic = annotationText.includes("dyslexic");
+  }
+
+  return tags;
+}
+
+/**
+ * Map a raw DB DTO row to a SongPagePerformance view. Pure function.
+ */
+export function transformToSongPagePerformanceView(row: PerformanceDto): SongPagePerformance {
+  return {
+    trackId: row.track_id,
+    show: {
+      id: row.id,
+      slug: row.slug,
+      date: row.date,
+      venueId: row.venue_id,
+    },
+    venue:
+      row.venue_id && row.venue_slug && row.venue_name
+        ? {
+            id: row.venue_id,
+            slug: row.venue_slug,
+            name: row.venue_name,
+            city: row.venue_city || "",
+            state: row.venue_state,
+            country: row.venue_country || "",
+          }
+        : undefined,
+    songBefore:
+      row.prev_song_id && row.prev_song_slug && row.prev_song_title
+        ? {
+            id: row.prev_song_id,
+            songId: row.prev_song_id,
+            segue: row.prev_track_segue,
+            songSlug: row.prev_song_slug,
+            songTitle: row.prev_song_title,
+          }
+        : undefined,
+    songAfter:
+      row.next_song_id && row.next_song_slug && row.next_song_title
+        ? {
+            id: row.next_song_id,
+            songId: row.next_song_id,
+            segue: row.next_track_segue,
+            songSlug: row.next_song_slug,
+            songTitle: row.next_song_title,
+          }
+        : undefined,
+    rating: row.average_rating || undefined,
+    ratingsCount: row.ratings_count || undefined,
+    notes: row.note || undefined,
+    allTimer: row.all_timer,
+    segue: row.segue,
+    set: row.set,
+    position: row.position,
+  };
+}
+
+export type PerformanceDto = {
   // Show fields
   id: string;
   date: string;

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -57,13 +57,19 @@ export const CacheKeys = {
     index: () => "songs:index:full",
     /** All-timers page data */
     allTimers: () => "songs:all-timers",
-    /** Filtered song results by era/author/cover */
+    /** Filtered song results by era/author/cover/tags/attended */
     filtered: (filters: CacheFilters) => {
       const filterHash = hashFilters(filters);
+      const attendedUserId = filters.attended;
+      if (attendedUserId) {
+        return `songs:filtered:user:${attendedUserId}:${filterHash}`;
+      }
       return `songs:filtered:${filterHash}`;
     },
     /** All filtered song caches (for pattern deletion) */
     allFiltered: () => "songs:filtered:*",
+    /** Filtered caches for a specific user's attendance (for pattern deletion) */
+    allFilteredForUser: (userId: string) => `songs:filtered:user:${userId}:*`,
   },
 
   /**

--- a/packages/domain/src/views/song-page.ts
+++ b/packages/domain/src/views/song-page.ts
@@ -25,6 +25,8 @@ export type SongPagePerformance = {
   position?: number;
   songTitle?: string;
   songSlug?: string;
+  cover?: boolean;
+  authorId?: string | null;
   tags?: {
     setOpener?: boolean;
     setCloser?: boolean;


### PR DESCRIPTION
## Summary

Unifies the filter infrastructure across `/songs`, `/songs/all-timers`, and `/songs/$slug` so all three pages share one hook, one filter controls component, and one set of SQL filter builders. Adds toggle chip filters (Encore, Set Opener, Segue In, etc.) to `/songs`, showing per-song performance counts when active. Adds a testing infrastructure so that Claude can test itself instead of having to manually test everything.


https://github.com/user-attachments/assets/24dfdbe0-a304-48f9-ac3a-0a37eb8e668a



### Line count context

| Category | Lines added | Lines deleted | Net |
|----------|------------|--------------|-----|
| Tests & test infrastructure | +2,334 | 0 | +2,334 |
| Product code | +1,947 | -1,278 | +669 |
| **Total** | **+4,281** | **-1,278** | **+3,003** |

Over half the diff is new tests. The product code is net +669 lines.

---

## How to read this PR

This PR is best read commit-by-commit. Each commit is self-contained and builds on the previous — no work is undone or rewritten in later commits:

1. **Add Vitest infrastructure and git hooks** — testing foundation, no product changes
2. **Move DataTable column widths to column-def meta** — prep: make DataTable generic by removing hardcoded widths
3. **Extract useAttendanceRowHighlight hook** — extract shared hook for attendance row highlighting
4. **Extract pure logic from song-page-composer and add tests** — extract testable pure functions + add backend tests
5. **Create filter primitives (SelectFilter, ToggleFilterGroup)** — reusable filter UI components
6. **Replace PerformanceTable with DataTable + shared building blocks** — the first big refactor: delete 400-line PerformanceTable, replace with 50-line thin wrapper over DataTable
7. **Move performance filtering server-side with shared infrastructure** — the architecture change: shared hook, controls, API endpoints, SQL filter builders, AND semantics
8. **Unify /songs with shared filter infrastructure and toggle chips** — the payoff: /songs uses shared infrastructure, gains toggle chips with per-song counts
9. **Add composite index and fix duplicate track positions** — performance optimization and data cleanup

---

## Major changes

### Behavioral changes

- **Performance filters use AND semantics (was OR)** — toggling Encore + Segue In now shows performances matching *both*, not *either*. This applies to all three song pages. This was necessary in order to make song statistics work — having this be an OR made counting the number of times something happened uncountable. I also think that AND lines up with user expectation, but I understand that you might have a different opinion on this functionality.
- **Performance filtering moved server-side** — filters previously applied client-side in the browser. Now the hook fetches filtered data from API endpoints with filter params, using the same SQL filter builders across all routes.
- **`/songs` now has toggle chip filters** — Set Opener, Set Closer, Encore, Segue In/Out, Standalone, Inverted, Dyslexic, All-Timer, Attended. When active, the Plays column shows the filtered count (e.g., "how many times was this song an encore").
- **`/songs/all-timers` gained Year, Era, Cover, and Author filters** — previously only had toggle chips.

### Technical changes

- **Generalized `usePerformancePageFilters<T>` hook** — works with any data type (Song[], SongPagePerformance[]), handles URL param sync, fetching, loading state with 200ms debounce, client-side search, and filter clearing.
- **`PerformanceFilterControls` shared component** — Year, Era, Cover, Author, Played filters and toggle chips in one component, controlled by optional props.
- **`SongPageComposer.buildFilterQuery` made public static** — SQL filter builders extracted for reuse. New `buildSongPerformanceCounts()` method for per-song aggregation.
- **Composite index on `tracks(show_id, set, position)`** — Set Opener/Closer filter queries went from 27s to 45ms.

### Visual changes

- **All filters always visible on `/songs`** — removed "Show More Filters" toggle. This was done so that the content was closer to the top of the page.
- **Attended moved from select dropdown to toggle chip** on all pages.
- **Filter control sizing unified** — dropdowns and toggle buttons both ~34px.
- **Clear All button moved to toggle chip row** (bottom line).
- **Loading indicator** added to all three table pages (200ms debounce).
- **Glass-content card wrappers removed** from song detail performance tables. The lasers can now be seen more. This is easy to undo if you want.
- **Back-to-songs link** moved inline with song title on `/songs/$slug`.

### Data fix: duplicate track positions

Five shows had tracks with duplicate `(show_id, set, position)` tuples in the database. This caused row duplication in filter query results (JOINs would multiply rows when two tracks shared a position). The new composite index also requires unique positions.

- **3 shows had two different songs at the same position** — renumbered the second song and shifted subsequent tracks.
- **2 shows had fully duplicated rows for the same song** — deduplicated by deleting the duplicate row (preserving the one with ratings), along with its duplicate annotation. Fixed linked-list pointers where needed.

### Infrastructure

- **Vitest + React Testing Library** added for both `apps/web` and `packages/core`, in order to allow Claude to debug itself. I was finding it slow to have Claude refactor code and having to manually test it. Having it write its own tests up front and then manage the refactors itself saved me a lot of time.
- **Git hooks** (`.githooks/`) — pre-commit runs lint, pre-push runs typecheck + tests.
- **106 tests** across 16 test files covering DataTable, columns, filters, hooks, and SQL composers.

---

## Reading guide

This PR spans 9 commits across 60 files, but has a logical structure. Here's the recommended reading order:

### 1. Start with the shared infrastructure (understand the building blocks)

- **[use-performance-page-filters.ts](apps/web/app/hooks/use-performance-page-filters.ts)** — The central hook. Manages URL params, fetching, loading, search, and filter state. Generic over `<T>`.
- **[performance-filter-controls.tsx](apps/web/app/components/performance/performance-filter-controls.tsx)** — Shared filter UI. Year, Era, Cover, Author, Played, toggle chips, search, Clear All.
- **[song-page-composer.ts](packages/core/src/page-composers/song-page-composer.ts)** — `FILTER_BUILDERS` map, `buildFilterQuery` static method, and `buildSongPerformanceCounts`. Search for these three names.

### 2. See how consumers use them (the payoff)

- **[songs/_index.tsx](apps/web/app/routes/songs/_index.tsx)** — Was ~500 lines with 6 useState hooks and manual URL sync. Now ~250 lines using the shared hook. Compare the component body.
- **[songs/all-timers.tsx](apps/web/app/routes/songs/all-timers.tsx)** — Clean consumer of the shared infrastructure.
- **[songs/$slug.tsx](apps/web/app/routes/songs/$slug.tsx)** — Minimal changes — same hook, same filter controls.

### 3. API layer

- **[api/songs.tsx](apps/web/app/routes/api/songs.tsx)** — Added toggle filter support via `buildSongPerformanceCounts`. Cross-references song-level filters with performance-level counts.
- **[api/all-timers.tsx](apps/web/app/routes/api/all-timers.tsx)** and **[api/songs/performances.tsx](apps/web/app/routes/api/songs/performances.tsx)** — New API endpoints using `parsePerformanceFilters` + composer methods.

### 4. Earlier refactoring (optional, for context)

- **[data-table.tsx](apps/web/app/components/ui/data-table.tsx)** — Column widths moved to meta, unified compact styling.
- **[performance-table.tsx](apps/web/app/components/performance/performance-table.tsx)** — Went from ~400 lines of duplicated DataTable logic to a ~50-line thin wrapper composing DataTable with attendance highlighting and rating hooks.
- **[use-attendance-row-highlight.ts](apps/web/app/hooks/use-attendance-row-highlight.ts)** — Extracted hook, replaces 3 duplicated call sites.

### 5. Tests (skip unless reviewing test quality)

- Test files mirror source files. The most interesting are:
  - **[use-performance-page-filters.test.ts](apps/web/app/hooks/use-performance-page-filters.test.ts)** — Tests the hook's filter detection, loading lifecycle, and clear behavior.
  - **[song-page-composer.test.ts](packages/core/src/page-composers/song-page-composer.test.ts)** — Tests pure functions + SQL filter builder behavior.

### 6. Migrations

- **[20260408000000_add_tracks_show_set_position_index](packages/core/src/_shared/prisma/migrations/20260408000000_add_tracks_show_set_position_index/migration.sql)** — `CREATE INDEX CONCURRENTLY` on `tracks(show_id, set, position)`. Uses CONCURRENTLY so no table lock in production.
- **[20260408010000_fix_duplicate_track_positions](packages/core/src/_shared/prisma/migrations/20260408010000_fix_duplicate_track_positions/migration.sql)** — Fixes 5 shows with duplicate track positions that caused row duplication in filter query results (JOINs multiply rows when two tracks share a position). Renumbers 3 shows, deduplicates 2 (preserving ratings/annotations/linked-list integrity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)