### PR TITLE
Add tab bar to /songs page with new Histories tab

### DIFF
--- a/apps/web/app/components/ui/data-table.tsx
+++ b/apps/web/app/components/ui/data-table.tsx
@@ -16,6 +16,7 @@ declare module "@tanstack/react-table" {
   // biome-ignore lint/correctness/noUnusedVariables: required by TanStack's module augmentation pattern
   interface ColumnMeta<TData extends RowData, TValue> {
     width?: string;
+    cellClassName?: string;
   }
 }
 
@@ -24,6 +25,7 @@ import { type KeyboardEvent, type ReactNode, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/ui/table";
+import { cn } from "~/lib/utils";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -219,7 +221,7 @@ export function DataTable<TData, TValue>({
                   className={`border-t border-glass-border/30 hover:bg-hover-glass ${rowClassName?.(row.original, index) ?? ""}`}
                 >
                   {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id} className="p-3">
+                    <TableCell key={cell.id} className={cn("p-3", cell.column.columnDef.meta?.cellClassName)}>
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </TableCell>
                   ))}

--- a/apps/web/app/lib/html.test.ts
+++ b/apps/web/app/lib/html.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+import { decodeHtmlEntities } from "./html";
+
+describe("decodeHtmlEntities", () => {
+  // Common entities stored in the history field of the song database.
+  test("decodes apostrophe entities (&#x27;, &apos;, &#39;)", () => {
+    expect(decodeHtmlEntities("Otomo&#x27;s")).toBe("Otomo's");
+    expect(decodeHtmlEntities("Otomo&apos;s")).toBe("Otomo's");
+    expect(decodeHtmlEntities("Otomo&#39;s")).toBe("Otomo's");
+  });
+
+  test("decodes quote entity (&quot;)", () => {
+    expect(decodeHtmlEntities("&quot;hello&quot;")).toBe('"hello"');
+  });
+
+  test("decodes angle bracket entities (&lt;, &gt;)", () => {
+    expect(decodeHtmlEntities("&lt;p&gt;")).toBe("<p>");
+  });
+
+  test("decodes non-breaking space (&nbsp;)", () => {
+    expect(decodeHtmlEntities("a&nbsp;b")).toBe("a b");
+  });
+
+  test("decodes ampersand entity (&amp;)", () => {
+    expect(decodeHtmlEntities("rock &amp; roll")).toBe("rock & roll");
+  });
+
+  test("leaves unknown entities unchanged", () => {
+    expect(decodeHtmlEntities("&fakeentity;")).toBe("&fakeentity;");
+  });
+
+  test("handles strings with no entities", () => {
+    expect(decodeHtmlEntities("plain text")).toBe("plain text");
+  });
+});

--- a/apps/web/app/lib/html.ts
+++ b/apps/web/app/lib/html.ts
@@ -1,0 +1,19 @@
+const HTML_ENTITIES: Record<string, string> = {
+  "&quot;": '"',
+  "&#x27;": "'",
+  "&#39;": "'",
+  "&apos;": "'",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&nbsp;": " ",
+  "&amp;": "&",
+};
+
+/**
+ * Decode common HTML entities in a string. Intended for rendering stored
+ * HTML as plain text (e.g. table cell previews). For full HTML rendering,
+ * use dangerouslySetInnerHTML instead — the browser handles entities there.
+ */
+export function decodeHtmlEntities(text: string): string {
+  return text.replace(/&(?:quot|#x27|#39|apos|lt|gt|nbsp|amp);/g, (entity) => HTML_ENTITIES[entity] ?? entity);
+}

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -94,6 +94,7 @@ export default [
     ...prefix("songs", [
       index("routes/songs/_index.tsx"),
       route("all-timers", "routes/songs/all-timers.tsx"),
+      route("histories", "routes/songs/histories.tsx"),
       route("new", "routes/songs/new.tsx"),
       route(":slug", "routes/songs/$slug.tsx"),
       route(":slug/edit", "routes/songs/$slug.edit.tsx"),

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -1,5 +1,5 @@
 import type { SongPageView } from "@bip/domain";
-import { ArrowLeft, BarChart3, FileTextIcon, GuitarIcon, History, Pencil, StarIcon } from "lucide-react";
+import { ArrowLeft, BarChart3, FileTextIcon, Flame, GuitarIcon, History, ListMusic, Pencil } from "lucide-react";
 import { useMemo, useState } from "react";
 import type { LoaderFunctionArgs } from "react-router";
 import { Link, useSearchParams } from "react-router-dom";
@@ -315,7 +315,7 @@ export default function SongPage() {
               "data-[state=inactive]:bg-transparent data-[state=inactive]:text-content-text-tertiary",
             )}
           >
-            <FileTextIcon className="h-4 w-4" />
+            <ListMusic className="h-4 w-4" />
             All Performances
           </TabsTrigger>
           {allTimers.length > 0 && (
@@ -327,7 +327,7 @@ export default function SongPage() {
                 "data-[state=inactive]:bg-transparent data-[state=inactive]:text-content-text-tertiary",
               )}
             >
-              <StarIcon className="h-4 w-4 stroke-yellow-500 fill-transparent" />
+              <Flame className="h-4 w-4 text-orange-500" />
               All-Timers
             </TabsTrigger>
           )}

--- a/apps/web/app/routes/songs/_index.test.tsx
+++ b/apps/web/app/routes/songs/_index.test.tsx
@@ -1,0 +1,94 @@
+import { mockShallowComponent } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+
+// Mock server-side modules that can't run in jsdom
+vi.mock("~/server/services", () => ({ services: {} }));
+vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
+vi.mock("~/lib/seo", () => ({ getSongsMeta: vi.fn() }));
+vi.mock("~/lib/song-utilities", () => ({ addVenueInfoToSongs: vi.fn() }));
+vi.mock("@bip/domain/cache-keys", () => ({ CacheKeys: { songs: { index: vi.fn() } } }));
+
+// Mock the loader data hook to return minimal song data
+vi.mock("~/hooks/use-serialized-loader-data", () => ({
+  useSerializedLoaderData: vi.fn(() => ({
+    songs: [],
+    trendingSongs: [],
+    yearlyTrendingSongs: [],
+    recentShowsCount: 10,
+  })),
+}));
+
+// Mock the filter hook to return default state
+vi.mock("~/hooks/use-performance-page-filters", () => ({
+  usePerformancePageFilters: vi.fn(() => ({
+    filteredData: [],
+    isLoading: false,
+    selectedYear: "all",
+    selectedEra: "all",
+    coverFilter: "all",
+    selectedAuthor: null,
+    playedFilter: "all",
+    activeToggleSet: new Set(),
+    hasActiveFilters: false,
+    searchText: "",
+    setSearchText: vi.fn(),
+    updateFilter: vi.fn(),
+    toggleFilter: vi.fn(),
+    clearFilters: vi.fn(),
+  })),
+}));
+
+// Stub heavy child components
+vi.mock("../../components/song/songs-table", () => ({
+  SongsTable: (props: object) => mockShallowComponent("SongsTable", props),
+}));
+vi.mock("~/components/performance/performance-filter-controls", () => ({
+  PerformanceFilterControls: (props: object) => mockShallowComponent("PerformanceFilterControls", props),
+}));
+vi.mock("~/components/admin/admin-only", () => ({
+  AdminOnly: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import Songs from "./_index";
+
+function renderSongsIndex() {
+  return render(
+    <MemoryRouter initialEntries={["/songs"]}>
+      <Songs />
+    </MemoryRouter>,
+  );
+}
+
+describe("Songs index page", () => {
+  // The heading is now in the layout, so the index page should not render its own.
+  test("does not render its own SONGS heading", () => {
+    renderSongsIndex();
+
+    expect(screen.queryByText("SONGS")).not.toBeInTheDocument();
+  });
+
+  // The all-timers link is now a tab in the layout, so the index page should not
+  // render a separate link to it.
+  test("does not render an all-timers link", () => {
+    renderSongsIndex();
+
+    expect(screen.queryByRole("link", { name: /all-timers/i })).not.toBeInTheDocument();
+  });
+
+  // The admin "New Song" button is now in the layout, so the index page should
+  // not render its own.
+  test("does not render a New Song button", () => {
+    renderSongsIndex();
+
+    expect(screen.queryByRole("link", { name: /new song/i })).not.toBeInTheDocument();
+  });
+
+  // The SongsTable should still render as the main content of the tab.
+  test("renders the SongsTable", () => {
+    renderSongsIndex();
+
+    expect(screen.getByTestId("SongsTable")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/routes/songs/_index.tsx
+++ b/apps/web/app/routes/songs/_index.tsx
@@ -1,10 +1,7 @@
 import type { Song, TrendingSong } from "@bip/domain";
 import { CacheKeys } from "@bip/domain/cache-keys";
-import { Flame, Plus } from "lucide-react";
 import { Link } from "react-router-dom";
-import { AdminOnly } from "~/components/admin/admin-only";
 import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
-import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
 import { usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
@@ -165,49 +162,26 @@ export default function Songs() {
   );
 
   return (
-    <div className="">
-      <div>
-        <div className="relative">
-          <h1 className="page-heading">SONGS</h1>
-          <div className="absolute top-0 right-0 flex items-center gap-3">
-            <Link
-              to="/songs/all-timers"
-              className="flex items-center gap-2 text-sm text-content-text-secondary hover:text-brand-primary transition-colors"
-            >
-              <Flame className="h-4 w-4 text-orange-500" />
-              All-Timers
-            </Link>
-            <AdminOnly>
-              <Button asChild className="btn-primary">
-                <Link to="/songs/new" className="flex items-center gap-2">
-                  <Plus className="h-4 w-4" />
-                  New Song
-                </Link>
-              </Button>
-            </AdminOnly>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-          <div className="lg:col-span-3">
-            {trendingSongs.length > 0 && (
-              <div className="mb-6">
-                <h2 className="text-xl font-semibold mb-4 text-content-text-primary">Trending in Recent Shows</h2>
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                  {trendingSongs.map((song: TrendingSong) => (
-                    <TrendingSongCard key={song.id} song={song} recentShowsCount={recentShowsCount} />
-                  ))}
-                </div>
+    <div>
+      <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+        <div className="lg:col-span-3">
+          {trendingSongs.length > 0 && (
+            <div className="mb-6">
+              <h2 className="text-xl font-semibold mb-4 text-content-text-primary">Trending in Recent Shows</h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                {trendingSongs.map((song: TrendingSong) => (
+                  <TrendingSongCard key={song.id} song={song} recentShowsCount={recentShowsCount} />
+                ))}
               </div>
-            )}
-          </div>
-          <div className="lg:col-span-1">
-            <YearlyTrendingSongs />
-          </div>
+            </div>
+          )}
         </div>
-
-        <SongsTable songs={filteredSongs} filterComponent={filterControls} isLoading={isLoading} />
+        <div className="lg:col-span-1">
+          <YearlyTrendingSongs />
+        </div>
       </div>
+
+      <SongsTable songs={filteredSongs} filterComponent={filterControls} isLoading={isLoading} />
     </div>
   );
 }

--- a/apps/web/app/routes/songs/_layout.test.tsx
+++ b/apps/web/app/routes/songs/_layout.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+
+// Mock Outlet so we don't need to wire up child routes
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, Outlet: () => <div data-testid="outlet" /> };
+});
+
+// Mock AdminOnly to render its children unconditionally in tests
+vi.mock("~/components/admin/admin-only", () => ({
+  AdminOnly: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import SongsLayout from "./_layout";
+
+function renderAtPath(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <SongsLayout />
+    </MemoryRouter>,
+  );
+}
+
+describe("SongsLayout", () => {
+  // The layout should render a tab bar with three navigation tabs
+  // linking to /songs, /songs/all-timers, and /songs/histories.
+  test("renders three tab links: All Songs, All-Timers, Histories", () => {
+    renderAtPath("/songs");
+
+    expect(screen.getByRole("link", { name: /all songs/i })).toHaveAttribute("href", "/songs");
+    expect(screen.getByRole("link", { name: /all-timers/i })).toHaveAttribute("href", "/songs/all-timers");
+    expect(screen.getByRole("link", { name: /histories/i })).toHaveAttribute("href", "/songs/histories");
+  });
+
+  // The active tab should be visually distinguished via a border-brand-primary
+  // class, determined by the current pathname.
+  test("highlights 'All Songs' tab when on /songs", () => {
+    renderAtPath("/songs");
+
+    const allSongsLink = screen.getByRole("link", { name: /all songs/i });
+    expect(allSongsLink.className).toContain("border-brand-primary");
+  });
+
+  // When navigated to /songs/all-timers, the All-Timers tab should be active.
+  test("highlights 'All-Timers' tab when on /songs/all-timers", () => {
+    renderAtPath("/songs/all-timers");
+
+    const allTimersLink = screen.getByRole("link", { name: /all-timers/i });
+    expect(allTimersLink.className).toContain("border-brand-primary");
+
+    const allSongsLink = screen.getByRole("link", { name: /all songs/i });
+    expect(allSongsLink.className).not.toContain("border-brand-primary");
+  });
+
+  // When navigated to /songs/histories, the Histories tab should be active.
+  test("highlights 'Histories' tab when on /songs/histories", () => {
+    renderAtPath("/songs/histories");
+
+    const historiesLink = screen.getByRole("link", { name: /histories/i });
+    expect(historiesLink.className).toContain("border-brand-primary");
+  });
+
+  // The tab bar should NOT render on song detail pages, edit pages, or new song page
+  // because those are distinct views, not tabs.
+  test("does not render tab bar on /songs/:slug", () => {
+    renderAtPath("/songs/basis-for-a-day");
+
+    expect(screen.queryByRole("link", { name: /all songs/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /all-timers/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /histories/i })).not.toBeInTheDocument();
+  });
+
+  // The tab bar should not render on the new song admin page.
+  test("does not render tab bar on /songs/new", () => {
+    renderAtPath("/songs/new");
+
+    expect(screen.queryByRole("link", { name: /all songs/i })).not.toBeInTheDocument();
+  });
+
+  // The "SONGS" heading should appear in the layout on tabbed pages.
+  test("renders SONGS heading on tabbed pages", () => {
+    renderAtPath("/songs");
+
+    expect(screen.getByText("SONGS")).toBeInTheDocument();
+  });
+
+  // The heading should also appear on non-tabbed pages (slug, new, edit)
+  // since the layout wraps all songs routes.
+  test("renders SONGS heading on song detail pages", () => {
+    renderAtPath("/songs/basis-for-a-day");
+
+    expect(screen.getByText("SONGS")).toBeInTheDocument();
+  });
+
+  // The Outlet should always render regardless of path, since child routes
+  // need to be rendered.
+  test("always renders Outlet for child routes", () => {
+    renderAtPath("/songs");
+
+    expect(screen.getByTestId("outlet")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/routes/songs/_layout.tsx
+++ b/apps/web/app/routes/songs/_layout.tsx
@@ -1,8 +1,69 @@
-import { Outlet } from "react-router-dom";
+import type { LucideIcon } from "lucide-react";
+import { Flame, History, ListMusic, Plus } from "lucide-react";
+import { Link, Outlet, useLocation } from "react-router-dom";
+import { AdminOnly } from "~/components/admin/admin-only";
+import { Button } from "~/components/ui/button";
+import { cn } from "~/lib/utils";
+
+interface Tab {
+  label: string;
+  path: string;
+  icon: LucideIcon;
+  iconClassName?: string;
+}
+
+const TABS: Tab[] = [
+  { label: "All Songs", path: "/songs", icon: ListMusic },
+  { label: "All-Timers", path: "/songs/all-timers", icon: Flame, iconClassName: "text-orange-500" },
+  { label: "Histories", path: "/songs/histories", icon: History },
+];
+
+const TABBED_PATHS = new Set(TABS.map((tab) => tab.path));
 
 export default function SongsLayout() {
+  const { pathname } = useLocation();
+  const showTabs = TABBED_PATHS.has(pathname);
+
   return (
     <div className="py-8">
+      <div className="relative">
+        <h1 className="page-heading">SONGS</h1>
+        <div className="absolute top-0 right-0 flex items-center gap-3">
+          <AdminOnly>
+            <Button asChild className="btn-primary">
+              <Link to="/songs/new" className="flex items-center gap-2">
+                <Plus className="h-4 w-4" />
+                New Song
+              </Link>
+            </Button>
+          </AdminOnly>
+        </div>
+      </div>
+
+      {showTabs && (
+        <div className="w-full flex justify-start border-b border-glass-border/30 mb-6">
+          {TABS.map((tab) => {
+            const isActive = pathname === tab.path;
+            const Icon = tab.icon;
+            return (
+              <Link
+                key={tab.path}
+                to={tab.path}
+                className={cn(
+                  "flex items-center gap-2 px-4 py-2 text-sm font-medium",
+                  isActive
+                    ? "border-b-2 border-brand-primary text-content-text-primary"
+                    : "text-content-text-tertiary hover:text-content-text-secondary",
+                )}
+              >
+                <Icon className={cn("h-4 w-4", tab.iconClassName)} />
+                {tab.label}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+
       <Outlet />
     </div>
   );

--- a/apps/web/app/routes/songs/all-timers.test.tsx
+++ b/apps/web/app/routes/songs/all-timers.test.tsx
@@ -1,0 +1,76 @@
+import { mockShallowComponent } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+
+// Mock server-side modules
+vi.mock("~/server/services", () => ({ services: {} }));
+vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
+vi.mock("@bip/domain", () => ({}));
+
+// Mock hooks
+vi.mock("~/hooks/use-serialized-loader-data", () => ({
+  useSerializedLoaderData: vi.fn(() => ({ performances: [] })),
+}));
+vi.mock("~/hooks/use-performance-page-filters", () => ({
+  usePerformancePageFilters: vi.fn(() => ({
+    filteredData: [],
+    isLoading: false,
+    selectedYear: "all",
+    selectedEra: "all",
+    coverFilter: "all",
+    selectedAuthor: null,
+    activeToggleSet: new Set(),
+    hasActiveFilters: false,
+    searchText: "",
+    setSearchText: vi.fn(),
+    updateFilter: vi.fn(),
+    toggleFilter: vi.fn(),
+    clearFilters: vi.fn(),
+  })),
+  searchPerformance: vi.fn(),
+}));
+
+// Stub child components
+vi.mock("~/components/performance", () => ({
+  PerformanceTable: (props: object) => mockShallowComponent("PerformanceTable", props),
+}));
+vi.mock("~/components/performance/performance-filter-controls", () => ({
+  PerformanceFilterControls: (props: object) => mockShallowComponent("PerformanceFilterControls", props),
+}));
+
+import AllTimersPage from "./all-timers";
+
+function renderAllTimers() {
+  return render(
+    <MemoryRouter initialEntries={["/songs/all-timers"]}>
+      <AllTimersPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("AllTimersPage", () => {
+  // The "All-Timers" header with flame icon is now handled by the layout tab bar,
+  // so the page should not render its own heading.
+  test("does not render its own All-Timers heading", () => {
+    renderAllTimers();
+
+    expect(screen.queryByRole("heading", { name: /all-timers/i })).not.toBeInTheDocument();
+  });
+
+  // The "Back to songs" link is replaced by the layout tab bar navigation.
+  test("does not render a Back to songs link", () => {
+    renderAllTimers();
+
+    expect(screen.queryByRole("link", { name: /back to songs/i })).not.toBeInTheDocument();
+  });
+
+  // The PerformanceTable should still render as the main content.
+  test("renders the PerformanceTable with showSongColumn", () => {
+    renderAllTimers();
+
+    const table = screen.getByTestId("PerformanceTable");
+    expect(table).toBeInTheDocument();
+    expect(table.textContent).toContain('"showSongColumn":true');
+  });
+});

--- a/apps/web/app/routes/songs/all-timers.tsx
+++ b/apps/web/app/routes/songs/all-timers.tsx
@@ -1,6 +1,4 @@
 import { type AllTimersPageView, CacheKeys } from "@bip/domain";
-import { ArrowLeft, Flame } from "lucide-react";
-import { Link } from "react-router-dom";
 import { PerformanceTable } from "~/components/performance";
 import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
 import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
@@ -42,21 +40,7 @@ export default function AllTimersPage() {
   });
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <Flame className="h-6 w-6 text-orange-500" />
-          <h1 className="text-3xl md:text-4xl font-bold text-content-text-primary">All-Timers</h1>
-        </div>
-        <Link
-          to="/songs"
-          className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors"
-        >
-          <ArrowLeft className="h-3 w-3" />
-          <span>Back to songs</span>
-        </Link>
-      </div>
-
+    <div>
       <PerformanceTable
         performances={filteredPerformances}
         isLoading={isLoading}

--- a/apps/web/app/routes/songs/histories.test.tsx
+++ b/apps/web/app/routes/songs/histories.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+
+// Mock server-side modules
+vi.mock("~/server/services", () => ({ services: {} }));
+vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
+vi.mock("@bip/domain/cache-keys", () => ({ CacheKeys: { songs: { histories: vi.fn() } } }));
+
+// Mock the loader data hook to return songs with history content
+vi.mock("~/hooks/use-serialized-loader-data", () => ({
+  useSerializedLoaderData: vi.fn(() => ({
+    songs: [
+      {
+        id: "1",
+        title: "Basis for a Day",
+        slug: "basis-for-a-day",
+        history: "Basis for a Day was composed by Marc Brownstein in the early days of the band. It quickly became a fan favorite.",
+      },
+      {
+        id: "2",
+        title: "Above the Waves",
+        slug: "above-the-waves",
+        history: "Above the Waves was first performed in 2003 and has been a staple of the band's second set ever since.",
+      },
+    ],
+  })),
+}));
+
+import HistoriesPage from "./histories";
+
+function renderHistories() {
+  return render(
+    <MemoryRouter initialEntries={["/songs/histories"]}>
+      <HistoriesPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("HistoriesPage", () => {
+  // Each song with history content should appear as a row in the table
+  // with its title linking to the song's history tab.
+  test("renders song titles as links to the song history tab", () => {
+    renderHistories();
+
+    const basisLink = screen.getByRole("link", { name: "Basis for a Day" });
+    expect(basisLink).toHaveAttribute("href", "/songs/basis-for-a-day?tab=history");
+
+    const wavesLink = screen.getByRole("link", { name: "Above the Waves" });
+    expect(wavesLink).toHaveAttribute("href", "/songs/above-the-waves?tab=history");
+  });
+
+  // Each row should show a preview snippet of the history text so users
+  // can browse without clicking through.
+  test("renders a preview of each song's history text", () => {
+    renderHistories();
+
+    expect(screen.getByText(/Basis for a Day was composed by Marc Brownstein/)).toBeInTheDocument();
+    expect(screen.getByText(/Above the Waves was first performed in 2003/)).toBeInTheDocument();
+  });
+
+  // The table should support pagination for when more histories are written.
+  // With only 2 items and a page size of 50, pagination nav should be hidden.
+  test("hides pagination when all items fit on one page", () => {
+    renderHistories();
+
+    expect(screen.queryByRole("button", { name: "Previous" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/routes/songs/histories.test.tsx
+++ b/apps/web/app/routes/songs/histories.test.tsx
@@ -7,7 +7,10 @@ vi.mock("~/server/services", () => ({ services: {} }));
 vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
 vi.mock("@bip/domain/cache-keys", () => ({ CacheKeys: { songs: { histories: vi.fn() } } }));
 
-// Mock the loader data hook to return songs with history content
+// Mock the loader data hook to return songs with history content. "Basis for
+// a Day" is stored as multi-paragraph HTML; "Above the Waves" uses plain text
+// with \n\n paragraph breaks. The preview should preserve paragraph structure
+// for both.
 vi.mock("~/hooks/use-serialized-loader-data", () => ({
   useSerializedLoaderData: vi.fn(() => ({
     songs: [
@@ -15,13 +18,23 @@ vi.mock("~/hooks/use-serialized-loader-data", () => ({
         id: "1",
         title: "Basis for a Day",
         slug: "basis-for-a-day",
-        history: "Basis for a Day was composed by Marc Brownstein in the early days of the band. It quickly became a fan favorite.",
+        history:
+          "<p>Basis for a Day was composed by Marc Brownstein in the early days of the band.</p><p>It quickly became a fan favorite and has remained in heavy rotation ever since.</p>",
       },
       {
         id: "2",
         title: "Above the Waves",
         slug: "above-the-waves",
-        history: "Above the Waves was first performed in 2003 and has been a staple of the band's second set ever since.",
+        history:
+          "Above the Waves was first performed in 2003.\n\nIt has been a staple of the band's second set ever since.",
+      },
+      {
+        id: "3",
+        title: "Akira Jam",
+        slug: "akira-jam",
+        // Real-world shape: indented paragraphs, HTML entities
+        history:
+          '<p>For the 2nd set on New Years Eve, 1999, The Disco Biscuits played along to Katsuhiro Otomo&#x27;s anime masterpiece, Akira.</p>\n  \n  <p>&quot;When the 1988 dateline appears, the first note of the DJ spinning should start up.&quot;</p>',
       },
     ],
   })),
@@ -50,13 +63,68 @@ describe("HistoriesPage", () => {
     expect(wavesLink).toHaveAttribute("href", "/songs/above-the-waves?tab=history");
   });
 
-  // Each row should show a preview snippet of the history text so users
-  // can browse without clicking through.
-  test("renders a preview of each song's history text", () => {
+  // The full history text is rendered into the DOM; CSS clamps it visually
+  // with a "more"/"less" toggle to expand/collapse.
+  test("renders the full history text in the DOM for CSS clamping", () => {
     renderHistories();
 
-    expect(screen.getByText(/Basis for a Day was composed by Marc Brownstein/)).toBeInTheDocument();
-    expect(screen.getByText(/Above the Waves was first performed in 2003/)).toBeInTheDocument();
+    const basisHistory = screen.getByText(/Basis for a Day was composed/);
+    expect(basisHistory.textContent).toContain("quickly became a fan favorite");
+
+    const wavesHistory = screen.getByText(/Above the Waves was first performed/);
+    expect(wavesHistory.textContent).toContain("staple of the band");
+  });
+
+  // History text stored as HTML should have tags stripped before display so
+  // users see clean text in the preview column.
+  test("strips HTML tags from history text", () => {
+    renderHistories();
+
+    // The <p> tag in the "Basis for a Day" history should not be rendered literally.
+    const basisHistory = screen.getByText(/Basis for a Day was composed by Marc Brownstein/);
+    expect(basisHistory.textContent).not.toContain("<p>");
+    expect(basisHistory.textContent).not.toContain("</p>");
+  });
+
+  // Paragraph breaks should be preserved so multi-paragraph histories don't
+  // collapse into a wall of text. Uses whitespace-pre-line CSS so \n\n renders
+  // as a visible blank line.
+  test("preserves paragraph breaks from HTML <p> tags", () => {
+    renderHistories();
+
+    const basisHistory = screen.getByText(/Basis for a Day was composed/);
+    expect(basisHistory.textContent).toContain("\n\n");
+    expect(basisHistory.className).toContain("whitespace-pre-line");
+  });
+
+  test("preserves paragraph breaks from plain text \\n\\n", () => {
+    renderHistories();
+
+    const wavesHistory = screen.getByText(/Above the Waves was first performed/);
+    expect(wavesHistory.textContent).toContain("\n\n");
+    expect(wavesHistory.className).toContain("whitespace-pre-line");
+  });
+
+  // HTML entities in stored history (e.g. &quot;, &#x27;) should decode to
+  // their characters so users don't see raw entity codes.
+  test("decodes common HTML entities", () => {
+    renderHistories();
+
+    const akiraHistory = screen.getByText(/Disco Biscuits played along/);
+    expect(akiraHistory.textContent).toContain("Otomo's");
+    expect(akiraHistory.textContent).toContain('"When the 1988 dateline appears');
+    expect(akiraHistory.textContent).not.toContain("&#x27;");
+    expect(akiraHistory.textContent).not.toContain("&quot;");
+  });
+
+  // Leading whitespace on paragraph lines (from indented source HTML) should
+  // be trimmed so whitespace-pre-line doesn't render visible indentation.
+  test("trims leading whitespace on paragraph lines", () => {
+    renderHistories();
+
+    const akiraHistory = screen.getByText(/Disco Biscuits played along/);
+    // The second paragraph should not start with leading spaces
+    expect(akiraHistory.textContent).not.toMatch(/\n\n {2,}"When/);
   });
 
   // The table should support pagination for when more histories are written.

--- a/apps/web/app/routes/songs/histories.tsx
+++ b/apps/web/app/routes/songs/histories.tsx
@@ -1,10 +1,13 @@
 import type { Song } from "@bip/domain";
 import { CacheKeys } from "@bip/domain/cache-keys";
 import type { ColumnDef } from "@tanstack/react-table";
+import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { DataTable } from "~/components/ui/data-table";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
+import { decodeHtmlEntities } from "~/lib/html";
+import { cn } from "~/lib/utils";
 import { services } from "~/server/services";
 
 interface HistorySong {
@@ -51,20 +54,61 @@ export function meta() {
   ];
 }
 
-function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, "");
+/**
+ * Convert history HTML or plain text to plain text with paragraph breaks as
+ * double newlines. Paired with whitespace-pre-line CSS to render paragraphs visibly.
+ */
+function normalizeHistoryText(history: string): string {
+  const stripped = history
+    .replace(/<\/p>\s*<p[^>]*>/gi, "\n\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]*>/g, "");
+
+  return decodeHtmlEntities(stripped)
+    .split("\n")
+    .map((line) => line.trim())
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
 }
 
-function truncateText(text: string, maxLength: number): string {
-  const stripped = stripHtml(text);
-  if (stripped.length <= maxLength) return stripped;
-  return `${stripped.slice(0, maxLength).trimEnd()}...`;
+function HistoryPreview({ text }: { text: string }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isTruncated, setIsTruncated] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (contentRef.current) {
+      setIsTruncated(contentRef.current.scrollHeight > contentRef.current.clientHeight);
+    }
+  });
+
+  return (
+    <div className="text-sm text-content-text-secondary">
+      <div ref={contentRef} className={cn("leading-relaxed whitespace-pre-line", !isExpanded && "line-clamp-2")}>
+        {text}
+      </div>
+      {(isTruncated || isExpanded) && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setIsExpanded(!isExpanded);
+          }}
+          className="text-brand-primary hover:text-brand-secondary underline text-xs mt-0.5"
+        >
+          {isExpanded ? "less" : "more"}
+        </button>
+      )}
+    </div>
+  );
 }
 
 const historiesColumns: ColumnDef<HistorySong>[] = [
   {
     accessorKey: "title",
-    meta: { width: "25%" },
+    meta: { width: "25%", cellClassName: "align-top" },
     header: "Song",
     cell: ({ row }) => (
       <Link
@@ -77,11 +121,9 @@ const historiesColumns: ColumnDef<HistorySong>[] = [
   },
   {
     accessorKey: "history",
-    meta: { width: "75%" },
+    meta: { width: "75%", cellClassName: "align-top" },
     header: "Preview",
-    cell: ({ row }) => (
-      <span className="text-content-text-secondary text-sm">{truncateText(row.original.history, 150)}</span>
-    ),
+    cell: ({ row }) => <HistoryPreview text={normalizeHistoryText(row.original.history)} />,
   },
 ];
 

--- a/apps/web/app/routes/songs/histories.tsx
+++ b/apps/web/app/routes/songs/histories.tsx
@@ -1,0 +1,96 @@
+import type { Song } from "@bip/domain";
+import { CacheKeys } from "@bip/domain/cache-keys";
+import type { ColumnDef } from "@tanstack/react-table";
+import { Link } from "react-router-dom";
+import { DataTable } from "~/components/ui/data-table";
+import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
+import { publicLoader } from "~/lib/base-loaders";
+import { services } from "~/server/services";
+
+interface HistorySong {
+  id: string;
+  title: string;
+  slug: string;
+  history: string;
+}
+
+interface LoaderData {
+  songs: HistorySong[];
+}
+
+const MINIMUM_HISTORY_LENGTH = 50;
+
+export const loader = publicLoader(async (): Promise<LoaderData> => {
+  const cacheKey = CacheKeys.songs.histories();
+  const cacheOptions = { ttl: 3600 };
+
+  return await services.cache.getOrSet(
+    cacheKey,
+    async () => {
+      const allSongs = await services.songs.findMany({});
+      const songsWithHistory = allSongs
+        .filter((song: Song) => song.history && song.history.length > MINIMUM_HISTORY_LENGTH)
+        .map((song: Song) => ({
+          id: song.id,
+          title: song.title,
+          slug: song.slug,
+          history: song.history as string,
+        }))
+        .sort((a: HistorySong, b: HistorySong) => a.title.localeCompare(b.title));
+
+      return { songs: songsWithHistory };
+    },
+    cacheOptions,
+  );
+});
+
+export function meta() {
+  return [
+    { title: "Song Histories | Songs" },
+    { name: "description", content: "Browse song histories for The Disco Biscuits" },
+  ];
+}
+
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, "");
+}
+
+function truncateText(text: string, maxLength: number): string {
+  const stripped = stripHtml(text);
+  if (stripped.length <= maxLength) return stripped;
+  return `${stripped.slice(0, maxLength).trimEnd()}...`;
+}
+
+const historiesColumns: ColumnDef<HistorySong>[] = [
+  {
+    accessorKey: "title",
+    meta: { width: "25%" },
+    header: "Song",
+    cell: ({ row }) => (
+      <Link
+        to={`/songs/${row.original.slug}?tab=history`}
+        className="text-brand-primary hover:text-brand-secondary transition-colors font-medium"
+      >
+        {row.original.title}
+      </Link>
+    ),
+  },
+  {
+    accessorKey: "history",
+    meta: { width: "75%" },
+    header: "Preview",
+    cell: ({ row }) => (
+      <span className="text-content-text-secondary text-sm">{truncateText(row.original.history, 150)}</span>
+    ),
+  },
+];
+
+export default function HistoriesPage() {
+  const { songs } = useSerializedLoaderData<LoaderData>();
+
+  return (
+    <div>
+      <DataTable columns={historiesColumns} data={songs} pageSize={50} hideSearch />
+    </div>
+  );
+}

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -60,6 +60,8 @@ export const CacheKeys = {
     index: () => "songs:index:full",
     /** All-timers page data */
     allTimers: () => "songs:all-timers",
+    /** Songs with history content */
+    histories: () => "songs:histories",
     /** All-timers for a specific calendar day (On This Day page) */
     allTimersOnThisDay: (monthDay: string) => `songs:all-timers:on-this-day:${monthDay}`,
     /** Filtered song results by era/author/cover/tags/attended */


### PR DESCRIPTION
## Summary
- A user wanted to browse songs with history sections written. Rather than adding a filter to the stats table, we added a tab bar to `/songs` with three tabs: **All Songs**, **All-Timers**, and **Histories**
- The Histories tab shows a paginated table of songs with history content
- Each row displays a preview of the history with click-to-expand/collapse (same pattern as the Notes column on all-timers), preserving paragraph breaks and decoding HTML entities
- Row cells are top-aligned so song titles stay visible when histories are expanded
- The All-Timers page is now a tab instead of a separate page with a back-link
- Heading and admin button moved to the shared layout
- Unified tab icons: `ListMusic` for All Songs/All Performances, `Flame` for All-Timers (consistent across `/songs` and `/songs/:slug`)
- Added shared `~/lib/html` utility for decoding common HTML entities
- Added `cellClassName` option to DataTable column meta for per-column cell styling

https://github.com/user-attachments/assets/66e0a7a9-9c26-4223-9824-f166828982ea


## Test plan
- [x] Navigate to `/songs` — tab bar visible with 3 tabs, "All Songs" active
- [x] Click "All-Timers" tab — navigates to `/songs/all-timers`, shows performances table
- [x] Click "Histories" tab — navigates to `/songs/histories`, shows ~26 songs with previews
- [x] Each Histories row shows 2 lines with a "more" button; clicking expands the full text
- [x] Expanded histories show paragraph breaks (e.g. Akira Jam, Pilin' It High)
- [x] Entities like `&#x27;` and `&quot;` render as real `'` and `"` characters
- [x] Song title stays visible at the top of the row when the history is expanded
- [x] Click a history entry — goes to song page with history tab active
- [x] Tab bar does NOT appear on `/songs/:slug`, `/songs/new`, or `/songs/:slug/edit`
- [x] Direct URL access works for `/songs/all-timers` and `/songs/histories`
- [x] On `/songs/:slug`, All Performances uses ListMusic icon, All-Timers uses Flame icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)