### PR TITLE
Add anniversary badges to SetlistCard

### DIFF
--- a/apps/web/app/components/setlist/anniversary-badge.test.tsx
+++ b/apps/web/app/components/setlist/anniversary-badge.test.tsx
@@ -1,0 +1,79 @@
+import { setupWithRouter } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { AnniversaryBadge } from "./anniversary-badge";
+
+describe("AnniversaryBadge", () => {
+  // Displays 5th anniversary text for a show 5 years ago
+  test("displays '5th Anniversary' for a 5-year-old show", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    await setupWithRouter(<AnniversaryBadge showDate="2021-04-14" />);
+    expect(screen.getByText(/5th Anniversary/)).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  // Displays 10th anniversary text for a show 10 years ago
+  test("displays '10th Anniversary' for a 10-year-old show", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    await setupWithRouter(<AnniversaryBadge showDate="2016-04-14" />);
+    expect(screen.getByText(/10th Anniversary/)).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  // Displays 20th anniversary text for a show 20 years ago
+  test("displays '20th Anniversary' for a 20-year-old show", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    await setupWithRouter(<AnniversaryBadge showDate="2006-04-14" />);
+    expect(screen.getByText(/20th Anniversary/)).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  // Displays 25th anniversary text for a show 25 years ago
+  test("displays '25th Anniversary' for a 25-year-old show", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    await setupWithRouter(<AnniversaryBadge showDate="2001-04-14" />);
+    expect(screen.getByText(/25th Anniversary/)).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  // Renders an icon for anniversary shows
+  test("renders an icon", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    const { container } = await setupWithRouter(<AnniversaryBadge showDate="2016-04-14" />);
+    expect(container.querySelector("svg")).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  // Uses amber-400 text color
+  test("applies amber-400 color", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    const { container } = await setupWithRouter(<AnniversaryBadge showDate="2021-04-14" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain("text-amber-400");
+    vi.useRealTimers();
+  });
+
+  // Renders nothing for a non-anniversary show
+  test("renders nothing for a non-anniversary show", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    const { container } = await setupWithRouter(<AnniversaryBadge showDate="2023-04-14" />);
+    expect(container.firstChild).toBeNull();
+    vi.useRealTimers();
+  });
+
+  // Renders nothing for a show from the current year
+  test("renders nothing for a show from the current year", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    const { container } = await setupWithRouter(<AnniversaryBadge showDate="2026-04-14" />);
+    expect(container.firstChild).toBeNull();
+    vi.useRealTimers();
+  });
+});

--- a/apps/web/app/components/setlist/anniversary-badge.tsx
+++ b/apps/web/app/components/setlist/anniversary-badge.tsx
@@ -1,0 +1,36 @@
+import { Cake, PartyPopper, Sparkle, Trophy } from "lucide-react";
+import { getAnniversaryYears, getOrdinalSuffix } from "~/lib/utils";
+
+type AnniversaryTier = "minor" | "medium" | "major" | "legendary";
+
+function getTier(years: number): AnniversaryTier {
+  if (years >= 25) return "legendary";
+  if (years === 20) return "major";
+  if (years === 10 || years === 15) return "medium";
+  return "minor";
+}
+
+const anniversaryIcons: Record<AnniversaryTier, typeof Sparkle> = {
+  minor: Sparkle,
+  medium: PartyPopper,
+  major: Cake,
+  legendary: Trophy,
+};
+
+interface AnniversaryBadgeProps {
+  showDate: string;
+}
+
+export function AnniversaryBadge({ showDate }: AnniversaryBadgeProps) {
+  const years = getAnniversaryYears(showDate);
+  if (!years) return null;
+  const tier = getTier(years);
+  const Icon = anniversaryIcons[tier];
+  return (
+    <span className="flex items-center gap-1 text-sm font-medium text-amber-400">
+      <Icon className="h-4 w-4" />
+      {years}
+      {getOrdinalSuffix(years)} Anniversary
+    </span>
+  );
+}

--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -1,0 +1,119 @@
+import type { SetlistLight } from "@bip/domain";
+import { expectMockedShallowComponent, mockShallowComponent, setupWithRouter } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+// Mock hooks used internally by SetlistCard
+vi.mock("~/hooks/use-session", () => ({
+  useSession: vi.fn(() => ({ user: null, supabase: null, loading: false })),
+}));
+vi.mock("~/hooks/use-show-user-data", () => ({
+  useAttendanceMutation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+// Stub heavy child components
+vi.mock("./track-rating-overlay", () => ({
+  TrackRatingOverlay: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("~/components/rating", () => ({
+  RatingComponent: (props: object) => mockShallowComponent("RatingComponent", props),
+}));
+vi.mock("~/components/ui/star-rating", () => ({
+  StarRating: (props: object) => mockShallowComponent("StarRating", props),
+}));
+vi.mock("./anniversary-badge", () => ({
+  AnniversaryBadge: (props: object) => mockShallowComponent("AnniversaryBadge", props),
+}));
+
+import { SetlistCard } from "./setlist-card";
+
+function makeSetlist(overrides: { showDate?: string } = {}): SetlistLight {
+  return {
+    show: {
+      id: "show-1",
+      slug: "2021-04-14",
+      date: overrides.showDate ?? "2021-04-14",
+      venueId: "venue-1",
+      bandId: "band-1",
+      notes: null,
+      createdAt: new Date("2021-04-14"),
+      updatedAt: new Date("2021-04-14"),
+      likesCount: 0,
+      relistenUrl: null,
+      averageRating: 4.0,
+      ratingsCount: 10,
+      showPhotosCount: 0,
+      showYoutubesCount: 0,
+      reviewsCount: 0,
+    },
+    venue: {
+      id: "venue-1",
+      name: "The Fillmore",
+      slug: "the-fillmore",
+      city: "Philadelphia",
+      state: "PA",
+      country: "USA",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      timesPlayed: 5,
+    },
+    sets: [
+      {
+        label: "Set 1",
+        sort: 1,
+        tracks: [
+          {
+            id: "track-1",
+            showId: "show-1",
+            songId: "song-1",
+            set: "1",
+            position: 1,
+            segue: null,
+            likesCount: 0,
+            note: null,
+            allTimer: false,
+            averageRating: null,
+            ratingsCount: 0,
+            song: { id: "song-1", title: "Basis for a Day", slug: "basis-for-a-day" },
+          },
+        ],
+      },
+    ],
+    annotations: [],
+  };
+}
+
+describe("SetlistCard", () => {
+  // Passes the show date to AnniversaryBadge so it can decide whether to render
+  test("passes showDate to AnniversaryBadge", async () => {
+    await setupWithRouter(
+      <SetlistCard setlist={makeSetlist({ showDate: "2016-04-14" })} userAttendance={null} userRating={null} showRating={null} />,
+    );
+    expectMockedShallowComponent("AnniversaryBadge", { showDate: "2016-04-14" });
+  });
+
+  // Renders the show date as a link
+  test("renders the show date", async () => {
+    await setupWithRouter(
+      <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={null} />,
+    );
+    expect(screen.getByText("4/14/2021")).toBeInTheDocument();
+  });
+
+  // Renders venue information
+  test("renders venue name and location", async () => {
+    await setupWithRouter(
+      <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={null} />,
+    );
+    expect(screen.getByText(/The Fillmore/)).toBeInTheDocument();
+    expect(screen.getByText(/Philadelphia, PA/)).toBeInTheDocument();
+  });
+
+  // Renders the setlist tracks
+  test("renders track names", async () => {
+    await setupWithRouter(
+      <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={null} />,
+    );
+    expect(screen.getByText("Basis for a Day")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -1,5 +1,5 @@
 import type { Attendance, Rating, Setlist, SetlistLight } from "@bip/domain";
-import { Camera, Check, Flame, } from "lucide-react";
+import { Camera, Check, Flame } from "lucide-react";
 import { memo, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { RatingComponent } from "~/components/rating";
@@ -9,6 +9,7 @@ import { StarRating } from "~/components/ui/star-rating";
 import { useSession } from "~/hooks/use-session";
 import { useAttendanceMutation } from "~/hooks/use-show-user-data";
 import { cn, formatDateShort } from "~/lib/utils";
+import { AnniversaryBadge } from "./anniversary-badge";
 import { TrackRatingOverlay } from "./track-rating-overlay";
 
 interface SetlistCardProps {
@@ -93,7 +94,9 @@ function SetlistCardComponent({
     const previousAttendance = localAttendance; // Capture BEFORE optimistic update
 
     // Optimistically update local state
-    setLocalAttendance(previousAttendance ? null : ({ id: "optimistic", showId: setlist.show.id, userId: "" } as Attendance));
+    setLocalAttendance(
+      previousAttendance ? null : ({ id: "optimistic", showId: setlist.show.id, userId: "" } as Attendance),
+    );
 
     attendanceMutation.mutate(
       { showId: setlist.show.id, currentAttendance: previousAttendance },
@@ -111,7 +114,7 @@ function SetlistCardComponent({
           // Revert on error using captured previous value
           setLocalAttendance(previousAttendance);
         },
-      }
+      },
     );
   };
 
@@ -176,8 +179,14 @@ function SetlistCardComponent({
       <CardHeader className="relative z-10 border-b border-glass-border/30 px-3 py-3 md:px-6 md:py-5">
         <div className="flex justify-between items-start">
           <div className="flex flex-col gap-1">
-            <div className="text-lg md:text-2xl font-medium text-brand-primary hover:text-brand-secondary transition-colors">
-              <Link to={setlist.show.slug ? `/shows/${setlist.show.slug}` : `/shows`}>{formattedDate}</Link>
+            <div className="flex items-center gap-2 text-lg md:text-2xl font-medium">
+              <Link
+                to={setlist.show.slug ? `/shows/${setlist.show.slug}` : `/shows`}
+                className="text-brand-primary hover:text-brand-secondary transition-colors"
+              >
+                {formattedDate}
+              </Link>
+              <AnniversaryBadge showDate={setlist.show.date} />
             </div>
             <div className="text-base md:text-xl text-content-text-primary">
               {setlist.venue.name} - {setlist.venue.city}, {setlist.venue.state}
@@ -197,14 +206,21 @@ function SetlistCardComponent({
                     ? "bg-green-500/10 border border-green-500/50 shadow-[0_0_8px_rgba(34,197,94,0.2)]"
                     : "glass-secondary border border-dashed border-glass-border hover:border-green-500/30",
                   isAttendanceAnimating && "animate-[avg-rating-update_0.5s_ease-out]",
-                  attendanceMutation.isPending && "opacity-50"
+                  attendanceMutation.isPending && "opacity-50",
                 )}
               >
-                <Check className={cn("h-3.5 w-3.5 sm:h-4 sm:w-4", isAttending ? "text-green-500" : "text-content-text-tertiary")} />
-                <span className={cn(
-                  "text-sm font-medium hidden sm:inline",
-                  isAttending ? "text-green-400" : "text-content-text-secondary"
-                )}>
+                <Check
+                  className={cn(
+                    "h-3.5 w-3.5 sm:h-4 sm:w-4",
+                    isAttending ? "text-green-500" : "text-content-text-tertiary",
+                  )}
+                />
+                <span
+                  className={cn(
+                    "text-sm font-medium hidden sm:inline",
+                    isAttending ? "text-green-400" : "text-content-text-secondary",
+                  )}
+                >
                   {isAttending ? "Saw it" : "Saw it?"}
                 </span>
               </button>
@@ -219,7 +235,7 @@ function SetlistCardComponent({
                   localHasRated
                     ? "bg-amber-500/10 border border-amber-500/50 shadow-[0_0_8px_rgba(245,158,11,0.2)]"
                     : "glass-secondary border border-dashed border-glass-border hover:border-amber-500/30",
-                  isRatingAnimating && "animate-[avg-rating-update_0.5s_ease-out]"
+                  isRatingAnimating && "animate-[avg-rating-update_0.5s_ease-out]",
                 )}
               >
                 {isRatingExpanded ? (
@@ -243,7 +259,7 @@ function SetlistCardComponent({
                 className={cn(
                   "flex items-center justify-center gap-1 glass-secondary px-2 h-6 sm:px-3 sm:h-8 rounded-md",
                   "cursor-pointer hover:brightness-110 border border-dashed border-glass-border hover:border-amber-500/30",
-                  isRatingAnimating && "animate-[avg-rating-update_0.5s_ease-out]"
+                  isRatingAnimating && "animate-[avg-rating-update_0.5s_ease-out]",
                 )}
               >
                 <RatingComponent rating={displayedRating} ratingsCount={displayedCount} />

--- a/apps/web/app/lib/utils.test.ts
+++ b/apps/web/app/lib/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "vitest";
-import { addDaysYearAgnostic, formatMonthDay, isValidMonthDay } from "./utils";
+import { describe, expect, test, vi } from "vitest";
+import { addDaysYearAgnostic, formatMonthDay, getAnniversaryYears, getOrdinalSuffix, isValidMonthDay } from "./utils";
 
 describe("formatMonthDay", () => {
   // Converts zero-padded MM-DD to human-readable "Month Day" format
@@ -150,5 +150,151 @@ describe("addDaysYearAgnostic", () => {
   // Output must always be zero-padded MM-DD
   test("zero-pads single-digit months and days", () => {
     expect(addDaysYearAgnostic("01-01", 1)).toBe("01-02");
+  });
+});
+
+describe("getOrdinalSuffix", () => {
+  // Standard "th" suffix for most numbers
+  test("returns 'th' for 0", () => {
+    expect(getOrdinalSuffix(0)).toBe("th");
+  });
+
+  // 1st, 2nd, 3rd are the special cases
+  test("returns 'st' for 1", () => {
+    expect(getOrdinalSuffix(1)).toBe("st");
+  });
+
+  test("returns 'nd' for 2", () => {
+    expect(getOrdinalSuffix(2)).toBe("nd");
+  });
+
+  test("returns 'rd' for 3", () => {
+    expect(getOrdinalSuffix(3)).toBe("rd");
+  });
+
+  // 4-9 all get "th"
+  test("returns 'th' for 5", () => {
+    expect(getOrdinalSuffix(5)).toBe("th");
+  });
+
+  // 11th, 12th, 13th are exceptions to the 1st/2nd/3rd rule
+  test("returns 'th' for 11 (not 'st')", () => {
+    expect(getOrdinalSuffix(11)).toBe("th");
+  });
+
+  test("returns 'th' for 12 (not 'nd')", () => {
+    expect(getOrdinalSuffix(12)).toBe("th");
+  });
+
+  test("returns 'th' for 13 (not 'rd')", () => {
+    expect(getOrdinalSuffix(13)).toBe("th");
+  });
+
+  // 21st, 22nd, 23rd resume the normal pattern
+  test("returns 'st' for 21", () => {
+    expect(getOrdinalSuffix(21)).toBe("st");
+  });
+
+  test("returns 'nd' for 22", () => {
+    expect(getOrdinalSuffix(22)).toBe("nd");
+  });
+
+  test("returns 'rd' for 23", () => {
+    expect(getOrdinalSuffix(23)).toBe("rd");
+  });
+
+  // Typical anniversary values used in this feature
+  test("returns 'th' for 10", () => {
+    expect(getOrdinalSuffix(10)).toBe("th");
+  });
+
+  test("returns 'th' for 20", () => {
+    expect(getOrdinalSuffix(20)).toBe("th");
+  });
+
+  test("returns 'th' for 25", () => {
+    expect(getOrdinalSuffix(25)).toBe("th");
+  });
+});
+
+describe("getAnniversaryYears", () => {
+  // Returns 5 for a show 5 years ago
+  test("returns 5 for 5-year anniversary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2021-04-14")).toBe(5);
+    vi.useRealTimers();
+  });
+
+  // Returns 10 for a show 10 years ago
+  test("returns 10 for 10-year anniversary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2016-04-14")).toBe(10);
+    vi.useRealTimers();
+  });
+
+  // Returns 15 for a show 15 years ago
+  test("returns 15 for 15-year anniversary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2011-04-14")).toBe(15);
+    vi.useRealTimers();
+  });
+
+  // Returns 20 for a show 20 years ago
+  test("returns 20 for 20-year anniversary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2006-04-14")).toBe(20);
+    vi.useRealTimers();
+  });
+
+  // Returns 25 for a show 25 years ago
+  test("returns 25 for 25-year anniversary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2001-04-14")).toBe(25);
+    vi.useRealTimers();
+  });
+
+  // Returns 30 for a show 30 years ago
+  test("returns 30 for 30-year anniversary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("1996-04-14")).toBe(30);
+    vi.useRealTimers();
+  });
+
+  // Returns null for non-multiples of 5
+  test("returns null for 3-year-old show", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2023-04-14")).toBeNull();
+    vi.useRealTimers();
+  });
+
+  // Returns null for 7-year-old show
+  test("returns null for 7-year-old show", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2019-04-14")).toBeNull();
+    vi.useRealTimers();
+  });
+
+  // Returns null for a show from the current year (0 years)
+  test("returns null for show from current year", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2026-04-14")).toBeNull();
+    vi.useRealTimers();
+  });
+
+  // Returns null for a future show date
+  test("returns null for future show date", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2027-01-01")).toBeNull();
+    vi.useRealTimers();
   });
 });

--- a/apps/web/app/lib/utils.ts
+++ b/apps/web/app/lib/utils.ts
@@ -69,6 +69,25 @@ export function addDaysYearAgnostic(monthDay: string, delta: number): string {
   return `${m}-${d}`;
 }
 
+export function getOrdinalSuffix(n: number): string {
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 === 1 && mod100 !== 11) return "st";
+  if (mod10 === 2 && mod100 !== 12) return "nd";
+  if (mod10 === 3 && mod100 !== 13) return "rd";
+  return "th";
+}
+
+export function getAnniversaryYears(showDate: string): number | null {
+  const showYear = Number.parseInt(showDate.split("-")[0], 10);
+  const currentYear = new Date().getFullYear();
+  const years = currentYear - showYear;
+
+  if (years <= 0 || years % 5 !== 0) return null;
+
+  return years;
+}
+
 // this input will be in the format "2025-01-01"
 // this should output as "January 1, 2025"
 export function formatDateLong(date: string): string {


### PR DESCRIPTION
## Summary
- Adds an `AnniversaryBadge` component that displays inline with the show date on every `SetlistCard` when a show is on a 5-year milestone anniversary (5th, 10th, 15th, 20th, 25th+)
- Icons escalate by milestone: Sparkle (5th), PartyPopper (10th/15th), Cake (20th), Trophy (25th+)
- The badge is fully self-contained — takes `showDate`, computes eligibility internally, renders or returns null
- Added `getAnniversaryYears` and `getOrdinalSuffix` utility functions

<img width="1169" height="347" alt="Screenshot 2026-04-14 at 4 08 54 PM" src="https://github.com/user-attachments/assets/88217f4d-46b5-4d0e-83a0-95aed61879b6" />

<img width="1153" height="337" alt="Screenshot 2026-04-14 at 4 08 16 PM" src="https://github.com/user-attachments/assets/d36f7754-fe3c-489f-8e92-08e0f6d63dd0" />
<img width="1178" height="434" alt="Screenshot 2026-04-14 at 4 06 42 PM" src="https://github.com/user-attachments/assets/b20f3f95-2456-467b-99eb-6db1819a832f" />
<img width="1174" height="375" alt="Screenshot 2026-04-14 at 4 06 49 PM" src="https://github.com/user-attachments/assets/892cbfdb-5a6c-45e3-a32a-a4e081ab92b4" />
<img width="1172" height="433" alt="Screenshot 2026-04-14 at 4 06 55 PM" src="https://github.com/user-attachments/assets/958ac716-66dc-4b8f-9e80-4f3aec345e91" />
<img width="1153" height="240" alt="Screenshot 2026-04-14 at 4 07 37 PM" src="https://github.com/user-attachments/assets/8ad22357-ba68-4fbd-a88a-bbeb252123ea" />

## Test plan
- [x] `AnniversaryBadge` component tests (8 tests) — rendering, null for non-milestones, color, icon
- [x] `SetlistCard` tests (4 tests) — verifies `showDate` is passed through to badge
- [x] `getAnniversaryYears` unit tests (10 tests) — all milestone years, non-multiples, edge cases
- [x] `getOrdinalSuffix` unit tests (14 tests) — standard suffixes, 11th/12th/13th exceptions
- [x] Visual: run `make web`, navigate to `/on-this-day/04-14` or any date with shows spanning 5+ year intervals

🤖 Generated with [Claude Code](https://claude.com/claude-code)