### PR TITLE
Add On This Day feature

### DIFF
--- a/apps/web/app/components/layout/header.tsx
+++ b/apps/web/app/components/layout/header.tsx
@@ -57,7 +57,7 @@ export function Header() {
 
   return (
     <>
-      <header className="fixed top-0 left-0 right-0 z-50 h-16 bg-background/95 backdrop-blur-sm border-b border-border/10 overflow-hidden">
+      <header className="fixed top-0 left-0 right-0 z-50 h-16 bg-[hsl(240,10%,3.9%)] border-b border-border/10 overflow-hidden">
         <div className="flex h-full items-center justify-between px-4 sm:px-6 lg:px-8 max-w-full">
           {/* Logo */}
           <div className="flex items-center">

--- a/apps/web/app/components/on-this-day/month-day-picker.test.tsx
+++ b/apps/web/app/components/on-this-day/month-day-picker.test.tsx
@@ -1,0 +1,71 @@
+import { setupWithRouter } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { MonthDayPicker } from "./month-day-picker";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+describe("MonthDayPicker", () => {
+  // The trigger button shows the formatted display label so users know
+  // what date they're viewing before opening the picker.
+  test("renders the display label as the trigger button", async () => {
+    await setupWithRouter(<MonthDayPicker monthDay="04-08" displayLabel="April 8" />);
+
+    expect(screen.getByRole("button", { name: /April 8/ })).toBeInTheDocument();
+  });
+
+  // The calendar icon next to the label hints that the date is clickable.
+  test("renders a calendar icon in the trigger", async () => {
+    const { container } = await setupWithRouter(<MonthDayPicker monthDay="12-30" displayLabel="December 30" />);
+
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  // Clicking the trigger opens the popover with a calendar showing the
+  // correct month for the current monthDay.
+  test("opens calendar popover on click showing the correct month", async () => {
+    const { user } = await setupWithRouter(<MonthDayPicker monthDay="04-08" displayLabel="April 8" />);
+
+    await user.click(screen.getByRole("button", { name: /April 8/ }));
+
+    expect(screen.getByText("April")).toBeInTheDocument();
+  });
+
+  // Selecting a date in the calendar navigates to the corresponding
+  // on-this-day URL with zero-padded MM-DD format.
+  test("navigates to selected date on click", async () => {
+    const { user } = await setupWithRouter(<MonthDayPicker monthDay="04-08" displayLabel="April 8" />);
+
+    await user.click(screen.getByRole("button", { name: /April 8/ }));
+    // Click day 15 in the opened calendar
+    await user.click(screen.getByText("15"));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/on-this-day/04-15");
+  });
+
+  // The calendar hides weekday headers since this picker is year-agnostic
+  // and weekdays are meaningless without a specific year.
+  test("does not render weekday headers", async () => {
+    const { user } = await setupWithRouter(<MonthDayPicker monthDay="04-08" displayLabel="April 8" />);
+
+    await user.click(screen.getByRole("button", { name: /April 8/ }));
+
+    expect(screen.queryByText("Su")).not.toBeInTheDocument();
+    expect(screen.queryByText("Mo")).not.toBeInTheDocument();
+  });
+
+  // The caption shows only the month name without a year, since year 2000
+  // is used internally just for date math (leap year support).
+  test("caption shows month name without year", async () => {
+    const { user } = await setupWithRouter(<MonthDayPicker monthDay="02-29" displayLabel="February 29" />);
+
+    await user.click(screen.getByRole("button", { name: /February 29/ }));
+
+    expect(screen.getByText("February")).toBeInTheDocument();
+    expect(screen.queryByText("2000")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/on-this-day/month-day-picker.test.tsx
+++ b/apps/web/app/components/on-this-day/month-day-picker.test.tsx
@@ -47,6 +47,18 @@ describe("MonthDayPicker", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/on-this-day/04-15");
   });
 
+  // Selecting a date dismisses the popover so it doesn't obscure the
+  // page content after navigation.
+  test("closes popover after selecting a date", async () => {
+    const { user } = await setupWithRouter(<MonthDayPicker monthDay="04-08" displayLabel="April 8" />);
+
+    await user.click(screen.getByRole("button", { name: /April 8/ }));
+    expect(screen.getByText("April")).toBeInTheDocument();
+
+    await user.click(screen.getByText("15"));
+    expect(screen.queryByText("April")).not.toBeInTheDocument();
+  });
+
   // The calendar hides weekday headers since this picker is year-agnostic
   // and weekdays are meaningless without a specific year.
   test("does not render weekday headers", async () => {

--- a/apps/web/app/components/on-this-day/month-day-picker.tsx
+++ b/apps/web/app/components/on-this-day/month-day-picker.tsx
@@ -1,0 +1,56 @@
+import { CalendarDays } from "lucide-react";
+import { useNavigate } from "react-router";
+import { Calendar } from "~/components/ui/calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
+
+interface MonthDayPickerProps {
+  monthDay: string;
+  displayLabel: string;
+}
+
+export function MonthDayPicker({ monthDay, displayLabel }: MonthDayPickerProps) {
+  const navigate = useNavigate();
+  const [mm, dd] = monthDay.split("-").map(Number);
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="flex items-center gap-2 text-content-text-secondary text-3xl font-medium hover:text-content-text-primary transition-colors cursor-pointer"
+        >
+          {displayLabel}
+          <CalendarDays className="h-5 w-5" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0 bg-[hsl(224,71%,4%)] border-[hsl(240,5%,20%)]" sideOffset={8}>
+        <Calendar
+          mode="single"
+          defaultMonth={new Date(2000, mm - 1)}
+          selected={new Date(2000, mm - 1, dd)}
+          onSelect={(date: Date | undefined) => {
+            if (!date) return;
+            const selectedMonth = String(date.getMonth() + 1).padStart(2, "0");
+            const selectedDay = String(date.getDate()).padStart(2, "0");
+            navigate(`/on-this-day/${selectedMonth}-${selectedDay}`);
+          }}
+          formatters={{
+            formatCaption: (month: Date) => month.toLocaleString("default", { month: "long" }),
+          }}
+          hideWeekdays
+          classNames={{
+            month_caption: "flex justify-center items-center relative mb-2",
+            caption_label: "text-sm font-medium",
+            nav: "absolute inset-x-0 flex justify-between px-1",
+            button_previous:
+              "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 inline-flex items-center justify-center",
+            button_next:
+              "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 inline-flex items-center justify-center",
+            day_button:
+              "cursor-pointer h-9 w-9 p-0 font-normal inline-flex items-center justify-center rounded-md hover:bg-white/10",
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/app/components/on-this-day/month-day-picker.tsx
+++ b/apps/web/app/components/on-this-day/month-day-picker.tsx
@@ -1,4 +1,5 @@
 import { CalendarDays } from "lucide-react";
+import { useState } from "react";
 import { useNavigate } from "react-router";
 import { Calendar } from "~/components/ui/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
@@ -10,10 +11,11 @@ interface MonthDayPickerProps {
 
 export function MonthDayPicker({ monthDay, displayLabel }: MonthDayPickerProps) {
   const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
   const [mm, dd] = monthDay.split("-").map(Number);
 
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <button
           type="button"
@@ -32,6 +34,7 @@ export function MonthDayPicker({ monthDay, displayLabel }: MonthDayPickerProps) 
             if (!date) return;
             const selectedMonth = String(date.getMonth() + 1).padStart(2, "0");
             const selectedDay = String(date.getDate()).padStart(2, "0");
+            setOpen(false);
             navigate(`/on-this-day/${selectedMonth}-${selectedDay}`);
           }}
           formatters={{

--- a/apps/web/app/components/performance/performance-table.test.tsx
+++ b/apps/web/app/components/performance/performance-table.test.tsx
@@ -170,13 +170,12 @@ describe("PerformanceTable", () => {
     expect(screen.getByText("Filter controls here")).toBeInTheDocument();
   });
 
-  // PerformanceTable shows pagination controls (Previous/Next buttons) so
-  // users can navigate large performance lists without scrolling through
-  // hundreds of rows.
-  test("renders pagination controls above and below the table", async () => {
+  // When all performances fit on a single page, pagination nav controls
+  // (Previous/Next) are hidden to avoid showing disabled "Page 1 of 1" UI.
+  test("hides pagination nav when data fits on one page", async () => {
     await setup(<PerformanceTable performances={[makePerformance()]} />);
 
-    expect(screen.getAllByRole("button", { name: "Previous" })).toHaveLength(2);
-    expect(screen.getAllByRole("button", { name: "Next" })).toHaveLength(2);
+    expect(screen.queryByRole("button", { name: "Previous" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/components/performance/performance-table.tsx
+++ b/apps/web/app/components/performance/performance-table.tsx
@@ -16,6 +16,7 @@ interface PerformanceTableProps {
   showAllTimerColumn?: boolean;
   headerContent?: ReactNode;
   isLoading?: boolean;
+  pageSize?: number;
 }
 
 /**
@@ -30,6 +31,7 @@ export function PerformanceTable({
   showAllTimerColumn,
   headerContent,
   isLoading,
+  pageSize,
 }: PerformanceTableProps) {
   const { user } = useSession();
   const isAuthenticated = !!user;
@@ -54,6 +56,7 @@ export function PerformanceTable({
       filterComponent={headerContent}
       rowClassName={rowClassName}
       initialSorting={[{ id: "date", desc: true }]}
+      pageSize={pageSize}
     />
   );
 }

--- a/apps/web/app/components/ui/data-table.test.tsx
+++ b/apps/web/app/components/ui/data-table.test.tsx
@@ -113,13 +113,28 @@ describe("DataTable", () => {
   });
 
   // The default/non-hidePagination mode shows Previous and Next buttons
-  // above and below the table. Complement to the previous test — together
-  // they pin pagination visibility to the `hidePagination` prop exactly.
-  test("pagination buttons render when not hidden", async () => {
-    await setup(<DataTable columns={basicColumns} data={rows} hideSearch />);
+  // above and below the table when there are multiple pages.
+  test("pagination buttons render when there are multiple pages", async () => {
+    const manyRows = Array.from({ length: 6 }, (_, i) => ({
+      id: String(i),
+      name: `Row ${i}`,
+      count: i,
+    }));
+
+    await setup(<DataTable columns={basicColumns} data={manyRows} hideSearch pageSize={3} />);
 
     expect(screen.getAllByRole("button", { name: "Previous" })).toHaveLength(2);
     expect(screen.getAllByRole("button", { name: "Next" })).toHaveLength(2);
+  });
+
+  // When all data fits on a single page, page navigation controls are hidden
+  // (Previous/Next buttons and page input) but the results summary still shows.
+  test("page controls are hidden when data fits on one page", async () => {
+    await setup(<DataTable columns={basicColumns} data={rows} hideSearch />);
+
+    expect(screen.queryByRole("button", { name: "Previous" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
+    expect(screen.getAllByText(/Showing 1 to 3 of 3 results/)).toHaveLength(2);
   });
 
   // The page input shows "Page [input] of N" between Previous and Next.

--- a/apps/web/app/components/ui/data-table.tsx
+++ b/apps/web/app/components/ui/data-table.tsx
@@ -114,39 +114,41 @@ export function DataTable<TData, TValue>({
       ) : (
         <div />
       )}
-      <div className="flex items-center space-x-2">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => table.previousPage()}
-          disabled={!table.getCanPreviousPage()}
-          className="hover:bg-brand-primary/20 hover:border-brand-primary/40"
-        >
-          Previous
-        </Button>
-        <span className="flex items-center gap-1.5 text-sm text-content-text-secondary">
-          Page
-          <input
-            type="number"
-            min={1}
-            max={totalPages}
-            defaultValue={currentPage}
-            key={currentPage}
-            onKeyDown={handlePageInputKeyDown}
-            className="w-12 rounded border border-glass-border bg-glass-bg px-2 py-1 text-center text-sm text-white focus:outline-none focus:ring-1 focus:ring-ring/20 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-          />
-          of {totalPages}
-        </span>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => table.nextPage()}
-          disabled={!table.getCanNextPage()}
-          className="hover:bg-brand-primary/20 hover:border-brand-primary/40"
-        >
-          Next
-        </Button>
-      </div>
+      {totalPages > 1 && (
+        <div className="flex items-center space-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+            className="hover:bg-brand-primary/20 hover:border-brand-primary/40"
+          >
+            Previous
+          </Button>
+          <span className="flex items-center gap-1.5 text-sm text-content-text-secondary">
+            Page
+            <input
+              type="number"
+              min={1}
+              max={totalPages}
+              defaultValue={currentPage}
+              key={currentPage}
+              onKeyDown={handlePageInputKeyDown}
+              className="w-12 rounded border border-glass-border bg-glass-bg px-2 py-1 text-center text-sm text-white focus:outline-none focus:ring-1 focus:ring-ring/20 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            />
+            of {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+            className="hover:bg-brand-primary/20 hover:border-brand-primary/40"
+          >
+            Next
+          </Button>
+        </div>
+      )}
     </div>
   );
 

--- a/apps/web/app/lib/performance-filter-params.ts
+++ b/apps/web/app/lib/performance-filter-params.ts
@@ -53,6 +53,7 @@ export async function parsePerformanceFilters(url: URL, context: PublicContext):
   const authorParam = url.searchParams.get("author");
   const filtersParam = url.searchParams.get("filters");
   const attendedParam = url.searchParams.get("attended");
+  const monthDayParam = url.searchParams.get("monthDay");
 
   const dateRangeKey = year || era;
   const dateRange = dateRangeKey && dateRangeKey in SONG_FILTERS ? SONG_FILTERS[dateRangeKey] : null;
@@ -64,6 +65,7 @@ export async function parsePerformanceFilters(url: URL, context: PublicContext):
   if (coverParam === "cover") filters.cover = true;
   else if (coverParam === "original") filters.cover = false;
   if (authorParam && UUID_REGEX.test(authorParam)) filters.authorId = authorParam;
+  if (monthDayParam) filters.monthDay = monthDayParam;
 
   const attendedUserId = await resolveAttendedUserId(attendedParam, context);
   if (attendedUserId) filters.attendedUserId = attendedUserId;
@@ -89,6 +91,7 @@ export function buildFilteredCacheKey(url: URL, scope: string, attendedUserId?: 
   const authorParam = url.searchParams.get("author");
   const filtersParam = url.searchParams.get("filters");
 
+  const monthDay = url.searchParams.get("monthDay");
   return CacheKeys.songs.filtered({
     scope,
     year: year || null,
@@ -97,5 +100,6 @@ export function buildFilteredCacheKey(url: URL, scope: string, attendedUserId?: 
     author: authorParam || null,
     filters: filtersParam || null,
     attended: attendedUserId || null,
+    monthDay: monthDay || null,
   });
 }

--- a/apps/web/app/lib/utils.test.ts
+++ b/apps/web/app/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { formatMonthDay, isValidMonthDay } from "./utils";
+import { addDaysYearAgnostic, formatMonthDay, isValidMonthDay } from "./utils";
 
 describe("formatMonthDay", () => {
   // Converts zero-padded MM-DD to human-readable "Month Day" format
@@ -103,5 +103,52 @@ describe("isValidMonthDay", () => {
   // Full date (includes year)
   test("rejects full date with year", () => {
     expect(isValidMonthDay("04-04-2024")).toBe(false);
+  });
+});
+
+describe("addDaysYearAgnostic", () => {
+  // Normal case: incrementing a mid-month day stays in the same month
+  test("increments a normal day", () => {
+    expect(addDaysYearAgnostic("04-08", 1)).toBe("04-09");
+  });
+
+  // Normal case: decrementing a mid-month day stays in the same month
+  test("decrements a normal day", () => {
+    expect(addDaysYearAgnostic("04-08", -1)).toBe("04-07");
+  });
+
+  // Dec 31 + 1 wraps to Jan 1 (year-end boundary)
+  test("wraps forward from December 31 to January 1", () => {
+    expect(addDaysYearAgnostic("12-31", 1)).toBe("01-01");
+  });
+
+  // Jan 1 - 1 wraps to Dec 31 (year-start boundary)
+  test("wraps backward from January 1 to December 31", () => {
+    expect(addDaysYearAgnostic("01-01", -1)).toBe("12-31");
+  });
+
+  // Uses leap year (2000) internally so Feb 29 is always reachable
+  test("Feb 28 + 1 = Feb 29", () => {
+    expect(addDaysYearAgnostic("02-28", 1)).toBe("02-29");
+  });
+
+  // Stepping past Feb 29 lands on Mar 1
+  test("Feb 29 + 1 = Mar 1", () => {
+    expect(addDaysYearAgnostic("02-29", 1)).toBe("03-01");
+  });
+
+  // Stepping back from Feb 29 lands on Feb 28
+  test("Feb 29 - 1 = Feb 28", () => {
+    expect(addDaysYearAgnostic("02-29", -1)).toBe("02-28");
+  });
+
+  // Stepping back from Mar 1 lands on Feb 29 (not Feb 28)
+  test("Mar 1 - 1 = Feb 29", () => {
+    expect(addDaysYearAgnostic("03-01", -1)).toBe("02-29");
+  });
+
+  // Output must always be zero-padded MM-DD
+  test("zero-pads single-digit months and days", () => {
+    expect(addDaysYearAgnostic("01-01", 1)).toBe("01-02");
   });
 });

--- a/apps/web/app/lib/utils.test.ts
+++ b/apps/web/app/lib/utils.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "vitest";
+import { formatMonthDay, isValidMonthDay } from "./utils";
+
+describe("formatMonthDay", () => {
+  // Converts zero-padded MM-DD to human-readable "Month Day" format
+  test("formats mid-year date", () => {
+    expect(formatMonthDay("04-04")).toBe("April 4");
+  });
+
+  // Handles first day of the year
+  test("formats January 1", () => {
+    expect(formatMonthDay("01-01")).toBe("January 1");
+  });
+
+  // Handles last month of the year
+  test("formats December 25", () => {
+    expect(formatMonthDay("12-25")).toBe("December 25");
+  });
+
+  // Leap day is valid across years
+  test("formats February 29", () => {
+    expect(formatMonthDay("02-29")).toBe("February 29");
+  });
+
+  // Day should not have leading zero in output
+  test("strips leading zero from single-digit day", () => {
+    expect(formatMonthDay("03-07")).toBe("March 7");
+  });
+
+  // Double-digit day stays as-is
+  test("preserves double-digit day", () => {
+    expect(formatMonthDay("11-15")).toBe("November 15");
+  });
+});
+
+describe("isValidMonthDay", () => {
+  // --- valid inputs ---
+
+  // Standard valid dates
+  test("accepts 04-04", () => {
+    expect(isValidMonthDay("04-04")).toBe(true);
+  });
+
+  test("accepts 01-01", () => {
+    expect(isValidMonthDay("01-01")).toBe(true);
+  });
+
+  test("accepts 12-31", () => {
+    expect(isValidMonthDay("12-31")).toBe(true);
+  });
+
+  // Leap day allowed — shows exist on Feb 29 in leap years
+  test("accepts 02-29 (leap day)", () => {
+    expect(isValidMonthDay("02-29")).toBe(true);
+  });
+
+  // --- invalid inputs: not zero-padded ---
+
+  // Single-digit month/day must be zero-padded
+  test("rejects 4-4 (not zero-padded)", () => {
+    expect(isValidMonthDay("4-4")).toBe(false);
+  });
+
+  // --- invalid inputs: out of range ---
+
+  // Month 13 doesn't exist
+  test("rejects 13-01 (invalid month)", () => {
+    expect(isValidMonthDay("13-01")).toBe(false);
+  });
+
+  // Month 0 doesn't exist
+  test("rejects 00-01 (month zero)", () => {
+    expect(isValidMonthDay("00-01")).toBe(false);
+  });
+
+  // Day 32 never exists
+  test("rejects 01-32 (day overflow)", () => {
+    expect(isValidMonthDay("01-32")).toBe(false);
+  });
+
+  // February only has 29 days max
+  test("rejects 02-30 (Feb 30 doesn't exist)", () => {
+    expect(isValidMonthDay("02-30")).toBe(false);
+  });
+
+  // April has 30 days
+  test("rejects 04-31 (April has 30 days)", () => {
+    expect(isValidMonthDay("04-31")).toBe(false);
+  });
+
+  // --- invalid inputs: wrong format ---
+
+  // Empty string
+  test("rejects empty string", () => {
+    expect(isValidMonthDay("")).toBe(false);
+  });
+
+  // Non-numeric
+  test("rejects non-numeric input", () => {
+    expect(isValidMonthDay("hello")).toBe(false);
+  });
+
+  // Full date (includes year)
+  test("rejects full date with year", () => {
+    expect(isValidMonthDay("04-04-2024")).toBe(false);
+  });
+});

--- a/apps/web/app/lib/utils.ts
+++ b/apps/web/app/lib/utils.ts
@@ -33,6 +33,29 @@ export function formatDateShort(date: string): string {
   return date;
 }
 
+const MAX_DAYS_PER_MONTH = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+/**
+ * Validates a zero-padded "MM-DD" string.
+ * Allows Feb 29 since shows can exist on leap days across years.
+ */
+export function isValidMonthDay(value: string): boolean {
+  if (!/^(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/.test(value)) {
+    return false;
+  }
+  const [mm, dd] = value.split("-").map(Number);
+  return dd <= MAX_DAYS_PER_MONTH[mm - 1];
+}
+
+/**
+ * Formats "MM-DD" as "Month Day" (e.g., "04-04" → "April 4").
+ */
+export function formatMonthDay(monthDay: string): string {
+  const [mm, dd] = monthDay.split("-").map(Number);
+  const monthName = new Date(2000, mm - 1, dd).toLocaleString("default", { month: "long" });
+  return `${monthName} ${dd}`;
+}
+
 // this input will be in the format "2025-01-01"
 // this should output as "January 1, 2025"
 export function formatDateLong(date: string): string {

--- a/apps/web/app/lib/utils.ts
+++ b/apps/web/app/lib/utils.ts
@@ -56,6 +56,19 @@ export function formatMonthDay(monthDay: string): string {
   return `${monthName} ${dd}`;
 }
 
+/**
+ * Steps a year-agnostic "MM-DD" string forward or backward by `delta` days.
+ * Uses year 2000 (a leap year) so Feb 29 is always traversable.
+ */
+export function addDaysYearAgnostic(monthDay: string, delta: number): string {
+  const [mm, dd] = monthDay.split("-").map(Number);
+  const date = new Date(Date.UTC(2000, mm - 1, dd));
+  date.setUTCDate(date.getUTCDate() + delta);
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(date.getUTCDate()).padStart(2, "0");
+  return `${m}-${d}`;
+}
+
 // this input will be in the format "2025-01-01"
 // this should output as "January 1, 2025"
 export function formatDateLong(date: string): string {

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -5,6 +5,9 @@ export default [
   // Root index route
   index("routes/_index.tsx"),
 
+  // On This Day
+  route("on-this-day/:monthDay?", "routes/on-this-day.$monthDay.tsx"),
+
   // Legal and info pages
   route("about", "routes/about.tsx"),
   route("terms", "routes/terms.tsx"),

--- a/apps/web/app/routes/_index.tsx
+++ b/apps/web/app/routes/_index.tsx
@@ -1,7 +1,7 @@
 import {
-  CacheKeys,
   type Attendance,
   type BlogPostWithUser,
+  CacheKeys,
   type Rating,
   type Setlist,
   type TourDate,
@@ -39,6 +39,7 @@ interface LoaderData {
   latestEpisode: AcastEpisode | null;
   nextTourDate: TourDate | null;
   recentShows: Setlist[];
+  onThisDayCounts: { showCount: number; allTimerCount: number };
 }
 
 export const loader = publicLoader<LoaderData>(async ({ context }) => {
@@ -147,6 +148,17 @@ export const loader = publicLoader<LoaderData>(async ({ context }) => {
     logger.error("Error fetching latest episode", { error });
   }
 
+  const today = new Date();
+  const monthDay = `${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+  const onThisDayCounts = await services.cache.getOrSet(
+    CacheKeys.shows.onThisDayCounts(monthDay),
+    async () => ({
+      showCount: await services.setlists.countByMonthDay(monthDay),
+      allTimerCount: await services.songPageComposer.countAllTimersByMonthDay(monthDay),
+    }),
+    { ttl: 3600 },
+  );
+
   return {
     tourDates,
     mobileRecentShows,
@@ -157,6 +169,7 @@ export const loader = publicLoader<LoaderData>(async ({ context }) => {
     latestEpisode,
     nextTourDate,
     recentShows,
+    onThisDayCounts,
   };
 });
 
@@ -175,6 +188,7 @@ export default function Index() {
     latestEpisode,
     nextTourDate,
     recentShows = [],
+    onThisDayCounts,
   } = useSerializedLoaderData<LoaderData>();
 
   return (
@@ -233,12 +247,22 @@ export default function Index() {
           <div className="lg:col-span-2">
             <div className="mb-6">
               <h2 className="text-2xl font-bold">Recent Shows</h2>
-              <Link
-                to="/shows"
-                className="text-sm text-content-text-tertiary hover:text-brand-primary transition-colors"
-              >
-                View all shows →
-              </Link>
+              <div className="flex gap-4">
+                <Link
+                  to="/shows"
+                  className="text-sm text-content-text-tertiary hover:text-brand-primary transition-colors"
+                >
+                  View all shows →
+                </Link>
+                {onThisDayCounts.showCount > 0 && (
+                  <Link
+                    to="/on-this-day"
+                    className="text-sm text-content-text-tertiary hover:text-brand-primary transition-colors"
+                  >
+                    On this day: {onThisDayCounts.showCount} shows, {onThisDayCounts.allTimerCount} all-timers →
+                  </Link>
+                )}
+              </div>
             </div>
 
             {desktopRecentShows.length > 0 ? (
@@ -374,7 +398,8 @@ export default function Index() {
                   </div>
                   <div className="p-3">
                     <p className="text-content-text-secondary text-sm leading-relaxed">
-                      A sci-fi concept album following an alien prince whose collision with The Disco Biscuits rewrites the fate of two worlds.
+                      A sci-fi concept album following an alien prince whose collision with The Disco Biscuits rewrites
+                      the fate of two worlds.
                     </p>
                     <span className="text-brand-primary text-sm font-medium mt-2 inline-block group-hover:text-brand-secondary transition-colors">
                       Explore the story →
@@ -472,9 +497,22 @@ export default function Index() {
         <div>
           <div className="mb-6">
             <h2 className="text-xl font-bold">Recent Shows</h2>
-            <Link to="/shows" className="text-sm text-content-text-tertiary hover:text-brand-primary transition-colors">
-              View all shows →
-            </Link>
+            <div className="flex gap-4">
+              <Link
+                to="/shows"
+                className="text-sm text-content-text-tertiary hover:text-brand-primary transition-colors"
+              >
+                View all shows →
+              </Link>
+              {onThisDayCounts.showCount > 0 && (
+                <Link
+                  to="/on-this-day"
+                  className="text-sm text-content-text-tertiary hover:text-brand-primary transition-colors"
+                >
+                  On this day: {onThisDayCounts.showCount} shows, {onThisDayCounts.allTimerCount} all-timers →
+                </Link>
+              )}
+            </div>
           </div>
 
           {mobileRecentShows.length > 0 ? (

--- a/apps/web/app/routes/on-this-day.$monthDay.tsx
+++ b/apps/web/app/routes/on-this-day.$monthDay.tsx
@@ -1,7 +1,9 @@
-import { CacheKeys, type SetlistLight } from "@bip/domain";
+import { CacheKeys, type SetlistLight, type SongPagePerformance } from "@bip/domain";
+import { Flame } from "lucide-react";
 import { useMemo } from "react";
 import type { ClientLoaderFunctionArgs } from "react-router";
-import { type LoaderFunctionArgs, redirect } from "react-router";
+import { Link, type LoaderFunctionArgs, redirect } from "react-router";
+import { PerformanceTable } from "~/components/performance";
 import { SetlistCard } from "~/components/setlist/setlist-card";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { useShowUserData } from "~/hooks/use-show-user-data";
@@ -11,6 +13,7 @@ import { services } from "~/server/services";
 
 interface LoaderData {
   setlists: SetlistLight[];
+  performances: SongPagePerformance[];
   monthDay: string;
   displayLabel: string;
 }
@@ -35,25 +38,31 @@ export const loader = publicLoader(async ({ params }: LoaderFunctionArgs): Promi
     throw new Response(null, { status: 404 });
   }
 
-  const cacheKey = CacheKeys.shows.list({ monthDay, sort: "desc" });
+  const setlistsCacheKey = CacheKeys.shows.list({ monthDay, sort: "desc" });
+  const allTimersCacheKey = CacheKeys.songs.allTimersOnThisDay(monthDay);
 
-  const setlists = await services.cache.getOrSet(cacheKey, async () => {
-    return services.setlists.findManyLight({
-      filters: { monthDay },
-      sort: [{ field: "date", direction: "desc" }],
-    });
-  });
+  const [setlists, allTimersResult] = await Promise.all([
+    services.cache.getOrSet(setlistsCacheKey, async () => {
+      return services.setlists.findManyLight({
+        filters: { monthDay },
+        sort: [{ field: "date", direction: "desc" }],
+      });
+    }),
+    services.cache.getOrSet(allTimersCacheKey, async () => {
+      return services.songPageComposer.buildAllTimers({ monthDay });
+    }),
+  ]);
 
   const displayLabel = formatMonthDay(monthDay);
 
-  return { setlists, monthDay, displayLabel };
+  return { setlists, performances: allTimersResult.performances, monthDay, displayLabel };
 });
 
 export function meta({ data }: { data: LoaderData }) {
   if (!data) return [{ title: "On This Day | Biscuits Internet Project" }];
   return [
     { title: `On This Day: ${data.displayLabel} | Biscuits Internet Project` },
-    { name: "description", content: `Disco Biscuits shows played on ${data.displayLabel}` },
+    { name: "description", content: `Disco Biscuits shows and all-time performances on ${data.displayLabel}` },
   ];
 }
 
@@ -63,7 +72,7 @@ export const clientLoader = async ({ serverLoader }: ClientLoaderFunctionArgs) =
 clientLoader.hydrate = true;
 
 export default function OnThisDay() {
-  const { setlists, displayLabel } = useSerializedLoaderData<LoaderData>();
+  const { setlists, performances, displayLabel } = useSerializedLoaderData<LoaderData>();
 
   const showIds = useMemo(() => setlists.map((setlist) => setlist.show.id), [setlists]);
   const { attendanceMap, userRatingMap, averageRatingMap } = useShowUserData(showIds);
@@ -76,6 +85,28 @@ export default function OnThisDay() {
           <div className="flex justify-center -mt-4">
             <span className="text-content-text-secondary text-3xl font-medium">{displayLabel}</span>
           </div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <Flame className="h-6 w-6 text-orange-500" />
+              <h2 className="text-2xl font-bold text-content-text-primary">All-Timers</h2>
+            </div>
+            <Link
+              to="/songs/all-timers"
+              className="text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors"
+            >
+              View all →
+            </Link>
+          </div>
+          {performances.length === 0 ? (
+            <div className="text-center py-2">
+              <p className="text-content-text-secondary text-lg">None on this date</p>
+            </div>
+          ) : (
+            <PerformanceTable performances={performances} showSongColumn />
+          )}
         </div>
 
         <div className="space-y-4">

--- a/apps/web/app/routes/on-this-day.$monthDay.tsx
+++ b/apps/web/app/routes/on-this-day.$monthDay.tsx
@@ -5,7 +5,9 @@ import type { ClientLoaderFunctionArgs } from "react-router";
 import { Link, type LoaderFunctionArgs, redirect } from "react-router";
 import { MonthDayPicker } from "~/components/on-this-day/month-day-picker";
 import { PerformanceTable } from "~/components/performance";
+import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
 import { SetlistCard } from "~/components/setlist/setlist-card";
+import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { useShowUserData } from "~/hooks/use-show-user-data";
 import { publicLoader } from "~/lib/base-loaders";
@@ -83,9 +85,32 @@ export const clientLoader = async ({ serverLoader }: ClientLoaderFunctionArgs) =
 };
 clientLoader.hydrate = true;
 
+const ALL_TIMERS_PAGE_SIZE = 10;
+
 export default function OnThisDay() {
   const { setlists, performances, displayLabel, monthDay, previousMonthDay, nextMonthDay } =
     useSerializedLoaderData<LoaderData>();
+
+  const {
+    filteredData: filteredPerformances,
+    isLoading,
+    selectedYear,
+    selectedEra,
+    coverFilter,
+    selectedAuthor,
+    activeToggleSet,
+    hasActiveFilters,
+    searchText,
+    setSearchText,
+    updateFilter,
+    toggleFilter,
+    clearFilters,
+  } = usePerformancePageFilters({
+    initialData: performances,
+    apiUrl: "/api/all-timers",
+    extraParams: { monthDay },
+    searchFilter: searchPerformance,
+  });
 
   const showIds = useMemo(() => setlists.map((setlist) => setlist.show.id), [setlists]);
   const { attendanceMap, userRatingMap, averageRatingMap } = useShowUserData(showIds);
@@ -134,7 +159,30 @@ export default function OnThisDay() {
               <p className="text-content-text-secondary text-lg">None on this date</p>
             </div>
           ) : (
-            <PerformanceTable performances={performances} showSongColumn pageSize={10} />
+            <PerformanceTable
+              performances={filteredPerformances}
+              isLoading={isLoading}
+              showSongColumn
+              pageSize={ALL_TIMERS_PAGE_SIZE}
+              headerContent={
+                performances.length > ALL_TIMERS_PAGE_SIZE ? (
+                  <PerformanceFilterControls
+                    selectedYear={selectedYear}
+                    selectedEra={selectedEra}
+                    activeToggleSet={activeToggleSet}
+                    updateFilter={updateFilter}
+                    toggleFilter={toggleFilter}
+                    clearFilters={clearFilters}
+                    coverFilter={coverFilter}
+                    selectedAuthor={selectedAuthor}
+                    showAllTimerToggle={false}
+                    searchValue={searchText}
+                    onSearchChange={setSearchText}
+                    hasActiveFilters={hasActiveFilters}
+                  />
+                ) : undefined
+              }
+            />
           )}
         </div>
 

--- a/apps/web/app/routes/on-this-day.$monthDay.tsx
+++ b/apps/web/app/routes/on-this-day.$monthDay.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft, ChevronRight, Flame } from "lucide-react";
 import { useMemo } from "react";
 import type { ClientLoaderFunctionArgs } from "react-router";
 import { Link, type LoaderFunctionArgs, redirect } from "react-router";
+import { MonthDayPicker } from "~/components/on-this-day/month-day-picker";
 import { PerformanceTable } from "~/components/performance";
 import { SetlistCard } from "~/components/setlist/setlist-card";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
@@ -83,7 +84,7 @@ export const clientLoader = async ({ serverLoader }: ClientLoaderFunctionArgs) =
 clientLoader.hydrate = true;
 
 export default function OnThisDay() {
-  const { setlists, performances, displayLabel, previousMonthDay, nextMonthDay } =
+  const { setlists, performances, displayLabel, monthDay, previousMonthDay, nextMonthDay } =
     useSerializedLoaderData<LoaderData>();
 
   const showIds = useMemo(() => setlists.map((setlist) => setlist.show.id), [setlists]);
@@ -103,7 +104,7 @@ export default function OnThisDay() {
               <ChevronLeft className="h-3 w-3" />
               <span>{formatMonthDay(previousMonthDay)}</span>
             </Link>
-            <span className="text-content-text-secondary text-3xl font-medium">{displayLabel}</span>
+            <MonthDayPicker monthDay={monthDay} displayLabel={displayLabel} />
             <Link
               to={`/on-this-day/${nextMonthDay}`}
               prefetch="intent"

--- a/apps/web/app/routes/on-this-day.$monthDay.tsx
+++ b/apps/web/app/routes/on-this-day.$monthDay.tsx
@@ -133,7 +133,7 @@ export default function OnThisDay() {
               <p className="text-content-text-secondary text-lg">None on this date</p>
             </div>
           ) : (
-            <PerformanceTable performances={performances} showSongColumn />
+            <PerformanceTable performances={performances} showSongColumn pageSize={10} />
           )}
         </div>
 

--- a/apps/web/app/routes/on-this-day.$monthDay.tsx
+++ b/apps/web/app/routes/on-this-day.$monthDay.tsx
@@ -1,5 +1,5 @@
 import { CacheKeys, type SetlistLight, type SongPagePerformance } from "@bip/domain";
-import { Flame } from "lucide-react";
+import { ChevronLeft, ChevronRight, Flame } from "lucide-react";
 import { useMemo } from "react";
 import type { ClientLoaderFunctionArgs } from "react-router";
 import { Link, type LoaderFunctionArgs, redirect } from "react-router";
@@ -8,7 +8,7 @@ import { SetlistCard } from "~/components/setlist/setlist-card";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { useShowUserData } from "~/hooks/use-show-user-data";
 import { publicLoader } from "~/lib/base-loaders";
-import { formatMonthDay, isValidMonthDay } from "~/lib/utils";
+import { addDaysYearAgnostic, formatMonthDay, isValidMonthDay } from "~/lib/utils";
 import { services } from "~/server/services";
 
 interface LoaderData {
@@ -16,6 +16,8 @@ interface LoaderData {
   performances: SongPagePerformance[];
   monthDay: string;
   displayLabel: string;
+  previousMonthDay: string;
+  nextMonthDay: string;
 }
 
 export function headers(): Headers {
@@ -54,8 +56,17 @@ export const loader = publicLoader(async ({ params }: LoaderFunctionArgs): Promi
   ]);
 
   const displayLabel = formatMonthDay(monthDay);
+  const previousMonthDay = addDaysYearAgnostic(monthDay, -1);
+  const nextMonthDay = addDaysYearAgnostic(monthDay, 1);
 
-  return { setlists, performances: allTimersResult.performances, monthDay, displayLabel };
+  return {
+    setlists,
+    performances: allTimersResult.performances,
+    monthDay,
+    displayLabel,
+    previousMonthDay,
+    nextMonthDay,
+  };
 });
 
 export function meta({ data }: { data: LoaderData }) {
@@ -72,7 +83,8 @@ export const clientLoader = async ({ serverLoader }: ClientLoaderFunctionArgs) =
 clientLoader.hydrate = true;
 
 export default function OnThisDay() {
-  const { setlists, performances, displayLabel } = useSerializedLoaderData<LoaderData>();
+  const { setlists, performances, displayLabel, previousMonthDay, nextMonthDay } =
+    useSerializedLoaderData<LoaderData>();
 
   const showIds = useMemo(() => setlists.map((setlist) => setlist.show.id), [setlists]);
   const { attendanceMap, userRatingMap, averageRatingMap } = useShowUserData(showIds);
@@ -82,8 +94,24 @@ export default function OnThisDay() {
       <div className="space-y-6 md:space-y-8">
         <div className="relative">
           <h1 className="page-heading">ON THIS DAY</h1>
-          <div className="flex justify-center -mt-4">
+          <div className="flex justify-between items-center -mt-4">
+            <Link
+              to={`/on-this-day/${previousMonthDay}`}
+              prefetch="intent"
+              className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors"
+            >
+              <ChevronLeft className="h-3 w-3" />
+              <span>{formatMonthDay(previousMonthDay)}</span>
+            </Link>
             <span className="text-content-text-secondary text-3xl font-medium">{displayLabel}</span>
+            <Link
+              to={`/on-this-day/${nextMonthDay}`}
+              prefetch="intent"
+              className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors"
+            >
+              <span>{formatMonthDay(nextMonthDay)}</span>
+              <ChevronRight className="h-3 w-3" />
+            </Link>
           </div>
         </div>
 

--- a/apps/web/app/routes/on-this-day.$monthDay.tsx
+++ b/apps/web/app/routes/on-this-day.$monthDay.tsx
@@ -1,0 +1,102 @@
+import { CacheKeys, type SetlistLight } from "@bip/domain";
+import { useMemo } from "react";
+import type { ClientLoaderFunctionArgs } from "react-router";
+import { type LoaderFunctionArgs, redirect } from "react-router";
+import { SetlistCard } from "~/components/setlist/setlist-card";
+import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
+import { useShowUserData } from "~/hooks/use-show-user-data";
+import { publicLoader } from "~/lib/base-loaders";
+import { formatMonthDay, isValidMonthDay } from "~/lib/utils";
+import { services } from "~/server/services";
+
+interface LoaderData {
+  setlists: SetlistLight[];
+  monthDay: string;
+  displayLabel: string;
+}
+
+export function headers(): Headers {
+  const headers = new Headers();
+  headers.set("Cache-Control", "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600");
+  return headers;
+}
+
+export const loader = publicLoader(async ({ params }: LoaderFunctionArgs): Promise<LoaderData> => {
+  const { monthDay } = params;
+
+  if (!monthDay) {
+    const today = new Date();
+    const mm = String(today.getMonth() + 1).padStart(2, "0");
+    const dd = String(today.getDate()).padStart(2, "0");
+    throw redirect(`/on-this-day/${mm}-${dd}`);
+  }
+
+  if (!isValidMonthDay(monthDay)) {
+    throw new Response(null, { status: 404 });
+  }
+
+  const cacheKey = CacheKeys.shows.list({ monthDay, sort: "desc" });
+
+  const setlists = await services.cache.getOrSet(cacheKey, async () => {
+    return services.setlists.findManyLight({
+      filters: { monthDay },
+      sort: [{ field: "date", direction: "desc" }],
+    });
+  });
+
+  const displayLabel = formatMonthDay(monthDay);
+
+  return { setlists, monthDay, displayLabel };
+});
+
+export function meta({ data }: { data: LoaderData }) {
+  if (!data) return [{ title: "On This Day | Biscuits Internet Project" }];
+  return [
+    { title: `On This Day: ${data.displayLabel} | Biscuits Internet Project` },
+    { name: "description", content: `Disco Biscuits shows played on ${data.displayLabel}` },
+  ];
+}
+
+export const clientLoader = async ({ serverLoader }: ClientLoaderFunctionArgs) => {
+  return serverLoader();
+};
+clientLoader.hydrate = true;
+
+export default function OnThisDay() {
+  const { setlists, displayLabel } = useSerializedLoaderData<LoaderData>();
+
+  const showIds = useMemo(() => setlists.map((setlist) => setlist.show.id), [setlists]);
+  const { attendanceMap, userRatingMap, averageRatingMap } = useShowUserData(showIds);
+
+  return (
+    <div className="py-2">
+      <div className="space-y-6 md:space-y-8">
+        <div className="relative">
+          <h1 className="page-heading">ON THIS DAY</h1>
+          <div className="flex justify-center -mt-4">
+            <span className="text-content-text-secondary text-3xl font-medium">{displayLabel}</span>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          {setlists.length === 0 ? (
+            <div className="text-center py-8">
+              <p className="text-content-text-secondary text-lg">No shows on {displayLabel}.</p>
+            </div>
+          ) : (
+            setlists.map((setlist) => (
+              <SetlistCard
+                key={setlist.show.id}
+                setlist={setlist}
+                userAttendance={attendanceMap.get(setlist.show.id) ?? null}
+                userRating={userRatingMap.get(setlist.show.id) ?? null}
+                showRating={averageRatingMap.get(setlist.show.id)?.average ?? setlist.show.averageRating}
+                className="transition-all duration-300 transform hover:scale-[1.01]"
+              />
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/routes/on-this-day.test.tsx
+++ b/apps/web/app/routes/on-this-day.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+
+/**
+ * Whether to show performance filter controls on the On This Day page.
+ * Filters are only useful when there are enough all-timers to paginate.
+ */
+function shouldShowFilters(performanceCount: number, pageSize: number): boolean {
+  return performanceCount > pageSize;
+}
+
+describe("shouldShowFilters", () => {
+  // Filters add noise when all performances fit on one page — hide them.
+  test("returns false when performances fit on one page", () => {
+    expect(shouldShowFilters(5, 10)).toBe(false);
+  });
+
+  // At exactly the page size, there's still no second page — hide filters.
+  test("returns false when performance count equals page size", () => {
+    expect(shouldShowFilters(10, 10)).toBe(false);
+  });
+
+  // With more performances than the page size, pagination kicks in and
+  // filters become useful for narrowing results.
+  test("returns true when performances exceed page size", () => {
+    expect(shouldShowFilters(11, 10)).toBe(true);
+  });
+});

--- a/apps/web/app/routes/shows/$slug.tsx
+++ b/apps/web/app/routes/shows/$slug.tsx
@@ -1,5 +1,5 @@
-import { CacheKeys, type Attendance, type ReviewMinimal, type Setlist, type ShowFile } from "@bip/domain";
 import type { ShowNavItem } from "@bip/core";
+import { type Attendance, CacheKeys, type ReviewMinimal, type Setlist, type ShowFile } from "@bip/domain";
 import { ArrowLeft, ChevronLeft, ChevronRight, Edit } from "lucide-react";
 import { Link, useRevalidator } from "react-router-dom";
 import { toast } from "sonner";
@@ -16,9 +16,9 @@ import { useSession } from "~/hooks/use-session";
 import { useShowUserData } from "~/hooks/use-show-user-data";
 import { type Context, publicLoader } from "~/lib/base-loaders";
 import { notFound } from "~/lib/errors";
-import { getShowMeta, getShowStructuredData } from "~/lib/seo";
 import { logger } from "~/lib/logger";
-import { formatDateLong } from "~/lib/utils";
+import { getShowMeta, getShowStructuredData } from "~/lib/seo";
+import { formatDateLong, formatMonthDay } from "~/lib/utils";
 import { services } from "~/server/services";
 
 interface ArchiveItem {
@@ -155,14 +155,8 @@ export function meta({ data }: { data: ShowLoaderData }) {
 }
 
 export default function Show() {
-  const {
-    setlist,
-    reviews,
-    selectedRecordingId,
-    userAttendance,
-    photos,
-    adjacentShows,
-  } = useSerializedLoaderData<ShowLoaderData>();
+  const { setlist, reviews, selectedRecordingId, userAttendance, photos, adjacentShows } =
+    useSerializedLoaderData<ShowLoaderData>();
   const { user } = useSession();
   const revalidator = useRevalidator();
   const { userRatingMap } = useShowUserData([setlist.show.id]);
@@ -289,6 +283,12 @@ export default function Show() {
           ) : (
             <div />
           )}
+          <Link
+            to={`/on-this-day/${setlist.show.date.slice(5)}`}
+            className="text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors"
+          >
+            All shows on {formatMonthDay(setlist.show.date.slice(5))} →
+          </Link>
           {adjacentShows.next ? (
             <Link
               to={`/shows/${adjacentShows.next.slug}`}
@@ -360,7 +360,9 @@ export default function Show() {
         <div className="mt-10 pt-8 border-t border-border/50">
           <div className="flex items-center justify-between mb-5">
             <h2 className="text-2xl font-bold text-content-text-primary">Photos</h2>
-            <span className="text-sm text-content-text-tertiary">{photos.length} photo{photos.length !== 1 ? 's' : ''}</span>
+            <span className="text-sm text-content-text-tertiary">
+              {photos.length} photo{photos.length !== 1 ? "s" : ""}
+            </span>
           </div>
           <ShowPhotos photos={photos} />
         </div>

--- a/packages/core/src/page-composers/song-page-composer.test.ts
+++ b/packages/core/src/page-composers/song-page-composer.test.ts
@@ -1,4 +1,5 @@
 import type { Annotation, SongPagePerformance } from "@bip/domain";
+import { CacheKeys } from "@bip/domain";
 import { Prisma } from "@prisma/client";
 import { describe, expect, test, vi } from "vitest";
 import {
@@ -377,6 +378,28 @@ describe("buildFilterQuery", () => {
     // attendedUserId produces a join
     expect(extraJoins).toHaveLength(1);
   });
+
+  // The monthDay filter produces a LIKE condition on shows.date (VARCHAR
+  // "YYYY-MM-DD") to match any year for a given month+day. Used by the
+  // On This Day page to fetch all-timers for a calendar day.
+  test("monthDay filter produces a LIKE condition on shows.date", () => {
+    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery([], { monthDay: "04-08" });
+
+    expect(conditions).toHaveLength(1);
+    expect(extraJoins).toHaveLength(0);
+    const sql = conditions[0].strings.join("");
+    expect(sql).toContain("shows.date LIKE");
+  });
+
+  // monthDay composes with base conditions (e.g., all_timer = true) via AND,
+  // so buildAllTimers({ monthDay }) produces the right two-condition WHERE.
+  test("monthDay combines with base conditions", () => {
+    const base = [Prisma.sql`tracks.all_timer = true`];
+    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery(base, { monthDay: "12-31" });
+
+    expect(conditions).toHaveLength(2);
+    expect(extraJoins).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -426,5 +449,17 @@ describe("buildSongPerformanceCounts", () => {
     await composer.buildSongPerformanceCounts({ encore: true, segueIn: true });
 
     expect(mockDb.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CacheKeys — on-this-day all-timers key
+// ---------------------------------------------------------------------------
+
+describe("CacheKeys", () => {
+  // The on-this-day all-timers cache key must embed the monthDay so each
+  // calendar day gets its own cache entry.
+  test("allTimersOnThisDay includes the monthDay in the key", () => {
+    expect(CacheKeys.songs.allTimersOnThisDay("04-08")).toBe("songs:all-timers:on-this-day:04-08");
   });
 });

--- a/packages/core/src/page-composers/song-page-composer.test.ts
+++ b/packages/core/src/page-composers/song-page-composer.test.ts
@@ -456,10 +456,40 @@ describe("buildSongPerformanceCounts", () => {
 // CacheKeys — on-this-day all-timers key
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// countAllTimersByMonthDay — raw count query
+// ---------------------------------------------------------------------------
+
+describe("countAllTimersByMonthDay", () => {
+  // Parses the raw SQL count string result into a number. Used by the
+  // home page to show how many all-timer performances occurred on a day.
+  test("returns parsed count from raw query", async () => {
+    const mockDb = {
+      $queryRaw: vi.fn().mockResolvedValue([{ count: "12" }]),
+    };
+    const composer = new SongPageComposer(mockDb as never, {} as never);
+
+    const result = await composer.countAllTimersByMonthDay("04-08");
+
+    expect(result).toBe(12);
+    expect(mockDb.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CacheKeys — on-this-day keys
+// ---------------------------------------------------------------------------
+
 describe("CacheKeys", () => {
   // The on-this-day all-timers cache key must embed the monthDay so each
   // calendar day gets its own cache entry.
   test("allTimersOnThisDay includes the monthDay in the key", () => {
     expect(CacheKeys.songs.allTimersOnThisDay("04-08")).toBe("songs:all-timers:on-this-day:04-08");
+  });
+
+  // The on-this-day counts cache key is used by the home page to cache
+  // show + all-timer counts for today's calendar day.
+  test("onThisDayCounts includes the monthDay in the key", () => {
+    expect(CacheKeys.shows.onThisDayCounts("04-08")).toBe("shows:on-this-day-counts:04-08");
   });
 });

--- a/packages/core/src/page-composers/song-page-composer.ts
+++ b/packages/core/src/page-composers/song-page-composer.ts
@@ -151,6 +151,16 @@ export class SongPageComposer {
     };
   }
 
+  async countAllTimersByMonthDay(monthDay: string): Promise<number> {
+    const result = await this.db.$queryRaw<[{ count: string }]>`
+      SELECT COUNT(*)::text as count
+      FROM tracks
+      JOIN shows ON tracks.show_id = shows.id
+      WHERE tracks.all_timer = true AND shows.date LIKE ${`%-${monthDay}`}
+    `;
+    return Number.parseInt(result[0].count, 10);
+  }
+
   /** Build the all-timers page view, optionally filtered by date range, cover, author, attendance, and performance tags. */
   async buildAllTimers(options?: PerformanceFilterOptions): Promise<AllTimersPageView> {
     const { conditions, extraJoins } = SongPageComposer.buildFilterQuery(

--- a/packages/core/src/page-composers/song-page-composer.ts
+++ b/packages/core/src/page-composers/song-page-composer.ts
@@ -23,6 +23,7 @@ export interface PerformanceFilterOptions {
   inverted?: boolean;
   dyslexic?: boolean;
   allTimer?: boolean;
+  monthDay?: string;
 }
 
 export class SongPageComposer {
@@ -273,6 +274,7 @@ export class SongPageComposer {
           }
         : null,
     allTimer: (o) => (o.allTimer ? { condition: Prisma.sql`tracks.all_timer = true` } : null),
+    monthDay: (o) => (o.monthDay ? { condition: Prisma.sql`shows.date LIKE ${`%-${o.monthDay}`}` } : null),
     inverted: (o) =>
       o.inverted
         ? {

--- a/packages/core/src/setlists/setlist-service.test.ts
+++ b/packages/core/src/setlists/setlist-service.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test, vi } from "vitest";
 import { SetlistService } from "./setlist-service";
 
-// Minimal mock DbClient — only the show.findMany path used by findManyLight
+// Minimal mock DbClient — only the paths used by tests
 function makeMockDb() {
   return {
     show: {
       findMany: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0),
     },
   };
 }
@@ -47,5 +48,22 @@ describe("SetlistService.findManyLight", () => {
 
     const call = db.show.findMany.mock.calls[0][0];
     expect(call.where.date).toBeUndefined();
+  });
+});
+
+describe("SetlistService.countByMonthDay", () => {
+  // Uses Prisma's count with endsWith to match any year for a given
+  // calendar day. Used by the home page to show On This Day counts.
+  test("calls db.show.count with endsWith date filter", async () => {
+    const db = makeMockDb();
+    db.show.count.mockResolvedValue(7);
+    const service = new SetlistService(db as never);
+
+    const result = await service.countByMonthDay("04-08");
+
+    expect(result).toBe(7);
+    expect(db.show.count).toHaveBeenCalledWith({
+      where: { date: { endsWith: "-04-08" } },
+    });
   });
 });

--- a/packages/core/src/setlists/setlist-service.test.ts
+++ b/packages/core/src/setlists/setlist-service.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test, vi } from "vitest";
+import { SetlistService } from "./setlist-service";
+
+// Minimal mock DbClient — only the show.findMany path used by findManyLight
+function makeMockDb() {
+  return {
+    show: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+  };
+}
+
+describe("SetlistService.findManyLight", () => {
+  // monthDay filter passes endsWith to Prisma's date where clause
+  test("applies endsWith date filter when monthDay is provided", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never);
+
+    await service.findManyLight({
+      filters: { monthDay: "04-04" },
+      sort: [{ field: "date", direction: "desc" }],
+    });
+
+    const call = db.show.findMany.mock.calls[0][0];
+    expect(call.where.date).toEqual({ endsWith: "-04-04" });
+  });
+
+  // Existing year filter still works (gte/lt range) — no regression
+  test("applies gte/lt date filter when year is provided", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never);
+
+    await service.findManyLight({
+      filters: { year: 2024 },
+    });
+
+    const call = db.show.findMany.mock.calls[0][0];
+    expect(call.where.date).toEqual({ gte: "2024-01-01", lt: "2025-01-01" });
+  });
+
+  // No date filter when neither year nor monthDay is provided
+  test("omits date filter when no year or monthDay provided", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never);
+
+    await service.findManyLight({ filters: {} });
+
+    const call = db.show.findMany.mock.calls[0][0];
+    expect(call.where.date).toBeUndefined();
+  });
+});

--- a/packages/core/src/setlists/setlist-service.ts
+++ b/packages/core/src/setlists/setlist-service.ts
@@ -462,4 +462,10 @@ export class SetlistService {
         }),
       );
   }
+
+  async countByMonthDay(monthDay: string): Promise<number> {
+    return this.db.show.count({
+      where: { date: { endsWith: `-${monthDay}` } },
+    });
+  }
 }

--- a/packages/core/src/setlists/setlist-service.ts
+++ b/packages/core/src/setlists/setlist-service.ts
@@ -5,6 +5,7 @@ import type { PaginationOptions, SortOptions } from "../_shared/database/types";
 
 export type SetlistFilter = {
   year?: number;
+  monthDay?: string;
   venueId?: string;
   hasPhotos?: boolean;
 };
@@ -331,6 +332,7 @@ export class SetlistService {
     filters?: SetlistFilter;
   }): Promise<Setlist[]> {
     const year = options?.filters?.year;
+    const monthDay = options?.filters?.monthDay;
     const venueId = options?.filters?.venueId;
     const hasPhotos = options?.filters?.hasPhotos;
 
@@ -344,12 +346,14 @@ export class SetlistService {
     const results = await this.db.show.findMany({
       where: {
         venueId,
-        date: year
-          ? {
-              gte: `${year}-01-01`,
-              lt: `${year + 1}-01-01`,
-            }
-          : undefined,
+        date: monthDay
+          ? { endsWith: `-${monthDay}` }
+          : year
+            ? {
+                gte: `${year}-01-01`,
+                lt: `${year + 1}-01-01`,
+              }
+            : undefined,
         showPhotosCount: hasPhotos ? { gt: 0 } : undefined,
       },
       orderBy,
@@ -390,6 +394,7 @@ export class SetlistService {
     filters?: SetlistFilter;
   }): Promise<SetlistLight[]> {
     const year = options?.filters?.year;
+    const monthDay = options?.filters?.monthDay;
     const venueId = options?.filters?.venueId;
     const hasPhotos = options?.filters?.hasPhotos;
 
@@ -403,12 +408,14 @@ export class SetlistService {
     const results = await this.db.show.findMany({
       where: {
         venueId,
-        date: year
-          ? {
-              gte: `${year}-01-01`,
-              lt: `${year + 1}-01-01`,
-            }
-          : undefined,
+        date: monthDay
+          ? { endsWith: `-${monthDay}` }
+          : year
+            ? {
+                gte: `${year}-01-01`,
+                lt: `${year + 1}-01-01`,
+              }
+            : undefined,
         showPhotosCount: hasPhotos ? { gt: 0 } : undefined,
       },
       orderBy,

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -57,6 +57,8 @@ export const CacheKeys = {
     index: () => "songs:index:full",
     /** All-timers page data */
     allTimers: () => "songs:all-timers",
+    /** All-timers for a specific calendar day (On This Day page) */
+    allTimersOnThisDay: (monthDay: string) => `songs:all-timers:on-this-day:${monthDay}`,
     /** Filtered song results by era/author/cover/tags/attended */
     filtered: (filters: CacheFilters) => {
       const filterHash = hashFilters(filters);

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -32,6 +32,9 @@ export const CacheKeys = {
 
     /** All show listing caches (for pattern deletion) */
     allLists: () => `shows:list:*`,
+
+    /** Show + all-timer counts for a calendar day (On This Day home page widget) */
+    onThisDayCounts: (monthDay: string) => `shows:on-this-day-counts:${monthDay}`,
   },
 
   /**


### PR DESCRIPTION
## Summary
- Adds `/on-this-day/MM-DD` page showing all Disco Biscuits shows and all-timer performances on a given calendar day
- All-timers table with 10-per-page pagination above setlist cards sorted newest-first
- Prev/next day navigation with chevron links and a calendar popover picker (year-agnostic, Feb 29 always reachable)
- Home page "On this day: X shows, Y all-timers" link with cached counts
- Show detail page "All shows on {date}" contextual link inline with prev/next show nav
- Hides DataTable pagination controls when data fits on one page (global improvement)
- Fixes header nav bar transparency


https://github.com/user-attachments/assets/78a9220c-3644-4b7d-b952-a612880900ad



## Test plan
- [x] Visit `/on-this-day` — redirects to today MM-DD
- [x] Visit `/on-this-day/04-08` — shows setlist cards and all-timers table
- [x] Visit `/on-this-day/13-45` or `/on-this-day/4-4` — returns 404
- [x] Click prev/next chevrons — navigates correctly, wraps at year boundaries
- [x] Click date label — calendar popover opens, select a date, popover closes and navigates
- [x] Navigate to February in picker — Feb 29 is selectable
- [x] Home page shows On this day link with correct counts
- [x] Show detail page shows All shows on {date} link, navigates to correct date
- [x] All-timers table paginates at 10 rows; single-page tables hide pagination controls
- [x] `make tc` and `make test` pass (151 tests)

Generated with [Claude Code](https://claude.com/claude-code)