### PR TITLE
Expand Not Played filter to work with toggle filters

### DIFF
--- a/apps/web/app/components/performance/performance-filter-controls.test.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.test.tsx
@@ -71,6 +71,109 @@ describe("PerformanceFilterControls", () => {
     expect(screen.queryByText("Time Range")).not.toBeInTheDocument();
   });
 
+  // The "Played" dropdown is opt-in via playedFilter prop, but the component
+  // only shows it when a qualifying filter is active (time range, toggles, or
+  // search). Author and cover alone don't qualify — "not played" only makes
+  // sense when narrowing to a subset of performances.
+  test("hides played filter when no qualifying filters are active", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} playedFilter="all" />);
+
+    expect(screen.queryByText("Played")).not.toBeInTheDocument();
+  });
+
+  test("shows played filter when time range is selected", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} playedFilter="all" selectedTimeRange="2024" />);
+
+    expect(screen.getByText("Played")).toBeInTheDocument();
+  });
+
+  test("shows played filter when any toggle is active", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} playedFilter="all" activeToggleSet={new Set(["jam"])} />);
+
+    expect(screen.getByText("Played")).toBeInTheDocument();
+  });
+
+  test("shows played filter when search has text", async () => {
+    await setup(
+      <PerformanceFilterControls
+        {...defaultProps}
+        playedFilter="all"
+        searchValue="Confrontation"
+        onSearchChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Played")).toBeInTheDocument();
+  });
+
+  test("hides played filter when only cover filter is set", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} playedFilter="all" coverFilter="cover" />);
+
+    expect(screen.queryByText("Played")).not.toBeInTheDocument();
+  });
+
+  test("hides played filter when only author is set", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} playedFilter="all" selectedAuthor="marc brownstein" />);
+
+    expect(screen.queryByText("Played")).not.toBeInTheDocument();
+  });
+
+  // When the played filter becomes hidden (qualifying filters removed), the
+  // component resets played to null so stale "notPlayed" state doesn't linger
+  // in the URL and silently affect the next API request.
+  test("resets played filter when it becomes hidden", async () => {
+    const handleUpdateFilter = vi.fn();
+    const { rerender } = await setup(
+      <PerformanceFilterControls
+        {...defaultProps}
+        updateFilter={handleUpdateFilter}
+        playedFilter="notPlayed"
+        activeToggleSet={new Set(["jam"])}
+      />,
+    );
+
+    handleUpdateFilter.mockClear();
+
+    rerender(
+      <PerformanceFilterControls
+        {...defaultProps}
+        updateFilter={handleUpdateFilter}
+        playedFilter="notPlayed"
+        activeToggleSet={new Set()}
+      />,
+    );
+
+    expect(handleUpdateFilter).toHaveBeenCalledWith({ played: null });
+  });
+
+  // When the played filter is already "all" (default), no reset is needed —
+  // the value is harmless and firing updateFilter would cause unnecessary
+  // re-renders.
+  test("does not reset played filter when value is already all", async () => {
+    const handleUpdateFilter = vi.fn();
+    const { rerender } = await setup(
+      <PerformanceFilterControls
+        {...defaultProps}
+        updateFilter={handleUpdateFilter}
+        playedFilter="all"
+        activeToggleSet={new Set(["jam"])}
+      />,
+    );
+
+    handleUpdateFilter.mockClear();
+
+    rerender(
+      <PerformanceFilterControls
+        {...defaultProps}
+        updateFilter={handleUpdateFilter}
+        playedFilter="all"
+        activeToggleSet={new Set()}
+      />,
+    );
+
+    expect(handleUpdateFilter).not.toHaveBeenCalled();
+  });
+
   // Clicking Clear All delegates to the parent's clearFilters callback, which
   // resets all URL params and search text in the hook.
   test("clicking Clear All calls clearFilters", async () => {

--- a/apps/web/app/components/performance/performance-filter-controls.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect } from "react";
 import { AuthorSearch } from "~/components/author/author-search";
 import { SelectFilter } from "~/components/ui/filters";
 import { ToggleFilterGroup } from "~/components/ui/filters/toggle-filter-group";
@@ -46,6 +46,15 @@ export function PerformanceFilterControls({
   hasActiveFilters = false,
 }: PerformanceFilterControlsProps) {
   const toggleFilters = showAllTimerToggle ? ALL_TOGGLE_FILTERS : TOGGLE_FILTERS_WITHOUT_ALL_TIMER;
+  const showPlayedFilter =
+    playedFilter !== undefined &&
+    (selectedTimeRange !== "all" || activeToggleSet.size > 0 || (searchValue !== undefined && searchValue.length > 0));
+
+  useEffect(() => {
+    if (!showPlayedFilter && playedFilter !== undefined && playedFilter !== "all") {
+      updateFilter({ played: null });
+    }
+  }, [showPlayedFilter, playedFilter, updateFilter]);
 
   return (
     <div className="space-y-3">
@@ -97,7 +106,7 @@ export function PerformanceFilterControls({
             />
           </div>
         )}
-        {playedFilter !== undefined && (
+        {showPlayedFilter && (
           <SelectFilter
             id="played-filter"
             label="Played"

--- a/apps/web/app/components/song/filtered-songs-table.tsx
+++ b/apps/web/app/components/song/filtered-songs-table.tsx
@@ -33,9 +33,6 @@ export function FilteredSongsTable({ songs, extraParams, hideTimeRange }: Filter
     searchFilter,
   });
 
-  const hasDateRange = selectedTimeRange !== "all";
-  const showPlayedFilter = hasDateRange || activeToggleSet.has("attended");
-
   const filterControls = (
     <PerformanceFilterControls
       selectedTimeRange={selectedTimeRange}
@@ -45,7 +42,7 @@ export function FilteredSongsTable({ songs, extraParams, hideTimeRange }: Filter
       clearFilters={clearFilters}
       coverFilter={coverFilter}
       selectedAuthor={selectedAuthor}
-      playedFilter={showPlayedFilter ? playedFilter : undefined}
+      playedFilter={playedFilter}
       searchValue={searchText}
       onSearchChange={setSearchText}
       hasActiveFilters={hasActiveFilters}

--- a/apps/web/app/lib/played-filter.test.ts
+++ b/apps/web/app/lib/played-filter.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import { shouldShowNotPlayed } from "~/lib/played-filter";
+
+const defaults = {
+  playedParam: null as string | null,
+  hasDateRange: false,
+  hasAttendedUser: false,
+  hasToggleFilters: false,
+};
+
+describe("shouldShowNotPlayed", () => {
+  // When no played param is set, not-played filtering never activates
+  // regardless of which other filters are active.
+  test("returns false when playedParam is not notPlayed", () => {
+    expect(shouldShowNotPlayed({ ...defaults, hasDateRange: true })).toBe(false);
+  });
+
+  // notPlayed alone isn't enough — there must be a narrowing filter that
+  // defines what "played in this view" means.
+  test("returns false when notPlayed but no narrowing filter is active", () => {
+    expect(shouldShowNotPlayed({ ...defaults, playedParam: "notPlayed" })).toBe(false);
+  });
+
+  // Date range narrows the view to a time period, so "not played" = songs
+  // not played in that period.
+  test("returns true when notPlayed with date range", () => {
+    expect(shouldShowNotPlayed({ ...defaults, playedParam: "notPlayed", hasDateRange: true })).toBe(true);
+  });
+
+  // Attended narrows the view to shows the user went to, so "not played" =
+  // songs never played at attended shows.
+  test("returns true when notPlayed with attended user", () => {
+    expect(shouldShowNotPlayed({ ...defaults, playedParam: "notPlayed", hasAttendedUser: true })).toBe(true);
+  });
+
+  // Toggle filters (set opener, jam, guest, etc.) narrow the view to
+  // performances matching those traits, so "not played" = songs that have
+  // never had a matching performance.
+  test("returns true when notPlayed with toggle filters", () => {
+    expect(shouldShowNotPlayed({ ...defaults, playedParam: "notPlayed", hasToggleFilters: true })).toBe(true);
+  });
+});

--- a/apps/web/app/lib/played-filter.ts
+++ b/apps/web/app/lib/played-filter.ts
@@ -1,0 +1,15 @@
+/**
+ * Determines whether the "not played" filter should take effect. Requires both
+ * the played=notPlayed param AND a narrowing filter (date range, attended, or
+ * toggle filters) that defines what "played in this view" means.
+ */
+export function shouldShowNotPlayed(params: {
+  playedParam: string | null;
+  hasDateRange: boolean;
+  hasAttendedUser: boolean;
+  hasToggleFilters: boolean;
+}): boolean {
+  return (
+    params.playedParam === "notPlayed" && (params.hasDateRange || params.hasAttendedUser || params.hasToggleFilters)
+  );
+}

--- a/apps/web/app/routes/api/songs.tsx
+++ b/apps/web/app/routes/api/songs.tsx
@@ -7,6 +7,7 @@ import {
   resolveAttendedUserId,
   resolveLast10ShowsDateRange,
 } from "~/lib/performance-filter-params";
+import { shouldShowNotPlayed } from "~/lib/played-filter";
 import { getTimeRangeParam, SONG_FILTERS } from "~/lib/song-filters";
 import { addVenueInfoToSongs } from "~/lib/song-utilities";
 import { services } from "~/server/services";
@@ -52,7 +53,6 @@ export const loader = publicLoader(async ({ request, context }) => {
   const coverParam = url.searchParams.get("cover");
   const attendedParam = url.searchParams.get("attended");
   const filtersParam = url.searchParams.get("filters");
-  const showNotPlayed = playedParam === "notPlayed";
 
   const coverFilter = coverParam === "cover" ? true : coverParam === "original" ? false : undefined;
 
@@ -120,7 +120,12 @@ export const loader = publicLoader(async ({ request, context }) => {
 
           const filtered = await splitByPlayStatus(
             songs,
-            showNotPlayed && (!!hasDateRange || !!attendedUserId),
+            shouldShowNotPlayed({
+              playedParam,
+              hasDateRange: !!hasDateRange,
+              hasAttendedUser: !!attendedUserId,
+              hasToggleFilters,
+            }),
             filter,
           );
           return await addVenueInfoToSongs(filtered);


### PR DESCRIPTION
## Summary
- Not Played filter now appears whenever any qualifying filter is active (time range, any toggle, or search text) — not just date range/attended
- API now applies not-played logic with toggle filters, so a user can see which songs have never been played as an Encore, which songs have never been played Dyslexic or Inverted, and so on
- Played filter resets to default when it becomes hidden, preventing stale state from affecting subsequent queries
- Moved played-filter visibility logic into `PerformanceFilterControls` so any consumer gets it for free

## Test plan
- [x] Navigate to `/songs`, enable Set Opener toggle — Not Played dropdown appears
- [x] Select Not Played with Set Opener — shows songs never played as a set opener
- [x] Remove all toggles — Not Played dropdown disappears and resets
- [x] Select only Author or Cover filter — Not Played does not appear
- [x] Date range + Not Played still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)