### PR TITLE
Combine songs tabs, unified time range, played filter fix, anniversary badge

### DIFF
--- a/apps/web/app/components/performance/performance-filter-controls.test.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.test.tsx
@@ -71,6 +71,109 @@ describe("PerformanceFilterControls", () => {
     expect(screen.queryByText("Time Range")).not.toBeInTheDocument();
   });
 
+  // The "Played" dropdown is opt-in via playedFilter prop, but the component
+  // only shows it when a qualifying filter is active (time range, toggles, or
+  // search). Author and cover alone don't qualify — "not played" only makes
+  // sense when narrowing to a subset of performances.
+  test("hides played filter when no qualifying filters are active", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} playedFilter="all" />);
+
+    expect(screen.queryByText("Played")).not.toBeInTheDocument();
+  });
+
+  test("shows played filter when time range is selected", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} playedFilter="all" selectedTimeRange="2024" />);
+
+    expect(screen.getByText("Played")).toBeInTheDocument();
+  });
+
+  test("shows played filter when any toggle is active", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} playedFilter="all" activeToggleSet={new Set(["jam"])} />);
+
+    expect(screen.getByText("Played")).toBeInTheDocument();
+  });
+
+  test("shows played filter when search has text", async () => {
+    await setup(
+      <PerformanceFilterControls
+        {...defaultProps}
+        playedFilter="all"
+        searchValue="Confrontation"
+        onSearchChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Played")).toBeInTheDocument();
+  });
+
+  test("hides played filter when only cover filter is set", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} playedFilter="all" coverFilter="cover" />);
+
+    expect(screen.queryByText("Played")).not.toBeInTheDocument();
+  });
+
+  test("hides played filter when only author is set", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} playedFilter="all" selectedAuthor="marc brownstein" />);
+
+    expect(screen.queryByText("Played")).not.toBeInTheDocument();
+  });
+
+  // When the played filter becomes hidden (qualifying filters removed), the
+  // component resets played to null so stale "notPlayed" state doesn't linger
+  // in the URL and silently affect the next API request.
+  test("resets played filter when it becomes hidden", async () => {
+    const handleUpdateFilter = vi.fn();
+    const { rerender } = await setup(
+      <PerformanceFilterControls
+        {...defaultProps}
+        updateFilter={handleUpdateFilter}
+        playedFilter="notPlayed"
+        activeToggleSet={new Set(["jam"])}
+      />,
+    );
+
+    handleUpdateFilter.mockClear();
+
+    rerender(
+      <PerformanceFilterControls
+        {...defaultProps}
+        updateFilter={handleUpdateFilter}
+        playedFilter="notPlayed"
+        activeToggleSet={new Set()}
+      />,
+    );
+
+    expect(handleUpdateFilter).toHaveBeenCalledWith({ played: null });
+  });
+
+  // When the played filter is already "all" (default), no reset is needed —
+  // the value is harmless and firing updateFilter would cause unnecessary
+  // re-renders.
+  test("does not reset played filter when value is already all", async () => {
+    const handleUpdateFilter = vi.fn();
+    const { rerender } = await setup(
+      <PerformanceFilterControls
+        {...defaultProps}
+        updateFilter={handleUpdateFilter}
+        playedFilter="all"
+        activeToggleSet={new Set(["jam"])}
+      />,
+    );
+
+    handleUpdateFilter.mockClear();
+
+    rerender(
+      <PerformanceFilterControls
+        {...defaultProps}
+        updateFilter={handleUpdateFilter}
+        playedFilter="all"
+        activeToggleSet={new Set()}
+      />,
+    );
+
+    expect(handleUpdateFilter).not.toHaveBeenCalled();
+  });
+
   // Clicking Clear All delegates to the parent's clearFilters callback, which
   // resets all URL params and search text in the hook.
   test("clicking Clear All calls clearFilters", async () => {

--- a/apps/web/app/components/performance/performance-filter-controls.test.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.test.tsx
@@ -106,6 +106,16 @@ describe("PerformanceFilterControls", () => {
     expect(screen.getByText("Played")).toBeInTheDocument();
   });
 
+  // On tab routes like /songs/this-year and /songs/recent, the time range is
+  // baked into the route and the dropdown is hidden (hideTimeRange). The local
+  // selectedTimeRange stays "all" because it isn't driven by URL params there,
+  // so we treat hideTimeRange itself as an active time-range scope.
+  test("shows played filter when hideTimeRange is true (fixed-scope tab routes)", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} playedFilter="all" hideTimeRange />);
+
+    expect(screen.getByText("Played")).toBeInTheDocument();
+  });
+
   test("hides played filter when only cover filter is set", async () => {
     await setup(<PerformanceFilterControls {...defaultProps} playedFilter="all" coverFilter="cover" />);
 

--- a/apps/web/app/components/performance/performance-filter-controls.test.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.test.tsx
@@ -4,8 +4,7 @@ import { describe, expect, test, vi } from "vitest";
 import { PerformanceFilterControls } from "./performance-filter-controls";
 
 const defaultProps = {
-  selectedYear: "all",
-  selectedEra: "all",
+  selectedTimeRange: "all",
   activeToggleSet: new Set<string>(),
   updateFilter: vi.fn(),
   toggleFilter: vi.fn(),
@@ -53,6 +52,23 @@ describe("PerformanceFilterControls", () => {
     await setup(<PerformanceFilterControls {...defaultProps} hasActiveFilters={false} />);
 
     expect(screen.queryByRole("button", { name: "Clear All" })).not.toBeInTheDocument();
+  });
+
+  // The Time Range dropdown renders with grouped options (Recent, Eras, Years).
+  test("renders a single Time Range dropdown", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} />);
+
+    expect(screen.getByText("Time Range")).toBeInTheDocument();
+    expect(screen.queryByText("Year")).not.toBeInTheDocument();
+    expect(screen.queryByText("Era")).not.toBeInTheDocument();
+  });
+
+  // The hideTimeRange prop suppresses the dropdown for pre-baked tab pages
+  // (e.g., /songs/recent) where the time range is already set by the route.
+  test("does not render Time Range dropdown when hideTimeRange is true", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} hideTimeRange />);
+
+    expect(screen.queryByText("Time Range")).not.toBeInTheDocument();
   });
 
   // Clicking Clear All delegates to the parent's clearFilters callback, which

--- a/apps/web/app/components/performance/performance-filter-controls.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.tsx
@@ -3,7 +3,7 @@ import { AuthorSearch } from "~/components/author/author-search";
 import { SelectFilter } from "~/components/ui/filters";
 import { ToggleFilterGroup } from "~/components/ui/filters/toggle-filter-group";
 import { Input } from "~/components/ui/input";
-import { ERA_OPTIONS, TOGGLE_FILTER_DEFINITIONS, YEAR_OPTIONS } from "~/lib/song-filters";
+import { TIME_RANGE_GROUPS, TOGGLE_FILTER_DEFINITIONS } from "~/lib/song-filters";
 
 const ALL_TOGGLE_FILTERS = TOGGLE_FILTER_DEFINITIONS as unknown as Array<{ key: string; label: string }>;
 
@@ -13,14 +13,14 @@ const labelClass =
   "text-xs font-medium text-content-text-secondary uppercase tracking-wide mb-1.5 h-[18px] flex items-center";
 
 interface PerformanceFilterControlsProps {
-  selectedYear: string;
-  selectedEra: string;
+  selectedTimeRange: string;
   activeToggleSet: Set<string>;
   updateFilter: (updates: Record<string, string | null>) => void;
   toggleFilter: (key: string) => void;
   clearFilters: () => void;
   extraSelectFilters?: ReactNode;
   showAllTimerToggle?: boolean;
+  hideTimeRange?: boolean;
   coverFilter?: string;
   selectedAuthor?: string | null;
   playedFilter?: string;
@@ -30,14 +30,14 @@ interface PerformanceFilterControlsProps {
 }
 
 export function PerformanceFilterControls({
-  selectedYear,
-  selectedEra,
+  selectedTimeRange,
   activeToggleSet,
   updateFilter,
   toggleFilter,
   clearFilters,
   extraSelectFilters,
   showAllTimerToggle = true,
+  hideTimeRange = false,
   coverFilter,
   selectedAuthor,
   playedFilter,
@@ -58,22 +58,17 @@ export function PerformanceFilterControls({
             className="w-auto min-w-[200px] sm:min-w-[250px] max-w-md h-[34px] text-sm bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20 placeholder:text-content-text-tertiary"
           />
         )}
-        <SelectFilter
-          id="year-filter"
-          label="Year"
-          value={selectedYear}
-          onValueChange={(value) => updateFilter({ year: value, era: null })}
-          options={[{ value: "all", label: "All Years" }, ...YEAR_OPTIONS]}
-          width="w-[130px]"
-        />
-        <SelectFilter
-          id="era-filter"
-          label="Era"
-          value={selectedEra}
-          onValueChange={(value) => updateFilter({ era: value, year: null })}
-          options={[{ value: "all", label: "All Eras" }, ...ERA_OPTIONS]}
-          width="w-[170px]"
-        />
+        {!hideTimeRange && (
+          <SelectFilter
+            id="time-range-filter"
+            label="Time Range"
+            value={selectedTimeRange}
+            onValueChange={(value) => updateFilter({ timeRange: value })}
+            options={[{ value: "all", label: "All Time" }]}
+            groups={TIME_RANGE_GROUPS}
+            width="w-[200px]"
+          />
+        )}
         {coverFilter !== undefined && (
           <SelectFilter
             id="cover-filter"

--- a/apps/web/app/components/performance/performance-filter-controls.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.tsx
@@ -48,7 +48,10 @@ export function PerformanceFilterControls({
   const toggleFilters = showAllTimerToggle ? ALL_TOGGLE_FILTERS : TOGGLE_FILTERS_WITHOUT_ALL_TIMER;
   const showPlayedFilter =
     playedFilter !== undefined &&
-    (selectedTimeRange !== "all" || activeToggleSet.size > 0 || (searchValue !== undefined && searchValue.length > 0));
+    (hideTimeRange ||
+      selectedTimeRange !== "all" ||
+      activeToggleSet.size > 0 ||
+      (searchValue !== undefined && searchValue.length > 0));
 
   useEffect(() => {
     if (!showPlayedFilter && playedFilter !== undefined && playedFilter !== "all") {

--- a/apps/web/app/components/performance/performance-filter-controls.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect } from "react";
 import { AuthorSearch } from "~/components/author/author-search";
 import { SelectFilter } from "~/components/ui/filters";
 import { ToggleFilterGroup } from "~/components/ui/filters/toggle-filter-group";
@@ -46,6 +46,15 @@ export function PerformanceFilterControls({
   hasActiveFilters = false,
 }: PerformanceFilterControlsProps) {
   const toggleFilters = showAllTimerToggle ? ALL_TOGGLE_FILTERS : TOGGLE_FILTERS_WITHOUT_ALL_TIMER;
+  const showPlayedFilter =
+    playedFilter !== undefined &&
+    (selectedTimeRange !== "all" || activeToggleSet.size > 0 || (searchValue !== undefined && searchValue.length > 0));
+
+  useEffect(() => {
+    if (!showPlayedFilter && playedFilter !== undefined && playedFilter !== "all") {
+      updateFilter({ played: null });
+    }
+  }, [showPlayedFilter, playedFilter, updateFilter]);
 
   return (
     <div className="space-y-3">
@@ -97,7 +106,7 @@ export function PerformanceFilterControls({
             />
           </div>
         )}
-        {playedFilter !== undefined && (
+        {showPlayedFilter && (
           <SelectFilter
             id="played-filter"
             label="Played"

--- a/apps/web/app/components/setlist/anniversary-badge.test.tsx
+++ b/apps/web/app/components/setlist/anniversary-badge.test.tsx
@@ -1,0 +1,79 @@
+import { setupWithRouter } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { AnniversaryBadge } from "./anniversary-badge";
+
+describe("AnniversaryBadge", () => {
+  // Displays 5th anniversary text for a show 5 years ago
+  test("displays '5th Anniversary' for a 5-year-old show", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    await setupWithRouter(<AnniversaryBadge showDate="2021-04-14" />);
+    expect(screen.getByText(/5th Anniversary/)).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  // Displays 10th anniversary text for a show 10 years ago
+  test("displays '10th Anniversary' for a 10-year-old show", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    await setupWithRouter(<AnniversaryBadge showDate="2016-04-14" />);
+    expect(screen.getByText(/10th Anniversary/)).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  // Displays 20th anniversary text for a show 20 years ago
+  test("displays '20th Anniversary' for a 20-year-old show", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    await setupWithRouter(<AnniversaryBadge showDate="2006-04-14" />);
+    expect(screen.getByText(/20th Anniversary/)).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  // Displays 25th anniversary text for a show 25 years ago
+  test("displays '25th Anniversary' for a 25-year-old show", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    await setupWithRouter(<AnniversaryBadge showDate="2001-04-14" />);
+    expect(screen.getByText(/25th Anniversary/)).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  // Renders an icon for anniversary shows
+  test("renders an icon", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    const { container } = await setupWithRouter(<AnniversaryBadge showDate="2016-04-14" />);
+    expect(container.querySelector("svg")).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  // Uses amber-400 text color
+  test("applies amber-400 color", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    const { container } = await setupWithRouter(<AnniversaryBadge showDate="2021-04-14" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain("text-amber-400");
+    vi.useRealTimers();
+  });
+
+  // Renders nothing for a non-anniversary show
+  test("renders nothing for a non-anniversary show", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    const { container } = await setupWithRouter(<AnniversaryBadge showDate="2023-04-14" />);
+    expect(container.firstChild).toBeNull();
+    vi.useRealTimers();
+  });
+
+  // Renders nothing for a show from the current year
+  test("renders nothing for a show from the current year", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    const { container } = await setupWithRouter(<AnniversaryBadge showDate="2026-04-14" />);
+    expect(container.firstChild).toBeNull();
+    vi.useRealTimers();
+  });
+});

--- a/apps/web/app/components/setlist/anniversary-badge.tsx
+++ b/apps/web/app/components/setlist/anniversary-badge.tsx
@@ -1,0 +1,36 @@
+import { Cake, PartyPopper, Sparkle, Trophy } from "lucide-react";
+import { getAnniversaryYears, getOrdinalSuffix } from "~/lib/utils";
+
+type AnniversaryTier = "minor" | "medium" | "major" | "legendary";
+
+function getTier(years: number): AnniversaryTier {
+  if (years >= 25) return "legendary";
+  if (years === 20) return "major";
+  if (years === 10 || years === 15) return "medium";
+  return "minor";
+}
+
+const anniversaryIcons: Record<AnniversaryTier, typeof Sparkle> = {
+  minor: Sparkle,
+  medium: PartyPopper,
+  major: Cake,
+  legendary: Trophy,
+};
+
+interface AnniversaryBadgeProps {
+  showDate: string;
+}
+
+export function AnniversaryBadge({ showDate }: AnniversaryBadgeProps) {
+  const years = getAnniversaryYears(showDate);
+  if (!years) return null;
+  const tier = getTier(years);
+  const Icon = anniversaryIcons[tier];
+  return (
+    <span className="flex items-center gap-1 text-sm font-medium text-amber-400">
+      <Icon className="h-4 w-4" />
+      {years}
+      {getOrdinalSuffix(years)} Anniversary
+    </span>
+  );
+}

--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -109,6 +109,16 @@ describe("SetlistCard", () => {
     expect(screen.getByText(/Philadelphia, PA/)).toBeInTheDocument();
   });
 
+  // The venue name is a clickable link to the venue page so users can
+  // navigate directly from any setlist card.
+  test("venue is a clickable link to the venue page", async () => {
+    await setupWithRouter(
+      <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={null} />,
+    );
+    const venueLink = screen.getByRole("link", { name: /The Fillmore/ });
+    expect(venueLink).toHaveAttribute("href", "/venues/the-fillmore");
+  });
+
   // Renders the setlist tracks
   test("renders track names", async () => {
     await setupWithRouter(

--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -1,0 +1,119 @@
+import type { SetlistLight } from "@bip/domain";
+import { expectMockedShallowComponent, mockShallowComponent, setupWithRouter } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+// Mock hooks used internally by SetlistCard
+vi.mock("~/hooks/use-session", () => ({
+  useSession: vi.fn(() => ({ user: null, supabase: null, loading: false })),
+}));
+vi.mock("~/hooks/use-show-user-data", () => ({
+  useAttendanceMutation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+// Stub heavy child components
+vi.mock("./track-rating-overlay", () => ({
+  TrackRatingOverlay: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("~/components/rating", () => ({
+  RatingComponent: (props: object) => mockShallowComponent("RatingComponent", props),
+}));
+vi.mock("~/components/ui/star-rating", () => ({
+  StarRating: (props: object) => mockShallowComponent("StarRating", props),
+}));
+vi.mock("./anniversary-badge", () => ({
+  AnniversaryBadge: (props: object) => mockShallowComponent("AnniversaryBadge", props),
+}));
+
+import { SetlistCard } from "./setlist-card";
+
+function makeSetlist(overrides: { showDate?: string } = {}): SetlistLight {
+  return {
+    show: {
+      id: "show-1",
+      slug: "2021-04-14",
+      date: overrides.showDate ?? "2021-04-14",
+      venueId: "venue-1",
+      bandId: "band-1",
+      notes: null,
+      createdAt: new Date("2021-04-14"),
+      updatedAt: new Date("2021-04-14"),
+      likesCount: 0,
+      relistenUrl: null,
+      averageRating: 4.0,
+      ratingsCount: 10,
+      showPhotosCount: 0,
+      showYoutubesCount: 0,
+      reviewsCount: 0,
+    },
+    venue: {
+      id: "venue-1",
+      name: "The Fillmore",
+      slug: "the-fillmore",
+      city: "Philadelphia",
+      state: "PA",
+      country: "USA",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      timesPlayed: 5,
+    },
+    sets: [
+      {
+        label: "Set 1",
+        sort: 1,
+        tracks: [
+          {
+            id: "track-1",
+            showId: "show-1",
+            songId: "song-1",
+            set: "1",
+            position: 1,
+            segue: null,
+            likesCount: 0,
+            note: null,
+            allTimer: false,
+            averageRating: null,
+            ratingsCount: 0,
+            song: { id: "song-1", title: "Basis for a Day", slug: "basis-for-a-day" },
+          },
+        ],
+      },
+    ],
+    annotations: [],
+  };
+}
+
+describe("SetlistCard", () => {
+  // Passes the show date to AnniversaryBadge so it can decide whether to render
+  test("passes showDate to AnniversaryBadge", async () => {
+    await setupWithRouter(
+      <SetlistCard setlist={makeSetlist({ showDate: "2016-04-14" })} userAttendance={null} userRating={null} showRating={null} />,
+    );
+    expectMockedShallowComponent("AnniversaryBadge", { showDate: "2016-04-14" });
+  });
+
+  // Renders the show date as a link
+  test("renders the show date", async () => {
+    await setupWithRouter(
+      <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={null} />,
+    );
+    expect(screen.getByText("4/14/2021")).toBeInTheDocument();
+  });
+
+  // Renders venue information
+  test("renders venue name and location", async () => {
+    await setupWithRouter(
+      <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={null} />,
+    );
+    expect(screen.getByText(/The Fillmore/)).toBeInTheDocument();
+    expect(screen.getByText(/Philadelphia, PA/)).toBeInTheDocument();
+  });
+
+  // Renders the setlist tracks
+  test("renders track names", async () => {
+    await setupWithRouter(
+      <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={null} />,
+    );
+    expect(screen.getByText("Basis for a Day")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -1,5 +1,5 @@
 import type { Attendance, Rating, Setlist, SetlistLight } from "@bip/domain";
-import { Camera, Check, Flame, } from "lucide-react";
+import { Camera, Check, Flame } from "lucide-react";
 import { memo, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { RatingComponent } from "~/components/rating";
@@ -9,6 +9,7 @@ import { StarRating } from "~/components/ui/star-rating";
 import { useSession } from "~/hooks/use-session";
 import { useAttendanceMutation } from "~/hooks/use-show-user-data";
 import { cn, formatDateShort } from "~/lib/utils";
+import { AnniversaryBadge } from "./anniversary-badge";
 import { TrackRatingOverlay } from "./track-rating-overlay";
 
 interface SetlistCardProps {
@@ -93,7 +94,9 @@ function SetlistCardComponent({
     const previousAttendance = localAttendance; // Capture BEFORE optimistic update
 
     // Optimistically update local state
-    setLocalAttendance(previousAttendance ? null : ({ id: "optimistic", showId: setlist.show.id, userId: "" } as Attendance));
+    setLocalAttendance(
+      previousAttendance ? null : ({ id: "optimistic", showId: setlist.show.id, userId: "" } as Attendance),
+    );
 
     attendanceMutation.mutate(
       { showId: setlist.show.id, currentAttendance: previousAttendance },
@@ -111,7 +114,7 @@ function SetlistCardComponent({
           // Revert on error using captured previous value
           setLocalAttendance(previousAttendance);
         },
-      }
+      },
     );
   };
 
@@ -176,8 +179,14 @@ function SetlistCardComponent({
       <CardHeader className="relative z-10 border-b border-glass-border/30 px-3 py-3 md:px-6 md:py-5">
         <div className="flex justify-between items-start">
           <div className="flex flex-col gap-1">
-            <div className="text-lg md:text-2xl font-medium text-brand-primary hover:text-brand-secondary transition-colors">
-              <Link to={setlist.show.slug ? `/shows/${setlist.show.slug}` : `/shows`}>{formattedDate}</Link>
+            <div className="flex items-center gap-2 text-lg md:text-2xl font-medium">
+              <Link
+                to={setlist.show.slug ? `/shows/${setlist.show.slug}` : `/shows`}
+                className="text-brand-primary hover:text-brand-secondary transition-colors"
+              >
+                {formattedDate}
+              </Link>
+              <AnniversaryBadge showDate={setlist.show.date} />
             </div>
             <div className="text-base md:text-xl text-content-text-primary">
               {setlist.venue.name} - {setlist.venue.city}, {setlist.venue.state}
@@ -197,14 +206,21 @@ function SetlistCardComponent({
                     ? "bg-green-500/10 border border-green-500/50 shadow-[0_0_8px_rgba(34,197,94,0.2)]"
                     : "glass-secondary border border-dashed border-glass-border hover:border-green-500/30",
                   isAttendanceAnimating && "animate-[avg-rating-update_0.5s_ease-out]",
-                  attendanceMutation.isPending && "opacity-50"
+                  attendanceMutation.isPending && "opacity-50",
                 )}
               >
-                <Check className={cn("h-3.5 w-3.5 sm:h-4 sm:w-4", isAttending ? "text-green-500" : "text-content-text-tertiary")} />
-                <span className={cn(
-                  "text-sm font-medium hidden sm:inline",
-                  isAttending ? "text-green-400" : "text-content-text-secondary"
-                )}>
+                <Check
+                  className={cn(
+                    "h-3.5 w-3.5 sm:h-4 sm:w-4",
+                    isAttending ? "text-green-500" : "text-content-text-tertiary",
+                  )}
+                />
+                <span
+                  className={cn(
+                    "text-sm font-medium hidden sm:inline",
+                    isAttending ? "text-green-400" : "text-content-text-secondary",
+                  )}
+                >
                   {isAttending ? "Saw it" : "Saw it?"}
                 </span>
               </button>
@@ -219,7 +235,7 @@ function SetlistCardComponent({
                   localHasRated
                     ? "bg-amber-500/10 border border-amber-500/50 shadow-[0_0_8px_rgba(245,158,11,0.2)]"
                     : "glass-secondary border border-dashed border-glass-border hover:border-amber-500/30",
-                  isRatingAnimating && "animate-[avg-rating-update_0.5s_ease-out]"
+                  isRatingAnimating && "animate-[avg-rating-update_0.5s_ease-out]",
                 )}
               >
                 {isRatingExpanded ? (
@@ -243,7 +259,7 @@ function SetlistCardComponent({
                 className={cn(
                   "flex items-center justify-center gap-1 glass-secondary px-2 h-6 sm:px-3 sm:h-8 rounded-md",
                   "cursor-pointer hover:brightness-110 border border-dashed border-glass-border hover:border-amber-500/30",
-                  isRatingAnimating && "animate-[avg-rating-update_0.5s_ease-out]"
+                  isRatingAnimating && "animate-[avg-rating-update_0.5s_ease-out]",
                 )}
               >
                 <RatingComponent rating={displayedRating} ratingsCount={displayedCount} />

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -192,7 +192,9 @@ function SetlistCardComponent({
               <AnniversaryBadge showDate={setlist.show.date} />
             </div>
             <div className="text-base md:text-xl text-content-text-primary">
-              {setlist.venue.name} - {setlist.venue.city}, {setlist.venue.state}
+              <Link to={`/venues/${setlist.venue.slug}`} className="hover:text-brand-secondary transition-colors">
+                {setlist.venue.name} - {setlist.venue.city}, {setlist.venue.state}
+              </Link>
             </div>
           </div>
           <div className="flex flex-col items-end gap-2">

--- a/apps/web/app/components/song/filtered-songs-table.test.tsx
+++ b/apps/web/app/components/song/filtered-songs-table.test.tsx
@@ -1,0 +1,84 @@
+import { mockShallowComponent } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("~/hooks/use-performance-page-filters", () => ({
+  usePerformancePageFilters: vi.fn(() => ({
+    filteredData: [],
+    isLoading: false,
+    selectedTimeRange: "all",
+    coverFilter: "all",
+    selectedAuthor: null,
+    playedFilter: "all",
+    activeToggleSet: new Set(),
+    hasActiveFilters: false,
+    searchText: "",
+    setSearchText: vi.fn(),
+    updateFilter: vi.fn(),
+    toggleFilter: vi.fn(),
+    clearFilters: vi.fn(),
+  })),
+}));
+
+vi.mock("~/components/performance/performance-filter-controls", () => ({
+  PerformanceFilterControls: (props: object) => mockShallowComponent("PerformanceFilterControls", props),
+}));
+
+vi.mock("./songs-table", () => ({
+  SongsTable: ({ filterComponent, ...rest }: { filterComponent?: React.ReactNode }) => (
+    <div data-testid="SongsTable">
+      {filterComponent}
+      <span>props: {JSON.stringify(rest, Object.keys(rest).sort())}</span>
+    </div>
+  ),
+}));
+
+import { usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
+import { FilteredSongsTable } from "./filtered-songs-table";
+
+function renderComponent(props: { extraParams?: Record<string, string>; hideTimeRange?: boolean }) {
+  return render(
+    <MemoryRouter>
+      <FilteredSongsTable songs={[]} {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe("FilteredSongsTable", () => {
+  // The component wires up usePerformancePageFilters, PerformanceFilterControls,
+  // and SongsTable together — verify SongsTable renders.
+  test("renders SongsTable", () => {
+    renderComponent({});
+
+    expect(screen.getByTestId("SongsTable")).toBeInTheDocument();
+  });
+
+  // extraParams should be forwarded to the hook so pre-baked tabs can
+  // set a fixed time range for API requests.
+  test("passes extraParams to usePerformancePageFilters", () => {
+    renderComponent({ extraParams: { timeRange: "last10shows" } });
+
+    expect(vi.mocked(usePerformancePageFilters)).toHaveBeenCalledWith(
+      expect.objectContaining({ extraParams: { timeRange: "last10shows" } }),
+    );
+  });
+
+  // When hideTimeRange is true, the PerformanceFilterControls should receive
+  // it so the Time Range dropdown is suppressed.
+  test("passes hideTimeRange to PerformanceFilterControls", () => {
+    renderComponent({ hideTimeRange: true });
+
+    const controls = screen.getByTestId("PerformanceFilterControls");
+    expect(controls.textContent).toContain('"hideTimeRange":true');
+  });
+
+  // When hideTimeRange is not set, it defaults to undefined (falsy),
+  // so the Time Range dropdown renders normally.
+  test("does not pass hideTimeRange when not set", () => {
+    renderComponent({});
+
+    const controls = screen.getByTestId("PerformanceFilterControls");
+    expect(controls.textContent).not.toContain('"hideTimeRange":true');
+  });
+});

--- a/apps/web/app/components/song/filtered-songs-table.tsx
+++ b/apps/web/app/components/song/filtered-songs-table.tsx
@@ -33,9 +33,6 @@ export function FilteredSongsTable({ songs, extraParams, hideTimeRange }: Filter
     searchFilter,
   });
 
-  const hasDateRange = selectedTimeRange !== "all";
-  const showPlayedFilter = hasDateRange || activeToggleSet.has("attended");
-
   const filterControls = (
     <PerformanceFilterControls
       selectedTimeRange={selectedTimeRange}
@@ -45,7 +42,7 @@ export function FilteredSongsTable({ songs, extraParams, hideTimeRange }: Filter
       clearFilters={clearFilters}
       coverFilter={coverFilter}
       selectedAuthor={selectedAuthor}
-      playedFilter={showPlayedFilter ? playedFilter : undefined}
+      playedFilter={playedFilter}
       searchValue={searchText}
       onSearchChange={setSearchText}
       hasActiveFilters={hasActiveFilters}

--- a/apps/web/app/components/song/filtered-songs-table.tsx
+++ b/apps/web/app/components/song/filtered-songs-table.tsx
@@ -1,0 +1,57 @@
+import type { Song } from "@bip/domain";
+import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
+import { usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
+import { SongsTable } from "./songs-table";
+
+interface FilteredSongsTableProps {
+  songs: Song[];
+  extraParams?: Record<string, string>;
+  hideTimeRange?: boolean;
+}
+
+const searchFilter = (song: Song, query: string) => song.title.toLowerCase().includes(query);
+
+export function FilteredSongsTable({ songs, extraParams, hideTimeRange }: FilteredSongsTableProps) {
+  const {
+    filteredData: filteredSongs,
+    isLoading,
+    selectedTimeRange,
+    coverFilter,
+    selectedAuthor,
+    playedFilter,
+    activeToggleSet,
+    hasActiveFilters,
+    searchText,
+    setSearchText,
+    updateFilter,
+    toggleFilter,
+    clearFilters,
+  } = usePerformancePageFilters<Song>({
+    initialData: songs,
+    apiUrl: "/api/songs",
+    extraParams,
+    searchFilter,
+  });
+
+  const hasDateRange = selectedTimeRange !== "all";
+  const showPlayedFilter = hasDateRange || activeToggleSet.has("attended");
+
+  const filterControls = (
+    <PerformanceFilterControls
+      selectedTimeRange={selectedTimeRange}
+      activeToggleSet={activeToggleSet}
+      updateFilter={updateFilter}
+      toggleFilter={toggleFilter}
+      clearFilters={clearFilters}
+      coverFilter={coverFilter}
+      selectedAuthor={selectedAuthor}
+      playedFilter={showPlayedFilter ? playedFilter : undefined}
+      searchValue={searchText}
+      onSearchChange={setSearchText}
+      hasActiveFilters={hasActiveFilters}
+      hideTimeRange={hideTimeRange}
+    />
+  );
+
+  return <SongsTable songs={filteredSongs} filterComponent={filterControls} isLoading={isLoading} />;
+}

--- a/apps/web/app/components/ui/data-table.tsx
+++ b/apps/web/app/components/ui/data-table.tsx
@@ -16,6 +16,7 @@ declare module "@tanstack/react-table" {
   // biome-ignore lint/correctness/noUnusedVariables: required by TanStack's module augmentation pattern
   interface ColumnMeta<TData extends RowData, TValue> {
     width?: string;
+    cellClassName?: string;
   }
 }
 
@@ -24,6 +25,7 @@ import { type KeyboardEvent, type ReactNode, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/ui/table";
+import { cn } from "~/lib/utils";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -219,7 +221,7 @@ export function DataTable<TData, TValue>({
                   className={`border-t border-glass-border/30 hover:bg-hover-glass ${rowClassName?.(row.original, index) ?? ""}`}
                 >
                   {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id} className="p-3">
+                    <TableCell key={cell.id} className={cn("p-3", cell.column.columnDef.meta?.cellClassName)}>
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </TableCell>
                   ))}

--- a/apps/web/app/components/ui/filters/select-filter.test.tsx
+++ b/apps/web/app/components/ui/filters/select-filter.test.tsx
@@ -1,5 +1,5 @@
-import { screen } from "@testing-library/react";
 import { setup } from "@test/test-utils";
+import { screen, within } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import { SelectFilter } from "./select-filter";
 
@@ -60,5 +60,75 @@ describe("SelectFilter", () => {
 
     const trigger = screen.getByRole("combobox");
     expect(trigger.className).toContain("w-[120px]");
+  });
+
+  // Grouped options should render with group labels so users can visually
+  // distinguish between Recent, Eras, and Years in the Time Range dropdown.
+  test("renders grouped options with group labels when groups prop is provided", async () => {
+    const groups = [
+      {
+        label: "Recent",
+        options: [
+          { value: "last10shows", label: "Last 10 Shows" },
+          { value: "thisYear", label: "This Year" },
+        ],
+      },
+      {
+        label: "Eras",
+        options: [
+          { value: "marlon", label: "Marlon Era" },
+          { value: "allen", label: "Allen Era" },
+        ],
+      },
+    ];
+
+    const { user } = await setup(
+      <SelectFilter id="test-filter" label="Time Range" value="all" onValueChange={() => {}} groups={groups} />,
+    );
+    await user.click(screen.getByRole("combobox"));
+
+    // Group labels should be visible
+    expect(screen.getByText("Recent")).toBeInTheDocument();
+    expect(screen.getByText("Eras")).toBeInTheDocument();
+
+    // Options within groups should be selectable
+    expect(screen.getByRole("option", { name: "Last 10 Shows" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "This Year" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Marlon Era" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Allen Era" })).toBeInTheDocument();
+  });
+
+  // When both standalone options and groups are provided, standalone options
+  // render before the groups (e.g., "All Time" above the grouped options).
+  test("renders standalone options before groups when both are provided", async () => {
+    const standaloneOptions = [{ value: "all", label: "All Time" }];
+    const groups = [
+      {
+        label: "Recent",
+        options: [{ value: "last10shows", label: "Last 10 Shows" }],
+      },
+    ];
+
+    const { user } = await setup(
+      <SelectFilter
+        id="test-filter"
+        label="Time Range"
+        value="all"
+        onValueChange={() => {}}
+        options={standaloneOptions}
+        groups={groups}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+
+    expect(screen.getByRole("option", { name: "All Time" })).toBeInTheDocument();
+    expect(screen.getByText("Recent")).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Last 10 Shows" })).toBeInTheDocument();
+
+    // "All Time" should appear before "Last 10 Shows" in the DOM
+    const listbox = screen.getByRole("listbox");
+    const allOptions = within(listbox).getAllByRole("option");
+    expect(allOptions[0]).toHaveTextContent("All Time");
+    expect(allOptions[1]).toHaveTextContent("Last 10 Shows");
   });
 });

--- a/apps/web/app/components/ui/filters/select-filter.tsx
+++ b/apps/web/app/components/ui/filters/select-filter.tsx
@@ -1,4 +1,12 @@
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
 
 const selectTriggerClass =
   "h-[34px] text-sm bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20";
@@ -6,18 +14,34 @@ const selectContentClass = "bg-glass-bg border-glass-border backdrop-blur-md";
 const selectItemClass = "text-content-text-primary hover:bg-hover-glass";
 const labelClass =
   "text-xs font-medium text-content-text-secondary uppercase tracking-wide mb-1.5 h-[18px] flex items-center";
+const groupLabelClass = "text-xs uppercase text-content-text-tertiary tracking-wide py-1";
+
+export interface SelectFilterOptionGroup {
+  label: string;
+  options: Array<{ value: string; label: string }>;
+}
 
 interface SelectFilterProps {
   id: string;
   label: string;
   value: string;
   onValueChange: (value: string) => void;
-  options: Array<{ value: string; label: string }>;
+  options?: Array<{ value: string; label: string }>;
+  groups?: SelectFilterOptionGroup[];
   placeholder?: string;
   width?: string;
 }
 
-export function SelectFilter({ id, label, value, onValueChange, options, placeholder, width }: SelectFilterProps) {
+export function SelectFilter({
+  id,
+  label,
+  value,
+  onValueChange,
+  options,
+  groups,
+  placeholder,
+  width,
+}: SelectFilterProps) {
   return (
     <div className="flex flex-col">
       <label htmlFor={id} className={labelClass}>
@@ -28,10 +52,20 @@ export function SelectFilter({ id, label, value, onValueChange, options, placeho
           <SelectValue placeholder={placeholder} />
         </SelectTrigger>
         <SelectContent className={selectContentClass}>
-          {options.map((option) => (
+          {options?.map((option) => (
             <SelectItem key={option.value} value={option.value} className={selectItemClass}>
               {option.label}
             </SelectItem>
+          ))}
+          {groups?.map((group) => (
+            <SelectGroup key={group.label}>
+              <SelectLabel className={groupLabelClass}>{group.label}</SelectLabel>
+              {group.options.map((option) => (
+                <SelectItem key={option.value} value={option.value} className={selectItemClass}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
           ))}
         </SelectContent>
       </Select>

--- a/apps/web/app/hooks/use-performance-page-filters.test.ts
+++ b/apps/web/app/hooks/use-performance-page-filters.test.ts
@@ -50,7 +50,7 @@ describe("usePerformancePageFilters", () => {
   // Loading state is debounced by 200ms to avoid flicker on fast responses.
   // Before the timeout fires, isLoading should remain false.
   test("isLoading becomes true after debounce when filters trigger a fetch", async () => {
-    mockSearchParams = new URLSearchParams("year=2024");
+    mockSearchParams = new URLSearchParams("timeRange=2024");
     // Never-resolving fetch so loading stays true
     globalThis.fetch = vi.fn().mockImplementation(() => new Promise(() => {}));
 
@@ -69,7 +69,7 @@ describe("usePerformancePageFilters", () => {
   // Once the fetch resolves, loading state should clear — even if the
   // debounce timeout already fired. Verifies the full loading lifecycle.
   test("isLoading returns to false when fetch completes", async () => {
-    mockSearchParams = new URLSearchParams("year=2024");
+    mockSearchParams = new URLSearchParams("timeRange=2024");
     let resolveResponse: (value: unknown) => void = () => {};
     globalThis.fetch = vi.fn().mockImplementation(
       () =>
@@ -99,7 +99,17 @@ describe("usePerformancePageFilters", () => {
     expect(result.current.hasFilters).toBe(false);
   });
 
-  test("hasFilters is true when year is set", () => {
+  // timeRange is the URL param for time-based filtering (years, eras, presets).
+  test("hasFilters is true when timeRange is set", () => {
+    mockSearchParams = new URLSearchParams("timeRange=2024");
+
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    expect(result.current.hasFilters).toBe(true);
+  });
+
+  // Legacy year= and era= URL params still activate filters for bookmarked URLs.
+  test("hasFilters is true when legacy year param is set", () => {
     mockSearchParams = new URLSearchParams("year=2024");
 
     const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
@@ -107,8 +117,8 @@ describe("usePerformancePageFilters", () => {
     expect(result.current.hasFilters).toBe(true);
   });
 
-  test("hasFilters is true when era is set", () => {
-    mockSearchParams = new URLSearchParams("era=1.0");
+  test("hasFilters is true when legacy era param is set", () => {
+    mockSearchParams = new URLSearchParams("era=sammy");
 
     const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
 
@@ -167,7 +177,7 @@ describe("usePerformancePageFilters", () => {
   });
 
   test("hasActiveFilters is true when URL params are set even if searchText is empty", () => {
-    mockSearchParams = new URLSearchParams("year=2024");
+    mockSearchParams = new URLSearchParams("timeRange=2024");
 
     const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
 
@@ -192,13 +202,13 @@ describe("usePerformancePageFilters", () => {
     expect(result.current.searchText).toBe("");
   });
 
-  // Verifies that the setSearchParams updater clears all seven URL param keys
-  // (year, era, cover, author, filters, attended, played). We call the updater
+  // Verifies that the setSearchParams updater clears all URL param keys
+  // (timeRange, cover, author, filters, attended, played). We call the updater
   // manually because the mock doesn't trigger React state updates — we just
   // need to confirm the function produces the right params.
   test("clearFilters resets all params", () => {
     mockSearchParams = new URLSearchParams(
-      "year=2024&era=1.0&cover=cover&author=Trey&filters=encore&attended=attended&played=notPlayed",
+      "timeRange=2024&cover=cover&author=Trey&filters=encore&attended=attended&played=notPlayed",
     );
 
     const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
@@ -212,12 +222,11 @@ describe("usePerformancePageFilters", () => {
     const updaterFn = mockSetSearchParams.mock.calls[0][0];
     const nextParams = updaterFn(
       new URLSearchParams(
-        "year=2024&era=1.0&cover=cover&author=Trey&filters=encore&attended=attended&played=notPlayed",
+        "timeRange=2024&cover=cover&author=Trey&filters=encore&attended=attended&played=notPlayed",
       ),
     );
 
-    expect(nextParams.get("year")).toBeNull();
-    expect(nextParams.get("era")).toBeNull();
+    expect(nextParams.get("timeRange")).toBeNull();
     expect(nextParams.get("cover")).toBeNull();
     expect(nextParams.get("author")).toBeNull();
     expect(nextParams.get("filters")).toBeNull();

--- a/apps/web/app/hooks/use-performance-page-filters.ts
+++ b/apps/web/app/hooks/use-performance-page-filters.ts
@@ -1,6 +1,7 @@
 import type { SongPagePerformance } from "@bip/domain";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
+import { getTimeRangeParam } from "~/lib/song-filters";
 
 export const searchPerformance = (performance: SongPagePerformance, query: string) =>
   performance.songTitle?.toLowerCase().includes(query) ||
@@ -24,8 +25,7 @@ export function usePerformancePageFilters<T>({
 }: PageFiltersOptions<T>) {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const selectedYear = searchParams.get("year") || "all";
-  const selectedEra = searchParams.get("era") || "all";
+  const selectedTimeRange = getTimeRangeParam(searchParams) || "all";
   const coverFilter = (searchParams.get("cover") as "all" | "cover" | "original") || "all";
   const selectedAuthor = searchParams.get("author") || null;
   const filtersParam = searchParams.get("filters") || "";
@@ -44,8 +44,7 @@ export function usePerformancePageFilters<T>({
   const loadingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const hasFilters =
-    selectedYear !== "all" ||
-    selectedEra !== "all" ||
+    selectedTimeRange !== "all" ||
     coverFilter !== "all" ||
     !!selectedAuthor ||
     filtersParam !== "" ||
@@ -70,8 +69,7 @@ export function usePerformancePageFilters<T>({
     }, 200);
 
     const params = new URLSearchParams();
-    if (selectedYear !== "all") params.set("year", selectedYear);
-    if (selectedEra !== "all") params.set("era", selectedEra);
+    if (selectedTimeRange !== "all") params.set("timeRange", selectedTimeRange);
     if (coverFilter !== "all") params.set("cover", coverFilter);
     if (selectedAuthor) params.set("author", selectedAuthor);
     if (filtersParam) params.set("filters", filtersParam);
@@ -115,8 +113,7 @@ export function usePerformancePageFilters<T>({
       }
     };
   }, [
-    selectedYear,
-    selectedEra,
+    selectedTimeRange,
     coverFilter,
     selectedAuthor,
     filtersParam,
@@ -178,7 +175,16 @@ export function usePerformancePageFilters<T>({
   const hasActiveFilters = hasFilters || searchText.length > 0;
 
   const clearFilters = useCallback(() => {
-    updateFilter({ year: null, era: null, cover: null, author: null, filters: null, attended: null, played: null });
+    updateFilter({
+      timeRange: null,
+      year: null,
+      era: null,
+      cover: null,
+      author: null,
+      filters: null,
+      attended: null,
+      played: null,
+    });
     setSearchText("");
   }, [updateFilter]);
 
@@ -186,8 +192,7 @@ export function usePerformancePageFilters<T>({
     data,
     filteredData,
     isLoading,
-    selectedYear,
-    selectedEra,
+    selectedTimeRange,
     coverFilter,
     selectedAuthor,
     playedFilter: playedParam || "all",

--- a/apps/web/app/lib/html.test.ts
+++ b/apps/web/app/lib/html.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+import { decodeHtmlEntities } from "./html";
+
+describe("decodeHtmlEntities", () => {
+  // Common entities stored in the history field of the song database.
+  test("decodes apostrophe entities (&#x27;, &apos;, &#39;)", () => {
+    expect(decodeHtmlEntities("Otomo&#x27;s")).toBe("Otomo's");
+    expect(decodeHtmlEntities("Otomo&apos;s")).toBe("Otomo's");
+    expect(decodeHtmlEntities("Otomo&#39;s")).toBe("Otomo's");
+  });
+
+  test("decodes quote entity (&quot;)", () => {
+    expect(decodeHtmlEntities("&quot;hello&quot;")).toBe('"hello"');
+  });
+
+  test("decodes angle bracket entities (&lt;, &gt;)", () => {
+    expect(decodeHtmlEntities("&lt;p&gt;")).toBe("<p>");
+  });
+
+  test("decodes non-breaking space (&nbsp;)", () => {
+    expect(decodeHtmlEntities("a&nbsp;b")).toBe("a b");
+  });
+
+  test("decodes ampersand entity (&amp;)", () => {
+    expect(decodeHtmlEntities("rock &amp; roll")).toBe("rock & roll");
+  });
+
+  test("leaves unknown entities unchanged", () => {
+    expect(decodeHtmlEntities("&fakeentity;")).toBe("&fakeentity;");
+  });
+
+  test("handles strings with no entities", () => {
+    expect(decodeHtmlEntities("plain text")).toBe("plain text");
+  });
+});

--- a/apps/web/app/lib/html.ts
+++ b/apps/web/app/lib/html.ts
@@ -1,0 +1,19 @@
+const HTML_ENTITIES: Record<string, string> = {
+  "&quot;": '"',
+  "&#x27;": "'",
+  "&#39;": "'",
+  "&apos;": "'",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&nbsp;": " ",
+  "&amp;": "&",
+};
+
+/**
+ * Decode common HTML entities in a string. Intended for rendering stored
+ * HTML as plain text (e.g. table cell previews). For full HTML rendering,
+ * use dangerouslySetInnerHTML instead — the browser handles entities there.
+ */
+export function decodeHtmlEntities(text: string): string {
+  return text.replace(/&(?:quot|#x27|#39|apos|lt|gt|nbsp|amp);/g, (entity) => HTML_ENTITIES[entity] ?? entity);
+}

--- a/apps/web/app/lib/performance-filter-params.ts
+++ b/apps/web/app/lib/performance-filter-params.ts
@@ -1,7 +1,7 @@
 import type { PerformanceFilterOptions } from "@bip/core/page-composers/song-page-composer";
 import { CacheKeys } from "@bip/domain/cache-keys";
 import type { PublicContext } from "~/lib/base-loaders";
-import { SONG_FILTERS } from "~/lib/song-filters";
+import { getTimeRangeParam, SONG_FILTERS } from "~/lib/song-filters";
 import { services } from "~/server/services";
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -46,22 +46,37 @@ export async function resolveAttendedUserId(
  * Parse URL search params into PerformanceFilterOptions.
  * Shared by /api/all-timers and /api/songs/performances.
  */
+/**
+ * Resolve "last10shows" to a date range by querying the 10th most recent show date.
+ */
+export async function resolveLast10ShowsDateRange(): Promise<{ startDate: Date } | null> {
+  const recentShows = await services.shows.findMany({
+    sort: [{ field: "date" as keyof import("@bip/domain").Show, direction: "desc" }],
+    pagination: { page: 1, limit: 10 },
+  });
+  if (recentShows.length === 0) return null;
+  const earliestDate = recentShows[recentShows.length - 1].date;
+  return { startDate: new Date(earliestDate) };
+}
+
 export async function parsePerformanceFilters(url: URL, context: PublicContext): Promise<PerformanceFilterOptions> {
-  const year = url.searchParams.get("year");
-  const era = url.searchParams.get("era");
+  const timeRangeParam = getTimeRangeParam(url.searchParams);
   const coverParam = url.searchParams.get("cover");
   const authorParam = url.searchParams.get("author");
   const filtersParam = url.searchParams.get("filters");
   const attendedParam = url.searchParams.get("attended");
   const monthDayParam = url.searchParams.get("monthDay");
 
-  const dateRangeKey = year || era;
-  const dateRange = dateRangeKey && dateRangeKey in SONG_FILTERS ? SONG_FILTERS[dateRangeKey] : null;
-
   const filters: PerformanceFilterOptions = {};
 
-  if (dateRange?.startDate) filters.startDate = dateRange.startDate;
-  if (dateRange?.endDate) filters.endDate = dateRange.endDate;
+  if (timeRangeParam === "last10shows") {
+    const dateRange = await resolveLast10ShowsDateRange();
+    if (dateRange) filters.startDate = dateRange.startDate;
+  } else if (timeRangeParam && timeRangeParam in SONG_FILTERS) {
+    const dateRange = SONG_FILTERS[timeRangeParam];
+    if (dateRange.startDate) filters.startDate = dateRange.startDate;
+    if (dateRange.endDate) filters.endDate = dateRange.endDate;
+  }
   if (coverParam === "cover") filters.cover = true;
   else if (coverParam === "original") filters.cover = false;
   if (authorParam && UUID_REGEX.test(authorParam)) filters.authorId = authorParam;
@@ -85,17 +100,15 @@ export async function parsePerformanceFilters(url: URL, context: PublicContext):
  * Build a cache key from URL search params for filtered performance queries.
  */
 export function buildFilteredCacheKey(url: URL, scope: string, attendedUserId?: string): string {
-  const year = url.searchParams.get("year");
-  const era = url.searchParams.get("era");
+  const timeRange = getTimeRangeParam(url.searchParams);
   const coverParam = url.searchParams.get("cover");
   const authorParam = url.searchParams.get("author");
   const filtersParam = url.searchParams.get("filters");
-
   const monthDay = url.searchParams.get("monthDay");
+
   return CacheKeys.songs.filtered({
     scope,
-    year: year || null,
-    era: era || null,
+    timeRange: timeRange || null,
     cover: coverParam || null,
     author: authorParam || null,
     filters: filtersParam || null,

--- a/apps/web/app/lib/played-filter.test.ts
+++ b/apps/web/app/lib/played-filter.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import { shouldShowNotPlayed } from "~/lib/played-filter";
+
+const defaults = {
+  playedParam: null as string | null,
+  hasDateRange: false,
+  hasAttendedUser: false,
+  hasToggleFilters: false,
+};
+
+describe("shouldShowNotPlayed", () => {
+  // When no played param is set, not-played filtering never activates
+  // regardless of which other filters are active.
+  test("returns false when playedParam is not notPlayed", () => {
+    expect(shouldShowNotPlayed({ ...defaults, hasDateRange: true })).toBe(false);
+  });
+
+  // notPlayed alone isn't enough — there must be a narrowing filter that
+  // defines what "played in this view" means.
+  test("returns false when notPlayed but no narrowing filter is active", () => {
+    expect(shouldShowNotPlayed({ ...defaults, playedParam: "notPlayed" })).toBe(false);
+  });
+
+  // Date range narrows the view to a time period, so "not played" = songs
+  // not played in that period.
+  test("returns true when notPlayed with date range", () => {
+    expect(shouldShowNotPlayed({ ...defaults, playedParam: "notPlayed", hasDateRange: true })).toBe(true);
+  });
+
+  // Attended narrows the view to shows the user went to, so "not played" =
+  // songs never played at attended shows.
+  test("returns true when notPlayed with attended user", () => {
+    expect(shouldShowNotPlayed({ ...defaults, playedParam: "notPlayed", hasAttendedUser: true })).toBe(true);
+  });
+
+  // Toggle filters (set opener, jam, guest, etc.) narrow the view to
+  // performances matching those traits, so "not played" = songs that have
+  // never had a matching performance.
+  test("returns true when notPlayed with toggle filters", () => {
+    expect(shouldShowNotPlayed({ ...defaults, playedParam: "notPlayed", hasToggleFilters: true })).toBe(true);
+  });
+});

--- a/apps/web/app/lib/played-filter.ts
+++ b/apps/web/app/lib/played-filter.ts
@@ -1,0 +1,15 @@
+/**
+ * Determines whether the "not played" filter should take effect. Requires both
+ * the played=notPlayed param AND a narrowing filter (date range, attended, or
+ * toggle filters) that defines what "played in this view" means.
+ */
+export function shouldShowNotPlayed(params: {
+  playedParam: string | null;
+  hasDateRange: boolean;
+  hasAttendedUser: boolean;
+  hasToggleFilters: boolean;
+}): boolean {
+  return (
+    params.playedParam === "notPlayed" && (params.hasDateRange || params.hasAttendedUser || params.hasToggleFilters)
+  );
+}

--- a/apps/web/app/lib/song-filters.test.ts
+++ b/apps/web/app/lib/song-filters.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+import { SONG_FILTERS, getTimeRangeParam, TIME_RANGE_GROUPS } from "./song-filters";
+
+describe("TIME_RANGE_GROUPS", () => {
+  // The groups should be ordered: Recent, Eras, Years — matching the
+  // visual layout in the Time Range dropdown.
+  test("has three groups: Recent, Eras, Years", () => {
+    expect(TIME_RANGE_GROUPS).toHaveLength(3);
+    expect(TIME_RANGE_GROUPS[0].label).toBe("Recent");
+    expect(TIME_RANGE_GROUPS[1].label).toBe("Eras");
+    expect(TIME_RANGE_GROUPS[2].label).toBe("Years");
+  });
+
+  // Recent group provides quick-access presets for commonly browsed time ranges.
+  test("Recent group contains Last 10 Shows and This Year", () => {
+    const recent = TIME_RANGE_GROUPS[0];
+    expect(recent.options).toHaveLength(2);
+    expect(recent.options[0]).toEqual({ value: "last10shows", label: "Last 10 Shows" });
+    expect(recent.options[1]).toEqual({ value: "thisYear", label: "This Year" });
+  });
+
+  // Eras group contains all band personnel eras.
+  test("Eras group contains all 4 eras", () => {
+    const eras = TIME_RANGE_GROUPS[1];
+    expect(eras.options).toHaveLength(4);
+    const eraValues = eras.options.map((o) => o.value);
+    expect(eraValues).toContain("marlon");
+    expect(eraValues).toContain("allen");
+    expect(eraValues).toContain("sammy");
+    expect(eraValues).toContain("triscuits");
+  });
+
+  // Years group should span from 1995 to the current year, newest first.
+  test("Years group contains years from current year down to 1995", () => {
+    const years = TIME_RANGE_GROUPS[2];
+    const currentYear = new Date().getFullYear();
+    expect(years.options[0].value).toBe(String(currentYear));
+    expect(years.options[years.options.length - 1].value).toBe("1995");
+    expect(years.options).toHaveLength(currentYear - 1995 + 1);
+  });
+});
+
+describe("SONG_FILTERS", () => {
+  // thisYear should resolve to the current year's date range.
+  test("thisYear resolves to current year date range", () => {
+    const currentYear = new Date().getFullYear();
+    const thisYear = SONG_FILTERS.thisYear;
+    expect(thisYear).toBeDefined();
+    expect(thisYear.startDate).toEqual(new Date(`${currentYear}-01-01`));
+    expect(thisYear.endDate).toEqual(new Date(`${currentYear}-12-31`));
+  });
+
+  // Existing year and era keys should still resolve correctly.
+  test("existing year keys still resolve to date ranges", () => {
+    expect(SONG_FILTERS["2024"]).toBeDefined();
+    expect(SONG_FILTERS["2024"].startDate).toEqual(new Date("2024-01-01"));
+    expect(SONG_FILTERS["2024"].endDate).toEqual(new Date("2024-12-31"));
+  });
+
+  test("existing era keys still resolve to date ranges", () => {
+    expect(SONG_FILTERS.sammy).toBeDefined();
+    expect(SONG_FILTERS.sammy.endDate).toEqual(new Date("2005-08-27"));
+  });
+});
+
+describe("getTimeRangeParam", () => {
+  // The primary param name for time-based filtering.
+  test("returns timeRange param when present", () => {
+    const params = new URLSearchParams("timeRange=2024");
+    expect(getTimeRangeParam(params)).toBe("2024");
+  });
+
+  // Legacy year param is accepted for bookmarked URLs.
+  test("falls back to year param when timeRange is absent", () => {
+    const params = new URLSearchParams("year=2024");
+    expect(getTimeRangeParam(params)).toBe("2024");
+  });
+
+  // Legacy era param is accepted for bookmarked URLs.
+  test("falls back to era param when timeRange and year are absent", () => {
+    const params = new URLSearchParams("era=sammy");
+    expect(getTimeRangeParam(params)).toBe("sammy");
+  });
+
+  // timeRange takes priority over year/era if multiple are somehow present.
+  test("prefers timeRange over year and era", () => {
+    const params = new URLSearchParams("timeRange=last10shows&year=2024&era=sammy");
+    expect(getTimeRangeParam(params)).toBe("last10shows");
+  });
+
+  // Returns null when no time-related params are set.
+  test("returns null when no time params are present", () => {
+    const params = new URLSearchParams("cover=original");
+    expect(getTimeRangeParam(params)).toBeNull();
+  });
+});

--- a/apps/web/app/lib/song-filters.ts
+++ b/apps/web/app/lib/song-filters.ts
@@ -27,9 +27,12 @@ const eraFilters: Record<string, SongFilterConfig> = {
   triscuits: { label: "Triscuits", startDate: new Date("2000-03-11"), endDate: new Date("2000-07-12") },
 };
 
+const currentYear = new Date().getFullYear();
+
 export const SONG_FILTERS: Record<string, SongFilterConfig> = {
   ...yearFilters,
   ...eraFilters,
+  thisYear: yearFilters[String(currentYear)],
 };
 
 export const YEAR_OPTIONS = Object.entries(yearFilters)
@@ -40,6 +43,32 @@ export const ERA_OPTIONS = Object.entries(eraFilters).map(([value, config]) => (
   value,
   label: config.label,
 }));
+
+export const TIME_RANGE_GROUPS = [
+  {
+    label: "Recent",
+    options: [
+      { value: "last10shows", label: "Last 10 Shows" },
+      { value: "thisYear", label: "This Year" },
+    ],
+  },
+  {
+    label: "Eras",
+    options: ERA_OPTIONS,
+  },
+  {
+    label: "Years",
+    options: YEAR_OPTIONS,
+  },
+];
+
+/**
+ * Extract the timeRange value from URL search params, accepting year/era as fallbacks
+ * for bookmarked URLs.
+ */
+export function getTimeRangeParam(params: URLSearchParams): string | null {
+  return params.get("timeRange") || params.get("year") || params.get("era") || null;
+}
 
 /**
  * Tag filters shared between /songs, /songs/all-timers, and /songs/$slug.

--- a/apps/web/app/lib/song-utilities.test.ts
+++ b/apps/web/app/lib/song-utilities.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mockSong = {
+  id: "1",
+  title: "Basis for a Day",
+  timesPlayed: 5,
+  dateFirstPlayed: null,
+  dateLastPlayed: null,
+};
+
+const mockUnplayedSong = {
+  id: "2",
+  title: "Shelby Rose",
+  timesPlayed: 0,
+  dateFirstPlayed: null,
+  dateLastPlayed: null,
+};
+
+const mockFindMany = vi.fn().mockResolvedValue([mockSong, mockUnplayedSong]);
+const mockFindManyInDateRange = vi.fn().mockResolvedValue([mockSong]);
+const mockCacheGetOrSet = vi.fn().mockImplementation((_key: string, fn: () => Promise<unknown>) => fn());
+const mockFindManyByDates = vi.fn().mockResolvedValue([]);
+
+vi.mock("~/server/services", () => ({
+  services: {
+    songs: {
+      findMany: (...args: unknown[]) => mockFindMany(...args),
+      findManyInDateRange: (...args: unknown[]) => mockFindManyInDateRange(...args),
+    },
+    cache: {
+      getOrSet: (...args: unknown[]) => mockCacheGetOrSet(...args),
+    },
+    shows: {
+      findManyByDates: (...args: unknown[]) => mockFindManyByDates(...args),
+    },
+  },
+}));
+
+import { loadSongsWithVenueInfo } from "./song-utilities";
+
+describe("loadSongsWithVenueInfo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Fetches all songs, filters out unplayed ones, and adds venue info.
+  test("fetches all songs when no date range is provided", async () => {
+    const result = await loadSongsWithVenueInfo("test-cache-key");
+
+    expect(mockCacheGetOrSet).toHaveBeenCalledWith("test-cache-key", expect.any(Function), { ttl: 3600 });
+    expect(mockFindMany).toHaveBeenCalledWith({});
+    expect(result.songs).toHaveLength(1);
+    expect(result.songs[0].title).toBe("Basis for a Day");
+  });
+
+  // When a date range is provided, uses findManyInDateRange instead.
+  test("fetches songs in date range when startDate is provided", async () => {
+    const startDate = new Date("2024-01-01");
+    const endDate = new Date("2024-12-31");
+
+    await loadSongsWithVenueInfo("test-cache-key", { startDate, endDate });
+
+    expect(mockFindManyInDateRange).toHaveBeenCalledWith({ startDate, endDate });
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  // Songs with timesPlayed === 0 should be excluded from results.
+  test("filters out songs with zero plays", async () => {
+    const result = await loadSongsWithVenueInfo("test-cache-key");
+
+    const titles = result.songs.map((s: { title: string }) => s.title);
+    expect(titles).not.toContain("Shelby Rose");
+  });
+});

--- a/apps/web/app/lib/song-utilities.ts
+++ b/apps/web/app/lib/song-utilities.ts
@@ -2,6 +2,38 @@ import type { Show, Song } from "@bip/domain";
 import { dateToISOStringSansTime } from "~/lib/date";
 import { services } from "~/server/services";
 
+interface SongsLoaderData {
+  songs: Song[];
+}
+
+interface DateRange {
+  startDate?: Date;
+  endDate?: Date;
+}
+
+/**
+ * Shared loader logic for songs pages: cache lookup, fetch songs (optionally
+ * filtered by date range), exclude unplayed songs, and add venue info.
+ */
+export async function loadSongsWithVenueInfo(
+  cacheKey: string,
+  dateRange?: DateRange,
+): Promise<SongsLoaderData> {
+  return await services.cache.getOrSet(
+    cacheKey,
+    async () => {
+      const allSongs = dateRange
+        ? await services.songs.findManyInDateRange(dateRange)
+        : await services.songs.findMany({});
+
+      const songs = allSongs.filter((song) => song.timesPlayed > 0);
+      const songsWithVenueInfo = await addVenueInfoToSongs(songs);
+      return { songs: songsWithVenueInfo };
+    },
+    { ttl: 3600 },
+  );
+}
+
 /**
  * Adds the venue info to a songs firstPlayedShow and lastPlayedShow.
  */

--- a/apps/web/app/lib/utils.test.ts
+++ b/apps/web/app/lib/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "vitest";
-import { addDaysYearAgnostic, formatMonthDay, isValidMonthDay } from "./utils";
+import { describe, expect, test, vi } from "vitest";
+import { addDaysYearAgnostic, formatMonthDay, getAnniversaryYears, getOrdinalSuffix, isValidMonthDay } from "./utils";
 
 describe("formatMonthDay", () => {
   // Converts zero-padded MM-DD to human-readable "Month Day" format
@@ -150,5 +150,151 @@ describe("addDaysYearAgnostic", () => {
   // Output must always be zero-padded MM-DD
   test("zero-pads single-digit months and days", () => {
     expect(addDaysYearAgnostic("01-01", 1)).toBe("01-02");
+  });
+});
+
+describe("getOrdinalSuffix", () => {
+  // Standard "th" suffix for most numbers
+  test("returns 'th' for 0", () => {
+    expect(getOrdinalSuffix(0)).toBe("th");
+  });
+
+  // 1st, 2nd, 3rd are the special cases
+  test("returns 'st' for 1", () => {
+    expect(getOrdinalSuffix(1)).toBe("st");
+  });
+
+  test("returns 'nd' for 2", () => {
+    expect(getOrdinalSuffix(2)).toBe("nd");
+  });
+
+  test("returns 'rd' for 3", () => {
+    expect(getOrdinalSuffix(3)).toBe("rd");
+  });
+
+  // 4-9 all get "th"
+  test("returns 'th' for 5", () => {
+    expect(getOrdinalSuffix(5)).toBe("th");
+  });
+
+  // 11th, 12th, 13th are exceptions to the 1st/2nd/3rd rule
+  test("returns 'th' for 11 (not 'st')", () => {
+    expect(getOrdinalSuffix(11)).toBe("th");
+  });
+
+  test("returns 'th' for 12 (not 'nd')", () => {
+    expect(getOrdinalSuffix(12)).toBe("th");
+  });
+
+  test("returns 'th' for 13 (not 'rd')", () => {
+    expect(getOrdinalSuffix(13)).toBe("th");
+  });
+
+  // 21st, 22nd, 23rd resume the normal pattern
+  test("returns 'st' for 21", () => {
+    expect(getOrdinalSuffix(21)).toBe("st");
+  });
+
+  test("returns 'nd' for 22", () => {
+    expect(getOrdinalSuffix(22)).toBe("nd");
+  });
+
+  test("returns 'rd' for 23", () => {
+    expect(getOrdinalSuffix(23)).toBe("rd");
+  });
+
+  // Typical anniversary values used in this feature
+  test("returns 'th' for 10", () => {
+    expect(getOrdinalSuffix(10)).toBe("th");
+  });
+
+  test("returns 'th' for 20", () => {
+    expect(getOrdinalSuffix(20)).toBe("th");
+  });
+
+  test("returns 'th' for 25", () => {
+    expect(getOrdinalSuffix(25)).toBe("th");
+  });
+});
+
+describe("getAnniversaryYears", () => {
+  // Returns 5 for a show 5 years ago
+  test("returns 5 for 5-year anniversary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2021-04-14")).toBe(5);
+    vi.useRealTimers();
+  });
+
+  // Returns 10 for a show 10 years ago
+  test("returns 10 for 10-year anniversary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2016-04-14")).toBe(10);
+    vi.useRealTimers();
+  });
+
+  // Returns 15 for a show 15 years ago
+  test("returns 15 for 15-year anniversary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2011-04-14")).toBe(15);
+    vi.useRealTimers();
+  });
+
+  // Returns 20 for a show 20 years ago
+  test("returns 20 for 20-year anniversary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2006-04-14")).toBe(20);
+    vi.useRealTimers();
+  });
+
+  // Returns 25 for a show 25 years ago
+  test("returns 25 for 25-year anniversary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2001-04-14")).toBe(25);
+    vi.useRealTimers();
+  });
+
+  // Returns 30 for a show 30 years ago
+  test("returns 30 for 30-year anniversary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("1996-04-14")).toBe(30);
+    vi.useRealTimers();
+  });
+
+  // Returns null for non-multiples of 5
+  test("returns null for 3-year-old show", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2023-04-14")).toBeNull();
+    vi.useRealTimers();
+  });
+
+  // Returns null for 7-year-old show
+  test("returns null for 7-year-old show", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2019-04-14")).toBeNull();
+    vi.useRealTimers();
+  });
+
+  // Returns null for a show from the current year (0 years)
+  test("returns null for show from current year", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2026-04-14")).toBeNull();
+    vi.useRealTimers();
+  });
+
+  // Returns null for a future show date
+  test("returns null for future show date", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14"));
+    expect(getAnniversaryYears("2027-01-01")).toBeNull();
+    vi.useRealTimers();
   });
 });

--- a/apps/web/app/lib/utils.ts
+++ b/apps/web/app/lib/utils.ts
@@ -69,6 +69,25 @@ export function addDaysYearAgnostic(monthDay: string, delta: number): string {
   return `${m}-${d}`;
 }
 
+export function getOrdinalSuffix(n: number): string {
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 === 1 && mod100 !== 11) return "st";
+  if (mod10 === 2 && mod100 !== 12) return "nd";
+  if (mod10 === 3 && mod100 !== 13) return "rd";
+  return "th";
+}
+
+export function getAnniversaryYears(showDate: string): number | null {
+  const showYear = Number.parseInt(showDate.split("-")[0], 10);
+  const currentYear = new Date().getFullYear();
+  const years = currentYear - showYear;
+
+  if (years <= 0 || years % 5 !== 0) return null;
+
+  return years;
+}
+
 // this input will be in the format "2025-01-01"
 // this should output as "January 1, 2025"
 export function formatDateLong(date: string): string {

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -94,6 +94,7 @@ export default [
     ...prefix("songs", [
       index("routes/songs/_index.tsx"),
       route("all-timers", "routes/songs/all-timers.tsx"),
+      route("histories", "routes/songs/histories.tsx"),
       route("new", "routes/songs/new.tsx"),
       route(":slug", "routes/songs/$slug.tsx"),
       route(":slug/edit", "routes/songs/$slug.edit.tsx"),

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -95,6 +95,8 @@ export default [
       index("routes/songs/_index.tsx"),
       route("all-timers", "routes/songs/all-timers.tsx"),
       route("histories", "routes/songs/histories.tsx"),
+      route("recent", "routes/songs/recent.tsx"),
+      route("this-year", "routes/songs/this-year.tsx"),
       route("new", "routes/songs/new.tsx"),
       route(":slug", "routes/songs/$slug.tsx"),
       route(":slug/edit", "routes/songs/$slug.edit.tsx"),

--- a/apps/web/app/routes/api/songs.tsx
+++ b/apps/web/app/routes/api/songs.tsx
@@ -7,6 +7,7 @@ import {
   resolveAttendedUserId,
   resolveLast10ShowsDateRange,
 } from "~/lib/performance-filter-params";
+import { shouldShowNotPlayed } from "~/lib/played-filter";
 import { getTimeRangeParam, SONG_FILTERS } from "~/lib/song-filters";
 import { addVenueInfoToSongs } from "~/lib/song-utilities";
 import { services } from "~/server/services";
@@ -52,7 +53,6 @@ export const loader = publicLoader(async ({ request, context }) => {
   const coverParam = url.searchParams.get("cover");
   const attendedParam = url.searchParams.get("attended");
   const filtersParam = url.searchParams.get("filters");
-  const showNotPlayed = playedParam === "notPlayed";
 
   const coverFilter = coverParam === "cover" ? true : coverParam === "original" ? false : undefined;
 
@@ -120,7 +120,12 @@ export const loader = publicLoader(async ({ request, context }) => {
 
           const filtered = await splitByPlayStatus(
             songs,
-            showNotPlayed && (!!hasDateRange || !!attendedUserId),
+            shouldShowNotPlayed({
+              playedParam,
+              hasDateRange: !!hasDateRange,
+              hasAttendedUser: !!attendedUserId,
+              hasToggleFilters,
+            }),
             filter,
           );
           return await addVenueInfoToSongs(filtered);

--- a/apps/web/app/routes/api/songs.tsx
+++ b/apps/web/app/routes/api/songs.tsx
@@ -2,8 +2,12 @@ import type { Song } from "@bip/domain";
 import { CacheKeys } from "@bip/domain/cache-keys";
 import { publicLoader } from "~/lib/base-loaders";
 import { logger } from "~/lib/logger";
-import { parsePerformanceFilters, resolveAttendedUserId } from "~/lib/performance-filter-params";
-import { SONG_FILTERS } from "~/lib/song-filters";
+import {
+  parsePerformanceFilters,
+  resolveAttendedUserId,
+  resolveLast10ShowsDateRange,
+} from "~/lib/performance-filter-params";
+import { getTimeRangeParam, SONG_FILTERS } from "~/lib/song-filters";
 import { addVenueInfoToSongs } from "~/lib/song-utilities";
 import { services } from "~/server/services";
 
@@ -42,8 +46,7 @@ async function splitByPlayStatus(
 export const loader = publicLoader(async ({ request, context }) => {
   const url = new URL(request.url);
   const query = url.searchParams.get("q");
-  const year = url.searchParams.get("year");
-  const era = url.searchParams.get("era");
+  const timeRangeParam = getTimeRangeParam(url.searchParams);
   const playedParam = url.searchParams.get("played");
   const authorParam = url.searchParams.get("author");
   const coverParam = url.searchParams.get("cover");
@@ -60,9 +63,7 @@ export const loader = publicLoader(async ({ request, context }) => {
 
   const attendedUserId = await resolveAttendedUserId(attendedParam, context);
 
-  // Year and era both resolve to a date-range key in SONG_FILTERS (mutually exclusive)
-  const dateRangeKey = year || era;
-  const hasDateRange = dateRangeKey && dateRangeKey in SONG_FILTERS;
+  const hasDateRange = timeRangeParam === "last10shows" || (timeRangeParam && timeRangeParam in SONG_FILTERS);
 
   const hasToggleFilters = !!filtersParam;
 
@@ -70,8 +71,7 @@ export const loader = publicLoader(async ({ request, context }) => {
   if (authorId || coverFilter !== undefined || hasDateRange || attendedUserId || hasToggleFilters) {
     try {
       const cacheKey = CacheKeys.songs.filtered({
-        year: year || null,
-        era: era || null,
+        timeRange: timeRangeParam || null,
         played: playedParam || null,
         author: authorId || null,
         cover: coverParam || null,
@@ -94,8 +94,15 @@ export const loader = publicLoader(async ({ request, context }) => {
           if (attendedUserId) filter.attendedUserId = attendedUserId;
 
           let songs: Song[];
-          if (hasDateRange) {
-            const { startDate, endDate } = SONG_FILTERS[dateRangeKey];
+          if (timeRangeParam === "last10shows") {
+            const dateRange = await resolveLast10ShowsDateRange();
+            if (dateRange) {
+              songs = await services.songs.findManyInDateRange({ startDate: dateRange.startDate, ...filter });
+            } else {
+              songs = await services.songs.findMany(filter);
+            }
+          } else if (timeRangeParam && timeRangeParam in SONG_FILTERS) {
+            const { startDate, endDate } = SONG_FILTERS[timeRangeParam];
             songs = await services.songs.findManyInDateRange({ startDate, endDate, ...filter });
           } else {
             songs = await services.songs.findMany(filter);

--- a/apps/web/app/routes/on-this-day.$monthDay.tsx
+++ b/apps/web/app/routes/on-this-day.$monthDay.tsx
@@ -94,8 +94,7 @@ export default function OnThisDay() {
   const {
     filteredData: filteredPerformances,
     isLoading,
-    selectedYear,
-    selectedEra,
+    selectedTimeRange,
     coverFilter,
     selectedAuthor,
     activeToggleSet,
@@ -167,8 +166,7 @@ export default function OnThisDay() {
               headerContent={
                 performances.length > ALL_TIMERS_PAGE_SIZE ? (
                   <PerformanceFilterControls
-                    selectedYear={selectedYear}
-                    selectedEra={selectedEra}
+                    selectedTimeRange={selectedTimeRange}
                     activeToggleSet={activeToggleSet}
                     updateFilter={updateFilter}
                     toggleFilter={toggleFilter}

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -108,8 +108,7 @@ export default function SongPage() {
   const {
     filteredData: filteredPerformances,
     isLoading,
-    selectedYear,
-    selectedEra,
+    selectedTimeRange,
     activeToggleSet,
     hasActiveFilters,
     searchText,
@@ -127,8 +126,7 @@ export default function SongPage() {
   const allTimers = useMemo(() => filteredPerformances.filter((p) => p.allTimer), [filteredPerformances]);
   const filterContent = (
     <PerformanceFilterControls
-      selectedYear={selectedYear}
-      selectedEra={selectedEra}
+      selectedTimeRange={selectedTimeRange}
       activeToggleSet={activeToggleSet}
       updateFilter={updateFilter}
       toggleFilter={toggleFilter}

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -1,5 +1,5 @@
 import type { SongPageView } from "@bip/domain";
-import { ArrowLeft, BarChart3, FileTextIcon, GuitarIcon, History, Pencil, StarIcon } from "lucide-react";
+import { ArrowLeft, BarChart3, FileTextIcon, Flame, GuitarIcon, History, ListMusic, Pencil } from "lucide-react";
 import { useMemo, useState } from "react";
 import type { LoaderFunctionArgs } from "react-router";
 import { Link, useSearchParams } from "react-router-dom";
@@ -315,7 +315,7 @@ export default function SongPage() {
               "data-[state=inactive]:bg-transparent data-[state=inactive]:text-content-text-tertiary",
             )}
           >
-            <FileTextIcon className="h-4 w-4" />
+            <ListMusic className="h-4 w-4" />
             All Performances
           </TabsTrigger>
           {allTimers.length > 0 && (
@@ -327,7 +327,7 @@ export default function SongPage() {
                 "data-[state=inactive]:bg-transparent data-[state=inactive]:text-content-text-tertiary",
               )}
             >
-              <StarIcon className="h-4 w-4 stroke-yellow-500 fill-transparent" />
+              <Flame className="h-4 w-4 text-orange-500" />
               All-Timers
             </TabsTrigger>
           )}

--- a/apps/web/app/routes/songs/_index.test.tsx
+++ b/apps/web/app/routes/songs/_index.test.tsx
@@ -10,45 +10,13 @@ vi.mock("~/lib/seo", () => ({ getSongsMeta: vi.fn() }));
 vi.mock("~/lib/song-utilities", () => ({ addVenueInfoToSongs: vi.fn() }));
 vi.mock("@bip/domain/cache-keys", () => ({ CacheKeys: { songs: { index: vi.fn() } } }));
 
-// Mock the loader data hook to return minimal song data
 vi.mock("~/hooks/use-serialized-loader-data", () => ({
-  useSerializedLoaderData: vi.fn(() => ({
-    songs: [],
-    trendingSongs: [],
-    yearlyTrendingSongs: [],
-    recentShowsCount: 10,
-  })),
+  useSerializedLoaderData: vi.fn(() => ({ songs: [] })),
 }));
 
-// Mock the filter hook to return default state
-vi.mock("~/hooks/use-performance-page-filters", () => ({
-  usePerformancePageFilters: vi.fn(() => ({
-    filteredData: [],
-    isLoading: false,
-    selectedYear: "all",
-    selectedEra: "all",
-    coverFilter: "all",
-    selectedAuthor: null,
-    playedFilter: "all",
-    activeToggleSet: new Set(),
-    hasActiveFilters: false,
-    searchText: "",
-    setSearchText: vi.fn(),
-    updateFilter: vi.fn(),
-    toggleFilter: vi.fn(),
-    clearFilters: vi.fn(),
-  })),
-}));
-
-// Stub heavy child components
-vi.mock("../../components/song/songs-table", () => ({
-  SongsTable: (props: object) => mockShallowComponent("SongsTable", props),
-}));
-vi.mock("~/components/performance/performance-filter-controls", () => ({
-  PerformanceFilterControls: (props: object) => mockShallowComponent("PerformanceFilterControls", props),
-}));
-vi.mock("~/components/admin/admin-only", () => ({
-  AdminOnly: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+// Stub the shared FilteredSongsTable component
+vi.mock("~/components/song/filtered-songs-table", () => ({
+  FilteredSongsTable: (props: object) => mockShallowComponent("FilteredSongsTable", props),
 }));
 
 import Songs from "./_index";
@@ -62,33 +30,46 @@ function renderSongsIndex() {
 }
 
 describe("Songs index page", () => {
-  // The heading is now in the layout, so the index page should not render its own.
+  // The layout renders the heading, so the index page should not render its own.
   test("does not render its own SONGS heading", () => {
     renderSongsIndex();
 
     expect(screen.queryByText("SONGS")).not.toBeInTheDocument();
   });
 
-  // The all-timers link is now a tab in the layout, so the index page should not
-  // render a separate link to it.
+  // The layout tab bar handles navigation to all-timers.
   test("does not render an all-timers link", () => {
     renderSongsIndex();
 
     expect(screen.queryByRole("link", { name: /all-timers/i })).not.toBeInTheDocument();
   });
 
-  // The admin "New Song" button is now in the layout, so the index page should
-  // not render its own.
+  // The layout renders the admin "New Song" button.
   test("does not render a New Song button", () => {
     renderSongsIndex();
 
     expect(screen.queryByRole("link", { name: /new song/i })).not.toBeInTheDocument();
   });
 
-  // The SongsTable should still render as the main content of the tab.
-  test("renders the SongsTable", () => {
+  // The FilteredSongsTable renders the songs table with filter controls.
+  test("renders the FilteredSongsTable", () => {
     renderSongsIndex();
 
-    expect(screen.getByTestId("SongsTable")).toBeInTheDocument();
+    expect(screen.getByTestId("FilteredSongsTable")).toBeInTheDocument();
+  });
+
+  // Trending data is accessible via the "Last 10 Shows" and "This Year" tabs,
+  // so the index page does not render its own trending sections.
+  test("does not render Trending in Recent Shows section", () => {
+    renderSongsIndex();
+
+    expect(screen.queryByText("Trending in Recent Shows")).not.toBeInTheDocument();
+  });
+
+  // Popular This Year data is accessible via the "This Year" tab.
+  test("does not render Popular This Year section", () => {
+    renderSongsIndex();
+
+    expect(screen.queryByText("Popular This Year")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/routes/songs/_index.test.tsx
+++ b/apps/web/app/routes/songs/_index.test.tsx
@@ -1,0 +1,94 @@
+import { mockShallowComponent } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+
+// Mock server-side modules that can't run in jsdom
+vi.mock("~/server/services", () => ({ services: {} }));
+vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
+vi.mock("~/lib/seo", () => ({ getSongsMeta: vi.fn() }));
+vi.mock("~/lib/song-utilities", () => ({ addVenueInfoToSongs: vi.fn() }));
+vi.mock("@bip/domain/cache-keys", () => ({ CacheKeys: { songs: { index: vi.fn() } } }));
+
+// Mock the loader data hook to return minimal song data
+vi.mock("~/hooks/use-serialized-loader-data", () => ({
+  useSerializedLoaderData: vi.fn(() => ({
+    songs: [],
+    trendingSongs: [],
+    yearlyTrendingSongs: [],
+    recentShowsCount: 10,
+  })),
+}));
+
+// Mock the filter hook to return default state
+vi.mock("~/hooks/use-performance-page-filters", () => ({
+  usePerformancePageFilters: vi.fn(() => ({
+    filteredData: [],
+    isLoading: false,
+    selectedYear: "all",
+    selectedEra: "all",
+    coverFilter: "all",
+    selectedAuthor: null,
+    playedFilter: "all",
+    activeToggleSet: new Set(),
+    hasActiveFilters: false,
+    searchText: "",
+    setSearchText: vi.fn(),
+    updateFilter: vi.fn(),
+    toggleFilter: vi.fn(),
+    clearFilters: vi.fn(),
+  })),
+}));
+
+// Stub heavy child components
+vi.mock("../../components/song/songs-table", () => ({
+  SongsTable: (props: object) => mockShallowComponent("SongsTable", props),
+}));
+vi.mock("~/components/performance/performance-filter-controls", () => ({
+  PerformanceFilterControls: (props: object) => mockShallowComponent("PerformanceFilterControls", props),
+}));
+vi.mock("~/components/admin/admin-only", () => ({
+  AdminOnly: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import Songs from "./_index";
+
+function renderSongsIndex() {
+  return render(
+    <MemoryRouter initialEntries={["/songs"]}>
+      <Songs />
+    </MemoryRouter>,
+  );
+}
+
+describe("Songs index page", () => {
+  // The heading is now in the layout, so the index page should not render its own.
+  test("does not render its own SONGS heading", () => {
+    renderSongsIndex();
+
+    expect(screen.queryByText("SONGS")).not.toBeInTheDocument();
+  });
+
+  // The all-timers link is now a tab in the layout, so the index page should not
+  // render a separate link to it.
+  test("does not render an all-timers link", () => {
+    renderSongsIndex();
+
+    expect(screen.queryByRole("link", { name: /all-timers/i })).not.toBeInTheDocument();
+  });
+
+  // The admin "New Song" button is now in the layout, so the index page should
+  // not render its own.
+  test("does not render a New Song button", () => {
+    renderSongsIndex();
+
+    expect(screen.queryByRole("link", { name: /new song/i })).not.toBeInTheDocument();
+  });
+
+  // The SongsTable should still render as the main content of the tab.
+  test("renders the SongsTable", () => {
+    renderSongsIndex();
+
+    expect(screen.getByTestId("SongsTable")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/routes/songs/_index.tsx
+++ b/apps/web/app/routes/songs/_index.tsx
@@ -1,10 +1,7 @@
 import type { Song, TrendingSong } from "@bip/domain";
 import { CacheKeys } from "@bip/domain/cache-keys";
-import { Flame, Plus } from "lucide-react";
 import { Link } from "react-router-dom";
-import { AdminOnly } from "~/components/admin/admin-only";
 import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
-import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
 import { usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
@@ -165,49 +162,26 @@ export default function Songs() {
   );
 
   return (
-    <div className="">
-      <div>
-        <div className="relative">
-          <h1 className="page-heading">SONGS</h1>
-          <div className="absolute top-0 right-0 flex items-center gap-3">
-            <Link
-              to="/songs/all-timers"
-              className="flex items-center gap-2 text-sm text-content-text-secondary hover:text-brand-primary transition-colors"
-            >
-              <Flame className="h-4 w-4 text-orange-500" />
-              All-Timers
-            </Link>
-            <AdminOnly>
-              <Button asChild className="btn-primary">
-                <Link to="/songs/new" className="flex items-center gap-2">
-                  <Plus className="h-4 w-4" />
-                  New Song
-                </Link>
-              </Button>
-            </AdminOnly>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-          <div className="lg:col-span-3">
-            {trendingSongs.length > 0 && (
-              <div className="mb-6">
-                <h2 className="text-xl font-semibold mb-4 text-content-text-primary">Trending in Recent Shows</h2>
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                  {trendingSongs.map((song: TrendingSong) => (
-                    <TrendingSongCard key={song.id} song={song} recentShowsCount={recentShowsCount} />
-                  ))}
-                </div>
+    <div>
+      <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+        <div className="lg:col-span-3">
+          {trendingSongs.length > 0 && (
+            <div className="mb-6">
+              <h2 className="text-xl font-semibold mb-4 text-content-text-primary">Trending in Recent Shows</h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                {trendingSongs.map((song: TrendingSong) => (
+                  <TrendingSongCard key={song.id} song={song} recentShowsCount={recentShowsCount} />
+                ))}
               </div>
-            )}
-          </div>
-          <div className="lg:col-span-1">
-            <YearlyTrendingSongs />
-          </div>
+            </div>
+          )}
         </div>
-
-        <SongsTable songs={filteredSongs} filterComponent={filterControls} isLoading={isLoading} />
+        <div className="lg:col-span-1">
+          <YearlyTrendingSongs />
+        </div>
       </div>
+
+      <SongsTable songs={filteredSongs} filterComponent={filterControls} isLoading={isLoading} />
     </div>
   );
 }

--- a/apps/web/app/routes/songs/_layout.test.tsx
+++ b/apps/web/app/routes/songs/_layout.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+
+// Mock Outlet so we don't need to wire up child routes
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, Outlet: () => <div data-testid="outlet" /> };
+});
+
+// Mock AdminOnly to render its children unconditionally in tests
+vi.mock("~/components/admin/admin-only", () => ({
+  AdminOnly: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import SongsLayout from "./_layout";
+
+function renderAtPath(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <SongsLayout />
+    </MemoryRouter>,
+  );
+}
+
+describe("SongsLayout", () => {
+  // The layout should render a tab bar with three navigation tabs
+  // linking to /songs, /songs/all-timers, and /songs/histories.
+  test("renders three tab links: All Songs, All-Timers, Histories", () => {
+    renderAtPath("/songs");
+
+    expect(screen.getByRole("link", { name: /all songs/i })).toHaveAttribute("href", "/songs");
+    expect(screen.getByRole("link", { name: /all-timers/i })).toHaveAttribute("href", "/songs/all-timers");
+    expect(screen.getByRole("link", { name: /histories/i })).toHaveAttribute("href", "/songs/histories");
+  });
+
+  // The active tab should be visually distinguished via a border-brand-primary
+  // class, determined by the current pathname.
+  test("highlights 'All Songs' tab when on /songs", () => {
+    renderAtPath("/songs");
+
+    const allSongsLink = screen.getByRole("link", { name: /all songs/i });
+    expect(allSongsLink.className).toContain("border-brand-primary");
+  });
+
+  // When navigated to /songs/all-timers, the All-Timers tab should be active.
+  test("highlights 'All-Timers' tab when on /songs/all-timers", () => {
+    renderAtPath("/songs/all-timers");
+
+    const allTimersLink = screen.getByRole("link", { name: /all-timers/i });
+    expect(allTimersLink.className).toContain("border-brand-primary");
+
+    const allSongsLink = screen.getByRole("link", { name: /all songs/i });
+    expect(allSongsLink.className).not.toContain("border-brand-primary");
+  });
+
+  // When navigated to /songs/histories, the Histories tab should be active.
+  test("highlights 'Histories' tab when on /songs/histories", () => {
+    renderAtPath("/songs/histories");
+
+    const historiesLink = screen.getByRole("link", { name: /histories/i });
+    expect(historiesLink.className).toContain("border-brand-primary");
+  });
+
+  // The tab bar should NOT render on song detail pages, edit pages, or new song page
+  // because those are distinct views, not tabs.
+  test("does not render tab bar on /songs/:slug", () => {
+    renderAtPath("/songs/basis-for-a-day");
+
+    expect(screen.queryByRole("link", { name: /all songs/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /all-timers/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /histories/i })).not.toBeInTheDocument();
+  });
+
+  // The tab bar should not render on the new song admin page.
+  test("does not render tab bar on /songs/new", () => {
+    renderAtPath("/songs/new");
+
+    expect(screen.queryByRole("link", { name: /all songs/i })).not.toBeInTheDocument();
+  });
+
+  // The "SONGS" heading should appear in the layout on tabbed pages.
+  test("renders SONGS heading on tabbed pages", () => {
+    renderAtPath("/songs");
+
+    expect(screen.getByText("SONGS")).toBeInTheDocument();
+  });
+
+  // The heading should also appear on non-tabbed pages (slug, new, edit)
+  // since the layout wraps all songs routes.
+  test("renders SONGS heading on song detail pages", () => {
+    renderAtPath("/songs/basis-for-a-day");
+
+    expect(screen.getByText("SONGS")).toBeInTheDocument();
+  });
+
+  // The Outlet should always render regardless of path, since child routes
+  // need to be rendered.
+  test("always renders Outlet for child routes", () => {
+    renderAtPath("/songs");
+
+    expect(screen.getByTestId("outlet")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/routes/songs/_layout.test.tsx
+++ b/apps/web/app/routes/songs/_layout.test.tsx
@@ -24,14 +24,15 @@ function renderAtPath(path: string) {
 }
 
 describe("SongsLayout", () => {
-  // The layout should render a tab bar with three navigation tabs
-  // linking to /songs, /songs/all-timers, and /songs/histories.
-  test("renders three tab links: All Songs, All-Timers, Histories", () => {
+  // The layout should render a tab bar with five navigation tabs.
+  test("renders five tab links: All Songs, All-Timers, Histories, Last 10 Shows, This Year", () => {
     renderAtPath("/songs");
 
     expect(screen.getByRole("link", { name: /all songs/i })).toHaveAttribute("href", "/songs");
     expect(screen.getByRole("link", { name: /all-timers/i })).toHaveAttribute("href", "/songs/all-timers");
     expect(screen.getByRole("link", { name: /histories/i })).toHaveAttribute("href", "/songs/histories");
+    expect(screen.getByRole("link", { name: /last 10 shows/i })).toHaveAttribute("href", "/songs/recent");
+    expect(screen.getByRole("link", { name: /this year/i })).toHaveAttribute("href", "/songs/this-year");
   });
 
   // The active tab should be visually distinguished via a border-brand-primary

--- a/apps/web/app/routes/songs/_layout.tsx
+++ b/apps/web/app/routes/songs/_layout.tsx
@@ -1,8 +1,69 @@
-import { Outlet } from "react-router-dom";
+import type { LucideIcon } from "lucide-react";
+import { Flame, History, ListMusic, Plus } from "lucide-react";
+import { Link, Outlet, useLocation } from "react-router-dom";
+import { AdminOnly } from "~/components/admin/admin-only";
+import { Button } from "~/components/ui/button";
+import { cn } from "~/lib/utils";
+
+interface Tab {
+  label: string;
+  path: string;
+  icon: LucideIcon;
+  iconClassName?: string;
+}
+
+const TABS: Tab[] = [
+  { label: "All Songs", path: "/songs", icon: ListMusic },
+  { label: "All-Timers", path: "/songs/all-timers", icon: Flame, iconClassName: "text-orange-500" },
+  { label: "Histories", path: "/songs/histories", icon: History },
+];
+
+const TABBED_PATHS = new Set(TABS.map((tab) => tab.path));
 
 export default function SongsLayout() {
+  const { pathname } = useLocation();
+  const showTabs = TABBED_PATHS.has(pathname);
+
   return (
     <div className="py-8">
+      <div className="relative">
+        <h1 className="page-heading">SONGS</h1>
+        <div className="absolute top-0 right-0 flex items-center gap-3">
+          <AdminOnly>
+            <Button asChild className="btn-primary">
+              <Link to="/songs/new" className="flex items-center gap-2">
+                <Plus className="h-4 w-4" />
+                New Song
+              </Link>
+            </Button>
+          </AdminOnly>
+        </div>
+      </div>
+
+      {showTabs && (
+        <div className="w-full flex justify-start border-b border-glass-border/30 mb-6">
+          {TABS.map((tab) => {
+            const isActive = pathname === tab.path;
+            const Icon = tab.icon;
+            return (
+              <Link
+                key={tab.path}
+                to={tab.path}
+                className={cn(
+                  "flex items-center gap-2 px-4 py-2 text-sm font-medium",
+                  isActive
+                    ? "border-b-2 border-brand-primary text-content-text-primary"
+                    : "text-content-text-tertiary hover:text-content-text-secondary",
+                )}
+              >
+                <Icon className={cn("h-4 w-4", tab.iconClassName)} />
+                {tab.label}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+
       <Outlet />
     </div>
   );

--- a/apps/web/app/routes/songs/_layout.tsx
+++ b/apps/web/app/routes/songs/_layout.tsx
@@ -1,5 +1,5 @@
 import type { LucideIcon } from "lucide-react";
-import { Flame, History, ListMusic, Plus } from "lucide-react";
+import { Calendar, Clock, Flame, History, ListMusic, Plus } from "lucide-react";
 import { Link, Outlet, useLocation } from "react-router-dom";
 import { AdminOnly } from "~/components/admin/admin-only";
 import { Button } from "~/components/ui/button";
@@ -14,6 +14,8 @@ interface Tab {
 
 const TABS: Tab[] = [
   { label: "All Songs", path: "/songs", icon: ListMusic },
+  { label: "Last 10 Shows", path: "/songs/recent", icon: Clock },
+  { label: "This Year", path: "/songs/this-year", icon: Calendar },
   { label: "All-Timers", path: "/songs/all-timers", icon: Flame, iconClassName: "text-orange-500" },
   { label: "Histories", path: "/songs/histories", icon: History },
 ];

--- a/apps/web/app/routes/songs/all-timers.test.tsx
+++ b/apps/web/app/routes/songs/all-timers.test.tsx
@@ -16,8 +16,7 @@ vi.mock("~/hooks/use-performance-page-filters", () => ({
   usePerformancePageFilters: vi.fn(() => ({
     filteredData: [],
     isLoading: false,
-    selectedYear: "all",
-    selectedEra: "all",
+    selectedTimeRange: "all",
     coverFilter: "all",
     selectedAuthor: null,
     activeToggleSet: new Set(),
@@ -50,15 +49,15 @@ function renderAllTimers() {
 }
 
 describe("AllTimersPage", () => {
-  // The "All-Timers" header with flame icon is now handled by the layout tab bar,
-  // so the page should not render its own heading.
+  // The layout tab bar handles the All-Timers heading,
+  // so the page should not render its own.
   test("does not render its own All-Timers heading", () => {
     renderAllTimers();
 
     expect(screen.queryByRole("heading", { name: /all-timers/i })).not.toBeInTheDocument();
   });
 
-  // The "Back to songs" link is replaced by the layout tab bar navigation.
+  // Navigation between song pages is handled by the layout tab bar.
   test("does not render a Back to songs link", () => {
     renderAllTimers();
 

--- a/apps/web/app/routes/songs/all-timers.test.tsx
+++ b/apps/web/app/routes/songs/all-timers.test.tsx
@@ -1,0 +1,76 @@
+import { mockShallowComponent } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+
+// Mock server-side modules
+vi.mock("~/server/services", () => ({ services: {} }));
+vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
+vi.mock("@bip/domain", () => ({}));
+
+// Mock hooks
+vi.mock("~/hooks/use-serialized-loader-data", () => ({
+  useSerializedLoaderData: vi.fn(() => ({ performances: [] })),
+}));
+vi.mock("~/hooks/use-performance-page-filters", () => ({
+  usePerformancePageFilters: vi.fn(() => ({
+    filteredData: [],
+    isLoading: false,
+    selectedYear: "all",
+    selectedEra: "all",
+    coverFilter: "all",
+    selectedAuthor: null,
+    activeToggleSet: new Set(),
+    hasActiveFilters: false,
+    searchText: "",
+    setSearchText: vi.fn(),
+    updateFilter: vi.fn(),
+    toggleFilter: vi.fn(),
+    clearFilters: vi.fn(),
+  })),
+  searchPerformance: vi.fn(),
+}));
+
+// Stub child components
+vi.mock("~/components/performance", () => ({
+  PerformanceTable: (props: object) => mockShallowComponent("PerformanceTable", props),
+}));
+vi.mock("~/components/performance/performance-filter-controls", () => ({
+  PerformanceFilterControls: (props: object) => mockShallowComponent("PerformanceFilterControls", props),
+}));
+
+import AllTimersPage from "./all-timers";
+
+function renderAllTimers() {
+  return render(
+    <MemoryRouter initialEntries={["/songs/all-timers"]}>
+      <AllTimersPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("AllTimersPage", () => {
+  // The "All-Timers" header with flame icon is now handled by the layout tab bar,
+  // so the page should not render its own heading.
+  test("does not render its own All-Timers heading", () => {
+    renderAllTimers();
+
+    expect(screen.queryByRole("heading", { name: /all-timers/i })).not.toBeInTheDocument();
+  });
+
+  // The "Back to songs" link is replaced by the layout tab bar navigation.
+  test("does not render a Back to songs link", () => {
+    renderAllTimers();
+
+    expect(screen.queryByRole("link", { name: /back to songs/i })).not.toBeInTheDocument();
+  });
+
+  // The PerformanceTable should still render as the main content.
+  test("renders the PerformanceTable with showSongColumn", () => {
+    renderAllTimers();
+
+    const table = screen.getByTestId("PerformanceTable");
+    expect(table).toBeInTheDocument();
+    expect(table.textContent).toContain('"showSongColumn":true');
+  });
+});

--- a/apps/web/app/routes/songs/all-timers.tsx
+++ b/apps/web/app/routes/songs/all-timers.tsx
@@ -22,8 +22,7 @@ export default function AllTimersPage() {
   const {
     filteredData: filteredPerformances,
     isLoading,
-    selectedYear,
-    selectedEra,
+    selectedTimeRange,
     coverFilter,
     selectedAuthor,
     activeToggleSet,
@@ -47,8 +46,7 @@ export default function AllTimersPage() {
         showSongColumn
         headerContent={
           <PerformanceFilterControls
-            selectedYear={selectedYear}
-            selectedEra={selectedEra}
+            selectedTimeRange={selectedTimeRange}
             activeToggleSet={activeToggleSet}
             updateFilter={updateFilter}
             toggleFilter={toggleFilter}

--- a/apps/web/app/routes/songs/all-timers.tsx
+++ b/apps/web/app/routes/songs/all-timers.tsx
@@ -1,6 +1,4 @@
 import { type AllTimersPageView, CacheKeys } from "@bip/domain";
-import { ArrowLeft, Flame } from "lucide-react";
-import { Link } from "react-router-dom";
 import { PerformanceTable } from "~/components/performance";
 import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
 import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
@@ -42,21 +40,7 @@ export default function AllTimersPage() {
   });
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <Flame className="h-6 w-6 text-orange-500" />
-          <h1 className="text-3xl md:text-4xl font-bold text-content-text-primary">All-Timers</h1>
-        </div>
-        <Link
-          to="/songs"
-          className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors"
-        >
-          <ArrowLeft className="h-3 w-3" />
-          <span>Back to songs</span>
-        </Link>
-      </div>
-
+    <div>
       <PerformanceTable
         performances={filteredPerformances}
         isLoading={isLoading}

--- a/apps/web/app/routes/songs/histories.test.tsx
+++ b/apps/web/app/routes/songs/histories.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+
+// Mock server-side modules
+vi.mock("~/server/services", () => ({ services: {} }));
+vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
+vi.mock("@bip/domain/cache-keys", () => ({ CacheKeys: { songs: { histories: vi.fn() } } }));
+
+// Mock the loader data hook to return songs with history content
+vi.mock("~/hooks/use-serialized-loader-data", () => ({
+  useSerializedLoaderData: vi.fn(() => ({
+    songs: [
+      {
+        id: "1",
+        title: "Basis for a Day",
+        slug: "basis-for-a-day",
+        history: "Basis for a Day was composed by Marc Brownstein in the early days of the band. It quickly became a fan favorite.",
+      },
+      {
+        id: "2",
+        title: "Above the Waves",
+        slug: "above-the-waves",
+        history: "Above the Waves was first performed in 2003 and has been a staple of the band's second set ever since.",
+      },
+    ],
+  })),
+}));
+
+import HistoriesPage from "./histories";
+
+function renderHistories() {
+  return render(
+    <MemoryRouter initialEntries={["/songs/histories"]}>
+      <HistoriesPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("HistoriesPage", () => {
+  // Each song with history content should appear as a row in the table
+  // with its title linking to the song's history tab.
+  test("renders song titles as links to the song history tab", () => {
+    renderHistories();
+
+    const basisLink = screen.getByRole("link", { name: "Basis for a Day" });
+    expect(basisLink).toHaveAttribute("href", "/songs/basis-for-a-day?tab=history");
+
+    const wavesLink = screen.getByRole("link", { name: "Above the Waves" });
+    expect(wavesLink).toHaveAttribute("href", "/songs/above-the-waves?tab=history");
+  });
+
+  // Each row should show a preview snippet of the history text so users
+  // can browse without clicking through.
+  test("renders a preview of each song's history text", () => {
+    renderHistories();
+
+    expect(screen.getByText(/Basis for a Day was composed by Marc Brownstein/)).toBeInTheDocument();
+    expect(screen.getByText(/Above the Waves was first performed in 2003/)).toBeInTheDocument();
+  });
+
+  // The table should support pagination for when more histories are written.
+  // With only 2 items and a page size of 50, pagination nav should be hidden.
+  test("hides pagination when all items fit on one page", () => {
+    renderHistories();
+
+    expect(screen.queryByRole("button", { name: "Previous" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/routes/songs/histories.test.tsx
+++ b/apps/web/app/routes/songs/histories.test.tsx
@@ -7,7 +7,10 @@ vi.mock("~/server/services", () => ({ services: {} }));
 vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
 vi.mock("@bip/domain/cache-keys", () => ({ CacheKeys: { songs: { histories: vi.fn() } } }));
 
-// Mock the loader data hook to return songs with history content
+// Mock the loader data hook to return songs with history content. "Basis for
+// a Day" is stored as multi-paragraph HTML; "Above the Waves" uses plain text
+// with \n\n paragraph breaks. The preview should preserve paragraph structure
+// for both.
 vi.mock("~/hooks/use-serialized-loader-data", () => ({
   useSerializedLoaderData: vi.fn(() => ({
     songs: [
@@ -15,13 +18,23 @@ vi.mock("~/hooks/use-serialized-loader-data", () => ({
         id: "1",
         title: "Basis for a Day",
         slug: "basis-for-a-day",
-        history: "Basis for a Day was composed by Marc Brownstein in the early days of the band. It quickly became a fan favorite.",
+        history:
+          "<p>Basis for a Day was composed by Marc Brownstein in the early days of the band.</p><p>It quickly became a fan favorite and has remained in heavy rotation ever since.</p>",
       },
       {
         id: "2",
         title: "Above the Waves",
         slug: "above-the-waves",
-        history: "Above the Waves was first performed in 2003 and has been a staple of the band's second set ever since.",
+        history:
+          "Above the Waves was first performed in 2003.\n\nIt has been a staple of the band's second set ever since.",
+      },
+      {
+        id: "3",
+        title: "Akira Jam",
+        slug: "akira-jam",
+        // Real-world shape: indented paragraphs, HTML entities
+        history:
+          '<p>For the 2nd set on New Years Eve, 1999, The Disco Biscuits played along to Katsuhiro Otomo&#x27;s anime masterpiece, Akira.</p>\n  \n  <p>&quot;When the 1988 dateline appears, the first note of the DJ spinning should start up.&quot;</p>',
       },
     ],
   })),
@@ -50,13 +63,68 @@ describe("HistoriesPage", () => {
     expect(wavesLink).toHaveAttribute("href", "/songs/above-the-waves?tab=history");
   });
 
-  // Each row should show a preview snippet of the history text so users
-  // can browse without clicking through.
-  test("renders a preview of each song's history text", () => {
+  // The full history text is rendered into the DOM; CSS clamps it visually
+  // with a "more"/"less" toggle to expand/collapse.
+  test("renders the full history text in the DOM for CSS clamping", () => {
     renderHistories();
 
-    expect(screen.getByText(/Basis for a Day was composed by Marc Brownstein/)).toBeInTheDocument();
-    expect(screen.getByText(/Above the Waves was first performed in 2003/)).toBeInTheDocument();
+    const basisHistory = screen.getByText(/Basis for a Day was composed/);
+    expect(basisHistory.textContent).toContain("quickly became a fan favorite");
+
+    const wavesHistory = screen.getByText(/Above the Waves was first performed/);
+    expect(wavesHistory.textContent).toContain("staple of the band");
+  });
+
+  // History text stored as HTML should have tags stripped before display so
+  // users see clean text in the preview column.
+  test("strips HTML tags from history text", () => {
+    renderHistories();
+
+    // The <p> tag in the "Basis for a Day" history should not be rendered literally.
+    const basisHistory = screen.getByText(/Basis for a Day was composed by Marc Brownstein/);
+    expect(basisHistory.textContent).not.toContain("<p>");
+    expect(basisHistory.textContent).not.toContain("</p>");
+  });
+
+  // Paragraph breaks should be preserved so multi-paragraph histories don't
+  // collapse into a wall of text. Uses whitespace-pre-line CSS so \n\n renders
+  // as a visible blank line.
+  test("preserves paragraph breaks from HTML <p> tags", () => {
+    renderHistories();
+
+    const basisHistory = screen.getByText(/Basis for a Day was composed/);
+    expect(basisHistory.textContent).toContain("\n\n");
+    expect(basisHistory.className).toContain("whitespace-pre-line");
+  });
+
+  test("preserves paragraph breaks from plain text \\n\\n", () => {
+    renderHistories();
+
+    const wavesHistory = screen.getByText(/Above the Waves was first performed/);
+    expect(wavesHistory.textContent).toContain("\n\n");
+    expect(wavesHistory.className).toContain("whitespace-pre-line");
+  });
+
+  // HTML entities in stored history (e.g. &quot;, &#x27;) should decode to
+  // their characters so users don't see raw entity codes.
+  test("decodes common HTML entities", () => {
+    renderHistories();
+
+    const akiraHistory = screen.getByText(/Disco Biscuits played along/);
+    expect(akiraHistory.textContent).toContain("Otomo's");
+    expect(akiraHistory.textContent).toContain('"When the 1988 dateline appears');
+    expect(akiraHistory.textContent).not.toContain("&#x27;");
+    expect(akiraHistory.textContent).not.toContain("&quot;");
+  });
+
+  // Leading whitespace on paragraph lines (from indented source HTML) should
+  // be trimmed so whitespace-pre-line doesn't render visible indentation.
+  test("trims leading whitespace on paragraph lines", () => {
+    renderHistories();
+
+    const akiraHistory = screen.getByText(/Disco Biscuits played along/);
+    // The second paragraph should not start with leading spaces
+    expect(akiraHistory.textContent).not.toMatch(/\n\n {2,}"When/);
   });
 
   // The table should support pagination for when more histories are written.

--- a/apps/web/app/routes/songs/histories.tsx
+++ b/apps/web/app/routes/songs/histories.tsx
@@ -1,10 +1,13 @@
 import type { Song } from "@bip/domain";
 import { CacheKeys } from "@bip/domain/cache-keys";
 import type { ColumnDef } from "@tanstack/react-table";
+import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { DataTable } from "~/components/ui/data-table";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
+import { decodeHtmlEntities } from "~/lib/html";
+import { cn } from "~/lib/utils";
 import { services } from "~/server/services";
 
 interface HistorySong {
@@ -51,20 +54,61 @@ export function meta() {
   ];
 }
 
-function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, "");
+/**
+ * Convert history HTML or plain text to plain text with paragraph breaks as
+ * double newlines. Paired with whitespace-pre-line CSS to render paragraphs visibly.
+ */
+function normalizeHistoryText(history: string): string {
+  const stripped = history
+    .replace(/<\/p>\s*<p[^>]*>/gi, "\n\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]*>/g, "");
+
+  return decodeHtmlEntities(stripped)
+    .split("\n")
+    .map((line) => line.trim())
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
 }
 
-function truncateText(text: string, maxLength: number): string {
-  const stripped = stripHtml(text);
-  if (stripped.length <= maxLength) return stripped;
-  return `${stripped.slice(0, maxLength).trimEnd()}...`;
+function HistoryPreview({ text }: { text: string }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isTruncated, setIsTruncated] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (contentRef.current) {
+      setIsTruncated(contentRef.current.scrollHeight > contentRef.current.clientHeight);
+    }
+  });
+
+  return (
+    <div className="text-sm text-content-text-secondary">
+      <div ref={contentRef} className={cn("leading-relaxed whitespace-pre-line", !isExpanded && "line-clamp-2")}>
+        {text}
+      </div>
+      {(isTruncated || isExpanded) && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setIsExpanded(!isExpanded);
+          }}
+          className="text-brand-primary hover:text-brand-secondary underline text-xs mt-0.5"
+        >
+          {isExpanded ? "less" : "more"}
+        </button>
+      )}
+    </div>
+  );
 }
 
 const historiesColumns: ColumnDef<HistorySong>[] = [
   {
     accessorKey: "title",
-    meta: { width: "25%" },
+    meta: { width: "25%", cellClassName: "align-top" },
     header: "Song",
     cell: ({ row }) => (
       <Link
@@ -77,11 +121,9 @@ const historiesColumns: ColumnDef<HistorySong>[] = [
   },
   {
     accessorKey: "history",
-    meta: { width: "75%" },
+    meta: { width: "75%", cellClassName: "align-top" },
     header: "Preview",
-    cell: ({ row }) => (
-      <span className="text-content-text-secondary text-sm">{truncateText(row.original.history, 150)}</span>
-    ),
+    cell: ({ row }) => <HistoryPreview text={normalizeHistoryText(row.original.history)} />,
   },
 ];
 

--- a/apps/web/app/routes/songs/histories.tsx
+++ b/apps/web/app/routes/songs/histories.tsx
@@ -1,0 +1,96 @@
+import type { Song } from "@bip/domain";
+import { CacheKeys } from "@bip/domain/cache-keys";
+import type { ColumnDef } from "@tanstack/react-table";
+import { Link } from "react-router-dom";
+import { DataTable } from "~/components/ui/data-table";
+import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
+import { publicLoader } from "~/lib/base-loaders";
+import { services } from "~/server/services";
+
+interface HistorySong {
+  id: string;
+  title: string;
+  slug: string;
+  history: string;
+}
+
+interface LoaderData {
+  songs: HistorySong[];
+}
+
+const MINIMUM_HISTORY_LENGTH = 50;
+
+export const loader = publicLoader(async (): Promise<LoaderData> => {
+  const cacheKey = CacheKeys.songs.histories();
+  const cacheOptions = { ttl: 3600 };
+
+  return await services.cache.getOrSet(
+    cacheKey,
+    async () => {
+      const allSongs = await services.songs.findMany({});
+      const songsWithHistory = allSongs
+        .filter((song: Song) => song.history && song.history.length > MINIMUM_HISTORY_LENGTH)
+        .map((song: Song) => ({
+          id: song.id,
+          title: song.title,
+          slug: song.slug,
+          history: song.history as string,
+        }))
+        .sort((a: HistorySong, b: HistorySong) => a.title.localeCompare(b.title));
+
+      return { songs: songsWithHistory };
+    },
+    cacheOptions,
+  );
+});
+
+export function meta() {
+  return [
+    { title: "Song Histories | Songs" },
+    { name: "description", content: "Browse song histories for The Disco Biscuits" },
+  ];
+}
+
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, "");
+}
+
+function truncateText(text: string, maxLength: number): string {
+  const stripped = stripHtml(text);
+  if (stripped.length <= maxLength) return stripped;
+  return `${stripped.slice(0, maxLength).trimEnd()}...`;
+}
+
+const historiesColumns: ColumnDef<HistorySong>[] = [
+  {
+    accessorKey: "title",
+    meta: { width: "25%" },
+    header: "Song",
+    cell: ({ row }) => (
+      <Link
+        to={`/songs/${row.original.slug}?tab=history`}
+        className="text-brand-primary hover:text-brand-secondary transition-colors font-medium"
+      >
+        {row.original.title}
+      </Link>
+    ),
+  },
+  {
+    accessorKey: "history",
+    meta: { width: "75%" },
+    header: "Preview",
+    cell: ({ row }) => (
+      <span className="text-content-text-secondary text-sm">{truncateText(row.original.history, 150)}</span>
+    ),
+  },
+];
+
+export default function HistoriesPage() {
+  const { songs } = useSerializedLoaderData<LoaderData>();
+
+  return (
+    <div>
+      <DataTable columns={historiesColumns} data={songs} pageSize={50} hideSearch />
+    </div>
+  );
+}

--- a/apps/web/app/routes/songs/recent.test.tsx
+++ b/apps/web/app/routes/songs/recent.test.tsx
@@ -1,0 +1,40 @@
+import { mockShallowComponent } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+
+// Mock server-side modules
+vi.mock("~/server/services", () => ({ services: {} }));
+vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
+vi.mock("~/lib/song-utilities", () => ({ addVenueInfoToSongs: vi.fn() }));
+vi.mock("~/lib/performance-filter-params", () => ({ resolveLast10ShowsDateRange: vi.fn() }));
+vi.mock("@bip/domain/cache-keys", () => ({ CacheKeys: { songs: { filtered: vi.fn() } } }));
+
+vi.mock("~/hooks/use-serialized-loader-data", () => ({
+  useSerializedLoaderData: vi.fn(() => ({ songs: [] })),
+}));
+
+// Stub the shared FilteredSongsTable to inspect props
+vi.mock("~/components/song/filtered-songs-table", () => ({
+  FilteredSongsTable: (props: object) => mockShallowComponent("FilteredSongsTable", props),
+}));
+
+import RecentPage from "./recent";
+
+function renderRecent() {
+  return render(
+    <MemoryRouter initialEntries={["/songs/recent"]}>
+      <RecentPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("RecentPage", () => {
+  // The Recent tab renders a FilteredSongsTable with the last10shows time range.
+  test("renders FilteredSongsTable with last10shows extraParams and hideTimeRange", () => {
+    renderRecent();
+
+    const table = screen.getByTestId("FilteredSongsTable");
+    expect(table.textContent).toContain('"hideTimeRange":true');
+  });
+});

--- a/apps/web/app/routes/songs/recent.tsx
+++ b/apps/web/app/routes/songs/recent.tsx
@@ -1,0 +1,25 @@
+import type { Song } from "@bip/domain";
+import { CacheKeys } from "@bip/domain/cache-keys";
+import { FilteredSongsTable } from "~/components/song/filtered-songs-table";
+import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
+import { publicLoader } from "~/lib/base-loaders";
+import { resolveLast10ShowsDateRange } from "~/lib/performance-filter-params";
+import { loadSongsWithVenueInfo } from "~/lib/song-utilities";
+
+export const loader = publicLoader(async () => {
+  const dateRange = await resolveLast10ShowsDateRange();
+  return loadSongsWithVenueInfo(
+    CacheKeys.songs.filtered({ timeRange: "last10shows" }),
+    dateRange ?? undefined,
+  );
+});
+
+export function meta() {
+  return [{ title: "Last 10 Shows | Songs" }, { name: "description", content: "Songs played in the last 10 shows" }];
+}
+
+export default function RecentPage() {
+  const { songs } = useSerializedLoaderData<{ songs: Song[] }>();
+
+  return <FilteredSongsTable songs={songs} extraParams={{ timeRange: "last10shows" }} hideTimeRange />;
+}

--- a/apps/web/app/routes/songs/this-year.test.tsx
+++ b/apps/web/app/routes/songs/this-year.test.tsx
@@ -1,0 +1,40 @@
+import { mockShallowComponent } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+
+// Mock server-side modules
+vi.mock("~/server/services", () => ({ services: {} }));
+vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
+vi.mock("~/lib/song-utilities", () => ({ addVenueInfoToSongs: vi.fn() }));
+vi.mock("~/lib/song-filters", () => ({ SONG_FILTERS: { thisYear: { startDate: new Date(), endDate: new Date() } } }));
+vi.mock("@bip/domain/cache-keys", () => ({ CacheKeys: { songs: { filtered: vi.fn() } } }));
+
+vi.mock("~/hooks/use-serialized-loader-data", () => ({
+  useSerializedLoaderData: vi.fn(() => ({ songs: [] })),
+}));
+
+// Stub the shared FilteredSongsTable to inspect props
+vi.mock("~/components/song/filtered-songs-table", () => ({
+  FilteredSongsTable: (props: object) => mockShallowComponent("FilteredSongsTable", props),
+}));
+
+import ThisYearPage from "./this-year";
+
+function renderThisYear() {
+  return render(
+    <MemoryRouter initialEntries={["/songs/this-year"]}>
+      <ThisYearPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("ThisYearPage", () => {
+  // The This Year tab renders a FilteredSongsTable with the thisYear time range.
+  test("renders FilteredSongsTable with thisYear extraParams and hideTimeRange", () => {
+    renderThisYear();
+
+    const table = screen.getByTestId("FilteredSongsTable");
+    expect(table.textContent).toContain('"hideTimeRange":true');
+  });
+});

--- a/apps/web/app/routes/songs/this-year.tsx
+++ b/apps/web/app/routes/songs/this-year.tsx
@@ -3,19 +3,26 @@ import { CacheKeys } from "@bip/domain/cache-keys";
 import { FilteredSongsTable } from "~/components/song/filtered-songs-table";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
-import { getSongsMeta } from "~/lib/seo";
+import { SONG_FILTERS } from "~/lib/song-filters";
 import { loadSongsWithVenueInfo } from "~/lib/song-utilities";
 
 export const loader = publicLoader(async () => {
-  return loadSongsWithVenueInfo(CacheKeys.songs.index());
+  const { startDate, endDate } = SONG_FILTERS.thisYear;
+  return loadSongsWithVenueInfo(
+    CacheKeys.songs.filtered({ timeRange: "thisYear" }),
+    { startDate, endDate },
+  );
 });
 
 export function meta() {
-  return getSongsMeta();
+  return [
+    { title: "This Year | Songs" },
+    { name: "description", content: `Songs played in ${new Date().getFullYear()}` },
+  ];
 }
 
-export default function Songs() {
+export default function ThisYearPage() {
   const { songs } = useSerializedLoaderData<{ songs: Song[] }>();
 
-  return <FilteredSongsTable songs={songs} />;
+  return <FilteredSongsTable songs={songs} extraParams={{ timeRange: "thisYear" }} hideTimeRange />;
 }

--- a/packages/core/src/songs/song-service.ts
+++ b/packages/core/src/songs/song-service.ts
@@ -275,59 +275,6 @@ export class SongService {
     return trendingSongs;
   }
 
-  async findTrendingLastYear(): Promise<TrendingSong[]> {
-    // Calculate date range for the current calendar year
-    const currentYear = new Date().getFullYear();
-
-    // Find shows from the current calendar year
-    const shows = await this.db.show.findMany({
-      where: {
-        date: {
-          gte: `${currentYear}-01-01`,
-          lte: `${currentYear}-12-31`,
-        },
-      },
-    });
-
-    if (shows.length === 0) return [];
-
-    // Get the show IDs
-    const showIds = shows.map((show) => show.id);
-
-    // Find tracks from these shows and count songs
-    const tracks = await this.db.track.findMany({
-      where: { showId: { in: showIds } },
-      include: { song: true },
-    });
-
-    // Count unique shows for each song (not individual tracks)
-    const songCounts = new Map<string, { song: DbSong; showIds: Set<string> }>();
-
-    for (const track of tracks) {
-      if (!track.song) continue;
-
-      const songId = track.song.id;
-      const existing = songCounts.get(songId);
-
-      if (existing) {
-        existing.showIds.add(track.showId);
-      } else {
-        songCounts.set(songId, { song: track.song, showIds: new Set([track.showId]) });
-      }
-    }
-
-    // Convert to array, sort by count, and limit to top 10
-    const trendingSongs = Array.from(songCounts.values())
-      .sort((a, b) => b.showIds.size - a.showIds.size)
-      .slice(0, 10)
-      .map(({ song, showIds }) => ({
-        ...mapSongToDomainEntity(song),
-        count: showIds.size,
-      }));
-
-    return trendingSongs;
-  }
-
   async create(input: CreateSongInput): Promise<Song> {
     const slug = slugify(input.title);
     const now = new Date();

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -60,6 +60,8 @@ export const CacheKeys = {
     index: () => "songs:index:full",
     /** All-timers page data */
     allTimers: () => "songs:all-timers",
+    /** Songs with history content */
+    histories: () => "songs:histories",
     /** All-timers for a specific calendar day (On This Day page) */
     allTimersOnThisDay: (monthDay: string) => `songs:all-timers:on-this-day:${monthDay}`,
     /** Filtered song results by era/author/cover/tags/attended */


### PR DESCRIPTION
## Summary

Combines four PRs onto one branch (similar to #101), plus two fixes surfaced during the merge:

- #93 — songs page tab bar
- #94 — unified time range filter - already approved
- #97 — fix not-played filter with toggles - already approved
- #96 — anniversary badge

**Fixes included:**

- **Not Played filter on tab routes.** #97 gated Not Played on `selectedTimeRange !== "all"`, but the `this-year` and `recent` tab routes from #94 fix time range via `extraParams` (not URL params), so `selectedTimeRange` stayed `"all"` and Not Played never surfaced. Now treats `hideTimeRange` as an active time-range scope.
- **Cherry-picked cbee30f** (venue name → `/venues/{slug}` link, from #91). That PR was approved and merged into the `on-this-day` branch after #90 had already squash-merged into main, so it never reached main.

## Test plan

- [x] `/songs` — All Songs / All-Timers / Histories tabs render, filters work
- [x] `/songs/this-year` — Not Played filter is visible by default
- [x] `/songs/recent` (Last 10 Shows) — Not Played filter is visible by default
- [x] `/songs/all-timers` — Not Played filter intentionally absent
- [x] Unified Time Range dropdown groups Recent / Eras / Years
- [x] Anniversary badges appear on setlist cards for milestone years
- [x] Venue name is a clickable link to `/venues/{slug}` on setlist cards
- [x] External show badges (nugs/photos) still render on setlist cards
