### PR TITLE
Replace /songs "This Year" column with "Filtered Plays" + unify filter pipeline

### DIFF
--- a/apps/web/app/components/song/filtered-songs-table.test.tsx
+++ b/apps/web/app/components/song/filtered-songs-table.test.tsx
@@ -3,22 +3,10 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, test, vi } from "vitest";
 
+const usePerformancePageFiltersMock = vi.fn();
+
 vi.mock("~/hooks/use-performance-page-filters", () => ({
-  usePerformancePageFilters: vi.fn(() => ({
-    filteredData: [],
-    isLoading: false,
-    selectedTimeRange: "all",
-    coverFilter: "all",
-    selectedAuthor: null,
-    playedFilter: "all",
-    activeToggleSet: new Set(),
-    hasActiveFilters: false,
-    searchText: "",
-    setSearchText: vi.fn(),
-    updateFilter: vi.fn(),
-    toggleFilter: vi.fn(),
-    clearFilters: vi.fn(),
-  })),
+  usePerformancePageFilters: (...args: unknown[]) => usePerformancePageFiltersMock(...args),
 }));
 
 vi.mock("~/components/performance/performance-filter-controls", () => ({
@@ -34,10 +22,44 @@ vi.mock("./songs-table", () => ({
   ),
 }));
 
-import { usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
 import { FilteredSongsTable } from "./filtered-songs-table";
 
-function renderComponent(props: { extraParams?: Record<string, string>; hideTimeRange?: boolean }) {
+interface HookReturnOverrides {
+  selectedTimeRange?: string;
+  coverFilter?: "all" | "cover" | "original";
+  selectedAuthor?: string | null;
+  activeToggleSet?: Set<string>;
+  playedFilter?: string;
+  hasFilters?: boolean;
+}
+
+function setHookReturn(overrides: HookReturnOverrides = {}) {
+  const selectedTimeRange = overrides.selectedTimeRange ?? "all";
+  const coverFilter = overrides.coverFilter ?? "all";
+  const selectedAuthor = overrides.selectedAuthor ?? null;
+  const activeToggleSet = overrides.activeToggleSet ?? new Set<string>();
+  const hasFilters =
+    overrides.hasFilters ??
+    (selectedTimeRange !== "all" || coverFilter !== "all" || selectedAuthor !== null || activeToggleSet.size > 0);
+  usePerformancePageFiltersMock.mockReturnValue({
+    filteredData: [],
+    isLoading: false,
+    selectedTimeRange,
+    coverFilter,
+    selectedAuthor,
+    playedFilter: overrides.playedFilter ?? "all",
+    activeToggleSet,
+    hasFilters,
+    hasActiveFilters: hasFilters,
+    searchText: "",
+    setSearchText: vi.fn(),
+    updateFilter: vi.fn(),
+    toggleFilter: vi.fn(),
+    clearFilters: vi.fn(),
+  });
+}
+
+function renderComponent(props: { extraParams?: Record<string, string>; hideTimeRange?: boolean } = {}) {
   return render(
     <MemoryRouter>
       <FilteredSongsTable songs={[]} {...props} />
@@ -49,7 +71,8 @@ describe("FilteredSongsTable", () => {
   // The component wires up usePerformancePageFilters, PerformanceFilterControls,
   // and SongsTable together — verify SongsTable renders.
   test("renders SongsTable", () => {
-    renderComponent({});
+    setHookReturn();
+    renderComponent();
 
     expect(screen.getByTestId("SongsTable")).toBeInTheDocument();
   });
@@ -57,16 +80,28 @@ describe("FilteredSongsTable", () => {
   // extraParams should be forwarded to the hook so pre-baked tabs can
   // set a fixed time range for API requests.
   test("passes extraParams to usePerformancePageFilters", () => {
+    setHookReturn();
     renderComponent({ extraParams: { timeRange: "last10shows" } });
 
-    expect(vi.mocked(usePerformancePageFilters)).toHaveBeenCalledWith(
+    expect(usePerformancePageFiltersMock).toHaveBeenCalledWith(
       expect.objectContaining({ extraParams: { timeRange: "last10shows" } }),
     );
+  });
+
+  // /songs and its tabs fetch through the loader (via fetchFilteredSongs),
+  // so the hook's client fetch would be a duplicate request. Pins that
+  // FilteredSongsTable opts out of the hook's internal fetch path.
+  test("passes skipClientFetch: true to usePerformancePageFilters", () => {
+    setHookReturn();
+    renderComponent();
+
+    expect(usePerformancePageFiltersMock).toHaveBeenCalledWith(expect.objectContaining({ skipClientFetch: true }));
   });
 
   // When hideTimeRange is true, the PerformanceFilterControls should receive
   // it so the Time Range dropdown is suppressed.
   test("passes hideTimeRange to PerformanceFilterControls", () => {
+    setHookReturn();
     renderComponent({ hideTimeRange: true });
 
     const controls = screen.getByTestId("PerformanceFilterControls");
@@ -76,9 +111,105 @@ describe("FilteredSongsTable", () => {
   // When hideTimeRange is not set, it defaults to undefined (falsy),
   // so the Time Range dropdown renders normally.
   test("does not pass hideTimeRange when not set", () => {
-    renderComponent({});
+    setHookReturn();
+    renderComponent();
 
     const controls = screen.getByTestId("PerformanceFilterControls");
     expect(controls.textContent).not.toContain('"hideTimeRange":true');
+  });
+
+  // When no filter scope is active (no URL filters and no extraParams),
+  // the Filtered Plays column is unnecessary — every row's filtered count
+  // would equal its all-time count. Hide the column to keep the table clean.
+  test("showFilteredPlays=false when no URL filters and no extraParams", () => {
+    setHookReturn();
+    renderComponent();
+
+    const table = screen.getByTestId("SongsTable");
+    expect(table.textContent).toContain('"showFilteredPlays":false');
+  });
+
+  // A time-range filter narrows which plays count, so the filtered count
+  // meaningfully differs from the all-time count — column should show.
+  test("showFilteredPlays=true when a time range is selected", () => {
+    setHookReturn({ selectedTimeRange: "1999" });
+    renderComponent();
+
+    const table = screen.getByTestId("SongsTable");
+    expect(table.textContent).toContain('"showFilteredPlays":true');
+  });
+
+  // Toggle filters (Set Opener, Encore, Attended, etc.) restrict which
+  // performances count — the filtered count is real information.
+  test("showFilteredPlays=true when a toggle filter is active", () => {
+    setHookReturn({ activeToggleSet: new Set(["encore"]) });
+    renderComponent();
+
+    const table = screen.getByTestId("SongsTable");
+    expect(table.textContent).toContain('"showFilteredPlays":true');
+  });
+
+  // Cover and author aren't "narrowing" filters — they pick which songs
+  // appear but every matching song still shows its full play history, so
+  // filteredTimesPlayed would just equal timesPlayed. Hide to avoid a
+  // duplicate column. Same rule the "not played" filter control uses.
+  test("showFilteredPlays=false when only cover filter is active", () => {
+    setHookReturn({ coverFilter: "cover" });
+    renderComponent();
+
+    const table = screen.getByTestId("SongsTable");
+    expect(table.textContent).toContain('"showFilteredPlays":false');
+  });
+
+  // Same reasoning as cover: picking an author filters the song list but
+  // doesn't change each song's play count, so the filtered column adds
+  // nothing.
+  test("showFilteredPlays=false when only author filter is active", () => {
+    setHookReturn({ selectedAuthor: "00000000-0000-0000-0000-000000000000" });
+    renderComponent();
+
+    const table = screen.getByTestId("SongsTable");
+    expect(table.textContent).toContain('"showFilteredPlays":false');
+  });
+
+  // Cover + author combined are still non-narrowing — same rule applies.
+  test("showFilteredPlays=false when only cover+author are active", () => {
+    setHookReturn({ coverFilter: "original", selectedAuthor: "00000000-0000-0000-0000-000000000000" });
+    renderComponent();
+
+    const table = screen.getByTestId("SongsTable");
+    expect(table.textContent).toContain('"showFilteredPlays":false');
+  });
+
+  // Cover alongside a narrowing filter: the narrowing one decides. Cover
+  // doesn't erase the need for the column when a time range is also set.
+  test("showFilteredPlays=true when cover and a time range are both active", () => {
+    setHookReturn({ coverFilter: "cover", selectedTimeRange: "1999" });
+    renderComponent();
+
+    const table = screen.getByTestId("SongsTable");
+    expect(table.textContent).toContain('"showFilteredPlays":true');
+  });
+
+  // On /songs/this-year and /songs/recent the date range is baked into the
+  // route via extraParams (the URL has no filter params). The Filtered Plays
+  // column should still appear because the tab itself IS the filter scope.
+  test("showFilteredPlays=true when extraParams is set even without URL filters", () => {
+    setHookReturn();
+    renderComponent({ extraParams: { timeRange: "thisYear" } });
+
+    const table = screen.getByTestId("SongsTable");
+    expect(table.textContent).toContain('"showFilteredPlays":true');
+  });
+
+  // "Not Played" returns songs NOT played within the filter, so the
+  // filtered count would be 0 for every row — a useless column. Hide it
+  // regardless of other active filters.
+  test("showFilteredPlays=false when playedFilter is 'notPlayed'", () => {
+    setHookReturn({ selectedTimeRange: "1999", playedFilter: "notPlayed" });
+    renderComponent({ extraParams: { timeRange: "thisYear" } });
+
+    const table = screen.getByTestId("SongsTable");
+    expect(table.textContent).toContain('"showFilteredPlays":false');
   });
 });

--- a/apps/web/app/components/song/filtered-songs-table.tsx
+++ b/apps/web/app/components/song/filtered-songs-table.tsx
@@ -1,6 +1,7 @@
 import type { Song } from "@bip/domain";
 import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
 import { usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
+import { hasNarrowingFilter } from "~/lib/played-filter";
 import { SongsTable } from "./songs-table";
 
 interface FilteredSongsTableProps {
@@ -31,7 +32,23 @@ export function FilteredSongsTable({ songs, extraParams, hideTimeRange }: Filter
     apiUrl: "/api/songs",
     extraParams,
     searchFilter,
+    // /songs and its tabs run their loader through fetchFilteredSongs, so
+    // React Router's loader revalidation refreshes data on filter changes.
+    // The hook's client fetch would be a duplicate request.
+    skipClientFetch: true,
   });
+
+  // Show the Filtered Plays column only when a narrowing filter is active
+  // (date range, attended, or a toggle like Set Opener/Encore). Cover and
+  // author aren't narrowing — they pick which songs appear but every
+  // matching song still surfaces its full play history. Tab-baked
+  // extraParams (e.g. /songs/this-year) always carry a time range, so they
+  // count as a date range here.
+  const hasDateRange = selectedTimeRange !== "all" || !!extraParams;
+  const hasAttendedUser = activeToggleSet.has("attended");
+  const hasToggleFilters = [...activeToggleSet].some((key) => key !== "attended");
+  const showFilteredPlays =
+    hasNarrowingFilter({ hasDateRange, hasAttendedUser, hasToggleFilters }) && playedFilter !== "notPlayed";
 
   const filterControls = (
     <PerformanceFilterControls
@@ -50,5 +67,12 @@ export function FilteredSongsTable({ songs, extraParams, hideTimeRange }: Filter
     />
   );
 
-  return <SongsTable songs={filteredSongs} filterComponent={filterControls} isLoading={isLoading} />;
+  return (
+    <SongsTable
+      songs={filteredSongs}
+      filterComponent={filterControls}
+      isLoading={isLoading}
+      showFilteredPlays={showFilteredPlays}
+    />
+  );
 }

--- a/apps/web/app/components/song/songs-columns.test.tsx
+++ b/apps/web/app/components/song/songs-columns.test.tsx
@@ -3,14 +3,15 @@ import { setupWithRouter } from "@test/test-utils";
 import { screen } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
 import { DataTable } from "~/components/ui/data-table";
-import { songsColumns } from "./songs-columns";
+import { getSongsColumns } from "./songs-columns";
 
 interface SongWithShows extends Song {
   firstPlayedShow?: Show | null;
   lastPlayedShow?: Show | null;
 }
 
-const currentYear = new Date().getFullYear().toString();
+const baseColumns = getSongsColumns({ showFilteredPlays: false });
+const filteredColumns = getSongsColumns({ showFilteredPlays: true });
 
 function makeShow(overrides: Partial<Show> = {}): Show {
   return {
@@ -47,8 +48,8 @@ function makeShow(overrides: Partial<Show> = {}): Show {
 function makeSong(overrides: Partial<SongWithShows> = {}): SongWithShows {
   return {
     id: overrides.id ?? "song-1",
-    title: overrides.title ?? "Cassidy",
-    slug: overrides.slug ?? "cassidy",
+    title: overrides.title ?? "Basis for a Day",
+    slug: overrides.slug ?? "basis-for-a-day",
     createdAt: new Date("2020-01-01"),
     updatedAt: new Date("2020-01-01"),
     lyrics: null,
@@ -79,22 +80,22 @@ function makeSong(overrides: Partial<SongWithShows> = {}): SongWithShows {
   };
 }
 
-describe("songsColumns", () => {
+describe("getSongsColumns", () => {
   // The Song Title column is how users navigate from /songs to /songs/$slug.
   // Verifies the title is rendered inside an <a> with the correct href.
   test("title cell renders a link to /songs/{slug}", async () => {
     await setupWithRouter(
       <DataTable
-        columns={songsColumns}
-        data={[makeSong({ title: "Cassidy", slug: "cassidy" })]}
+        columns={baseColumns}
+        data={[makeSong({ title: "Basis for a Day", slug: "basis-for-a-day" })]}
         hideSearch
         hidePagination
       />,
     );
 
-    const link = screen.getByRole("link", { name: "Cassidy" });
+    const link = screen.getByRole("link", { name: "Basis for a Day" });
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute("href", "/songs/cassidy");
+    expect(link).toHaveAttribute("href", "/songs/basis-for-a-day");
   });
 
   // Songs with no performances (DB songs that exist but were never played)
@@ -103,54 +104,73 @@ describe("songsColumns", () => {
   // but the "Not Played" filter flips that.
   test('timesPlayed === 0 renders "Never performed"', async () => {
     await setupWithRouter(
-      <DataTable columns={songsColumns} data={[makeSong({ timesPlayed: 0 })]} hideSearch hidePagination />,
+      <DataTable columns={baseColumns} data={[makeSong({ timesPlayed: 0 })]} hideSearch hidePagination />,
     );
 
     expect(screen.getByText("Never performed")).toBeInTheDocument();
   });
 
-  // The normal case: `timesPlayed` is rendered as a bold number. Paired with
-  // the previous test to pin "Never performed" to exactly the 0 case.
+  // The normal case: `timesPlayed` (all-time) is rendered as a bold number.
+  // Paired with the previous test to pin "Never performed" to exactly the 0 case.
   test("timesPlayed > 0 renders the play count", async () => {
     await setupWithRouter(
-      <DataTable columns={songsColumns} data={[makeSong({ timesPlayed: 42 })]} hideSearch hidePagination />,
+      <DataTable columns={baseColumns} data={[makeSong({ timesPlayed: 42 })]} hideSearch hidePagination />,
     );
 
     expect(screen.getByText("42")).toBeInTheDocument();
     expect(screen.queryByText("Never performed")).not.toBeInTheDocument();
   });
 
-  // The "This Year" column reads from `yearlyPlayData[currentYear]` — a
-  // per-year play-count map. Verifies the cell extracts the current year's
-  // value and renders it as a number when present.
-  test("yearlyPlayData cell renders the current-year count when present", async () => {
+  // When showFilteredPlays is false (no filter active), the factory omits
+  // the "Filtered Plays" column entirely so the table stays minimal.
+  test("showFilteredPlays=false: Filtered Plays column is not rendered", async () => {
     await setupWithRouter(
       <DataTable
-        columns={songsColumns}
-        data={[makeSong({ yearlyPlayData: { [currentYear]: 7 } })]}
+        columns={baseColumns}
+        data={[makeSong({ timesPlayed: 42, filteredTimesPlayed: 5 })]}
         hideSearch
         hidePagination
       />,
     );
 
+    expect(screen.queryByRole("button", { name: /Filtered Plays/i })).not.toBeInTheDocument();
+  });
+
+  // When showFilteredPlays is true, the factory inserts a "Filtered Plays"
+  // column next to Plays showing the scoped count. This is the replacement
+  // for the removed "This Year" column.
+  test("showFilteredPlays=true: Filtered Plays column renders the scoped count", async () => {
+    await setupWithRouter(
+      <DataTable
+        columns={filteredColumns}
+        data={[makeSong({ timesPlayed: 42, filteredTimesPlayed: 7 })]}
+        hideSearch
+        hidePagination
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /Filtered Plays/i })).toBeInTheDocument();
+    // Both the all-time count (42) and the scoped count (7) are present.
+    expect(screen.getByText("42")).toBeInTheDocument();
     expect(screen.getByText("7")).toBeInTheDocument();
   });
 
-  // If the current year has no plays (either missing from the map or zero),
-  // the "This Year" cell renders an em-dash rather than "0". Avoids crowding
-  // the table with zeros for songs that haven't been played yet this year.
-  test("yearlyPlayData cell renders em-dash when current-year count is 0 or missing", async () => {
+  // When a song is in the filtered result set but has 0 (or undefined)
+  // filtered plays, the cell renders an em-dash rather than "0". Keeps the
+  // column readable for rows like "Not Played" entries that shouldn't be
+  // shown at all — defensive if the column is ever displayed in that mode.
+  test("Filtered Plays cell renders em-dash when filteredTimesPlayed is 0 or missing", async () => {
     await setupWithRouter(
       <DataTable
-        columns={songsColumns}
-        data={[makeSong({ title: "OldSong", slug: "oldsong", yearlyPlayData: { "2010": 3 } })]}
+        columns={filteredColumns}
+        data={[makeSong({ title: "Crickets", slug: "crickets", filteredTimesPlayed: 0 })]}
         hideSearch
         hidePagination
       />,
     );
 
-    // em-dash appears for both the yearlyPlayData cell. (Date cells may also render em-dash
-    // when dates are null, but fixture dates are non-null here.)
+    // em-dash appears at least once for the Filtered Plays cell (date cells
+    // are non-null in this fixture).
     const dashes = screen.getAllByText("—");
     expect(dashes.length).toBeGreaterThanOrEqual(1);
   });
@@ -165,7 +185,7 @@ describe("songsColumns", () => {
       dateLastPlayed: new Date("2024-06-15"),
       lastPlayedShow: makeShow({ slug: "2024-06-15-the-cap" }),
     });
-    await setupWithRouter(<DataTable columns={songsColumns} data={[song]} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={baseColumns} data={[song]} hideSearch hidePagination />);
 
     // Date text is formatted (not ISO). Regex avoids pinning exact locale format.
     expect(screen.getByText(/Jun 15, 2024/)).toBeInTheDocument();
@@ -182,7 +202,7 @@ describe("songsColumns", () => {
   // em-dash placeholder instead of crashing or showing "Invalid Date".
   test("Last Played cell renders em-dash when dateLastPlayed is null", async () => {
     const song = makeSong({ dateLastPlayed: null, lastPlayedShow: null });
-    await setupWithRouter(<DataTable columns={songsColumns} data={[song]} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={baseColumns} data={[song]} hideSearch hidePagination />);
 
     // Both Last Played and First Played will be null → 2 em-dashes expected
     // (we null out dateFirstPlayed below to make the assertion precise).
@@ -198,7 +218,7 @@ describe("songsColumns", () => {
       dateLastPlayed: new Date("2024-06-15"),
       lastPlayedShow: null,
     });
-    await setupWithRouter(<DataTable columns={songsColumns} data={[song]} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={baseColumns} data={[song]} hideSearch hidePagination />);
 
     expect(screen.getByText(/Jun 15, 2024/)).toBeInTheDocument();
     // No link wraps the date
@@ -214,7 +234,7 @@ describe("songsColumns", () => {
       dateFirstPlayed: new Date("1995-07-04"),
       firstPlayedShow: makeShow({ id: "show-first", slug: "1995-07-04-red-rocks" }),
     });
-    await setupWithRouter(<DataTable columns={songsColumns} data={[song]} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={baseColumns} data={[song]} hideSearch hidePagination />);
 
     expect(screen.getByText(/Jul 4, 1995/)).toBeInTheDocument();
     const showLink = screen.getByRole("link", { name: /Jul 4, 1995/ });
@@ -225,7 +245,7 @@ describe("songsColumns", () => {
   // null dates gracefully with an em-dash.
   test("First Played cell renders em-dash when dateFirstPlayed is null", async () => {
     const song = makeSong({ dateFirstPlayed: null, firstPlayedShow: null });
-    await setupWithRouter(<DataTable columns={songsColumns} data={[song]} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={baseColumns} data={[song]} hideSearch hidePagination />);
     expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1);
   });
 
@@ -234,25 +254,25 @@ describe("songsColumns", () => {
   // historical browsing. Symmetric with the Last Played sort test.
   test("clicking First Played header sorts by dateFirstPlayed ascending, then descending", async () => {
     const songs = [
-      makeSong({ id: "a", title: "Alpha", slug: "alpha", dateFirstPlayed: new Date("1995-07-04") }),
-      makeSong({ id: "b", title: "Beta", slug: "beta", dateFirstPlayed: new Date("2020-01-01") }),
-      makeSong({ id: "c", title: "Gamma", slug: "gamma", dateFirstPlayed: new Date("2010-06-15") }),
+      makeSong({ id: "a", title: "Home Again", slug: "home-again", dateFirstPlayed: new Date("1995-07-04") }),
+      makeSong({ id: "b", title: "Crickets", slug: "crickets", dateFirstPlayed: new Date("2020-01-01") }),
+      makeSong({ id: "c", title: "Plan B", slug: "plan-b", dateFirstPlayed: new Date("2010-06-15") }),
     ];
-    const { user } = await setupWithRouter(<DataTable columns={songsColumns} data={songs} hideSearch hidePagination />);
+    const { user } = await setupWithRouter(<DataTable columns={baseColumns} data={songs} hideSearch hidePagination />);
 
     const sortHeader = screen.getByRole("button", { name: /^First Played/i });
     await user.click(sortHeader);
 
     const titlesAsc = screen
       .getAllByRole("link")
-      .filter((el) => ["Alpha", "Beta", "Gamma"].includes(el.textContent ?? ""));
-    expect(titlesAsc.map((el) => el.textContent)).toEqual(["Alpha", "Gamma", "Beta"]);
+      .filter((el) => ["Home Again", "Crickets", "Plan B"].includes(el.textContent ?? ""));
+    expect(titlesAsc.map((el) => el.textContent)).toEqual(["Home Again", "Plan B", "Crickets"]);
 
     await user.click(sortHeader);
     const titlesDesc = screen
       .getAllByRole("link")
-      .filter((el) => ["Alpha", "Beta", "Gamma"].includes(el.textContent ?? ""));
-    expect(titlesDesc.map((el) => el.textContent)).toEqual(["Beta", "Gamma", "Alpha"]);
+      .filter((el) => ["Home Again", "Crickets", "Plan B"].includes(el.textContent ?? ""));
+    expect(titlesDesc.map((el) => el.textContent)).toEqual(["Crickets", "Plan B", "Home Again"]);
   });
 
   // The Plays column sorts by `timesPlayed`. Users click it to find songs
@@ -260,25 +280,25 @@ describe("songsColumns", () => {
   // browse the song catalog.
   test("clicking Plays header sorts by timesPlayed ascending, then descending", async () => {
     const songs = [
-      makeSong({ id: "a", title: "Alpha", slug: "alpha", timesPlayed: 50 }),
-      makeSong({ id: "b", title: "Beta", slug: "beta", timesPlayed: 10 }),
-      makeSong({ id: "c", title: "Gamma", slug: "gamma", timesPlayed: 30 }),
+      makeSong({ id: "a", title: "Home Again", slug: "home-again", timesPlayed: 50 }),
+      makeSong({ id: "b", title: "Crickets", slug: "crickets", timesPlayed: 10 }),
+      makeSong({ id: "c", title: "Plan B", slug: "plan-b", timesPlayed: 30 }),
     ];
-    const { user } = await setupWithRouter(<DataTable columns={songsColumns} data={songs} hideSearch hidePagination />);
+    const { user } = await setupWithRouter(<DataTable columns={baseColumns} data={songs} hideSearch hidePagination />);
 
     const sortHeader = screen.getByRole("button", { name: /^Plays/i });
     await user.click(sortHeader);
 
     const titlesAsc = screen
       .getAllByRole("link")
-      .filter((el) => ["Alpha", "Beta", "Gamma"].includes(el.textContent ?? ""));
-    expect(titlesAsc.map((el) => el.textContent)).toEqual(["Beta", "Gamma", "Alpha"]);
+      .filter((el) => ["Home Again", "Crickets", "Plan B"].includes(el.textContent ?? ""));
+    expect(titlesAsc.map((el) => el.textContent)).toEqual(["Crickets", "Plan B", "Home Again"]);
 
     await user.click(sortHeader);
     const titlesDesc = screen
       .getAllByRole("link")
-      .filter((el) => ["Alpha", "Beta", "Gamma"].includes(el.textContent ?? ""));
-    expect(titlesDesc.map((el) => el.textContent)).toEqual(["Alpha", "Gamma", "Beta"]);
+      .filter((el) => ["Home Again", "Crickets", "Plan B"].includes(el.textContent ?? ""));
+    expect(titlesDesc.map((el) => el.textContent)).toEqual(["Home Again", "Plan B", "Crickets"]);
   });
 
   // The Last Played column sorts by `dateLastPlayed`. Users click it to find
@@ -286,11 +306,11 @@ describe("songsColumns", () => {
   // dormant songs. TanStack's default date sort handles the comparison.
   test("clicking Last Played header sorts by dateLastPlayed ascending, then descending", async () => {
     const songs = [
-      makeSong({ id: "a", title: "Alpha", slug: "alpha", dateLastPlayed: new Date("2020-01-01") }),
-      makeSong({ id: "b", title: "Beta", slug: "beta", dateLastPlayed: new Date("2024-06-15") }),
-      makeSong({ id: "c", title: "Gamma", slug: "gamma", dateLastPlayed: new Date("2022-03-10") }),
+      makeSong({ id: "a", title: "Home Again", slug: "home-again", dateLastPlayed: new Date("2020-01-01") }),
+      makeSong({ id: "b", title: "Crickets", slug: "crickets", dateLastPlayed: new Date("2024-06-15") }),
+      makeSong({ id: "c", title: "Plan B", slug: "plan-b", dateLastPlayed: new Date("2022-03-10") }),
     ];
-    const { user } = await setupWithRouter(<DataTable columns={songsColumns} data={songs} hideSearch hidePagination />);
+    const { user } = await setupWithRouter(<DataTable columns={baseColumns} data={songs} hideSearch hidePagination />);
 
     const sortHeader = screen.getByRole("button", { name: /^Last Played/i });
     await user.click(sortHeader);
@@ -298,61 +318,93 @@ describe("songsColumns", () => {
     // The title column uses the same tag as date cells, so filter by title set
     const titlesAsc = screen
       .getAllByRole("link")
-      .filter((el) => ["Alpha", "Beta", "Gamma"].includes(el.textContent ?? ""));
-    expect(titlesAsc.map((el) => el.textContent)).toEqual(["Alpha", "Gamma", "Beta"]);
+      .filter((el) => ["Home Again", "Crickets", "Plan B"].includes(el.textContent ?? ""));
+    expect(titlesAsc.map((el) => el.textContent)).toEqual(["Home Again", "Plan B", "Crickets"]);
 
     await user.click(sortHeader);
     const titlesDesc = screen
       .getAllByRole("link")
-      .filter((el) => ["Alpha", "Beta", "Gamma"].includes(el.textContent ?? ""));
-    expect(titlesDesc.map((el) => el.textContent)).toEqual(["Beta", "Gamma", "Alpha"]);
+      .filter((el) => ["Home Again", "Crickets", "Plan B"].includes(el.textContent ?? ""));
+    expect(titlesDesc.map((el) => el.textContent)).toEqual(["Crickets", "Plan B", "Home Again"]);
   });
 
-  // The "This Year" column has a custom `sortingFn` that sorts by the
-  // CURRENT year's play count (not the default alphanumeric sort over the
-  // JSON blob). Users click the header to find songs trending this year.
-  // Verifies asc/desc order by checking row position after each click.
-  test("yearlyPlayData sortingFn sorts by current-year count ascending, then descending", async () => {
+  // When two songs have the same filteredTimesPlayed value, fall back to
+  // sorting by all-time `timesPlayed` in the same direction. Most useful
+  // tiebreaker for "rank within filter" browsing — e.g. on a 1999 filter,
+  // ties at "played twice that year" surface the more-played-overall song
+  // first under desc.
+  test("Filtered Plays sort breaks ties using all-time timesPlayed in the same direction", async () => {
+    const songs = [
+      // Two songs tied at filteredTimesPlayed=2; differ by timesPlayed
+      makeSong({ id: "a", title: "Plan B", slug: "plan-b", filteredTimesPlayed: 2, timesPlayed: 30 }),
+      makeSong({ id: "b", title: "Crickets", slug: "crickets", filteredTimesPlayed: 2, timesPlayed: 80 }),
+      // Higher filtered count — first under desc / last under asc
+      makeSong({ id: "c", title: "Home Again", slug: "home-again", filteredTimesPlayed: 5, timesPlayed: 10 }),
+    ];
+    const { user } = await setupWithRouter(
+      <DataTable columns={filteredColumns} data={songs} hideSearch hidePagination />,
+    );
+
+    const sortHeader = screen.getByRole("button", { name: /Filtered Plays/i });
+    await user.click(sortHeader); // asc
+
+    // asc: [filtered=2, timesPlayed=30 (Plan B)], [filtered=2, timesPlayed=80 (Crickets)], [filtered=5 (Home Again)]
+    const titlesAsc = screen
+      .getAllByRole("link")
+      .filter((el) => ["Home Again", "Crickets", "Plan B"].includes(el.textContent ?? ""));
+    expect(titlesAsc.map((el) => el.textContent)).toEqual(["Plan B", "Crickets", "Home Again"]);
+
+    await user.click(sortHeader); // desc
+
+    // desc: [filtered=5 (Home Again)], [filtered=2, timesPlayed=80 (Crickets)], [filtered=2, timesPlayed=30 (Plan B)]
+    const titlesDesc = screen
+      .getAllByRole("link")
+      .filter((el) => ["Home Again", "Crickets", "Plan B"].includes(el.textContent ?? ""));
+    expect(titlesDesc.map((el) => el.textContent)).toEqual(["Home Again", "Crickets", "Plan B"]);
+  });
+
+  // The Filtered Plays column sorts numerically by `filteredTimesPlayed`.
+  // When a filter is active, users click this to rank songs by how often
+  // they appeared in the filtered scope (e.g. "most-played songs in 1999").
+  test("clicking Filtered Plays header sorts by filteredTimesPlayed ascending, then descending", async () => {
     const songs = [
       makeSong({
         id: "a",
-        title: "Alpha",
-        slug: "alpha",
-        yearlyPlayData: { [currentYear]: 1 },
+        title: "Home Again",
+        slug: "home-again",
+        filteredTimesPlayed: 1,
       }),
       makeSong({
         id: "b",
-        title: "Beta",
-        slug: "beta",
-        yearlyPlayData: { [currentYear]: 5 },
+        title: "Crickets",
+        slug: "crickets",
+        filteredTimesPlayed: 5,
       }),
       makeSong({
         id: "c",
-        title: "Gamma",
-        slug: "gamma",
-        yearlyPlayData: { [currentYear]: 3 },
+        title: "Plan B",
+        slug: "plan-b",
+        filteredTimesPlayed: 3,
       }),
     ];
-    const { user } = await setupWithRouter(<DataTable columns={songsColumns} data={songs} hideSearch hidePagination />);
+    const { user } = await setupWithRouter(
+      <DataTable columns={filteredColumns} data={songs} hideSearch hidePagination />,
+    );
 
-    // Click the "This Year" sort header twice:
-    //   first click → asc order (1, 3, 5)
-    //   second click → desc order (5, 3, 1)
-    const sortHeader = screen.getByRole("button", { name: /This Year/i });
+    // First click: asc. Second click: desc.
+    const sortHeader = screen.getByRole("button", { name: /Filtered Plays/i });
     await user.click(sortHeader);
 
-    // First click: asc. Assert row order by finding song titles in document order.
     const titlesAsc = screen
       .getAllByRole("link")
-      .filter((el) => ["Alpha", "Beta", "Gamma"].includes(el.textContent ?? ""));
-    expect(titlesAsc.map((el) => el.textContent)).toEqual(["Alpha", "Gamma", "Beta"]);
+      .filter((el) => ["Home Again", "Crickets", "Plan B"].includes(el.textContent ?? ""));
+    expect(titlesAsc.map((el) => el.textContent)).toEqual(["Home Again", "Plan B", "Crickets"]);
 
-    // Second click: desc.
     await user.click(sortHeader);
     const titlesDesc = screen
       .getAllByRole("link")
-      .filter((el) => ["Alpha", "Beta", "Gamma"].includes(el.textContent ?? ""));
-    expect(titlesDesc.map((el) => el.textContent)).toEqual(["Beta", "Gamma", "Alpha"]);
+      .filter((el) => ["Home Again", "Crickets", "Plan B"].includes(el.textContent ?? ""));
+    expect(titlesDesc.map((el) => el.textContent)).toEqual(["Crickets", "Plan B", "Home Again"]);
   });
 
   // The /songs page shows songs sorted by times played (most played first)
@@ -361,7 +413,7 @@ describe("songsColumns", () => {
   test("Plays header shows descending sort icon when initialSorting is timesPlayed desc", async () => {
     await setupWithRouter(
       <DataTable
-        columns={songsColumns}
+        columns={baseColumns}
         data={[makeSong()]}
         hideSearch
         hidePagination

--- a/apps/web/app/components/song/songs-columns.tsx
+++ b/apps/web/app/components/song/songs-columns.tsx
@@ -25,10 +25,20 @@ const getSortIcon = (sortState: false | "asc" | "desc") => {
   return <ArrowUpDown className="ml-2 h-4 w-4" />;
 };
 
-export const songsColumns: ColumnDef<SongWithShows>[] = [
-  {
+interface GetSongsColumnsOptions {
+  showFilteredPlays: boolean;
+}
+
+/**
+ * Produces the column definitions for the /songs table. The "Filtered Plays"
+ * column is inserted only when a filter scope is active (time range, toggles,
+ * tab-level extraParams, etc.); when absent, "Plays" alone represents all-time
+ * counts.
+ */
+export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): ColumnDef<SongWithShows>[] {
+  const titleColumn: ColumnDef<SongWithShows> = {
     accessorKey: "title",
-    meta: { width: "30%" },
+    meta: { width: showFilteredPlays ? "30%" : "40%" },
     header: ({ column }) => {
       return (
         <Button
@@ -52,8 +62,9 @@ export const songsColumns: ColumnDef<SongWithShows>[] = [
         </Link>
       );
     },
-  },
-  {
+  };
+
+  const playsColumn: ColumnDef<SongWithShows> = {
     accessorKey: "timesPlayed",
     meta: { width: "10%" },
     header: ({ column }) => {
@@ -76,8 +87,43 @@ export const songsColumns: ColumnDef<SongWithShows>[] = [
         <span className="text-content-text-tertiary text-sm italic">Never performed</span>
       );
     },
-  },
-  {
+  };
+
+  const filteredPlaysColumn: ColumnDef<SongWithShows> = {
+    accessorKey: "filteredTimesPlayed",
+    meta: { width: "10%" },
+    header: ({ column }) => {
+      return (
+        <Button
+          variant="ghost"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          className="h-auto p-0 font-semibold text-left justify-start hover:bg-brand-primary/10 hover:text-brand-primary transition-colors whitespace-normal leading-tight"
+        >
+          Filtered Plays
+          {getSortIcon(column.getIsSorted())}
+        </Button>
+      );
+    },
+    cell: ({ row }) => {
+      const plays = row.original.filteredTimesPlayed ?? 0;
+      return plays > 0 ? (
+        <span className="text-content-text-primary font-medium">{plays}</span>
+      ) : (
+        <span className="text-content-text-tertiary text-sm">—</span>
+      );
+    },
+    sortingFn: (rowA, rowB) => {
+      const aFiltered = rowA.original.filteredTimesPlayed ?? 0;
+      const bFiltered = rowB.original.filteredTimesPlayed ?? 0;
+      if (aFiltered !== bFiltered) return aFiltered - bFiltered;
+      // Same direction tiebreaker on all-time Plays — TanStack flips the
+      // sign of the whole comparator for desc, so the secondary sort
+      // automatically follows the primary direction.
+      return rowA.original.timesPlayed - rowB.original.timesPlayed;
+    },
+  };
+
+  const lastPlayedColumn: ColumnDef<SongWithShows> = {
     accessorKey: "dateLastPlayed",
     meta: { width: "25%" },
     header: ({ column }) => {
@@ -124,8 +170,9 @@ export const songsColumns: ColumnDef<SongWithShows>[] = [
         <span className="text-content-text-tertiary text-sm">—</span>
       );
     },
-  },
-  {
+  };
+
+  const firstPlayedColumn: ColumnDef<SongWithShows> = {
     accessorKey: "dateFirstPlayed",
     meta: { width: "25%" },
     header: ({ column }) => {
@@ -172,39 +219,10 @@ export const songsColumns: ColumnDef<SongWithShows>[] = [
         <span className="text-content-text-tertiary text-sm">—</span>
       );
     },
-  },
-  {
-    accessorKey: "yearlyPlayData",
-    meta: { width: "10%" },
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-          className="h-auto p-0 font-semibold text-left justify-start hover:bg-brand-primary/10 hover:text-brand-primary transition-colors"
-        >
-          This Year
-          {getSortIcon(column.getIsSorted())}
-        </Button>
-      );
-    },
-    cell: ({ row }) => {
-      const yearlyData = row.original.yearlyPlayData as Record<string, number>;
-      const currentYear = new Date().getFullYear().toString();
-      const thisYearPlays = yearlyData?.[currentYear] || 0;
-      return thisYearPlays > 0 ? (
-        <span className="text-content-text-primary font-medium">{thisYearPlays}</span>
-      ) : (
-        <span className="text-content-text-tertiary text-sm">—</span>
-      );
-    },
-    sortingFn: (rowA, rowB) => {
-      const currentYear = new Date().getFullYear().toString();
-      const aData = rowA.original.yearlyPlayData as Record<string, number>;
-      const bData = rowB.original.yearlyPlayData as Record<string, number>;
-      const aPlays = aData?.[currentYear] || 0;
-      const bPlays = bData?.[currentYear] || 0;
-      return aPlays - bPlays;
-    },
-  },
-];
+  };
+
+  const columns: ColumnDef<SongWithShows>[] = [titleColumn, playsColumn];
+  if (showFilteredPlays) columns.push(filteredPlaysColumn);
+  columns.push(lastPlayedColumn, firstPlayedColumn);
+  return columns;
+}

--- a/apps/web/app/components/song/songs-table.tsx
+++ b/apps/web/app/components/song/songs-table.tsx
@@ -1,25 +1,37 @@
 import type { Song } from "@bip/domain";
-import type { ReactNode } from "react";
-import { songsColumns } from "~/components/song/songs-columns";
+import { type ReactNode, useMemo } from "react";
+import { getSongsColumns } from "~/components/song/songs-columns";
 import { DataTable } from "~/components/ui/data-table";
 
 interface SongsTableProps {
   songs: Song[];
   filterComponent?: ReactNode;
   isLoading?: boolean;
+  showFilteredPlays?: boolean;
 }
 
-export function SongsTable({ songs, filterComponent, isLoading = false }: SongsTableProps) {
+export function SongsTable({ songs, filterComponent, isLoading = false, showFilteredPlays = false }: SongsTableProps) {
+  const columns = useMemo(() => getSongsColumns({ showFilteredPlays }), [showFilteredPlays]);
+  const initialSorting = useMemo(
+    () => [{ id: showFilteredPlays ? "filteredTimesPlayed" : "timesPlayed", desc: true }],
+    [showFilteredPlays],
+  );
+
   return (
     <div>
       <DataTable
-        columns={songsColumns}
+        // Remount when the filtered-plays column appears/disappears so the
+        // default sort actually flips between `timesPlayed` and
+        // `filteredTimesPlayed`. DataTable's `initialSorting` only runs
+        // once per mount, so a prop change alone would leave the prior sort.
+        key={showFilteredPlays ? "filtered" : "base"}
+        columns={columns}
         data={songs}
         hideSearch
         pageSize={50}
         filterComponent={filterComponent}
         isLoading={isLoading}
-        initialSorting={[{ id: "timesPlayed", desc: true }]}
+        initialSorting={initialSorting}
       />
     </div>
   );

--- a/apps/web/app/hooks/use-performance-page-filters.test.ts
+++ b/apps/web/app/hooks/use-performance-page-filters.test.ts
@@ -202,6 +202,47 @@ describe("usePerformancePageFilters", () => {
     expect(result.current.searchText).toBe("");
   });
 
+  // skipClientFetch lets a consumer disable the internal fetch when the
+  // page's loader is already returning filter-aware data (e.g. /songs).
+  // Filters can be active and yet no fetch fires; data stays = initialData
+  // and isLoading stays false. Loader revalidation drives data updates.
+  test("skipClientFetch=true: no fetch fires even when filters are active", async () => {
+    mockSearchParams = new URLSearchParams("timeRange=2024");
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+
+    const { result } = renderHook(() =>
+      usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test", skipClientFetch: true }),
+    );
+
+    // Advance past the debounce window — still no fetch.
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toEqual(EMPTY);
+  });
+
+  // Default behavior preserved: with skipClientFetch unset (or false), the
+  // hook still fetches when filters are active. Pins that the new option
+  // doesn't accidentally silence the existing client-fetch consumers
+  // (/songs/$slug performances, /songs/all-timers, /on-this-day).
+  test("skipClientFetch defaults to false: fetch still fires for other consumers", async () => {
+    mockSearchParams = new URLSearchParams("timeRange=2024");
+    const fetchMock = vi.fn().mockImplementation(() => new Promise(() => {}));
+    globalThis.fetch = fetchMock;
+
+    renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   // Verifies that the setSearchParams updater clears all URL param keys
   // (timeRange, cover, author, filters, attended, played). We call the updater
   // manually because the mock doesn't trigger React state updates — we just
@@ -221,9 +262,7 @@ describe("usePerformancePageFilters", () => {
 
     const updaterFn = mockSetSearchParams.mock.calls[0][0];
     const nextParams = updaterFn(
-      new URLSearchParams(
-        "timeRange=2024&cover=cover&author=Trey&filters=encore&attended=attended&played=notPlayed",
-      ),
+      new URLSearchParams("timeRange=2024&cover=cover&author=Trey&filters=encore&attended=attended&played=notPlayed"),
     );
 
     expect(nextParams.get("timeRange")).toBeNull();

--- a/apps/web/app/hooks/use-performance-page-filters.ts
+++ b/apps/web/app/hooks/use-performance-page-filters.ts
@@ -15,6 +15,14 @@ interface PageFiltersOptions<T> {
   apiUrl: string;
   extraParams?: Record<string, string>;
   searchFilter?: (item: T, query: string) => boolean;
+  /**
+   * When true, the hook never fires its internal `fetch(apiUrl, ...)` —
+   * `data` stays equal to `initialData` and `isLoading` stays false. Use
+   * this when the page's React Router loader is already returning
+   * filter-aware data; loader revalidation drives data updates instead of
+   * a duplicate client-side request.
+   */
+  skipClientFetch?: boolean;
 }
 
 export function usePerformancePageFilters<T>({
@@ -22,6 +30,7 @@ export function usePerformancePageFilters<T>({
   apiUrl,
   extraParams,
   searchFilter,
+  skipClientFetch = false,
 }: PageFiltersOptions<T>) {
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -52,7 +61,11 @@ export function usePerformancePageFilters<T>({
     playedParam !== "";
 
   useEffect(() => {
-    if (!hasFilters) {
+    // No filters → use initialData. Or skipClientFetch (e.g. /songs index,
+    // where the loader is already filter-aware) → also use initialData and
+    // let React Router's loader revalidation drive data updates instead
+    // of firing a duplicate fetch.
+    if (!hasFilters || skipClientFetch) {
       setData(initialData);
       setIsLoading(false);
       if (loadingTimeoutRef.current) {
@@ -123,6 +136,7 @@ export function usePerformancePageFilters<T>({
     hasFilters,
     apiUrl,
     extraParams,
+    skipClientFetch,
   ]);
 
   const updateFilter = useCallback(

--- a/apps/web/app/lib/played-filter.test.ts
+++ b/apps/web/app/lib/played-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { shouldShowNotPlayed } from "~/lib/played-filter";
+import { hasNarrowingFilter, shouldShowNotPlayed } from "~/lib/played-filter";
 
 const defaults = {
   playedParam: null as string | null,
@@ -7,6 +7,26 @@ const defaults = {
   hasAttendedUser: false,
   hasToggleFilters: false,
 };
+
+describe("hasNarrowingFilter", () => {
+  // None of date range / attended / toggles → no narrowing happening.
+  // (Cover and author are deliberately not "narrowing" — they pick which
+  // songs appear but don't restrict which performances contribute to a
+  // count, so they stay out of this predicate.)
+  test("returns false when no narrowing input is set", () => {
+    expect(hasNarrowingFilter({ hasDateRange: false, hasAttendedUser: false, hasToggleFilters: false })).toBe(false);
+  });
+
+  // Each of the three narrowing inputs is sufficient on its own. Parameterized
+  // to keep the rule visible in one place if a fourth narrowing kind is added.
+  test.each([
+    ["hasDateRange", { hasDateRange: true, hasAttendedUser: false, hasToggleFilters: false }],
+    ["hasAttendedUser", { hasDateRange: false, hasAttendedUser: true, hasToggleFilters: false }],
+    ["hasToggleFilters", { hasDateRange: false, hasAttendedUser: false, hasToggleFilters: true }],
+  ])("returns true when %s is set", (_label, input) => {
+    expect(hasNarrowingFilter(input)).toBe(true);
+  });
+});
 
 describe("shouldShowNotPlayed", () => {
   // When no played param is set, not-played filtering never activates

--- a/apps/web/app/lib/played-filter.ts
+++ b/apps/web/app/lib/played-filter.ts
@@ -1,15 +1,26 @@
-/**
- * Determines whether the "not played" filter should take effect. Requires both
- * the played=notPlayed param AND a narrowing filter (date range, attended, or
- * toggle filters) that defines what "played in this view" means.
- */
-export function shouldShowNotPlayed(params: {
-  playedParam: string | null;
+interface NarrowingFilterInputs {
   hasDateRange: boolean;
   hasAttendedUser: boolean;
   hasToggleFilters: boolean;
-}): boolean {
-  return (
-    params.playedParam === "notPlayed" && (params.hasDateRange || params.hasAttendedUser || params.hasToggleFilters)
-  );
+}
+
+/**
+ * True when at least one filter is active that restricts which performances
+ * contribute to a count (date range, attended-shows, or a toggle like
+ * encore/setOpener). Cover and author filters intentionally don't count —
+ * they pick which songs appear but every matching song still surfaces its
+ * full play history. Used by the "not played" gate and by the /songs UI to
+ * decide whether the Filtered Plays column is meaningful.
+ */
+export function hasNarrowingFilter(inputs: NarrowingFilterInputs): boolean {
+  return inputs.hasDateRange || inputs.hasAttendedUser || inputs.hasToggleFilters;
+}
+
+/**
+ * Determines whether the "not played" filter should take effect. Requires both
+ * the played=notPlayed param AND a narrowing filter that defines what "played
+ * in this view" means.
+ */
+export function shouldShowNotPlayed(params: NarrowingFilterInputs & { playedParam: string | null }): boolean {
+  return params.playedParam === "notPlayed" && hasNarrowingFilter(params);
 }

--- a/apps/web/app/lib/song-utilities.test.ts
+++ b/apps/web/app/lib/song-utilities.test.ts
@@ -1,25 +1,46 @@
+import type { Song } from "@bip/domain";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-const mockSong = {
+const basisForADay = {
   id: "1",
   title: "Basis for a Day",
-  timesPlayed: 5,
+  timesPlayed: 100,
   dateFirstPlayed: null,
   dateLastPlayed: null,
-};
+} as unknown as Song;
 
-const mockUnplayedSong = {
+const homeAgain = {
   id: "2",
+  title: "Home Again",
+  timesPlayed: 50,
+  dateFirstPlayed: null,
+  dateLastPlayed: null,
+} as unknown as Song;
+
+const crickets = {
+  id: "3",
+  title: "Crickets",
+  timesPlayed: 30,
+  dateFirstPlayed: null,
+  dateLastPlayed: null,
+} as unknown as Song;
+
+const shelbyRose = {
+  id: "4",
   title: "Shelby Rose",
   timesPlayed: 0,
   dateFirstPlayed: null,
   dateLastPlayed: null,
-};
+} as unknown as Song;
 
-const mockFindMany = vi.fn().mockResolvedValue([mockSong, mockUnplayedSong]);
-const mockFindManyInDateRange = vi.fn().mockResolvedValue([mockSong]);
-const mockCacheGetOrSet = vi.fn().mockImplementation((_key: string, fn: () => Promise<unknown>) => fn());
+const mockFindMany = vi.fn();
+const mockFindManyInDateRange = vi.fn();
+const mockShowsFindMany = vi.fn();
 const mockFindManyByDates = vi.fn().mockResolvedValue([]);
+const mockBuildSongPerformanceCounts = vi.fn();
+const mockCacheGetOrSet = vi.fn().mockImplementation((_key: string, fn: () => Promise<unknown>) => fn());
+const mockFindByEmail = vi.fn();
+const mockFindByUsername = vi.fn();
 
 vi.mock("~/server/services", () => ({
   services: {
@@ -27,48 +48,161 @@ vi.mock("~/server/services", () => ({
       findMany: (...args: unknown[]) => mockFindMany(...args),
       findManyInDateRange: (...args: unknown[]) => mockFindManyInDateRange(...args),
     },
+    songPageComposer: {
+      buildSongPerformanceCounts: (...args: unknown[]) => mockBuildSongPerformanceCounts(...args),
+    },
     cache: {
       getOrSet: (...args: unknown[]) => mockCacheGetOrSet(...args),
     },
     shows: {
+      findMany: (...args: unknown[]) => mockShowsFindMany(...args),
       findManyByDates: (...args: unknown[]) => mockFindManyByDates(...args),
+    },
+    users: {
+      findByEmail: (...args: unknown[]) => mockFindByEmail(...args),
+      findByUsername: (...args: unknown[]) => mockFindByUsername(...args),
     },
   },
 }));
 
-import { loadSongsWithVenueInfo } from "./song-utilities";
+import type { PublicContext } from "~/lib/base-loaders";
+import { fetchFilteredSongs } from "./song-utilities";
 
-describe("loadSongsWithVenueInfo", () => {
+const ctx = {} as PublicContext;
+
+describe("fetchFilteredSongs", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFindMany.mockResolvedValue([basisForADay, homeAgain, crickets, shelbyRose]);
+    mockFindManyInDateRange.mockResolvedValue([]);
+    mockBuildSongPerformanceCounts.mockResolvedValue({});
+    mockShowsFindMany.mockResolvedValue([]);
+    mockFindManyByDates.mockResolvedValue([]);
   });
 
-  // Fetches all songs, filters out unplayed ones, and adds venue info.
-  test("fetches all songs when no date range is provided", async () => {
-    const result = await loadSongsWithVenueInfo("test-cache-key");
+  // The unfiltered /songs path calls findMany({}) for the canonical all-time
+  // dataset, drops never-played rows, and leaves filteredTimesPlayed unset
+  // (no scope to compare against).
+  test("no filters: returns all-time songs with no filteredTimesPlayed and unplayed excluded", async () => {
+    const result = await fetchFilteredSongs(new URL("http://test/songs"), ctx);
 
-    expect(mockCacheGetOrSet).toHaveBeenCalledWith("test-cache-key", expect.any(Function), { ttl: 3600 });
     expect(mockFindMany).toHaveBeenCalledWith({});
-    expect(result.songs).toHaveLength(1);
-    expect(result.songs[0].title).toBe("Basis for a Day");
-  });
+    expect(mockFindManyInDateRange).not.toHaveBeenCalled();
+    expect(mockBuildSongPerformanceCounts).not.toHaveBeenCalled();
 
-  // When a date range is provided, uses findManyInDateRange instead.
-  test("fetches songs in date range when startDate is provided", async () => {
-    const startDate = new Date("2024-01-01");
-    const endDate = new Date("2024-12-31");
-
-    await loadSongsWithVenueInfo("test-cache-key", { startDate, endDate });
-
-    expect(mockFindManyInDateRange).toHaveBeenCalledWith({ startDate, endDate });
-    expect(mockFindMany).not.toHaveBeenCalled();
-  });
-
-  // Songs with timesPlayed === 0 should be excluded from results.
-  test("filters out songs with zero plays", async () => {
-    const result = await loadSongsWithVenueInfo("test-cache-key");
-
-    const titles = result.songs.map((s: { title: string }) => s.title);
+    const titles = result.map((s) => s.title);
     expect(titles).not.toContain("Shelby Rose");
+    expect(titles).toContain("Basis for a Day");
+    expect(result.every((s) => s.filteredTimesPlayed === undefined)).toBe(true);
+  });
+
+  // Cover and author are non-narrowing — they restrict which songs appear
+  // but every matching song still surfaces its full play history. So the
+  // canonical fetch carries the cover/author filter and no scope counting
+  // happens. filteredTimesPlayed stays undefined.
+  test("cover only: includes cover in baseFilter, no scope counts attached", async () => {
+    await fetchFilteredSongs(new URL("http://test/songs?cover=cover"), ctx);
+
+    expect(mockFindMany).toHaveBeenCalledWith({ cover: true });
+    expect(mockFindManyInDateRange).not.toHaveBeenCalled();
+    expect(mockBuildSongPerformanceCounts).not.toHaveBeenCalled();
+  });
+
+  test("author only: includes authorId in baseFilter, no scope counts attached", async () => {
+    const author = "11111111-1111-1111-1111-111111111111";
+    await fetchFilteredSongs(new URL(`http://test/songs?author=${author}`), ctx);
+
+    expect(mockFindMany).toHaveBeenCalledWith({ authorId: author });
+    expect(mockBuildSongPerformanceCounts).not.toHaveBeenCalled();
+  });
+
+  // A bogus author param (not a UUID) is dropped rather than passed
+  // through, so the filter degrades to "no author constraint" instead of
+  // hitting the DB with garbage.
+  test("invalid author UUID is ignored", async () => {
+    await fetchFilteredSongs(new URL("http://test/songs?author=not-a-uuid"), ctx);
+
+    expect(mockFindMany).toHaveBeenCalledWith({});
+  });
+
+  // Date range is narrowing: timesPlayed must remain all-time (from the
+  // canonical findMany), and filteredTimesPlayed comes from the range
+  // count returned by findManyInDateRange. Songs with no plays in the
+  // range are excluded.
+  test("date range: timesPlayed is all-time, filteredTimesPlayed is the range count", async () => {
+    // findManyInDateRange returns rows where timesPlayed represents the
+    // range count. Only basisForADay had any plays in 1999.
+    mockFindManyInDateRange.mockResolvedValueOnce([
+      { ...basisForADay, timesPlayed: 7 },
+      { ...crickets, timesPlayed: 0 },
+    ]);
+
+    const result = await fetchFilteredSongs(new URL("http://test/songs?timeRange=1999"), ctx);
+
+    expect(mockFindManyInDateRange).toHaveBeenCalled();
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("1");
+    expect(result[0].timesPlayed).toBe(100); // all-time, from findMany
+    expect(result[0].filteredTimesPlayed).toBe(7); // range count
+  });
+
+  // Toggle filters route through buildSongPerformanceCounts, which is the
+  // only counter that understands toggles. We still hit findMany for the
+  // canonical all-time list; the Map<id, count> attaches as
+  // filteredTimesPlayed.
+  test("toggle filter: uses buildSongPerformanceCounts for scope, all-time from findMany", async () => {
+    mockBuildSongPerformanceCounts.mockResolvedValueOnce({ "2": 4 });
+
+    const result = await fetchFilteredSongs(new URL("http://test/songs?filters=encore"), ctx);
+
+    expect(mockBuildSongPerformanceCounts).toHaveBeenCalled();
+    expect(mockFindMany).toHaveBeenCalledWith({});
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("2");
+    expect(result[0].timesPlayed).toBe(50); // Home Again all-time
+    expect(result[0].filteredTimesPlayed).toBe(4);
+  });
+
+  // played=notPlayed combined with a narrowing filter returns songs that
+  // exist all-time but didn't appear in the filter scope. They keep their
+  // canonical timesPlayed and have no filteredTimesPlayed — there's
+  // nothing to scope to. Sort is most-played-overall first.
+  test("played=notPlayed with date range: returns played-overall-but-not-in-range, no filteredTimesPlayed", async () => {
+    // basisForADay played in range; the other two played overall did not
+    mockFindManyInDateRange.mockResolvedValueOnce([{ ...basisForADay, timesPlayed: 7 }]);
+
+    const result = await fetchFilteredSongs(new URL("http://test/songs?timeRange=1999&played=notPlayed"), ctx);
+
+    const ids = result.map((s) => s.id);
+    expect(ids).not.toContain("1"); // basisForADay was in range
+    expect(ids).not.toContain("4"); // shelbyRose never played overall
+    expect(ids).toEqual(["2", "3"]); // sorted by all-time desc: Home Again, Crickets
+    expect(result.every((s) => s.filteredTimesPlayed === undefined)).toBe(true);
+    expect(result.every((s) => typeof s.timesPlayed === "number" && s.timesPlayed > 0)).toBe(true);
+  });
+
+  // played=notPlayed without a narrowing filter is ignored — there's no
+  // scope to be "not played in." Behaves like the unfiltered case.
+  test("played=notPlayed without narrowing filter behaves as unfiltered", async () => {
+    const result = await fetchFilteredSongs(new URL("http://test/songs?played=notPlayed"), ctx);
+
+    expect(result.every((s) => s.filteredTimesPlayed === undefined)).toBe(true);
+    expect(result.map((s) => s.title)).not.toContain("Shelby Rose");
+  });
+
+  // The cache wrapper keys off the URL params. Same URL → one upstream
+  // call; different URL → distinct keys. Pins the contract that the same
+  // /songs?timeRange=X URL and /api/songs?timeRange=X URL hit the same
+  // entry (the keys are derived purely from search params, ignoring the
+  // path).
+  test("cache: invokes getOrSet with a stable key per filter combination", async () => {
+    await fetchFilteredSongs(new URL("http://test/songs?timeRange=1999"), ctx);
+    await fetchFilteredSongs(new URL("http://test/api/songs?timeRange=1999"), ctx);
+
+    const keys = mockCacheGetOrSet.mock.calls.map((c) => c[0]);
+    expect(keys[0]).toBe(keys[1]);
+
+    await fetchFilteredSongs(new URL("http://test/songs?timeRange=2000"), ctx);
+    expect(mockCacheGetOrSet.mock.calls[2][0]).not.toBe(keys[0]);
   });
 });

--- a/apps/web/app/lib/song-utilities.ts
+++ b/apps/web/app/lib/song-utilities.ts
@@ -1,37 +1,167 @@
 import type { Show, Song } from "@bip/domain";
+import { CacheKeys } from "@bip/domain/cache-keys";
+import type { PublicContext } from "~/lib/base-loaders";
 import { dateToISOStringSansTime } from "~/lib/date";
+import {
+  parsePerformanceFilters,
+  resolveAttendedUserId,
+  resolveLast10ShowsDateRange,
+} from "~/lib/performance-filter-params";
+import { shouldShowNotPlayed } from "~/lib/played-filter";
+import { getTimeRangeParam, SONG_FILTERS } from "~/lib/song-filters";
 import { services } from "~/server/services";
 
-interface SongsLoaderData {
-  songs: Song[];
-}
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-interface DateRange {
-  startDate?: Date;
-  endDate?: Date;
+interface BaseFilter {
+  authorId?: string;
+  cover?: boolean;
 }
 
 /**
- * Shared loader logic for songs pages: cache lookup, fetch songs (optionally
- * filtered by date range), exclude unplayed songs, and add venue info.
+ * Single source of truth for the /songs filter pipeline. Called by the
+ * `/api/songs` endpoint and by the page loaders for `/songs`,
+ * `/songs/this-year`, and `/songs/recent`, so loader revalidation can
+ * drive filter updates without a separate client fetch.
+ *
+ * The canonical all-time list comes from `services.songs.findMany` keyed
+ * only on cover/author — those filters pick which songs appear, not which
+ * performances contribute to a count. Narrowing filters (date range,
+ * attended, toggle flags) compute scope counts as a separate
+ * `Map<songId, count>` and attach as `filteredTimesPlayed`. `timesPlayed`
+ * always means the all-time count from the denormalized song column.
  */
-export async function loadSongsWithVenueInfo(
-  cacheKey: string,
-  dateRange?: DateRange,
-): Promise<SongsLoaderData> {
+export async function fetchFilteredSongs(url: URL, context: PublicContext): Promise<Song[]> {
+  const params = url.searchParams;
+  const timeRangeParam = getTimeRangeParam(params);
+  const playedParam = params.get("played");
+  const authorParam = params.get("author");
+  const coverParam = params.get("cover");
+  const attendedParam = params.get("attended");
+  const filtersParam = params.get("filters");
+
+  const coverFilter = coverParam === "cover" ? true : coverParam === "original" ? false : undefined;
+  const authorId = authorParam && UUID_REGEX.test(authorParam) ? authorParam : undefined;
+  const attendedUserId = await resolveAttendedUserId(attendedParam, context);
+
+  const hasDateRange = timeRangeParam === "last10shows" || (timeRangeParam !== null && timeRangeParam in SONG_FILTERS);
+  const hasToggleFilters = !!filtersParam;
+  const hasAttendedUser = !!attendedUserId;
+  const showNotPlayed = shouldShowNotPlayed({
+    playedParam,
+    hasDateRange,
+    hasAttendedUser,
+    hasToggleFilters,
+  });
+
+  const baseFilter: BaseFilter = {};
+  if (authorId) baseFilter.authorId = authorId;
+  if (coverFilter !== undefined) baseFilter.cover = coverFilter;
+
+  const cacheKey = CacheKeys.songs.filtered({
+    timeRange: timeRangeParam || null,
+    played: playedParam || null,
+    author: authorId || null,
+    cover: coverParam || null,
+    attended: attendedUserId || null,
+    filters: filtersParam || null,
+  });
+
   return await services.cache.getOrSet(
     cacheKey,
     async () => {
-      const allSongs = dateRange
-        ? await services.songs.findManyInDateRange(dateRange)
-        : await services.songs.findMany({});
+      const allSongs = await services.songs.findMany(baseFilter);
 
-      const songs = allSongs.filter((song) => song.timesPlayed > 0);
-      const songsWithVenueInfo = await addVenueInfoToSongs(songs);
-      return { songs: songsWithVenueInfo };
+      const scopeCountsById = await computeScopeCounts({
+        url,
+        context,
+        baseFilter,
+        attendedUserId,
+        timeRangeParam,
+        hasDateRange,
+        hasAttendedUser,
+        hasToggleFilters,
+      });
+
+      let result: Song[];
+      if (!scopeCountsById) {
+        result = allSongs.filter((song) => song.timesPlayed > 0);
+      } else if (showNotPlayed) {
+        result = allSongs
+          .filter((song) => song.timesPlayed > 0 && !scopeCountsById.has(song.id))
+          .sort((a, b) => b.timesPlayed - a.timesPlayed);
+      } else {
+        result = allSongs
+          .filter((song) => scopeCountsById.has(song.id))
+          .map((song) => ({ ...song, filteredTimesPlayed: scopeCountsById.get(song.id) }));
+      }
+
+      return await addVenueInfoToSongs(result);
     },
     { ttl: 3600 },
   );
+}
+
+interface ScopeContext {
+  url: URL;
+  context: PublicContext;
+  baseFilter: BaseFilter;
+  attendedUserId: string | undefined;
+  timeRangeParam: string | null;
+  hasDateRange: boolean;
+  hasAttendedUser: boolean;
+  hasToggleFilters: boolean;
+}
+
+/**
+ * Returns scope counts as a `Map<songId, count>` for whichever narrowing
+ * filter is active, or `null` when no narrowing is happening. Dispatch:
+ * `buildSongPerformanceCounts` is the only counter that understands toggle
+ * flags, so any toggle wins; otherwise date range or attended routes
+ * through the song service. The two paths count differently on same-show
+ * repeats (distinct-tracks vs distinct-shows-with-track) — call sites
+ * surface whichever the active filter selects.
+ */
+async function computeScopeCounts(scope: ScopeContext): Promise<Map<string, number> | null> {
+  const { url, context, baseFilter, attendedUserId, timeRangeParam, hasDateRange, hasAttendedUser, hasToggleFilters } =
+    scope;
+
+  if (hasToggleFilters) {
+    const performanceFilters = await parsePerformanceFilters(url, context);
+    const counts = await services.songPageComposer.buildSongPerformanceCounts(performanceFilters);
+    return new Map(Object.entries(counts).filter(([, c]) => c > 0));
+  }
+
+  if (hasDateRange) {
+    const dateRange = await resolveDateRangeForTimeRange(timeRangeParam);
+    if (!dateRange) return new Map();
+    const scoped = await services.songs.findManyInDateRange({
+      ...baseFilter,
+      ...(attendedUserId ? { attendedUserId } : {}),
+      ...dateRange,
+    });
+    return new Map(scoped.filter((song) => song.timesPlayed > 0).map((song) => [song.id, song.timesPlayed]));
+  }
+
+  if (hasAttendedUser) {
+    const scoped = await services.songs.findMany({ ...baseFilter, attendedUserId });
+    return new Map(scoped.filter((song) => song.timesPlayed > 0).map((song) => [song.id, song.timesPlayed]));
+  }
+
+  return null;
+}
+
+async function resolveDateRangeForTimeRange(
+  timeRangeParam: string | null,
+): Promise<{ startDate?: Date; endDate?: Date } | null> {
+  if (timeRangeParam === "last10shows") {
+    return await resolveLast10ShowsDateRange();
+  }
+  if (timeRangeParam && timeRangeParam in SONG_FILTERS) {
+    const { startDate, endDate } = SONG_FILTERS[timeRangeParam];
+    return { startDate, endDate };
+  }
+  return null;
 }
 
 /**
@@ -40,7 +170,6 @@ export async function loadSongsWithVenueInfo(
 export async function addVenueInfoToSongs(
   songs: Song[],
 ): Promise<Array<Song & { firstPlayedShow: Show | null; lastPlayedShow: Show | null }>> {
-  // Get unique show dates for first/last played venue lookup
   const showDates = new Set<string>();
   songs.forEach((song) => {
     if (song.dateFirstPlayed) {

--- a/apps/web/app/routes/api/songs.tsx
+++ b/apps/web/app/routes/api/songs.tsx
@@ -1,156 +1,37 @@
-import type { Song } from "@bip/domain";
-import { CacheKeys } from "@bip/domain/cache-keys";
 import { publicLoader } from "~/lib/base-loaders";
 import { logger } from "~/lib/logger";
-import {
-  parsePerformanceFilters,
-  resolveAttendedUserId,
-  resolveLast10ShowsDateRange,
-} from "~/lib/performance-filter-params";
-import { shouldShowNotPlayed } from "~/lib/played-filter";
-import { getTimeRangeParam, SONG_FILTERS } from "~/lib/song-filters";
-import { addVenueInfoToSongs } from "~/lib/song-utilities";
+import { fetchFilteredSongs } from "~/lib/song-utilities";
 import { services } from "~/server/services";
 
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const FILTER_PARAMS = ["timeRange", "year", "era", "played", "author", "cover", "attended", "filters"] as const;
 
-/**
- * For "not played" songs: returns songs matching the base filters (author/cover)
- * that have been played overall but NOT in the date-range results.
- * For "played" songs: filters to those with timesPlayed > 0 in the filtered results.
- */
-async function splitByPlayStatus(
-  filteredSongs: Song[],
-  showNotPlayed: boolean,
-  baseFilter: { authorId?: string; cover?: boolean; attendedUserId?: string },
-): Promise<Song[]> {
-  const playedInFilter = filteredSongs.filter((song) => song.timesPlayed > 0);
-
-  if (!showNotPlayed) {
-    return playedInFilter;
-  }
-
-  // Get all songs matching author/cover, but without date range or attended constraint.
-  // This ensures "not played" = played overall but not in the filtered view.
-  const { attendedUserId: _, ...baseFilterWithoutAttended } = baseFilter;
-  const allSongs = await services.songs.findMany(baseFilterWithoutAttended);
-  const allSongsPlayed = allSongs.filter((song) => song.timesPlayed > 0);
-
-  // Songs NOT played in this filter = matching played songs minus filter played
-  const playedIds = new Set(playedInFilter.map((song) => song.id));
-  const notPlayed = allSongsPlayed.filter((song) => !playedIds.has(song.id));
-
-  // Sort by overall timesPlayed descending (most popular first)
-  return notPlayed.sort((a, b) => b.timesPlayed - a.timesPlayed);
+function hasAnyFilterParam(url: URL): boolean {
+  return FILTER_PARAMS.some((key) => url.searchParams.has(key));
 }
 
 export const loader = publicLoader(async ({ request, context }) => {
   const url = new URL(request.url);
   const query = url.searchParams.get("q");
-  const timeRangeParam = getTimeRangeParam(url.searchParams);
-  const playedParam = url.searchParams.get("played");
-  const authorParam = url.searchParams.get("author");
-  const coverParam = url.searchParams.get("cover");
-  const attendedParam = url.searchParams.get("attended");
-  const filtersParam = url.searchParams.get("filters");
 
-  const coverFilter = coverParam === "cover" ? true : coverParam === "original" ? false : undefined;
-
-  const authorId = authorParam ? (UUID_REGEX.test(authorParam) ? authorParam : null) : null;
-  if (authorParam && !authorId) {
-    logger.warn("Ignoring invalid author filter", { authorParam });
-  }
-
-  const attendedUserId = await resolveAttendedUserId(attendedParam, context);
-
-  const hasDateRange = timeRangeParam === "last10shows" || (timeRangeParam && timeRangeParam in SONG_FILTERS);
-
-  const hasToggleFilters = !!filtersParam;
-
-  // Handle filtering by author, cover, date range, attended, toggle filters, or any combination
-  if (authorId || coverFilter !== undefined || hasDateRange || attendedUserId || hasToggleFilters) {
+  // The `q=` path is a name-search fallback used by the admin SongSearch
+  // (track-manager). It bypasses the filter pipeline entirely — no cache,
+  // no venue info, just a string match against song titles.
+  if (!hasAnyFilterParam(url) && query && query.length >= 2) {
+    logger.info(`Song search for '${query}'`);
     try {
-      const cacheKey = CacheKeys.songs.filtered({
-        timeRange: timeRangeParam || null,
-        played: playedParam || null,
-        author: authorId || null,
-        cover: coverParam || null,
-        attended: attendedUserId || null,
-        filters: filtersParam || null,
-      });
-
-      return await services.cache.getOrSet(
-        cacheKey,
-        async () => {
-          const filter: {
-            authorId?: string;
-            cover?: boolean;
-            startDate?: Date;
-            endDate?: Date;
-            attendedUserId?: string;
-          } = {};
-          if (authorId) filter.authorId = authorId;
-          if (coverFilter !== undefined) filter.cover = coverFilter;
-          if (attendedUserId) filter.attendedUserId = attendedUserId;
-
-          let songs: Song[];
-          if (timeRangeParam === "last10shows") {
-            const dateRange = await resolveLast10ShowsDateRange();
-            if (dateRange) {
-              songs = await services.songs.findManyInDateRange({ startDate: dateRange.startDate, ...filter });
-            } else {
-              songs = await services.songs.findMany(filter);
-            }
-          } else if (timeRangeParam && timeRangeParam in SONG_FILTERS) {
-            const { startDate, endDate } = SONG_FILTERS[timeRangeParam];
-            songs = await services.songs.findManyInDateRange({ startDate, endDate, ...filter });
-          } else {
-            songs = await services.songs.findMany(filter);
-          }
-
-          // When toggle filters are active, cross-reference with performance counts
-          if (hasToggleFilters) {
-            const performanceFilters = await parsePerformanceFilters(url, context);
-            const counts = await services.songPageComposer.buildSongPerformanceCounts(performanceFilters);
-
-            songs = songs
-              .filter((song) => (counts[song.id] ?? 0) > 0)
-              .map((song) => ({ ...song, timesPlayed: counts[song.id] }));
-          }
-
-          const filtered = await splitByPlayStatus(
-            songs,
-            shouldShowNotPlayed({
-              playedParam,
-              hasDateRange: !!hasDateRange,
-              hasAttendedUser: !!attendedUserId,
-              hasToggleFilters,
-            }),
-            filter,
-          );
-          return await addVenueInfoToSongs(filtered);
-        },
-        { ttl: 3600 },
-      );
+      const songs = await services.songs.search(query, 20);
+      logger.info(`Song search for '${query}' returned ${songs.length} results`);
+      return songs;
     } catch (error) {
-      logger.error("Error fetching filtered songs", { error });
+      logger.error("Song search error", { error });
       return [];
     }
   }
 
-  // Handle search query
-  if (!query || query.length < 2) {
-    return [];
-  }
-
-  logger.info(`Song search for '${query}'`);
-
   try {
-    const songs = await services.songs.search(query, 20);
-    logger.info(`Song search for '${query}' returned ${songs.length} results`);
-    return songs;
+    return await fetchFilteredSongs(url, context);
   } catch (error) {
-    logger.error("Song search error", { error });
+    logger.error("Error fetching filtered songs", { error });
     return [];
   }
 });

--- a/apps/web/app/routes/songs/_index.test.tsx
+++ b/apps/web/app/routes/songs/_index.test.tsx
@@ -7,8 +7,10 @@ import { describe, expect, test, vi } from "vitest";
 vi.mock("~/server/services", () => ({ services: {} }));
 vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
 vi.mock("~/lib/seo", () => ({ getSongsMeta: vi.fn() }));
-vi.mock("~/lib/song-utilities", () => ({ addVenueInfoToSongs: vi.fn() }));
-vi.mock("@bip/domain/cache-keys", () => ({ CacheKeys: { songs: { index: vi.fn() } } }));
+vi.mock("~/lib/song-utilities", () => ({
+  addVenueInfoToSongs: vi.fn(),
+  fetchFilteredSongs: vi.fn(),
+}));
 
 vi.mock("~/hooks/use-serialized-loader-data", () => ({
   useSerializedLoaderData: vi.fn(() => ({ songs: [] })),

--- a/apps/web/app/routes/songs/_index.tsx
+++ b/apps/web/app/routes/songs/_index.tsx
@@ -1,13 +1,13 @@
 import type { Song } from "@bip/domain";
-import { CacheKeys } from "@bip/domain/cache-keys";
 import { FilteredSongsTable } from "~/components/song/filtered-songs-table";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
 import { getSongsMeta } from "~/lib/seo";
-import { loadSongsWithVenueInfo } from "~/lib/song-utilities";
+import { fetchFilteredSongs } from "~/lib/song-utilities";
 
-export const loader = publicLoader(async () => {
-  return loadSongsWithVenueInfo(CacheKeys.songs.index());
+export const loader = publicLoader(async ({ request, context }) => {
+  const url = new URL(request.url);
+  return { songs: await fetchFilteredSongs(url, context) };
 });
 
 export function meta() {

--- a/apps/web/app/routes/songs/recent.test.tsx
+++ b/apps/web/app/routes/songs/recent.test.tsx
@@ -6,9 +6,10 @@ import { describe, expect, test, vi } from "vitest";
 // Mock server-side modules
 vi.mock("~/server/services", () => ({ services: {} }));
 vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
-vi.mock("~/lib/song-utilities", () => ({ addVenueInfoToSongs: vi.fn() }));
-vi.mock("~/lib/performance-filter-params", () => ({ resolveLast10ShowsDateRange: vi.fn() }));
-vi.mock("@bip/domain/cache-keys", () => ({ CacheKeys: { songs: { filtered: vi.fn() } } }));
+vi.mock("~/lib/song-utilities", () => ({
+  addVenueInfoToSongs: vi.fn(),
+  fetchFilteredSongs: vi.fn(),
+}));
 
 vi.mock("~/hooks/use-serialized-loader-data", () => ({
   useSerializedLoaderData: vi.fn(() => ({ songs: [] })),

--- a/apps/web/app/routes/songs/recent.tsx
+++ b/apps/web/app/routes/songs/recent.tsx
@@ -1,17 +1,16 @@
 import type { Song } from "@bip/domain";
-import { CacheKeys } from "@bip/domain/cache-keys";
 import { FilteredSongsTable } from "~/components/song/filtered-songs-table";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
-import { resolveLast10ShowsDateRange } from "~/lib/performance-filter-params";
-import { loadSongsWithVenueInfo } from "~/lib/song-utilities";
+import { fetchFilteredSongs } from "~/lib/song-utilities";
 
-export const loader = publicLoader(async () => {
-  const dateRange = await resolveLast10ShowsDateRange();
-  return loadSongsWithVenueInfo(
-    CacheKeys.songs.filtered({ timeRange: "last10shows" }),
-    dateRange ?? undefined,
-  );
+export const loader = publicLoader(async ({ request, context }) => {
+  // Synthesize the timeRange into the URL so fetchFilteredSongs sees the
+  // tab's implicit filter as if it were a regular query param. Same cache
+  // entry as /api/songs?timeRange=last10shows.
+  const url = new URL(request.url);
+  url.searchParams.set("timeRange", "last10shows");
+  return { songs: await fetchFilteredSongs(url, context) };
 });
 
 export function meta() {

--- a/apps/web/app/routes/songs/this-year.test.tsx
+++ b/apps/web/app/routes/songs/this-year.test.tsx
@@ -6,9 +6,10 @@ import { describe, expect, test, vi } from "vitest";
 // Mock server-side modules
 vi.mock("~/server/services", () => ({ services: {} }));
 vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
-vi.mock("~/lib/song-utilities", () => ({ addVenueInfoToSongs: vi.fn() }));
-vi.mock("~/lib/song-filters", () => ({ SONG_FILTERS: { thisYear: { startDate: new Date(), endDate: new Date() } } }));
-vi.mock("@bip/domain/cache-keys", () => ({ CacheKeys: { songs: { filtered: vi.fn() } } }));
+vi.mock("~/lib/song-utilities", () => ({
+  addVenueInfoToSongs: vi.fn(),
+  fetchFilteredSongs: vi.fn(),
+}));
 
 vi.mock("~/hooks/use-serialized-loader-data", () => ({
   useSerializedLoaderData: vi.fn(() => ({ songs: [] })),

--- a/apps/web/app/routes/songs/this-year.tsx
+++ b/apps/web/app/routes/songs/this-year.tsx
@@ -1,17 +1,16 @@
 import type { Song } from "@bip/domain";
-import { CacheKeys } from "@bip/domain/cache-keys";
 import { FilteredSongsTable } from "~/components/song/filtered-songs-table";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
-import { SONG_FILTERS } from "~/lib/song-filters";
-import { loadSongsWithVenueInfo } from "~/lib/song-utilities";
+import { fetchFilteredSongs } from "~/lib/song-utilities";
 
-export const loader = publicLoader(async () => {
-  const { startDate, endDate } = SONG_FILTERS.thisYear;
-  return loadSongsWithVenueInfo(
-    CacheKeys.songs.filtered({ timeRange: "thisYear" }),
-    { startDate, endDate },
-  );
+export const loader = publicLoader(async ({ request, context }) => {
+  // Synthesize the timeRange into the URL so fetchFilteredSongs sees the
+  // tab's implicit filter as if it were a regular query param. Same cache
+  // entry as /api/songs?timeRange=thisYear.
+  const url = new URL(request.url);
+  url.searchParams.set("timeRange", "thisYear");
+  return { songs: await fetchFilteredSongs(url, context) };
 });
 
 export function meta() {

--- a/packages/domain/src/models/song.ts
+++ b/packages/domain/src/models/song.ts
@@ -14,6 +14,10 @@ export const songSchema = z.object({
   history: z.string().nullable(),
   featuredLyric: z.string().nullable(),
   timesPlayed: z.number().default(0),
+  // Count of plays within the currently-applied filter scope (time range, toggles, etc.).
+  // Absent when no filter is active; the UI uses its presence to decide whether to render
+  // the "Filtered Plays" column alongside the all-time Plays column.
+  filteredTimesPlayed: z.number().optional(),
   dateLastPlayed: z.date().nullable(),
   dateFirstPlayed: z.date().nullable(),
   actualLastPlayedDate: z.date().nullable(),


### PR DESCRIPTION
## Summary

- **`/songs` UI**: replaces the "This Year" column with a sortable "Filtered Plays" column that shows the count under whatever filter is active (date range, attended, toggles like Set Opener/Encore). "Plays" stays as the all-time count. The new column appears only when a *narrowing* filter is active and `played !== "notPlayed"`. A same-direction tiebreaker on `filteredTimesPlayed` falls back to all-time `timesPlayed`.
- **Filter pipeline unified**: `fetchFilteredSongs` in `app/lib/song-utilities.ts` is now the single source of truth for the `Song[]` filter pipeline, called by both `/api/songs` and the page loaders for `/songs`, `/songs/this-year`, and `/songs/recent`. Page loaders are now filter-aware so React Router's loader revalidation handles filter changes — no more flash of un-counted rows on `/songs?timeRange=…`. `usePerformancePageFilters` gains `skipClientFetch` to opt out of the now-duplicate client request.
- **Pipeline structure**: all-time-first. `services.songs.findMany(baseFilter)` returns the canonical `Song[]` with all-time `timesPlayed`. Narrowing filters compute scope counts as `Map<id, count>` and attach as `filteredTimesPlayed`. The deleted `splitPlayCounts` / `splitByPlayStatus` / `loadSongsWithVenueInfo` are folded into this single pipeline.
- **New shared predicate**: `hasNarrowingFilter` in `app/lib/played-filter.ts` keeps the visibility rule consistent between client (Filtered Plays column) and server (`shouldShowNotPlayed`).


https://github.com/user-attachments/assets/e0f29871-0d20-4d32-a53a-e35242d02399


## Counts: 322 web tests + 68 core tests passing. Type clean. Biome clean on touched files.

## Test plan

- [ ] `/songs` no filter → 4 columns (Title, Plays, Last Played, First Played); sort defaults to Plays desc.
- [ ] `/songs?timeRange=1999` direct URL load → 5 columns on first paint, Filtered Plays populated, sort = Filtered Plays desc.
- [ ] `/songs` → click a filter → URL updates → rows refresh **without flash** (loader revalidation drives the new data).
- [ ] `/songs?filters=encore` → Filtered Plays = encore counts; Plays unchanged.
- [ ] `/songs?timeRange=1999&played=notPlayed` → 4 columns; Plays = all-time; Filtered Plays hidden.
- [ ] `/songs?cover=cover` (cover-only) → 4 columns; Filtered Plays hidden (cover isn't narrowing).
- [ ] `/songs/this-year` and `/songs/recent` → 5 columns, Filtered Plays populated on first paint.
- [ ] `/songs?q=…` (no other filters) → search fallback still returns matches (used by admin track-manager's SongSearch).
- [ ] `/songs/$slug`, `/songs/all-timers`, `/on-this-day` → behave identically to before.
- [ ] After deploy: one-time Redis blip — the unfiltered `/songs` cache entry moves from `songs:index:full` to a `buildFilteredCacheKey` hash. First post-deploy load misses; warms within an hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
