### PR TITLE
Unify time range filters, add Last 10 Shows and This Year tabs

### DIFF
--- a/apps/web/app/components/performance/performance-filter-controls.test.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.test.tsx
@@ -4,8 +4,7 @@ import { describe, expect, test, vi } from "vitest";
 import { PerformanceFilterControls } from "./performance-filter-controls";
 
 const defaultProps = {
-  selectedYear: "all",
-  selectedEra: "all",
+  selectedTimeRange: "all",
   activeToggleSet: new Set<string>(),
   updateFilter: vi.fn(),
   toggleFilter: vi.fn(),
@@ -53,6 +52,23 @@ describe("PerformanceFilterControls", () => {
     await setup(<PerformanceFilterControls {...defaultProps} hasActiveFilters={false} />);
 
     expect(screen.queryByRole("button", { name: "Clear All" })).not.toBeInTheDocument();
+  });
+
+  // The Time Range dropdown renders with grouped options (Recent, Eras, Years).
+  test("renders a single Time Range dropdown", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} />);
+
+    expect(screen.getByText("Time Range")).toBeInTheDocument();
+    expect(screen.queryByText("Year")).not.toBeInTheDocument();
+    expect(screen.queryByText("Era")).not.toBeInTheDocument();
+  });
+
+  // The hideTimeRange prop suppresses the dropdown for pre-baked tab pages
+  // (e.g., /songs/recent) where the time range is already set by the route.
+  test("does not render Time Range dropdown when hideTimeRange is true", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} hideTimeRange />);
+
+    expect(screen.queryByText("Time Range")).not.toBeInTheDocument();
   });
 
   // Clicking Clear All delegates to the parent's clearFilters callback, which

--- a/apps/web/app/components/performance/performance-filter-controls.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.tsx
@@ -3,7 +3,7 @@ import { AuthorSearch } from "~/components/author/author-search";
 import { SelectFilter } from "~/components/ui/filters";
 import { ToggleFilterGroup } from "~/components/ui/filters/toggle-filter-group";
 import { Input } from "~/components/ui/input";
-import { ERA_OPTIONS, TOGGLE_FILTER_DEFINITIONS, YEAR_OPTIONS } from "~/lib/song-filters";
+import { TIME_RANGE_GROUPS, TOGGLE_FILTER_DEFINITIONS } from "~/lib/song-filters";
 
 const ALL_TOGGLE_FILTERS = TOGGLE_FILTER_DEFINITIONS as unknown as Array<{ key: string; label: string }>;
 
@@ -13,14 +13,14 @@ const labelClass =
   "text-xs font-medium text-content-text-secondary uppercase tracking-wide mb-1.5 h-[18px] flex items-center";
 
 interface PerformanceFilterControlsProps {
-  selectedYear: string;
-  selectedEra: string;
+  selectedTimeRange: string;
   activeToggleSet: Set<string>;
   updateFilter: (updates: Record<string, string | null>) => void;
   toggleFilter: (key: string) => void;
   clearFilters: () => void;
   extraSelectFilters?: ReactNode;
   showAllTimerToggle?: boolean;
+  hideTimeRange?: boolean;
   coverFilter?: string;
   selectedAuthor?: string | null;
   playedFilter?: string;
@@ -30,14 +30,14 @@ interface PerformanceFilterControlsProps {
 }
 
 export function PerformanceFilterControls({
-  selectedYear,
-  selectedEra,
+  selectedTimeRange,
   activeToggleSet,
   updateFilter,
   toggleFilter,
   clearFilters,
   extraSelectFilters,
   showAllTimerToggle = true,
+  hideTimeRange = false,
   coverFilter,
   selectedAuthor,
   playedFilter,
@@ -58,22 +58,17 @@ export function PerformanceFilterControls({
             className="w-auto min-w-[200px] sm:min-w-[250px] max-w-md h-[34px] text-sm bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20 placeholder:text-content-text-tertiary"
           />
         )}
-        <SelectFilter
-          id="year-filter"
-          label="Year"
-          value={selectedYear}
-          onValueChange={(value) => updateFilter({ year: value, era: null })}
-          options={[{ value: "all", label: "All Years" }, ...YEAR_OPTIONS]}
-          width="w-[130px]"
-        />
-        <SelectFilter
-          id="era-filter"
-          label="Era"
-          value={selectedEra}
-          onValueChange={(value) => updateFilter({ era: value, year: null })}
-          options={[{ value: "all", label: "All Eras" }, ...ERA_OPTIONS]}
-          width="w-[170px]"
-        />
+        {!hideTimeRange && (
+          <SelectFilter
+            id="time-range-filter"
+            label="Time Range"
+            value={selectedTimeRange}
+            onValueChange={(value) => updateFilter({ timeRange: value })}
+            options={[{ value: "all", label: "All Time" }]}
+            groups={TIME_RANGE_GROUPS}
+            width="w-[200px]"
+          />
+        )}
         {coverFilter !== undefined && (
           <SelectFilter
             id="cover-filter"

--- a/apps/web/app/components/song/filtered-songs-table.test.tsx
+++ b/apps/web/app/components/song/filtered-songs-table.test.tsx
@@ -1,0 +1,84 @@
+import { mockShallowComponent } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("~/hooks/use-performance-page-filters", () => ({
+  usePerformancePageFilters: vi.fn(() => ({
+    filteredData: [],
+    isLoading: false,
+    selectedTimeRange: "all",
+    coverFilter: "all",
+    selectedAuthor: null,
+    playedFilter: "all",
+    activeToggleSet: new Set(),
+    hasActiveFilters: false,
+    searchText: "",
+    setSearchText: vi.fn(),
+    updateFilter: vi.fn(),
+    toggleFilter: vi.fn(),
+    clearFilters: vi.fn(),
+  })),
+}));
+
+vi.mock("~/components/performance/performance-filter-controls", () => ({
+  PerformanceFilterControls: (props: object) => mockShallowComponent("PerformanceFilterControls", props),
+}));
+
+vi.mock("./songs-table", () => ({
+  SongsTable: ({ filterComponent, ...rest }: { filterComponent?: React.ReactNode }) => (
+    <div data-testid="SongsTable">
+      {filterComponent}
+      <span>props: {JSON.stringify(rest, Object.keys(rest).sort())}</span>
+    </div>
+  ),
+}));
+
+import { usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
+import { FilteredSongsTable } from "./filtered-songs-table";
+
+function renderComponent(props: { extraParams?: Record<string, string>; hideTimeRange?: boolean }) {
+  return render(
+    <MemoryRouter>
+      <FilteredSongsTable songs={[]} {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe("FilteredSongsTable", () => {
+  // The component wires up usePerformancePageFilters, PerformanceFilterControls,
+  // and SongsTable together — verify SongsTable renders.
+  test("renders SongsTable", () => {
+    renderComponent({});
+
+    expect(screen.getByTestId("SongsTable")).toBeInTheDocument();
+  });
+
+  // extraParams should be forwarded to the hook so pre-baked tabs can
+  // set a fixed time range for API requests.
+  test("passes extraParams to usePerformancePageFilters", () => {
+    renderComponent({ extraParams: { timeRange: "last10shows" } });
+
+    expect(vi.mocked(usePerformancePageFilters)).toHaveBeenCalledWith(
+      expect.objectContaining({ extraParams: { timeRange: "last10shows" } }),
+    );
+  });
+
+  // When hideTimeRange is true, the PerformanceFilterControls should receive
+  // it so the Time Range dropdown is suppressed.
+  test("passes hideTimeRange to PerformanceFilterControls", () => {
+    renderComponent({ hideTimeRange: true });
+
+    const controls = screen.getByTestId("PerformanceFilterControls");
+    expect(controls.textContent).toContain('"hideTimeRange":true');
+  });
+
+  // When hideTimeRange is not set, it defaults to undefined (falsy),
+  // so the Time Range dropdown renders normally.
+  test("does not pass hideTimeRange when not set", () => {
+    renderComponent({});
+
+    const controls = screen.getByTestId("PerformanceFilterControls");
+    expect(controls.textContent).not.toContain('"hideTimeRange":true');
+  });
+});

--- a/apps/web/app/components/song/filtered-songs-table.tsx
+++ b/apps/web/app/components/song/filtered-songs-table.tsx
@@ -1,0 +1,57 @@
+import type { Song } from "@bip/domain";
+import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
+import { usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
+import { SongsTable } from "./songs-table";
+
+interface FilteredSongsTableProps {
+  songs: Song[];
+  extraParams?: Record<string, string>;
+  hideTimeRange?: boolean;
+}
+
+const searchFilter = (song: Song, query: string) => song.title.toLowerCase().includes(query);
+
+export function FilteredSongsTable({ songs, extraParams, hideTimeRange }: FilteredSongsTableProps) {
+  const {
+    filteredData: filteredSongs,
+    isLoading,
+    selectedTimeRange,
+    coverFilter,
+    selectedAuthor,
+    playedFilter,
+    activeToggleSet,
+    hasActiveFilters,
+    searchText,
+    setSearchText,
+    updateFilter,
+    toggleFilter,
+    clearFilters,
+  } = usePerformancePageFilters<Song>({
+    initialData: songs,
+    apiUrl: "/api/songs",
+    extraParams,
+    searchFilter,
+  });
+
+  const hasDateRange = selectedTimeRange !== "all";
+  const showPlayedFilter = hasDateRange || activeToggleSet.has("attended");
+
+  const filterControls = (
+    <PerformanceFilterControls
+      selectedTimeRange={selectedTimeRange}
+      activeToggleSet={activeToggleSet}
+      updateFilter={updateFilter}
+      toggleFilter={toggleFilter}
+      clearFilters={clearFilters}
+      coverFilter={coverFilter}
+      selectedAuthor={selectedAuthor}
+      playedFilter={showPlayedFilter ? playedFilter : undefined}
+      searchValue={searchText}
+      onSearchChange={setSearchText}
+      hasActiveFilters={hasActiveFilters}
+      hideTimeRange={hideTimeRange}
+    />
+  );
+
+  return <SongsTable songs={filteredSongs} filterComponent={filterControls} isLoading={isLoading} />;
+}

--- a/apps/web/app/components/ui/filters/select-filter.test.tsx
+++ b/apps/web/app/components/ui/filters/select-filter.test.tsx
@@ -1,5 +1,5 @@
-import { screen } from "@testing-library/react";
 import { setup } from "@test/test-utils";
+import { screen, within } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import { SelectFilter } from "./select-filter";
 
@@ -60,5 +60,75 @@ describe("SelectFilter", () => {
 
     const trigger = screen.getByRole("combobox");
     expect(trigger.className).toContain("w-[120px]");
+  });
+
+  // Grouped options should render with group labels so users can visually
+  // distinguish between Recent, Eras, and Years in the Time Range dropdown.
+  test("renders grouped options with group labels when groups prop is provided", async () => {
+    const groups = [
+      {
+        label: "Recent",
+        options: [
+          { value: "last10shows", label: "Last 10 Shows" },
+          { value: "thisYear", label: "This Year" },
+        ],
+      },
+      {
+        label: "Eras",
+        options: [
+          { value: "marlon", label: "Marlon Era" },
+          { value: "allen", label: "Allen Era" },
+        ],
+      },
+    ];
+
+    const { user } = await setup(
+      <SelectFilter id="test-filter" label="Time Range" value="all" onValueChange={() => {}} groups={groups} />,
+    );
+    await user.click(screen.getByRole("combobox"));
+
+    // Group labels should be visible
+    expect(screen.getByText("Recent")).toBeInTheDocument();
+    expect(screen.getByText("Eras")).toBeInTheDocument();
+
+    // Options within groups should be selectable
+    expect(screen.getByRole("option", { name: "Last 10 Shows" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "This Year" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Marlon Era" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Allen Era" })).toBeInTheDocument();
+  });
+
+  // When both standalone options and groups are provided, standalone options
+  // render before the groups (e.g., "All Time" above the grouped options).
+  test("renders standalone options before groups when both are provided", async () => {
+    const standaloneOptions = [{ value: "all", label: "All Time" }];
+    const groups = [
+      {
+        label: "Recent",
+        options: [{ value: "last10shows", label: "Last 10 Shows" }],
+      },
+    ];
+
+    const { user } = await setup(
+      <SelectFilter
+        id="test-filter"
+        label="Time Range"
+        value="all"
+        onValueChange={() => {}}
+        options={standaloneOptions}
+        groups={groups}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+
+    expect(screen.getByRole("option", { name: "All Time" })).toBeInTheDocument();
+    expect(screen.getByText("Recent")).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Last 10 Shows" })).toBeInTheDocument();
+
+    // "All Time" should appear before "Last 10 Shows" in the DOM
+    const listbox = screen.getByRole("listbox");
+    const allOptions = within(listbox).getAllByRole("option");
+    expect(allOptions[0]).toHaveTextContent("All Time");
+    expect(allOptions[1]).toHaveTextContent("Last 10 Shows");
   });
 });

--- a/apps/web/app/components/ui/filters/select-filter.tsx
+++ b/apps/web/app/components/ui/filters/select-filter.tsx
@@ -1,4 +1,12 @@
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
 
 const selectTriggerClass =
   "h-[34px] text-sm bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20";
@@ -6,18 +14,34 @@ const selectContentClass = "bg-glass-bg border-glass-border backdrop-blur-md";
 const selectItemClass = "text-content-text-primary hover:bg-hover-glass";
 const labelClass =
   "text-xs font-medium text-content-text-secondary uppercase tracking-wide mb-1.5 h-[18px] flex items-center";
+const groupLabelClass = "text-xs uppercase text-content-text-tertiary tracking-wide py-1";
+
+export interface SelectFilterOptionGroup {
+  label: string;
+  options: Array<{ value: string; label: string }>;
+}
 
 interface SelectFilterProps {
   id: string;
   label: string;
   value: string;
   onValueChange: (value: string) => void;
-  options: Array<{ value: string; label: string }>;
+  options?: Array<{ value: string; label: string }>;
+  groups?: SelectFilterOptionGroup[];
   placeholder?: string;
   width?: string;
 }
 
-export function SelectFilter({ id, label, value, onValueChange, options, placeholder, width }: SelectFilterProps) {
+export function SelectFilter({
+  id,
+  label,
+  value,
+  onValueChange,
+  options,
+  groups,
+  placeholder,
+  width,
+}: SelectFilterProps) {
   return (
     <div className="flex flex-col">
       <label htmlFor={id} className={labelClass}>
@@ -28,10 +52,20 @@ export function SelectFilter({ id, label, value, onValueChange, options, placeho
           <SelectValue placeholder={placeholder} />
         </SelectTrigger>
         <SelectContent className={selectContentClass}>
-          {options.map((option) => (
+          {options?.map((option) => (
             <SelectItem key={option.value} value={option.value} className={selectItemClass}>
               {option.label}
             </SelectItem>
+          ))}
+          {groups?.map((group) => (
+            <SelectGroup key={group.label}>
+              <SelectLabel className={groupLabelClass}>{group.label}</SelectLabel>
+              {group.options.map((option) => (
+                <SelectItem key={option.value} value={option.value} className={selectItemClass}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
           ))}
         </SelectContent>
       </Select>

--- a/apps/web/app/hooks/use-performance-page-filters.test.ts
+++ b/apps/web/app/hooks/use-performance-page-filters.test.ts
@@ -50,7 +50,7 @@ describe("usePerformancePageFilters", () => {
   // Loading state is debounced by 200ms to avoid flicker on fast responses.
   // Before the timeout fires, isLoading should remain false.
   test("isLoading becomes true after debounce when filters trigger a fetch", async () => {
-    mockSearchParams = new URLSearchParams("year=2024");
+    mockSearchParams = new URLSearchParams("timeRange=2024");
     // Never-resolving fetch so loading stays true
     globalThis.fetch = vi.fn().mockImplementation(() => new Promise(() => {}));
 
@@ -69,7 +69,7 @@ describe("usePerformancePageFilters", () => {
   // Once the fetch resolves, loading state should clear — even if the
   // debounce timeout already fired. Verifies the full loading lifecycle.
   test("isLoading returns to false when fetch completes", async () => {
-    mockSearchParams = new URLSearchParams("year=2024");
+    mockSearchParams = new URLSearchParams("timeRange=2024");
     let resolveResponse: (value: unknown) => void = () => {};
     globalThis.fetch = vi.fn().mockImplementation(
       () =>
@@ -99,7 +99,17 @@ describe("usePerformancePageFilters", () => {
     expect(result.current.hasFilters).toBe(false);
   });
 
-  test("hasFilters is true when year is set", () => {
+  // timeRange is the URL param for time-based filtering (years, eras, presets).
+  test("hasFilters is true when timeRange is set", () => {
+    mockSearchParams = new URLSearchParams("timeRange=2024");
+
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    expect(result.current.hasFilters).toBe(true);
+  });
+
+  // Legacy year= and era= URL params still activate filters for bookmarked URLs.
+  test("hasFilters is true when legacy year param is set", () => {
     mockSearchParams = new URLSearchParams("year=2024");
 
     const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
@@ -107,8 +117,8 @@ describe("usePerformancePageFilters", () => {
     expect(result.current.hasFilters).toBe(true);
   });
 
-  test("hasFilters is true when era is set", () => {
-    mockSearchParams = new URLSearchParams("era=1.0");
+  test("hasFilters is true when legacy era param is set", () => {
+    mockSearchParams = new URLSearchParams("era=sammy");
 
     const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
 
@@ -167,7 +177,7 @@ describe("usePerformancePageFilters", () => {
   });
 
   test("hasActiveFilters is true when URL params are set even if searchText is empty", () => {
-    mockSearchParams = new URLSearchParams("year=2024");
+    mockSearchParams = new URLSearchParams("timeRange=2024");
 
     const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
 
@@ -192,13 +202,13 @@ describe("usePerformancePageFilters", () => {
     expect(result.current.searchText).toBe("");
   });
 
-  // Verifies that the setSearchParams updater clears all seven URL param keys
-  // (year, era, cover, author, filters, attended, played). We call the updater
+  // Verifies that the setSearchParams updater clears all URL param keys
+  // (timeRange, cover, author, filters, attended, played). We call the updater
   // manually because the mock doesn't trigger React state updates — we just
   // need to confirm the function produces the right params.
   test("clearFilters resets all params", () => {
     mockSearchParams = new URLSearchParams(
-      "year=2024&era=1.0&cover=cover&author=Trey&filters=encore&attended=attended&played=notPlayed",
+      "timeRange=2024&cover=cover&author=Trey&filters=encore&attended=attended&played=notPlayed",
     );
 
     const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
@@ -212,12 +222,11 @@ describe("usePerformancePageFilters", () => {
     const updaterFn = mockSetSearchParams.mock.calls[0][0];
     const nextParams = updaterFn(
       new URLSearchParams(
-        "year=2024&era=1.0&cover=cover&author=Trey&filters=encore&attended=attended&played=notPlayed",
+        "timeRange=2024&cover=cover&author=Trey&filters=encore&attended=attended&played=notPlayed",
       ),
     );
 
-    expect(nextParams.get("year")).toBeNull();
-    expect(nextParams.get("era")).toBeNull();
+    expect(nextParams.get("timeRange")).toBeNull();
     expect(nextParams.get("cover")).toBeNull();
     expect(nextParams.get("author")).toBeNull();
     expect(nextParams.get("filters")).toBeNull();

--- a/apps/web/app/hooks/use-performance-page-filters.ts
+++ b/apps/web/app/hooks/use-performance-page-filters.ts
@@ -1,6 +1,7 @@
 import type { SongPagePerformance } from "@bip/domain";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
+import { getTimeRangeParam } from "~/lib/song-filters";
 
 export const searchPerformance = (performance: SongPagePerformance, query: string) =>
   performance.songTitle?.toLowerCase().includes(query) ||
@@ -24,8 +25,7 @@ export function usePerformancePageFilters<T>({
 }: PageFiltersOptions<T>) {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const selectedYear = searchParams.get("year") || "all";
-  const selectedEra = searchParams.get("era") || "all";
+  const selectedTimeRange = getTimeRangeParam(searchParams) || "all";
   const coverFilter = (searchParams.get("cover") as "all" | "cover" | "original") || "all";
   const selectedAuthor = searchParams.get("author") || null;
   const filtersParam = searchParams.get("filters") || "";
@@ -44,8 +44,7 @@ export function usePerformancePageFilters<T>({
   const loadingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const hasFilters =
-    selectedYear !== "all" ||
-    selectedEra !== "all" ||
+    selectedTimeRange !== "all" ||
     coverFilter !== "all" ||
     !!selectedAuthor ||
     filtersParam !== "" ||
@@ -70,8 +69,7 @@ export function usePerformancePageFilters<T>({
     }, 200);
 
     const params = new URLSearchParams();
-    if (selectedYear !== "all") params.set("year", selectedYear);
-    if (selectedEra !== "all") params.set("era", selectedEra);
+    if (selectedTimeRange !== "all") params.set("timeRange", selectedTimeRange);
     if (coverFilter !== "all") params.set("cover", coverFilter);
     if (selectedAuthor) params.set("author", selectedAuthor);
     if (filtersParam) params.set("filters", filtersParam);
@@ -115,8 +113,7 @@ export function usePerformancePageFilters<T>({
       }
     };
   }, [
-    selectedYear,
-    selectedEra,
+    selectedTimeRange,
     coverFilter,
     selectedAuthor,
     filtersParam,
@@ -178,7 +175,16 @@ export function usePerformancePageFilters<T>({
   const hasActiveFilters = hasFilters || searchText.length > 0;
 
   const clearFilters = useCallback(() => {
-    updateFilter({ year: null, era: null, cover: null, author: null, filters: null, attended: null, played: null });
+    updateFilter({
+      timeRange: null,
+      year: null,
+      era: null,
+      cover: null,
+      author: null,
+      filters: null,
+      attended: null,
+      played: null,
+    });
     setSearchText("");
   }, [updateFilter]);
 
@@ -186,8 +192,7 @@ export function usePerformancePageFilters<T>({
     data,
     filteredData,
     isLoading,
-    selectedYear,
-    selectedEra,
+    selectedTimeRange,
     coverFilter,
     selectedAuthor,
     playedFilter: playedParam || "all",

--- a/apps/web/app/lib/performance-filter-params.ts
+++ b/apps/web/app/lib/performance-filter-params.ts
@@ -1,7 +1,7 @@
 import type { PerformanceFilterOptions } from "@bip/core/page-composers/song-page-composer";
 import { CacheKeys } from "@bip/domain/cache-keys";
 import type { PublicContext } from "~/lib/base-loaders";
-import { SONG_FILTERS } from "~/lib/song-filters";
+import { getTimeRangeParam, SONG_FILTERS } from "~/lib/song-filters";
 import { services } from "~/server/services";
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -46,22 +46,37 @@ export async function resolveAttendedUserId(
  * Parse URL search params into PerformanceFilterOptions.
  * Shared by /api/all-timers and /api/songs/performances.
  */
+/**
+ * Resolve "last10shows" to a date range by querying the 10th most recent show date.
+ */
+export async function resolveLast10ShowsDateRange(): Promise<{ startDate: Date } | null> {
+  const recentShows = await services.shows.findMany({
+    sort: [{ field: "date" as keyof import("@bip/domain").Show, direction: "desc" }],
+    pagination: { page: 1, limit: 10 },
+  });
+  if (recentShows.length === 0) return null;
+  const earliestDate = recentShows[recentShows.length - 1].date;
+  return { startDate: new Date(earliestDate) };
+}
+
 export async function parsePerformanceFilters(url: URL, context: PublicContext): Promise<PerformanceFilterOptions> {
-  const year = url.searchParams.get("year");
-  const era = url.searchParams.get("era");
+  const timeRangeParam = getTimeRangeParam(url.searchParams);
   const coverParam = url.searchParams.get("cover");
   const authorParam = url.searchParams.get("author");
   const filtersParam = url.searchParams.get("filters");
   const attendedParam = url.searchParams.get("attended");
   const monthDayParam = url.searchParams.get("monthDay");
 
-  const dateRangeKey = year || era;
-  const dateRange = dateRangeKey && dateRangeKey in SONG_FILTERS ? SONG_FILTERS[dateRangeKey] : null;
-
   const filters: PerformanceFilterOptions = {};
 
-  if (dateRange?.startDate) filters.startDate = dateRange.startDate;
-  if (dateRange?.endDate) filters.endDate = dateRange.endDate;
+  if (timeRangeParam === "last10shows") {
+    const dateRange = await resolveLast10ShowsDateRange();
+    if (dateRange) filters.startDate = dateRange.startDate;
+  } else if (timeRangeParam && timeRangeParam in SONG_FILTERS) {
+    const dateRange = SONG_FILTERS[timeRangeParam];
+    if (dateRange.startDate) filters.startDate = dateRange.startDate;
+    if (dateRange.endDate) filters.endDate = dateRange.endDate;
+  }
   if (coverParam === "cover") filters.cover = true;
   else if (coverParam === "original") filters.cover = false;
   if (authorParam && UUID_REGEX.test(authorParam)) filters.authorId = authorParam;
@@ -85,17 +100,15 @@ export async function parsePerformanceFilters(url: URL, context: PublicContext):
  * Build a cache key from URL search params for filtered performance queries.
  */
 export function buildFilteredCacheKey(url: URL, scope: string, attendedUserId?: string): string {
-  const year = url.searchParams.get("year");
-  const era = url.searchParams.get("era");
+  const timeRange = getTimeRangeParam(url.searchParams);
   const coverParam = url.searchParams.get("cover");
   const authorParam = url.searchParams.get("author");
   const filtersParam = url.searchParams.get("filters");
-
   const monthDay = url.searchParams.get("monthDay");
+
   return CacheKeys.songs.filtered({
     scope,
-    year: year || null,
-    era: era || null,
+    timeRange: timeRange || null,
     cover: coverParam || null,
     author: authorParam || null,
     filters: filtersParam || null,

--- a/apps/web/app/lib/song-filters.test.ts
+++ b/apps/web/app/lib/song-filters.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+import { SONG_FILTERS, getTimeRangeParam, TIME_RANGE_GROUPS } from "./song-filters";
+
+describe("TIME_RANGE_GROUPS", () => {
+  // The groups should be ordered: Recent, Eras, Years — matching the
+  // visual layout in the Time Range dropdown.
+  test("has three groups: Recent, Eras, Years", () => {
+    expect(TIME_RANGE_GROUPS).toHaveLength(3);
+    expect(TIME_RANGE_GROUPS[0].label).toBe("Recent");
+    expect(TIME_RANGE_GROUPS[1].label).toBe("Eras");
+    expect(TIME_RANGE_GROUPS[2].label).toBe("Years");
+  });
+
+  // Recent group provides quick-access presets for commonly browsed time ranges.
+  test("Recent group contains Last 10 Shows and This Year", () => {
+    const recent = TIME_RANGE_GROUPS[0];
+    expect(recent.options).toHaveLength(2);
+    expect(recent.options[0]).toEqual({ value: "last10shows", label: "Last 10 Shows" });
+    expect(recent.options[1]).toEqual({ value: "thisYear", label: "This Year" });
+  });
+
+  // Eras group contains all band personnel eras.
+  test("Eras group contains all 4 eras", () => {
+    const eras = TIME_RANGE_GROUPS[1];
+    expect(eras.options).toHaveLength(4);
+    const eraValues = eras.options.map((o) => o.value);
+    expect(eraValues).toContain("marlon");
+    expect(eraValues).toContain("allen");
+    expect(eraValues).toContain("sammy");
+    expect(eraValues).toContain("triscuits");
+  });
+
+  // Years group should span from 1995 to the current year, newest first.
+  test("Years group contains years from current year down to 1995", () => {
+    const years = TIME_RANGE_GROUPS[2];
+    const currentYear = new Date().getFullYear();
+    expect(years.options[0].value).toBe(String(currentYear));
+    expect(years.options[years.options.length - 1].value).toBe("1995");
+    expect(years.options).toHaveLength(currentYear - 1995 + 1);
+  });
+});
+
+describe("SONG_FILTERS", () => {
+  // thisYear should resolve to the current year's date range.
+  test("thisYear resolves to current year date range", () => {
+    const currentYear = new Date().getFullYear();
+    const thisYear = SONG_FILTERS.thisYear;
+    expect(thisYear).toBeDefined();
+    expect(thisYear.startDate).toEqual(new Date(`${currentYear}-01-01`));
+    expect(thisYear.endDate).toEqual(new Date(`${currentYear}-12-31`));
+  });
+
+  // Existing year and era keys should still resolve correctly.
+  test("existing year keys still resolve to date ranges", () => {
+    expect(SONG_FILTERS["2024"]).toBeDefined();
+    expect(SONG_FILTERS["2024"].startDate).toEqual(new Date("2024-01-01"));
+    expect(SONG_FILTERS["2024"].endDate).toEqual(new Date("2024-12-31"));
+  });
+
+  test("existing era keys still resolve to date ranges", () => {
+    expect(SONG_FILTERS.sammy).toBeDefined();
+    expect(SONG_FILTERS.sammy.endDate).toEqual(new Date("2005-08-27"));
+  });
+});
+
+describe("getTimeRangeParam", () => {
+  // The primary param name for time-based filtering.
+  test("returns timeRange param when present", () => {
+    const params = new URLSearchParams("timeRange=2024");
+    expect(getTimeRangeParam(params)).toBe("2024");
+  });
+
+  // Legacy year param is accepted for bookmarked URLs.
+  test("falls back to year param when timeRange is absent", () => {
+    const params = new URLSearchParams("year=2024");
+    expect(getTimeRangeParam(params)).toBe("2024");
+  });
+
+  // Legacy era param is accepted for bookmarked URLs.
+  test("falls back to era param when timeRange and year are absent", () => {
+    const params = new URLSearchParams("era=sammy");
+    expect(getTimeRangeParam(params)).toBe("sammy");
+  });
+
+  // timeRange takes priority over year/era if multiple are somehow present.
+  test("prefers timeRange over year and era", () => {
+    const params = new URLSearchParams("timeRange=last10shows&year=2024&era=sammy");
+    expect(getTimeRangeParam(params)).toBe("last10shows");
+  });
+
+  // Returns null when no time-related params are set.
+  test("returns null when no time params are present", () => {
+    const params = new URLSearchParams("cover=original");
+    expect(getTimeRangeParam(params)).toBeNull();
+  });
+});

--- a/apps/web/app/lib/song-filters.ts
+++ b/apps/web/app/lib/song-filters.ts
@@ -27,9 +27,12 @@ const eraFilters: Record<string, SongFilterConfig> = {
   triscuits: { label: "Triscuits", startDate: new Date("2000-03-11"), endDate: new Date("2000-07-12") },
 };
 
+const currentYear = new Date().getFullYear();
+
 export const SONG_FILTERS: Record<string, SongFilterConfig> = {
   ...yearFilters,
   ...eraFilters,
+  thisYear: yearFilters[String(currentYear)],
 };
 
 export const YEAR_OPTIONS = Object.entries(yearFilters)
@@ -40,6 +43,32 @@ export const ERA_OPTIONS = Object.entries(eraFilters).map(([value, config]) => (
   value,
   label: config.label,
 }));
+
+export const TIME_RANGE_GROUPS = [
+  {
+    label: "Recent",
+    options: [
+      { value: "last10shows", label: "Last 10 Shows" },
+      { value: "thisYear", label: "This Year" },
+    ],
+  },
+  {
+    label: "Eras",
+    options: ERA_OPTIONS,
+  },
+  {
+    label: "Years",
+    options: YEAR_OPTIONS,
+  },
+];
+
+/**
+ * Extract the timeRange value from URL search params, accepting year/era as fallbacks
+ * for bookmarked URLs.
+ */
+export function getTimeRangeParam(params: URLSearchParams): string | null {
+  return params.get("timeRange") || params.get("year") || params.get("era") || null;
+}
 
 /**
  * Tag filters shared between /songs, /songs/all-timers, and /songs/$slug.

--- a/apps/web/app/lib/song-utilities.test.ts
+++ b/apps/web/app/lib/song-utilities.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mockSong = {
+  id: "1",
+  title: "Basis for a Day",
+  timesPlayed: 5,
+  dateFirstPlayed: null,
+  dateLastPlayed: null,
+};
+
+const mockUnplayedSong = {
+  id: "2",
+  title: "Shelby Rose",
+  timesPlayed: 0,
+  dateFirstPlayed: null,
+  dateLastPlayed: null,
+};
+
+const mockFindMany = vi.fn().mockResolvedValue([mockSong, mockUnplayedSong]);
+const mockFindManyInDateRange = vi.fn().mockResolvedValue([mockSong]);
+const mockCacheGetOrSet = vi.fn().mockImplementation((_key: string, fn: () => Promise<unknown>) => fn());
+const mockFindManyByDates = vi.fn().mockResolvedValue([]);
+
+vi.mock("~/server/services", () => ({
+  services: {
+    songs: {
+      findMany: (...args: unknown[]) => mockFindMany(...args),
+      findManyInDateRange: (...args: unknown[]) => mockFindManyInDateRange(...args),
+    },
+    cache: {
+      getOrSet: (...args: unknown[]) => mockCacheGetOrSet(...args),
+    },
+    shows: {
+      findManyByDates: (...args: unknown[]) => mockFindManyByDates(...args),
+    },
+  },
+}));
+
+import { loadSongsWithVenueInfo } from "./song-utilities";
+
+describe("loadSongsWithVenueInfo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Fetches all songs, filters out unplayed ones, and adds venue info.
+  test("fetches all songs when no date range is provided", async () => {
+    const result = await loadSongsWithVenueInfo("test-cache-key");
+
+    expect(mockCacheGetOrSet).toHaveBeenCalledWith("test-cache-key", expect.any(Function), { ttl: 3600 });
+    expect(mockFindMany).toHaveBeenCalledWith({});
+    expect(result.songs).toHaveLength(1);
+    expect(result.songs[0].title).toBe("Basis for a Day");
+  });
+
+  // When a date range is provided, uses findManyInDateRange instead.
+  test("fetches songs in date range when startDate is provided", async () => {
+    const startDate = new Date("2024-01-01");
+    const endDate = new Date("2024-12-31");
+
+    await loadSongsWithVenueInfo("test-cache-key", { startDate, endDate });
+
+    expect(mockFindManyInDateRange).toHaveBeenCalledWith({ startDate, endDate });
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  // Songs with timesPlayed === 0 should be excluded from results.
+  test("filters out songs with zero plays", async () => {
+    const result = await loadSongsWithVenueInfo("test-cache-key");
+
+    const titles = result.songs.map((s: { title: string }) => s.title);
+    expect(titles).not.toContain("Shelby Rose");
+  });
+});

--- a/apps/web/app/lib/song-utilities.ts
+++ b/apps/web/app/lib/song-utilities.ts
@@ -2,6 +2,38 @@ import type { Show, Song } from "@bip/domain";
 import { dateToISOStringSansTime } from "~/lib/date";
 import { services } from "~/server/services";
 
+interface SongsLoaderData {
+  songs: Song[];
+}
+
+interface DateRange {
+  startDate?: Date;
+  endDate?: Date;
+}
+
+/**
+ * Shared loader logic for songs pages: cache lookup, fetch songs (optionally
+ * filtered by date range), exclude unplayed songs, and add venue info.
+ */
+export async function loadSongsWithVenueInfo(
+  cacheKey: string,
+  dateRange?: DateRange,
+): Promise<SongsLoaderData> {
+  return await services.cache.getOrSet(
+    cacheKey,
+    async () => {
+      const allSongs = dateRange
+        ? await services.songs.findManyInDateRange(dateRange)
+        : await services.songs.findMany({});
+
+      const songs = allSongs.filter((song) => song.timesPlayed > 0);
+      const songsWithVenueInfo = await addVenueInfoToSongs(songs);
+      return { songs: songsWithVenueInfo };
+    },
+    { ttl: 3600 },
+  );
+}
+
 /**
  * Adds the venue info to a songs firstPlayedShow and lastPlayedShow.
  */

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -95,6 +95,8 @@ export default [
       index("routes/songs/_index.tsx"),
       route("all-timers", "routes/songs/all-timers.tsx"),
       route("histories", "routes/songs/histories.tsx"),
+      route("recent", "routes/songs/recent.tsx"),
+      route("this-year", "routes/songs/this-year.tsx"),
       route("new", "routes/songs/new.tsx"),
       route(":slug", "routes/songs/$slug.tsx"),
       route(":slug/edit", "routes/songs/$slug.edit.tsx"),

--- a/apps/web/app/routes/api/songs.tsx
+++ b/apps/web/app/routes/api/songs.tsx
@@ -2,8 +2,12 @@ import type { Song } from "@bip/domain";
 import { CacheKeys } from "@bip/domain/cache-keys";
 import { publicLoader } from "~/lib/base-loaders";
 import { logger } from "~/lib/logger";
-import { parsePerformanceFilters, resolveAttendedUserId } from "~/lib/performance-filter-params";
-import { SONG_FILTERS } from "~/lib/song-filters";
+import {
+  parsePerformanceFilters,
+  resolveAttendedUserId,
+  resolveLast10ShowsDateRange,
+} from "~/lib/performance-filter-params";
+import { getTimeRangeParam, SONG_FILTERS } from "~/lib/song-filters";
 import { addVenueInfoToSongs } from "~/lib/song-utilities";
 import { services } from "~/server/services";
 
@@ -42,8 +46,7 @@ async function splitByPlayStatus(
 export const loader = publicLoader(async ({ request, context }) => {
   const url = new URL(request.url);
   const query = url.searchParams.get("q");
-  const year = url.searchParams.get("year");
-  const era = url.searchParams.get("era");
+  const timeRangeParam = getTimeRangeParam(url.searchParams);
   const playedParam = url.searchParams.get("played");
   const authorParam = url.searchParams.get("author");
   const coverParam = url.searchParams.get("cover");
@@ -60,9 +63,7 @@ export const loader = publicLoader(async ({ request, context }) => {
 
   const attendedUserId = await resolveAttendedUserId(attendedParam, context);
 
-  // Year and era both resolve to a date-range key in SONG_FILTERS (mutually exclusive)
-  const dateRangeKey = year || era;
-  const hasDateRange = dateRangeKey && dateRangeKey in SONG_FILTERS;
+  const hasDateRange = timeRangeParam === "last10shows" || (timeRangeParam && timeRangeParam in SONG_FILTERS);
 
   const hasToggleFilters = !!filtersParam;
 
@@ -70,8 +71,7 @@ export const loader = publicLoader(async ({ request, context }) => {
   if (authorId || coverFilter !== undefined || hasDateRange || attendedUserId || hasToggleFilters) {
     try {
       const cacheKey = CacheKeys.songs.filtered({
-        year: year || null,
-        era: era || null,
+        timeRange: timeRangeParam || null,
         played: playedParam || null,
         author: authorId || null,
         cover: coverParam || null,
@@ -94,8 +94,15 @@ export const loader = publicLoader(async ({ request, context }) => {
           if (attendedUserId) filter.attendedUserId = attendedUserId;
 
           let songs: Song[];
-          if (hasDateRange) {
-            const { startDate, endDate } = SONG_FILTERS[dateRangeKey];
+          if (timeRangeParam === "last10shows") {
+            const dateRange = await resolveLast10ShowsDateRange();
+            if (dateRange) {
+              songs = await services.songs.findManyInDateRange({ startDate: dateRange.startDate, ...filter });
+            } else {
+              songs = await services.songs.findMany(filter);
+            }
+          } else if (timeRangeParam && timeRangeParam in SONG_FILTERS) {
+            const { startDate, endDate } = SONG_FILTERS[timeRangeParam];
             songs = await services.songs.findManyInDateRange({ startDate, endDate, ...filter });
           } else {
             songs = await services.songs.findMany(filter);

--- a/apps/web/app/routes/on-this-day.$monthDay.tsx
+++ b/apps/web/app/routes/on-this-day.$monthDay.tsx
@@ -94,8 +94,7 @@ export default function OnThisDay() {
   const {
     filteredData: filteredPerformances,
     isLoading,
-    selectedYear,
-    selectedEra,
+    selectedTimeRange,
     coverFilter,
     selectedAuthor,
     activeToggleSet,
@@ -167,8 +166,7 @@ export default function OnThisDay() {
               headerContent={
                 performances.length > ALL_TIMERS_PAGE_SIZE ? (
                   <PerformanceFilterControls
-                    selectedYear={selectedYear}
-                    selectedEra={selectedEra}
+                    selectedTimeRange={selectedTimeRange}
                     activeToggleSet={activeToggleSet}
                     updateFilter={updateFilter}
                     toggleFilter={toggleFilter}

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -108,8 +108,7 @@ export default function SongPage() {
   const {
     filteredData: filteredPerformances,
     isLoading,
-    selectedYear,
-    selectedEra,
+    selectedTimeRange,
     activeToggleSet,
     hasActiveFilters,
     searchText,
@@ -127,8 +126,7 @@ export default function SongPage() {
   const allTimers = useMemo(() => filteredPerformances.filter((p) => p.allTimer), [filteredPerformances]);
   const filterContent = (
     <PerformanceFilterControls
-      selectedYear={selectedYear}
-      selectedEra={selectedEra}
+      selectedTimeRange={selectedTimeRange}
       activeToggleSet={activeToggleSet}
       updateFilter={updateFilter}
       toggleFilter={toggleFilter}

--- a/apps/web/app/routes/songs/_index.test.tsx
+++ b/apps/web/app/routes/songs/_index.test.tsx
@@ -10,45 +10,13 @@ vi.mock("~/lib/seo", () => ({ getSongsMeta: vi.fn() }));
 vi.mock("~/lib/song-utilities", () => ({ addVenueInfoToSongs: vi.fn() }));
 vi.mock("@bip/domain/cache-keys", () => ({ CacheKeys: { songs: { index: vi.fn() } } }));
 
-// Mock the loader data hook to return minimal song data
 vi.mock("~/hooks/use-serialized-loader-data", () => ({
-  useSerializedLoaderData: vi.fn(() => ({
-    songs: [],
-    trendingSongs: [],
-    yearlyTrendingSongs: [],
-    recentShowsCount: 10,
-  })),
+  useSerializedLoaderData: vi.fn(() => ({ songs: [] })),
 }));
 
-// Mock the filter hook to return default state
-vi.mock("~/hooks/use-performance-page-filters", () => ({
-  usePerformancePageFilters: vi.fn(() => ({
-    filteredData: [],
-    isLoading: false,
-    selectedYear: "all",
-    selectedEra: "all",
-    coverFilter: "all",
-    selectedAuthor: null,
-    playedFilter: "all",
-    activeToggleSet: new Set(),
-    hasActiveFilters: false,
-    searchText: "",
-    setSearchText: vi.fn(),
-    updateFilter: vi.fn(),
-    toggleFilter: vi.fn(),
-    clearFilters: vi.fn(),
-  })),
-}));
-
-// Stub heavy child components
-vi.mock("../../components/song/songs-table", () => ({
-  SongsTable: (props: object) => mockShallowComponent("SongsTable", props),
-}));
-vi.mock("~/components/performance/performance-filter-controls", () => ({
-  PerformanceFilterControls: (props: object) => mockShallowComponent("PerformanceFilterControls", props),
-}));
-vi.mock("~/components/admin/admin-only", () => ({
-  AdminOnly: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+// Stub the shared FilteredSongsTable component
+vi.mock("~/components/song/filtered-songs-table", () => ({
+  FilteredSongsTable: (props: object) => mockShallowComponent("FilteredSongsTable", props),
 }));
 
 import Songs from "./_index";
@@ -62,33 +30,46 @@ function renderSongsIndex() {
 }
 
 describe("Songs index page", () => {
-  // The heading is now in the layout, so the index page should not render its own.
+  // The layout renders the heading, so the index page should not render its own.
   test("does not render its own SONGS heading", () => {
     renderSongsIndex();
 
     expect(screen.queryByText("SONGS")).not.toBeInTheDocument();
   });
 
-  // The all-timers link is now a tab in the layout, so the index page should not
-  // render a separate link to it.
+  // The layout tab bar handles navigation to all-timers.
   test("does not render an all-timers link", () => {
     renderSongsIndex();
 
     expect(screen.queryByRole("link", { name: /all-timers/i })).not.toBeInTheDocument();
   });
 
-  // The admin "New Song" button is now in the layout, so the index page should
-  // not render its own.
+  // The layout renders the admin "New Song" button.
   test("does not render a New Song button", () => {
     renderSongsIndex();
 
     expect(screen.queryByRole("link", { name: /new song/i })).not.toBeInTheDocument();
   });
 
-  // The SongsTable should still render as the main content of the tab.
-  test("renders the SongsTable", () => {
+  // The FilteredSongsTable renders the songs table with filter controls.
+  test("renders the FilteredSongsTable", () => {
     renderSongsIndex();
 
-    expect(screen.getByTestId("SongsTable")).toBeInTheDocument();
+    expect(screen.getByTestId("FilteredSongsTable")).toBeInTheDocument();
+  });
+
+  // Trending data is accessible via the "Last 10 Shows" and "This Year" tabs,
+  // so the index page does not render its own trending sections.
+  test("does not render Trending in Recent Shows section", () => {
+    renderSongsIndex();
+
+    expect(screen.queryByText("Trending in Recent Shows")).not.toBeInTheDocument();
+  });
+
+  // Popular This Year data is accessible via the "This Year" tab.
+  test("does not render Popular This Year section", () => {
+    renderSongsIndex();
+
+    expect(screen.queryByText("Popular This Year")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/routes/songs/_layout.test.tsx
+++ b/apps/web/app/routes/songs/_layout.test.tsx
@@ -24,14 +24,15 @@ function renderAtPath(path: string) {
 }
 
 describe("SongsLayout", () => {
-  // The layout should render a tab bar with three navigation tabs
-  // linking to /songs, /songs/all-timers, and /songs/histories.
-  test("renders three tab links: All Songs, All-Timers, Histories", () => {
+  // The layout should render a tab bar with five navigation tabs.
+  test("renders five tab links: All Songs, All-Timers, Histories, Last 10 Shows, This Year", () => {
     renderAtPath("/songs");
 
     expect(screen.getByRole("link", { name: /all songs/i })).toHaveAttribute("href", "/songs");
     expect(screen.getByRole("link", { name: /all-timers/i })).toHaveAttribute("href", "/songs/all-timers");
     expect(screen.getByRole("link", { name: /histories/i })).toHaveAttribute("href", "/songs/histories");
+    expect(screen.getByRole("link", { name: /last 10 shows/i })).toHaveAttribute("href", "/songs/recent");
+    expect(screen.getByRole("link", { name: /this year/i })).toHaveAttribute("href", "/songs/this-year");
   });
 
   // The active tab should be visually distinguished via a border-brand-primary

--- a/apps/web/app/routes/songs/_layout.tsx
+++ b/apps/web/app/routes/songs/_layout.tsx
@@ -1,5 +1,5 @@
 import type { LucideIcon } from "lucide-react";
-import { Flame, History, ListMusic, Plus } from "lucide-react";
+import { Calendar, Clock, Flame, History, ListMusic, Plus } from "lucide-react";
 import { Link, Outlet, useLocation } from "react-router-dom";
 import { AdminOnly } from "~/components/admin/admin-only";
 import { Button } from "~/components/ui/button";
@@ -14,6 +14,8 @@ interface Tab {
 
 const TABS: Tab[] = [
   { label: "All Songs", path: "/songs", icon: ListMusic },
+  { label: "Last 10 Shows", path: "/songs/recent", icon: Clock },
+  { label: "This Year", path: "/songs/this-year", icon: Calendar },
   { label: "All-Timers", path: "/songs/all-timers", icon: Flame, iconClassName: "text-orange-500" },
   { label: "Histories", path: "/songs/histories", icon: History },
 ];

--- a/apps/web/app/routes/songs/all-timers.test.tsx
+++ b/apps/web/app/routes/songs/all-timers.test.tsx
@@ -16,8 +16,7 @@ vi.mock("~/hooks/use-performance-page-filters", () => ({
   usePerformancePageFilters: vi.fn(() => ({
     filteredData: [],
     isLoading: false,
-    selectedYear: "all",
-    selectedEra: "all",
+    selectedTimeRange: "all",
     coverFilter: "all",
     selectedAuthor: null,
     activeToggleSet: new Set(),
@@ -50,15 +49,15 @@ function renderAllTimers() {
 }
 
 describe("AllTimersPage", () => {
-  // The "All-Timers" header with flame icon is now handled by the layout tab bar,
-  // so the page should not render its own heading.
+  // The layout tab bar handles the All-Timers heading,
+  // so the page should not render its own.
   test("does not render its own All-Timers heading", () => {
     renderAllTimers();
 
     expect(screen.queryByRole("heading", { name: /all-timers/i })).not.toBeInTheDocument();
   });
 
-  // The "Back to songs" link is replaced by the layout tab bar navigation.
+  // Navigation between song pages is handled by the layout tab bar.
   test("does not render a Back to songs link", () => {
     renderAllTimers();
 

--- a/apps/web/app/routes/songs/all-timers.tsx
+++ b/apps/web/app/routes/songs/all-timers.tsx
@@ -22,8 +22,7 @@ export default function AllTimersPage() {
   const {
     filteredData: filteredPerformances,
     isLoading,
-    selectedYear,
-    selectedEra,
+    selectedTimeRange,
     coverFilter,
     selectedAuthor,
     activeToggleSet,
@@ -47,8 +46,7 @@ export default function AllTimersPage() {
         showSongColumn
         headerContent={
           <PerformanceFilterControls
-            selectedYear={selectedYear}
-            selectedEra={selectedEra}
+            selectedTimeRange={selectedTimeRange}
             activeToggleSet={activeToggleSet}
             updateFilter={updateFilter}
             toggleFilter={toggleFilter}

--- a/apps/web/app/routes/songs/recent.test.tsx
+++ b/apps/web/app/routes/songs/recent.test.tsx
@@ -1,0 +1,40 @@
+import { mockShallowComponent } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+
+// Mock server-side modules
+vi.mock("~/server/services", () => ({ services: {} }));
+vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
+vi.mock("~/lib/song-utilities", () => ({ addVenueInfoToSongs: vi.fn() }));
+vi.mock("~/lib/performance-filter-params", () => ({ resolveLast10ShowsDateRange: vi.fn() }));
+vi.mock("@bip/domain/cache-keys", () => ({ CacheKeys: { songs: { filtered: vi.fn() } } }));
+
+vi.mock("~/hooks/use-serialized-loader-data", () => ({
+  useSerializedLoaderData: vi.fn(() => ({ songs: [] })),
+}));
+
+// Stub the shared FilteredSongsTable to inspect props
+vi.mock("~/components/song/filtered-songs-table", () => ({
+  FilteredSongsTable: (props: object) => mockShallowComponent("FilteredSongsTable", props),
+}));
+
+import RecentPage from "./recent";
+
+function renderRecent() {
+  return render(
+    <MemoryRouter initialEntries={["/songs/recent"]}>
+      <RecentPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("RecentPage", () => {
+  // The Recent tab renders a FilteredSongsTable with the last10shows time range.
+  test("renders FilteredSongsTable with last10shows extraParams and hideTimeRange", () => {
+    renderRecent();
+
+    const table = screen.getByTestId("FilteredSongsTable");
+    expect(table.textContent).toContain('"hideTimeRange":true');
+  });
+});

--- a/apps/web/app/routes/songs/recent.tsx
+++ b/apps/web/app/routes/songs/recent.tsx
@@ -1,0 +1,25 @@
+import type { Song } from "@bip/domain";
+import { CacheKeys } from "@bip/domain/cache-keys";
+import { FilteredSongsTable } from "~/components/song/filtered-songs-table";
+import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
+import { publicLoader } from "~/lib/base-loaders";
+import { resolveLast10ShowsDateRange } from "~/lib/performance-filter-params";
+import { loadSongsWithVenueInfo } from "~/lib/song-utilities";
+
+export const loader = publicLoader(async () => {
+  const dateRange = await resolveLast10ShowsDateRange();
+  return loadSongsWithVenueInfo(
+    CacheKeys.songs.filtered({ timeRange: "last10shows" }),
+    dateRange ?? undefined,
+  );
+});
+
+export function meta() {
+  return [{ title: "Last 10 Shows | Songs" }, { name: "description", content: "Songs played in the last 10 shows" }];
+}
+
+export default function RecentPage() {
+  const { songs } = useSerializedLoaderData<{ songs: Song[] }>();
+
+  return <FilteredSongsTable songs={songs} extraParams={{ timeRange: "last10shows" }} hideTimeRange />;
+}

--- a/apps/web/app/routes/songs/this-year.test.tsx
+++ b/apps/web/app/routes/songs/this-year.test.tsx
@@ -1,0 +1,40 @@
+import { mockShallowComponent } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+
+// Mock server-side modules
+vi.mock("~/server/services", () => ({ services: {} }));
+vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
+vi.mock("~/lib/song-utilities", () => ({ addVenueInfoToSongs: vi.fn() }));
+vi.mock("~/lib/song-filters", () => ({ SONG_FILTERS: { thisYear: { startDate: new Date(), endDate: new Date() } } }));
+vi.mock("@bip/domain/cache-keys", () => ({ CacheKeys: { songs: { filtered: vi.fn() } } }));
+
+vi.mock("~/hooks/use-serialized-loader-data", () => ({
+  useSerializedLoaderData: vi.fn(() => ({ songs: [] })),
+}));
+
+// Stub the shared FilteredSongsTable to inspect props
+vi.mock("~/components/song/filtered-songs-table", () => ({
+  FilteredSongsTable: (props: object) => mockShallowComponent("FilteredSongsTable", props),
+}));
+
+import ThisYearPage from "./this-year";
+
+function renderThisYear() {
+  return render(
+    <MemoryRouter initialEntries={["/songs/this-year"]}>
+      <ThisYearPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("ThisYearPage", () => {
+  // The This Year tab renders a FilteredSongsTable with the thisYear time range.
+  test("renders FilteredSongsTable with thisYear extraParams and hideTimeRange", () => {
+    renderThisYear();
+
+    const table = screen.getByTestId("FilteredSongsTable");
+    expect(table.textContent).toContain('"hideTimeRange":true');
+  });
+});

--- a/apps/web/app/routes/songs/this-year.tsx
+++ b/apps/web/app/routes/songs/this-year.tsx
@@ -3,19 +3,26 @@ import { CacheKeys } from "@bip/domain/cache-keys";
 import { FilteredSongsTable } from "~/components/song/filtered-songs-table";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
-import { getSongsMeta } from "~/lib/seo";
+import { SONG_FILTERS } from "~/lib/song-filters";
 import { loadSongsWithVenueInfo } from "~/lib/song-utilities";
 
 export const loader = publicLoader(async () => {
-  return loadSongsWithVenueInfo(CacheKeys.songs.index());
+  const { startDate, endDate } = SONG_FILTERS.thisYear;
+  return loadSongsWithVenueInfo(
+    CacheKeys.songs.filtered({ timeRange: "thisYear" }),
+    { startDate, endDate },
+  );
 });
 
 export function meta() {
-  return getSongsMeta();
+  return [
+    { title: "This Year | Songs" },
+    { name: "description", content: `Songs played in ${new Date().getFullYear()}` },
+  ];
 }
 
-export default function Songs() {
+export default function ThisYearPage() {
   const { songs } = useSerializedLoaderData<{ songs: Song[] }>();
 
-  return <FilteredSongsTable songs={songs} />;
+  return <FilteredSongsTable songs={songs} extraParams={{ timeRange: "thisYear" }} hideTimeRange />;
 }

--- a/packages/core/src/songs/song-service.ts
+++ b/packages/core/src/songs/song-service.ts
@@ -275,59 +275,6 @@ export class SongService {
     return trendingSongs;
   }
 
-  async findTrendingLastYear(): Promise<TrendingSong[]> {
-    // Calculate date range for the current calendar year
-    const currentYear = new Date().getFullYear();
-
-    // Find shows from the current calendar year
-    const shows = await this.db.show.findMany({
-      where: {
-        date: {
-          gte: `${currentYear}-01-01`,
-          lte: `${currentYear}-12-31`,
-        },
-      },
-    });
-
-    if (shows.length === 0) return [];
-
-    // Get the show IDs
-    const showIds = shows.map((show) => show.id);
-
-    // Find tracks from these shows and count songs
-    const tracks = await this.db.track.findMany({
-      where: { showId: { in: showIds } },
-      include: { song: true },
-    });
-
-    // Count unique shows for each song (not individual tracks)
-    const songCounts = new Map<string, { song: DbSong; showIds: Set<string> }>();
-
-    for (const track of tracks) {
-      if (!track.song) continue;
-
-      const songId = track.song.id;
-      const existing = songCounts.get(songId);
-
-      if (existing) {
-        existing.showIds.add(track.showId);
-      } else {
-        songCounts.set(songId, { song: track.song, showIds: new Set([track.showId]) });
-      }
-    }
-
-    // Convert to array, sort by count, and limit to top 10
-    const trendingSongs = Array.from(songCounts.values())
-      .sort((a, b) => b.showIds.size - a.showIds.size)
-      .slice(0, 10)
-      .map(({ song, showIds }) => ({
-        ...mapSongToDomainEntity(song),
-        count: showIds.size,
-      }));
-
-    return trendingSongs;
-  }
-
   async create(input: CreateSongInput): Promise<Song> {
     const slug = slugify(input.title);
     const now = new Date();


### PR DESCRIPTION
## Summary

Now that we have time filters in the songs table, and tabs on the song page, the data displayed in "Trending in Recent Shows" and "Popular This Year" are a bit redundant because that information can easily be surfaced in the table view. However, users also want to easily see this information.

This change collapses the Year and Era dropdowns into a single Time Range dropdown which now also includes options for "Last 10 Shows" and "This Year". In addition, we've added tabs for those to make this data even more visible (for those who would look for it). This should, hopefully, be the best of both worlds, and get the Songs table closer to the top of the page.

### Changes
- Merge Year + Era into unified Time Range dropdown with grouped options (Recent, Eras, Years) via Radix SelectGroup/SelectLabel
- Add `/songs/recent` and `/songs/this-year` tab routes with pre-filtered song tables
- Remove "Trending in Recent Shows" cards and "Popular This Year" sidebar
- Remove `findTrendingLastYear` from SongService (MCP route keeps `findTrendingLastXShows`)
- Extend `SelectFilter` to support grouped options
- Old `?year=` and `?era=` URLs still work for backward compatibility

https://github.com/user-attachments/assets/87a23fe4-33e8-4e28-b337-a062879c75d4


## Test plan
- [x] Navigate to `/songs` — single Time Range dropdown (no separate Year/Era), no trending sections
- [x] Open Time Range dropdown — grouped options: All Time, then Recent (Last 10 Shows, This Year), Eras, Years
- [x] Select "Last 10 Shows" in dropdown — filters to songs played in 10 most recent shows
- [x] Select a year or era — works as before
- [x] Click "Last 10 Shows" tab — navigates to `/songs/recent`, no Time Range dropdown, filters still work
- [x] Click "This Year" tab — navigates to `/songs/this-year`, same behavior
- [x] Tab bar order: All Songs | Last 10 Shows | This Year | All-Timers | Histories
- [x] Time Range dropdown also appears on `/songs/:slug` and `/on-this-day` pages
- [ ] Old URLs with `?year=2024` or `?era=sammy` still work
- [x] Clear All resets the time range filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)