### PR TITLE
Mobile design pass across shows, songs, and song detail

### DIFF
--- a/apps/web/app/components/filter-nav.test.tsx
+++ b/apps/web/app/components/filter-nav.test.tsx
@@ -1,0 +1,60 @@
+import { setupWithRouter } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { FilterNav } from "./filter-nav";
+
+describe("FilterNav", () => {
+  // The (N) per-filter count is helpful on desktop but causes the labels
+  // to overlap on mobile (filter-by-year grid is too narrow). Hiding the
+  // count span via `hidden sm:inline` keeps the data in the DOM but
+  // suppresses it visually until sm+.
+  test("filter count spans use 'hidden sm:inline' so they hide on mobile", async () => {
+    await setupWithRouter(
+      <FilterNav
+        title="Filter by Year"
+        filters={["2024", "2025"]}
+        basePath="/shows/year/"
+        filterCounts={{ "2024": 12, "2025": 7 }}
+      />,
+    );
+
+    const countSpan = screen.getByText("(12)");
+    expect(countSpan.className).toContain("hidden");
+    expect(countSpan.className).toContain("sm:inline");
+  });
+
+  // The panel always collapses on mobile (so the long year list doesn't
+  // push the rest of the page out of the viewport) but stays expanded at
+  // sm+ by default. The mobile toggle button is `sm:hidden`; desktop gets
+  // a static heading.
+  test("renders a mobile toggle button (sm:hidden)", async () => {
+    await setupWithRouter(<FilterNav title="Filter by Year" filters={["2024"]} basePath="/shows/year/" />);
+
+    const trigger = screen.getByRole("button", { name: /Filter by Year/ });
+    expect(trigger.className).toContain("sm:hidden");
+  });
+
+  // On desktop the panel renders a non-button heading so the panel is
+  // always expanded and there is no functional toggle visible.
+  test("renders a static heading at sm+ (hidden sm:flex)", async () => {
+    const { container } = await setupWithRouter(
+      <FilterNav title="Filter by Year" filters={["2024"]} basePath="/shows/year/" />,
+    );
+
+    const desktopHeading = container.querySelector("h2");
+    expect(desktopHeading?.className).toContain("hidden");
+    expect(desktopHeading?.className).toContain("sm:flex");
+  });
+
+  // The "All" button's count should follow the same hide-on-mobile rule
+  // so it does not overlap the "All" label on phones.
+  test("allCount span uses 'hidden sm:inline' so it hides on mobile", async () => {
+    await setupWithRouter(
+      <FilterNav title="Filter by Year" filters={["2024"]} basePath="/shows/year/" showAllButton allCount={100} />,
+    );
+
+    const countSpan = screen.getByText("(100)");
+    expect(countSpan.className).toContain("hidden");
+    expect(countSpan.className).toContain("sm:inline");
+  });
+});

--- a/apps/web/app/components/filter-nav.tsx
+++ b/apps/web/app/components/filter-nav.tsx
@@ -45,7 +45,10 @@ export function FilterNav({
   filterCounts,
   allCount,
 }: FilterNavProps) {
-  const [expanded, setExpanded] = useState(defaultExpanded);
+  // The panel always collapses on mobile (`<sm`); on desktop it stays
+  // expanded unless the caller opts in with `defaultExpanded={false}`.
+  const [expanded, setExpanded] = useState(false);
+  const desktopCollapsible = !defaultExpanded;
 
   const subtitleCSS = cn(
     "text-xs font-normal text-content-text-tertiary",
@@ -73,50 +76,61 @@ export function FilterNav({
 
   const allSelected = currentFilter === null || currentFilter === undefined;
   const actualAllURL = allURL || basePath;
-  const canBeCollapsed = !defaultExpanded;
+
+  const headingContent = (
+    <>
+      {title}
+      {subtitle && <span className={subtitleCSS}>{subtitle}</span>}
+      {additionalText && <span className={subtitleCSS}>{additionalText}</span>}
+    </>
+  );
+
+  // The mobile toggle button is always rendered (`sm:hidden`). On desktop
+  // we render either a static h2 (always expanded) or the same toggle
+  // button (collapsible) depending on `defaultExpanded`.
+  const ToggleButton = (
+    <button
+      type="button"
+      className={cn(
+        "w-full flex items-center gap-2 text-sm font-semibold text-white cursor-pointer select-none transition-colors",
+        expanded ? "mb-3" : "mb-0",
+        !desktopCollapsible && "sm:hidden",
+        {
+          "hover:text-brand-primary": expanded,
+          "hover:text-brand-secondary": !expanded,
+        },
+      )}
+      onClick={() => setExpanded((v) => !v)}
+      aria-expanded={expanded}
+    >
+      {headingContent}
+      <span
+        className={cn("transition-transform duration-300 ml-2", {
+          "rotate-90": expanded,
+          "rotate-0": !expanded,
+        })}
+        aria-hidden
+      >
+        ▶
+      </span>
+    </button>
+  );
 
   return (
     <div className="card-premium rounded-lg overflow-hidden">
       <div className="px-4 py-3">
-        {canBeCollapsed ? (
-          <button
-            type="button"
-            className={cn(
-              "w-full flex items-center gap-2 text-sm font-semibold text-white mb-3 cursor-pointer select-none transition-colors",
-              {
-                "hover:text-brand-primary": expanded,
-                "hover:text-brand-secondary": !expanded,
-              },
-            )}
-            style={{ cursor: "pointer" }}
-            onClick={() => setExpanded((v) => !v)}
-            aria-expanded={expanded}
-          >
-            {title}
-            {subtitle && <span className={subtitleCSS}>{subtitle}</span>}
-            {additionalText && <span className={subtitleCSS}>{additionalText}</span>}
-            <span
-              className={cn("transition-transform duration-300 ml-2", {
-                "rotate-90": expanded,
-                "rotate-0": !expanded,
-              })}
-              aria-hidden
-            >
-              ▶
-            </span>
-          </button>
-        ) : (
-          <h2 className="text-sm font-semibold text-white mb-3 flex items-center gap-2">
-            {title}
-            {subtitle && <span className={subtitleCSS}>{subtitle}</span>}
-            {additionalText && <span className={subtitleCSS}>{additionalText}</span>}
-          </h2>
+        {ToggleButton}
+        {!desktopCollapsible && (
+          <h2 className="hidden sm:flex text-sm font-semibold text-white mb-3 items-center gap-2">{headingContent}</h2>
         )}
         <div
-          className={cn("overflow-hidden transition-all duration-300", {
-            "max-h-[1000px] opacity-100": expanded || !canBeCollapsed,
-            "max-h-0 opacity-0 pointer-events-none": !expanded && canBeCollapsed,
-          })}
+          className={cn(
+            "overflow-hidden transition-all duration-300",
+            expanded ? "max-h-[1000px] opacity-100" : "max-h-0 opacity-0 pointer-events-none",
+            // Desktop is always visible unless the caller opted into a
+            // desktop-collapsible variant via `defaultExpanded={false}`.
+            !desktopCollapsible && "sm:!max-h-[1000px] sm:!opacity-100 sm:!pointer-events-auto",
+          )}
         >
           <div className={cn("grid gap-1.5", columnCSS)}>
             {filters.map((filter) => {
@@ -125,7 +139,7 @@ export function FilterNav({
               const label = filterCounts ? (
                 <>
                   {filter}
-                  <span className="ml-1 text-xs opacity-70">({count ?? 0})</span>
+                  <span className="ml-1 text-xs opacity-70 hidden sm:inline">({count ?? 0})</span>
                 </>
               ) : (
                 filter
@@ -162,7 +176,9 @@ export function FilterNav({
                 })}
               >
                 All
-                {allCount !== undefined && <span className="ml-1 text-xs opacity-70">({allCount})</span>}
+                {allCount !== undefined && (
+                  <span className="ml-1 text-xs opacity-70 hidden sm:inline">({allCount})</span>
+                )}
               </Link>
             )}
           </div>

--- a/apps/web/app/components/performance/date-venue-cell.test.tsx
+++ b/apps/web/app/components/performance/date-venue-cell.test.tsx
@@ -1,0 +1,46 @@
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { DateVenueCell } from "./date-venue-cell";
+
+describe("DateVenueCell", () => {
+  // The date is the only always-visible piece on mobile; the venue line
+  // sits beneath it but is hidden by CSS at narrow widths so the column
+  // collapses to a single short line on phones.
+  test("renders date as the primary line", async () => {
+    await setup(<DateVenueCell date="2024-06-15" venue={{ name: "The Capitol Theatre", city: "Port Chester" }} />);
+
+    expect(screen.getByText("2024-06-15")).toBeInTheDocument();
+  });
+
+  // The venue line is rendered, but only visible at sm+ breakpoints. We
+  // verify presence + the responsive class so mobile column overlap (the
+  // bug this component fixes) cannot regress silently.
+  test("renders venue line with hidden sm:block so it is hidden on mobile", async () => {
+    await setup(<DateVenueCell date="2024-06-15" venue={{ name: "The Capitol Theatre", city: "Port Chester" }} />);
+
+    const venueLine = screen.getByText(/The Capitol Theatre/);
+    expect(venueLine.className).toContain("hidden");
+    expect(venueLine.className).toContain("sm:block");
+  });
+
+  // City and state are appended to the venue name when present so users
+  // can disambiguate venues with the same name (e.g. multiple Fillmores).
+  test("appends city and state to venue name", async () => {
+    await setup(
+      <DateVenueCell date="2024-06-15" venue={{ name: "The Fillmore", city: "Philadelphia", state: "PA" }} />,
+    );
+
+    expect(screen.getByText(/The Fillmore, Philadelphia, PA/)).toBeInTheDocument();
+  });
+
+  // When there is no venue, the venue line is omitted entirely (rather
+  // than rendering an empty bullet) so the cell collapses to date-only.
+  test("omits venue line when venue is undefined", async () => {
+    const { container } = await setup(<DateVenueCell date="2024-06-15" />);
+
+    expect(screen.getByText("2024-06-15")).toBeInTheDocument();
+    // Only the date div should render — no second child line.
+    expect(container.querySelectorAll("div").length).toBeLessThanOrEqual(1);
+  });
+});

--- a/apps/web/app/components/performance/date-venue-cell.tsx
+++ b/apps/web/app/components/performance/date-venue-cell.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+
+interface VenueInfo {
+  name?: string | null;
+  city?: string | null;
+  state?: string | null;
+}
+
+interface DateVenueCellProps {
+  date: ReactNode;
+  venue?: VenueInfo;
+}
+
+/**
+ * Combined Date + Venue cell for the performance tables (song-detail
+ * "All Performances" and /songs/all-timers). The date renders on top; the
+ * venue stacks beneath it at sm+ and is hidden on mobile so the column
+ * collapses to a single-line date at narrow widths.
+ */
+export function DateVenueCell({ date, venue }: DateVenueCellProps) {
+  const venueLabel = venue?.name ? [venue.name, venue.city, venue.state].filter(Boolean).join(", ") : null;
+
+  return (
+    <>
+      <div className="font-medium">{date}</div>
+      {venueLabel && <div className="text-xs text-content-text-tertiary mt-0.5 hidden sm:block">{venueLabel}</div>}
+    </>
+  );
+}

--- a/apps/web/app/components/performance/performance-columns.test.tsx
+++ b/apps/web/app/components/performance/performance-columns.test.tsx
@@ -45,19 +45,58 @@ const defaultOptions = {
 };
 
 describe("createPerformanceColumns", () => {
-  // The default column set (no optional columns) renders Date, Venue, Set,
-  // Sequence, Notes, and Rating headers. These are always present regardless
-  // of which page renders the table.
-  test("default columns include Date, Venue, Set, Sequence, Notes, Rating headers", async () => {
+  // The default column set renders Date, Set, Sequence, Notes, and Rating
+  // headers. Venue isn't a separate column — it's folded into the Date
+  // cell via DateVenueCell so narrow viewports show date-only and wider
+  // viewports stack venue beneath the date in the same column.
+  test("default columns include Date, Set, Sequence, Notes, Rating headers (Venue is not a separate column)", async () => {
     const columns = createPerformanceColumns(defaultOptions);
     await setup(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
 
     expect(screen.getByText("Date")).toBeInTheDocument();
-    expect(screen.getByText("Venue")).toBeInTheDocument();
     expect(screen.getByText("Set")).toBeInTheDocument();
     expect(screen.getByText("Sequence")).toBeInTheDocument();
     expect(screen.getByText("Notes")).toBeInTheDocument();
     expect(screen.getByText("Rating")).toBeInTheDocument();
+    // No standalone Venue column header — venue text lives in the Date cell.
+    expect(screen.queryByRole("columnheader", { name: "Venue" })).not.toBeInTheDocument();
+  });
+
+  // The Date cell renders the venue underneath the date so the venue
+  // information is preserved without a dedicated column. The venue line
+  // is responsive (hidden sm:block) but still in the DOM for desktop users.
+  test("Date cell renders venue name beneath the date", async () => {
+    const columns = createPerformanceColumns(defaultOptions);
+    await setup(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
+
+    expect(screen.getByText(/The Capitol Theatre, Port Chester, NY/)).toBeInTheDocument();
+  });
+
+  // The Notes column carries `hideOnMobile` so the long free-text annotations
+  // do not crowd narrow viewports — DataTable reads this meta and hides the
+  // column on mobile.
+  test("Notes column has meta.hideOnMobile = true", () => {
+    const columns = createPerformanceColumns(defaultOptions);
+    const notesColumn = columns.find((column) => "id" in column && column.id === "notes");
+    expect(notesColumn?.meta?.hideOnMobile).toBe(true);
+  });
+
+  // When the Song column is present (all-timers, on-this-day), Sequence
+  // gets hidden on mobile because the row is already too tight — Song is
+  // the more important column there.
+  test("Sequence column has meta.hideOnMobile when showSongColumn is true", () => {
+    const columns = createPerformanceColumns({ ...defaultOptions, showSongColumn: true });
+    const sequenceColumn = columns.find((column) => "id" in column && column.id === "sequence");
+    expect(sequenceColumn?.meta?.hideOnMobile).toBe(true);
+  });
+
+  // On the song-detail page the Song column is absent (we already know which
+  // song this is), leaving room for Sequence on mobile — and Sequence is
+  // one of the most useful columns in that view.
+  test("Sequence column does not hide on mobile when showSongColumn is false", () => {
+    const columns = createPerformanceColumns(defaultOptions);
+    const sequenceColumn = columns.find((column) => "id" in column && column.id === "sequence");
+    expect(sequenceColumn?.meta?.hideOnMobile).toBeFalsy();
   });
 
   // The Song column only appears on /songs/all-timers where performances
@@ -123,7 +162,9 @@ describe("createPerformanceColumns", () => {
     const columns = createPerformanceColumns(defaultOptions);
     await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
 
-    const dateLink = screen.getByRole("link", { name: "2024-06-15" });
+    // Date is formatted M/D/YYYY (formatDateShort) for visual consistency
+    // with /shows listings and song-detail stat cards.
+    const dateLink = screen.getByRole("link", { name: /6\/15\/2024/ });
     expect(dateLink).toHaveAttribute("href", "/shows/2024-06-15-the-cap");
   });
 
@@ -149,9 +190,6 @@ describe("createPerformanceColumns", () => {
     expect(ratingHeader?.querySelector("svg")).not.toBeNull();
 
     // Non-sortable columns render a plain <span> with no button
-    const venueHeader = screen.getByText("Venue").closest("th");
-    expect(venueHeader?.querySelector("button")).toBeNull();
-
     const sequenceHeader = screen.getByText("Sequence").closest("th");
     expect(sequenceHeader?.querySelector("button")).toBeNull();
   });

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -1,7 +1,9 @@
 import type { SongPagePerformance } from "@bip/domain";
 import { type Column, type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon, Flame } from "lucide-react";
+import { ShowDate } from "~/components/show-date";
 import { CombinedNotes } from "./combined-notes";
+import { DateVenueCell } from "./date-venue-cell";
 import { TrackRatingCell } from "./track-rating-cell";
 
 interface PerformanceColumnOptions {
@@ -51,11 +53,16 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
           const title = info.getValue() as string;
           const slug = info.row.original.songSlug;
           return slug ? (
-            <a href={`/songs/${slug}`} className="text-base text-brand-primary hover:text-brand-secondary font-medium">
+            <a
+              href={`/songs/${slug}`}
+              className="inline-block min-w-[10ch] text-base text-brand-primary hover:text-brand-secondary font-medium [overflow-wrap:anywhere]"
+            >
               {title}
             </a>
           ) : (
-            <span className="text-content-text-secondary">{title}</span>
+            <span className="inline-block min-w-[10ch] text-content-text-secondary [overflow-wrap:anywhere]">
+              {title}
+            </span>
           );
         },
       }) as ColumnDef<SongPagePerformance, unknown>,
@@ -67,7 +74,10 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       columnHelper.accessor((row) => row.allTimer ?? false, {
         id: "allTimer",
         header: "",
-        meta: { width: "24px" },
+        // Flame icon sits flush against the row edge at every viewport —
+        // the default cell padding (`px-1.5` on mobile, `sm:p-3` on
+        // desktop) doubles the visual width of the column for no benefit.
+        meta: { width: "24px", cellClassName: "px-0 sm:px-0" },
         enableSorting: false,
         cell: (info) => (info.getValue() ? <Flame className="h-3.5 w-3.5 text-orange-500" /> : null),
       }) as ColumnDef<SongPagePerformance, unknown>,
@@ -77,42 +87,24 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
   columns.push(
     columnHelper.accessor("show.date", {
       id: "date",
-      meta: { width: "120px" },
+      meta: { width: "180px" },
       header: ({ column }) => <SortableHeader column={column} label="Date" />,
       enableSorting: true,
       sortingFn: "datetime",
-      cell: (info) => (
-        <a
-          href={`/shows/${info.row.original.show.slug}`}
-          className="text-base text-brand-primary hover:text-brand-secondary"
-        >
-          {info.getValue()}
-        </a>
-      ),
-    }) as ColumnDef<SongPagePerformance, unknown>,
-    columnHelper.accessor(
-      (row) => ({
-        name: row.venue?.name,
-        city: row.venue?.city,
-        state: row.venue?.state,
-        slug: row.show.slug,
-      }),
-      {
-        id: "venue",
-        header: "Venue",
-        enableSorting: false,
-        cell: (info) => {
-          const venue = info.getValue();
-          return venue.city ? (
-            <a href={`/shows/${venue.slug}`} className="text-brand-primary hover:text-brand-secondary">
-              {venue.name}
-              <br />
-              {venue.city}, {venue.state}
-            </a>
-          ) : null;
-        },
+      cell: (info) => {
+        const date = info.getValue();
+        const showSlug = info.row.original.show.slug;
+        const venue = info.row.original.venue;
+        return (
+          <a href={`/shows/${showSlug}`} className="text-base text-brand-primary hover:text-brand-secondary block">
+            <DateVenueCell
+              date={<ShowDate date={date} />}
+              venue={{ name: venue?.name, city: venue?.city, state: venue?.state }}
+            />
+          </a>
+        );
       },
-    ) as ColumnDef<SongPagePerformance, unknown>,
+    }) as ColumnDef<SongPagePerformance, unknown>,
     columnHelper.accessor("set", {
       header: "Set",
       meta: { width: "48px" },
@@ -136,6 +128,10 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
         id: "sequence",
         header: "Sequence",
         enableSorting: false,
+        // Hidden on mobile only when there's a Song column already
+        // competing for room — the song-detail page (no Song column)
+        // has the slack to keep Sequence visible at narrow widths.
+        meta: { hideOnMobile: Boolean(showSongColumn) },
         cell: (info) => {
           const { before, after, currentSong } = info.getValue();
           const parts = [];
@@ -198,7 +194,9 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
             );
           }
 
-          return parts.length > 0 ? <div className="flex items-center flex-wrap">{parts}</div> : null;
+          return parts.length > 0 ? (
+            <div className="flex items-center flex-wrap [overflow-wrap:anywhere]">{parts}</div>
+          ) : null;
         },
       },
     ) as ColumnDef<SongPagePerformance, unknown>,
@@ -211,6 +209,7 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
         id: "notes",
         header: "Notes",
         enableSorting: false,
+        meta: { hideOnMobile: true },
         cell: (info) => {
           const { annotations, notes } = info.getValue();
           const items = [];

--- a/apps/web/app/components/performance/performance-filter-controls.test.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.test.tsx
@@ -184,6 +184,55 @@ describe("PerformanceFilterControls", () => {
     expect(handleUpdateFilter).not.toHaveBeenCalled();
   });
 
+  // On mobile the entire filter block is collapsed behind a "Filters"
+  // toggle button so it doesn't eat the viewport before any results show.
+  // The wrapper carries `hidden` until expanded; sm+ breakpoints keep it
+  // visible regardless via `sm:flex`/`sm:block`.
+  test("renders a mobile-only Filters toggle button (sm:hidden)", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} searchValue="" onSearchChange={() => {}} />);
+
+    const toggle = screen.getByRole("button", { name: /^Filters/ });
+    expect(toggle.className).toContain("sm:hidden");
+  });
+
+  // The filter content wrapper starts hidden on mobile and becomes visible
+  // when the toggle is clicked. At sm+ it is always visible regardless of
+  // the toggle state so desktop users see filters by default.
+  test("filter content is hidden on mobile by default and revealed when Filters is clicked", async () => {
+    const { user, container } = await setup(
+      <PerformanceFilterControls {...defaultProps} searchValue="" onSearchChange={() => {}} />,
+    );
+
+    const wrapper = container.querySelector("[data-testid='filter-content-wrapper']") as HTMLElement;
+    expect(wrapper.className).toContain("hidden");
+    expect(wrapper.className).toContain("sm:block");
+
+    await user.click(screen.getByRole("button", { name: /^Filters/ }));
+
+    // After click, mobile-collapse should release.
+    expect(wrapper.className).not.toMatch(/(^|\s)hidden(\s|$)/);
+  });
+
+  // The Filters toggle shows an active-filter count when filters are
+  // applied so users know there's state hidden behind the button without
+  // having to expand it.
+  test("Filters toggle shows count badge when filters are active", async () => {
+    await setup(
+      <PerformanceFilterControls
+        {...defaultProps}
+        searchValue=""
+        onSearchChange={() => {}}
+        hasActiveFilters
+        activeToggleSet={new Set(["jam", "encore"])}
+        selectedTimeRange="2024"
+      />,
+    );
+
+    const toggle = screen.getByRole("button", { name: /^Filters/ });
+    // Badge is the count of active filters (timeRange + 2 toggles = 3).
+    expect(toggle.textContent).toMatch(/3/);
+  });
+
   // Clicking Clear All delegates to the parent's clearFilters callback, which
   // resets all URL params and search text in the hook.
   test("clicking Clear All calls clearFilters", async () => {

--- a/apps/web/app/components/performance/performance-filter-controls.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.tsx
@@ -1,9 +1,11 @@
-import { type ReactNode, useEffect } from "react";
+import { ChevronDown } from "lucide-react";
+import { type ReactNode, useEffect, useState } from "react";
 import { AuthorSearch } from "~/components/author/author-search";
 import { SelectFilter } from "~/components/ui/filters";
 import { ToggleFilterGroup } from "~/components/ui/filters/toggle-filter-group";
 import { Input } from "~/components/ui/input";
 import { TIME_RANGE_GROUPS, TOGGLE_FILTER_DEFINITIONS } from "~/lib/song-filters";
+import { cn } from "~/lib/utils";
 
 const ALL_TOGGLE_FILTERS = TOGGLE_FILTER_DEFINITIONS as unknown as Array<{ key: string; label: string }>;
 
@@ -59,82 +61,110 @@ export function PerformanceFilterControls({
     }
   }, [showPlayedFilter, playedFilter, updateFilter]);
 
+  const activeFilterCount =
+    (searchValue && searchValue.length > 0 ? 1 : 0) +
+    (!hideTimeRange && selectedTimeRange !== "all" ? 1 : 0) +
+    (coverFilter && coverFilter !== "all" ? 1 : 0) +
+    (selectedAuthor ? 1 : 0) +
+    (playedFilter && playedFilter !== "all" ? 1 : 0) +
+    activeToggleSet.size;
+
+  const [mobileOpen, setMobileOpen] = useState(false);
+
   return (
     <div className="space-y-3">
-      <div className="flex items-end flex-wrap gap-x-3 gap-y-2">
-        {searchValue !== undefined && onSearchChange && (
-          <Input
-            placeholder="Search..."
-            value={searchValue}
-            onChange={(event) => onSearchChange(event.target.value)}
-            className="w-auto min-w-[200px] sm:min-w-[250px] max-w-md h-[34px] text-sm bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20 placeholder:text-content-text-tertiary"
-          />
-        )}
-        {!hideTimeRange && (
-          <SelectFilter
-            id="time-range-filter"
-            label="Time Range"
-            value={selectedTimeRange}
-            onValueChange={(value) => updateFilter({ timeRange: value })}
-            options={[{ value: "all", label: "All Time" }]}
-            groups={TIME_RANGE_GROUPS}
-            width="w-[200px]"
-          />
-        )}
-        {coverFilter !== undefined && (
-          <SelectFilter
-            id="cover-filter"
-            label="Original / Cover"
-            value={coverFilter}
-            onValueChange={(value) => updateFilter({ cover: value })}
-            options={[
-              { value: "all", label: "All" },
-              { value: "original", label: "Original" },
-              { value: "cover", label: "Cover" },
-            ]}
-            placeholder="Type"
-            width="w-[120px]"
-          />
-        )}
-        {selectedAuthor !== undefined && (
-          <div className="flex flex-col">
-            <label htmlFor="author-search" className={labelClass}>
-              Author
-            </label>
-            <AuthorSearch
-              value={selectedAuthor}
-              onValueChange={(value) => updateFilter({ author: value === "none" ? null : value })}
-              placeholder="All Authors"
-              className="w-[150px] sm:w-[200px] h-[34px] text-sm"
+      <button
+        type="button"
+        onClick={() => setMobileOpen((open) => !open)}
+        className="sm:hidden w-full flex items-center justify-between px-3 py-2 rounded-md bg-glass-bg border border-glass-border text-sm font-medium text-content-text-primary"
+        aria-expanded={mobileOpen}
+      >
+        <span className="flex items-center gap-2">
+          Filters
+          {activeFilterCount > 0 && (
+            <span className="px-2 py-0.5 rounded-full bg-brand-primary/20 text-brand-primary text-xs">
+              {activeFilterCount}
+            </span>
+          )}
+        </span>
+        <ChevronDown className={cn("h-4 w-4 transition-transform", mobileOpen && "rotate-180")} />
+      </button>
+      <div data-testid="filter-content-wrapper" className={cn("space-y-3 sm:block", mobileOpen ? "block" : "hidden")}>
+        <div className="flex items-end flex-wrap gap-x-3 gap-y-2">
+          {searchValue !== undefined && onSearchChange && (
+            <Input
+              placeholder="Search..."
+              value={searchValue}
+              onChange={(event) => onSearchChange(event.target.value)}
+              className="w-full sm:w-auto sm:min-w-[250px] sm:max-w-md h-[34px] text-sm bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20 placeholder:text-content-text-tertiary"
             />
-          </div>
-        )}
-        {showPlayedFilter && (
-          <SelectFilter
-            id="played-filter"
-            label="Played"
-            value={playedFilter}
-            onValueChange={(value) => updateFilter({ played: value })}
-            options={[
-              { value: "all", label: "All" },
-              { value: "notPlayed", label: "Not Played" },
-            ]}
-            width="w-[150px]"
-          />
-        )}
-        {extraSelectFilters}
-      </div>
-      <div className="flex flex-wrap gap-2 items-center">
-        <ToggleFilterGroup filters={toggleFilters} activeFilters={activeToggleSet} onToggle={toggleFilter} />
-        {hasActiveFilters && (
-          <button
-            type="button"
-            onClick={clearFilters}
-            className="px-3 py-1.5 text-sm rounded-md bg-transparent border border-glass-border text-content-text-tertiary hover:text-content-text-secondary transition-colors"
-          >
-            Clear All
-          </button>
-        )}
+          )}
+          {!hideTimeRange && (
+            <SelectFilter
+              id="time-range-filter"
+              label="Time Range"
+              value={selectedTimeRange}
+              onValueChange={(value) => updateFilter({ timeRange: value })}
+              options={[{ value: "all", label: "All Time" }]}
+              groups={TIME_RANGE_GROUPS}
+              width="w-[200px]"
+            />
+          )}
+          {coverFilter !== undefined && (
+            <SelectFilter
+              id="cover-filter"
+              label="Original / Cover"
+              value={coverFilter}
+              onValueChange={(value) => updateFilter({ cover: value })}
+              options={[
+                { value: "all", label: "All" },
+                { value: "original", label: "Original" },
+                { value: "cover", label: "Cover" },
+              ]}
+              placeholder="Type"
+              width="w-[120px]"
+            />
+          )}
+          {selectedAuthor !== undefined && (
+            <div className="flex flex-col">
+              <label htmlFor="author-search" className={labelClass}>
+                Author
+              </label>
+              <AuthorSearch
+                value={selectedAuthor}
+                onValueChange={(value) => updateFilter({ author: value === "none" ? null : value })}
+                placeholder="All Authors"
+                className="w-[150px] sm:w-[200px] h-[34px] text-sm"
+              />
+            </div>
+          )}
+          {showPlayedFilter && (
+            <SelectFilter
+              id="played-filter"
+              label="Played"
+              value={playedFilter}
+              onValueChange={(value) => updateFilter({ played: value })}
+              options={[
+                { value: "all", label: "All" },
+                { value: "notPlayed", label: "Not Played" },
+              ]}
+              width="w-[150px]"
+            />
+          )}
+          {extraSelectFilters}
+        </div>
+        <div className="flex flex-wrap gap-2 items-center">
+          <ToggleFilterGroup filters={toggleFilters} activeFilters={activeToggleSet} onToggle={toggleFilter} />
+          {hasActiveFilters && (
+            <button
+              type="button"
+              onClick={clearFilters}
+              className="px-3 py-1.5 text-sm rounded-md bg-transparent border border-glass-border text-content-text-tertiary hover:text-content-text-secondary transition-colors"
+            >
+              Clear All
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/app/components/performance/performance-table.test.tsx
+++ b/apps/web/app/components/performance/performance-table.test.tsx
@@ -89,8 +89,10 @@ describe("PerformanceTable", () => {
     await setup(<PerformanceTable performances={performances} />);
 
     expect(screen.getAllByTestId("TrackRatingCell")).toHaveLength(2);
-    expect(screen.getByText("2024-06-15")).toBeInTheDocument();
-    expect(screen.getByText("2024-07-20")).toBeInTheDocument();
+    // Dates render via ShowDate (M/D/YYYY at sm+, M/D/YY on mobile); both
+    // spans are in the DOM regardless of viewport.
+    expect(screen.getByText("6/15/2024")).toBeInTheDocument();
+    expect(screen.getByText("7/20/2024")).toBeInTheDocument();
   });
 
   // The Song column is only needed on /songs/all-timers where performances

--- a/apps/web/app/components/performance/track-rating-cell.tsx
+++ b/apps/web/app/components/performance/track-rating-cell.tsx
@@ -93,11 +93,11 @@ export function TrackRatingCell({
 
   if (!isAuthenticated) {
     return (
-      <div className="w-[140px]">
+      <div className="w-auto sm:w-[140px]">
         <LoginPromptPopover message="Sign in to rate">{ratingButton}</LoginPromptPopover>
       </div>
     );
   }
 
-  return <div className="w-[140px]">{ratingButton}</div>;
+  return <div className="w-auto sm:w-[140px]">{ratingButton}</div>;
 }

--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -133,9 +133,9 @@ describe("SetlistCard", () => {
     expect(screen.getByText("Basis for a Day")).toBeInTheDocument();
   });
 
-  // Regression guard: callers that don't opt into collapsible (year route, etc.)
-  // still see the full body on first paint — the new mode must not change the
-  // default.
+  // Callers that don't opt into collapsible (year route, etc.) see the
+  // full body on first paint. Pinning the default so the collapsible mode
+  // can evolve without affecting non-collapsible callers.
   test("renders body by default when collapsible is not set", async () => {
     await setupWithRouter(
       <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={null} />,
@@ -204,7 +204,7 @@ describe("SetlistCard", () => {
     const body = screen.getByTestId("setlist-card-body");
     expect(body).toHaveAttribute("aria-hidden", "true");
 
-    const dateLink = screen.getByRole("link", { name: "4/14/2021" });
+    const dateLink = screen.getByRole("link", { name: /4\/14\/2021/ });
     await user.click(dateLink);
 
     expect(body).toHaveAttribute("aria-hidden", "true");

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -3,19 +3,19 @@ import { Check, Flame } from "lucide-react";
 import { memo, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { RatingComponent } from "~/components/rating";
+import { ShowDate } from "~/components/show-date";
 import { Card, CardContent, CardHeader } from "~/components/ui/card";
 import { LoginPromptPopover } from "~/components/ui/login-prompt-popover";
 import { StarRating } from "~/components/ui/star-rating";
 import { useSession } from "~/hooks/use-session";
 import { useAttendanceMutation } from "~/hooks/use-show-user-data";
-import { cn, formatDateShort } from "~/lib/utils";
+import { cn } from "~/lib/utils";
 import { AnniversaryBadge } from "./anniversary-badge";
 import { ShowExternalBadges, type ShowExternalSources } from "./show-external-badges";
 import { TrackRatingOverlay } from "./track-rating-overlay";
 
 interface SetlistCardProps {
   setlist: Setlist | SetlistLight;
-  className?: string;
   userAttendance: Attendance | null;
   userRating: Rating | number | null;
   showRating: number | null;
@@ -30,7 +30,6 @@ interface SetlistCardProps {
 
 function SetlistCardComponent({
   setlist,
-  className,
   userAttendance,
   userRating,
   showRating,
@@ -38,7 +37,6 @@ function SetlistCardComponent({
   collapsible = false,
 }: SetlistCardProps) {
   const { user } = useSession();
-  const formattedDate = formatDateShort(setlist.show.date);
   const [displayedRating, setDisplayedRating] = useState<number>(showRating ?? setlist.show.averageRating ?? 0);
   const [displayedCount, setDisplayedCount] = useState<number>(setlist.show.ratingsCount ?? 0);
   const [isRatingAnimating, setIsRatingAnimating] = useState(false);
@@ -181,12 +179,7 @@ function SetlistCardComponent({
   const orderedAnnotations = Array.from(uniqueAnnotations.values()).sort((a, b) => a.index - b.index);
 
   return (
-    <Card
-      className={cn(
-        "card-premium relative overflow-hidden transition-all duration-300 hover:shadow-lg hover:shadow-purple-900/30 hover:border-brand-primary/80",
-        className,
-      )}
-    >
+    <Card className="card-premium relative overflow-hidden">
       <CardHeader
         data-testid="setlist-card-header"
         onClick={
@@ -211,7 +204,7 @@ function SetlistCardComponent({
                 to={setlist.show.slug ? `/shows/${setlist.show.slug}` : `/shows`}
                 className="text-brand-primary hover:text-brand-secondary transition-colors"
               >
-                {formattedDate}
+                <ShowDate date={setlist.show.date} />
               </Link>
               <AnniversaryBadge showDate={setlist.show.date} />
             </div>
@@ -296,12 +289,13 @@ function SetlistCardComponent({
                 </button>
               </LoginPromptPopover>
             )}
-            <ShowExternalBadges
-              sources={externalSources ?? {}}
-              photosHref={setlist.show.slug ? `/shows/${setlist.show.slug}#photos` : undefined}
-              photosCount={setlist.show.showPhotosCount}
-              className="pr-2 sm:pr-3"
-            />
+            <div className="pr-2 sm:pr-3">
+              <ShowExternalBadges
+                sources={externalSources ?? {}}
+                photosHref={setlist.show.slug ? `/shows/${setlist.show.slug}#photos` : undefined}
+                photosCount={setlist.show.showPhotosCount}
+              />
+            </div>
           </div>
         </div>
       </CardHeader>

--- a/apps/web/app/components/setlist/setlist-highlights.tsx
+++ b/apps/web/app/components/setlist/setlist-highlights.tsx
@@ -1,7 +1,6 @@
 import type { Setlist } from "@bip/domain";
 import { FileText, Flame } from "lucide-react";
 import { Link } from "react-router";
-import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 
 interface SetlistHighlightsProps {
   setlist: Setlist;
@@ -30,64 +29,60 @@ export function SetlistHighlights({ setlist }: SetlistHighlightsProps) {
   }
 
   return (
-    <Card className="card-premium h-full">
-      <CardHeader className="border-b border-glass-border/50 px-6 py-4">
-        <CardTitle className="text-xl text-content-text-primary">Show Highlights</CardTitle>
-      </CardHeader>
-      <CardContent className="px-6 py-4 space-y-6">
-        {allTimerTracks.length > 0 && (
-          <div>
-            <h3 className="text-lg font-medium text-content-text-primary flex items-center gap-2 mb-3">
-              <Flame className="h-5 w-5 text-orange-500" />
-              <span>All-Timers</span>
-            </h3>
-            <ul className="space-y-2">
-              {allTimerTracks.map((track) => (
-                <li key={track.id} className="text-content-text-secondary">
-                  <div className="flex items-baseline">
-                    <span className="text-xs text-content-text-tertiary font-medium w-6">{track.set}</span>
+    <div className="card-premium rounded-lg px-3 py-2 space-y-3">
+      <h3 className="text-sm font-medium text-content-text-secondary">Show Highlights</h3>
+      {allTimerTracks.length > 0 && (
+        <div>
+          <h4 className="text-sm font-medium text-content-text-primary flex items-center gap-2 mb-1.5">
+            <Flame className="h-4 w-4 text-orange-500 shrink-0" />
+            <span>All-Timers</span>
+          </h4>
+          <ul className="space-y-0.5 pl-6">
+            {allTimerTracks.map((track) => (
+              <li key={track.id} className="text-content-text-secondary text-sm">
+                <div className="flex items-baseline gap-2">
+                  <span className="text-xs text-content-text-tertiary font-medium">{track.set}</span>
+                  <Link
+                    to={`/songs/${track.song?.slug}`}
+                    className="text-brand-tertiary hover:text-brand-primary hover:underline transition-colors"
+                  >
+                    {track.song?.title}
+                  </Link>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {tracksWithNotes.length > 0 && (
+        <div>
+          <h4 className="text-sm font-medium text-content-text-primary flex items-center gap-2 mb-1.5">
+            <FileText className="h-4 w-4 text-info shrink-0" />
+            <span>Track Notes</span>
+          </h4>
+          <ul className="space-y-2 pl-6">
+            {tracksWithNotes.map((track) => (
+              <li key={track.id} className="text-content-text-secondary text-sm">
+                <div className="flex items-baseline gap-2">
+                  <span className="text-xs text-content-text-tertiary font-medium">{track.set}</span>
+                  <div className="flex-1">
                     <Link
                       to={`/songs/${track.song?.slug}`}
-                      className="text-brand-tertiary hover:text-brand-primary hover:underline transition-colors"
+                      className="text-brand-primary hover:text-brand-secondary hover:underline transition-colors"
                     >
                       {track.song?.title}
                     </Link>
+                    <p className="text-xs text-content-text-tertiary mt-0.5 pl-2 border-l-2 border-glass-border">
+                      {track.note}
+                    </p>
                   </div>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-
-        {tracksWithNotes.length > 0 && (
-          <div>
-            <h3 className="text-lg font-medium text-content-text-primary flex items-center gap-2 mb-3">
-              <FileText className="h-5 w-5 text-info" />
-              <span>Track Notes</span>
-            </h3>
-            <ul className="space-y-3">
-              {tracksWithNotes.map((track) => (
-                <li key={track.id} className="text-content-text-secondary">
-                  <div className="flex items-baseline">
-                    <span className="text-xs text-content-text-tertiary font-medium w-6">{track.set}</span>
-                    <div className="flex-1">
-                      <Link
-                        to={`/songs/${track.song?.slug}`}
-                        className="text-brand-primary hover:text-brand-secondary hover:underline transition-colors"
-                      >
-                        {track.song?.title}
-                      </Link>
-                      <p className="text-sm text-content-text-tertiary mt-1 pl-1 border-l-2 border-glass-border ml-1">
-                        {track.note}
-                      </p>
-                    </div>
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-      </CardContent>
-    </Card>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
   );
 }

--- a/apps/web/app/components/setlist/setlist-list.tsx
+++ b/apps/web/app/components/setlist/setlist-list.tsx
@@ -26,8 +26,6 @@ interface SetlistListProps {
    * responsible for sorting setlists before passing them in.
    */
   groupByMonth?: boolean;
-  /** Forwarded to each SetlistCard (not the list container). */
-  className?: string;
   /**
    * When true, renders a left gutter with the 1-based rank (setlist index + 1)
    * next to each card. The caller orders the list by rank before passing it in.
@@ -43,7 +41,6 @@ export function SetlistList({
   initialUserData,
   empty,
   groupByMonth,
-  className,
   numbered,
   collapsible,
 }: SetlistListProps) {
@@ -60,7 +57,6 @@ export function SetlistList({
     const card = (
       <SetlistCard
         setlist={setlist}
-        className={className}
         userAttendance={attendanceMap.get(showId) ?? null}
         userRating={userRatingMap.get(showId) ?? null}
         showRating={liveAverage ?? setlist.show.averageRating ?? null}

--- a/apps/web/app/components/setlist/show-external-badges.test.tsx
+++ b/apps/web/app/components/setlist/show-external-badges.test.tsx
@@ -18,7 +18,7 @@ describe("ShowExternalBadges", () => {
     await setupWithRouter(
       <ShowExternalBadges
         sources={{
-          nugsUrl: "https://play.nugs.net/release/1",
+          nugsUrls: ["https://play.nugs.net/release/1"],
           archiveUrl: "https://archive.org/details/db2004",
           youtubeUrl: "https://youtube.com/watch?v=aaa",
         }}
@@ -39,10 +39,48 @@ describe("ShowExternalBadges", () => {
     );
   });
 
+  // Dual-billed nights (Disco Biscuits + Tractorbeam) surface two nugs
+  // releases for the same date. We render one favicon per release so users
+  // can tell at a glance there's more than one — disambiguating labels keep
+  // the link names unique for assistive tech.
+  test("renders one nugs favicon per release URL with disambiguated labels", async () => {
+    await setupWithRouter(
+      <ShowExternalBadges
+        sources={{
+          nugsUrls: ["https://play.nugs.net/release/biscuits", "https://play.nugs.net/release/tractorbeam"],
+        }}
+      />,
+    );
+
+    const first = screen.getByRole("link", { name: "Available on nugs.net (release 1)" });
+    const second = screen.getByRole("link", { name: "Available on nugs.net (release 2)" });
+    expect(first).toHaveAttribute("href", "https://play.nugs.net/release/biscuits");
+    expect(second).toHaveAttribute("href", "https://play.nugs.net/release/tractorbeam");
+  });
+
+  // Badge icons must carry shrink-0 so they don't get horizontally squeezed
+  // when the surrounding row has long sibling text (the "nugs icon looks
+  // squished" bug observed on /shows/top-rated mobile rows).
+  test("favicon icon and photos camera icon both carry shrink-0", async () => {
+    const { container } = await setupWithRouter(
+      <ShowExternalBadges
+        sources={{ nugsUrls: ["https://play.nugs.net/release/1"] }}
+        photosHref="/shows/x#photos"
+        photosCount={5}
+      />,
+    );
+
+    const favicon = container.querySelector("img");
+    expect(favicon?.className).toContain("shrink-0");
+
+    const cameraIcon = container.querySelector("svg");
+    expect(cameraIcon?.getAttribute("class") ?? "").toContain("shrink-0");
+  });
+
   // External-source links open in a new tab because they leave the site;
   // rel=noopener guards against tab-nabbing.
   test("external-source links open in a new tab with noopener rel", async () => {
-    await setupWithRouter(<ShowExternalBadges sources={{ nugsUrl: "https://play.nugs.net/release/1" }} />);
+    await setupWithRouter(<ShowExternalBadges sources={{ nugsUrls: ["https://play.nugs.net/release/1"] }} />);
 
     const link = screen.getByRole("link", { name: "Available on nugs.net" });
     expect(link).toHaveAttribute("target", "_blank");
@@ -52,16 +90,15 @@ describe("ShowExternalBadges", () => {
   // Undefined URLs collapse silently — the parent passes raw optional URLs
   // without per-field `&&` gates, so missing services just disappear.
   test("omits favicon links whose URL is undefined", async () => {
-    await setupWithRouter(<ShowExternalBadges sources={{ nugsUrl: "https://play.nugs.net/release/1" }} />);
+    await setupWithRouter(<ShowExternalBadges sources={{ nugsUrls: ["https://play.nugs.net/release/1"] }} />);
 
     expect(screen.getByRole("link", { name: "Available on nugs.net" })).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Available on archive.org" })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Video on YouTube" })).not.toBeInTheDocument();
   });
 
-  // Photos badge shows count + camera icon and links to the show's #photos
-  // anchor; it used to live in the card footer but was hoisted here so the
-  // visual grouping matches the external-source badges.
+  // Photos badge shows count + camera icon and links to the show's
+  // #photos anchor, alongside the external-source favicons.
   test("renders photos badge with count when href + positive count provided", async () => {
     await setupWithRouter(<ShowExternalBadges sources={{}} photosHref="/shows/2004-12-31#photos" photosCount={12} />);
 
@@ -85,15 +122,5 @@ describe("ShowExternalBadges", () => {
     await setupWithRouter(<ShowExternalBadges sources={{}} photosCount={5} />);
 
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
-  });
-
-  // Custom className is applied to the container so callers can tweak
-  // spacing/alignment per route without touching the component.
-  test("applies custom className to the container", async () => {
-    const { container } = await setupWithRouter(
-      <ShowExternalBadges sources={{ nugsUrl: "https://play.nugs.net/release/1" }} className="my-strip" />,
-    );
-
-    expect(container.firstChild).toHaveClass("my-strip");
   });
 });

--- a/apps/web/app/components/setlist/show-external-badges.tsx
+++ b/apps/web/app/components/setlist/show-external-badges.tsx
@@ -10,7 +10,13 @@ import { cn } from "~/lib/utils";
  * listing pages pre-resolve these once so per-row rendering stays cheap.
  */
 export interface ShowExternalSources {
-  nugsUrl?: string;
+  /**
+   * Every nugs.net release URL for the show date. Most dates have zero or
+   * one URL; dual-billed nights (Disco Biscuits + Tractorbeam) have two.
+   * Storing the full list lets the badge strip render one favicon per
+   * release so users can tell a rare two-release night at a glance.
+   */
+  nugsUrls?: string[];
   archiveUrl?: string;
   youtubeUrl?: string;
 }
@@ -26,7 +32,6 @@ interface ShowExternalBadgesProps {
   photosHref?: string;
   /** Count of photos attached to the show; suppresses the photos badge when zero. */
   photosCount?: number;
-  className?: string;
 }
 
 /**
@@ -52,8 +57,9 @@ interface PhotosBadgeProps {
   count: number | undefined;
 }
 
-const BADGE_LINK_CLASS = "opacity-80 hover:opacity-100 transition-opacity inline-flex items-center";
-const BADGE_ICON_CLASS = "h-5 w-5";
+const BADGE_LINK_CLASS =
+  "inline-flex items-center transition-transform hover:scale-110 hover:-translate-y-0.5 hover:drop-shadow-[0_0_6px_rgba(167,139,250,0.55)]";
+const BADGE_ICON_CLASS = "h-5 w-5 shrink-0";
 
 /**
  * A single favicon-as-link inside the badge strip. Owns its own absence —
@@ -89,14 +95,26 @@ function PhotosBadge({ href, count }: PhotosBadgeProps) {
  * photos anchor. Returns null when nothing matches so listing pages don't
  * show an empty strip.
  */
-export function ShowExternalBadges({ sources, photosHref, photosCount, className }: ShowExternalBadgesProps) {
+export function ShowExternalBadges({ sources, photosHref, photosCount }: ShowExternalBadgesProps) {
+  const nugsUrls = sources.nugsUrls ?? [];
   const hasAny =
-    sources.nugsUrl || sources.archiveUrl || sources.youtubeUrl || (photosHref && photosCount && photosCount > 0);
+    nugsUrls.length > 0 || sources.archiveUrl || sources.youtubeUrl || (photosHref && photosCount && photosCount > 0);
   if (!hasAny) return null;
 
   return (
-    <div className={cn("flex items-center gap-2", className)}>
-      <FaviconLink domain={EXTERNAL_SOURCE_DOMAINS.nugs} href={sources.nugsUrl} label="Available on nugs.net" />
+    <div className="flex items-center gap-2">
+      {/* One favicon per nugs release so dual-billed nights (Disco Biscuits +
+          Tractorbeam) read as "two releases" at a glance — that double-icon
+          is the cue users have asked for. Single-release nights look the same
+          as before. */}
+      {nugsUrls.map((url, index) => (
+        <FaviconLink
+          key={url}
+          domain={EXTERNAL_SOURCE_DOMAINS.nugs}
+          href={url}
+          label={nugsUrls.length > 1 ? `Available on nugs.net (release ${index + 1})` : "Available on nugs.net"}
+        />
+      ))}
       <FaviconLink domain={EXTERNAL_SOURCE_DOMAINS.youtube} href={sources.youtubeUrl} label="Video on YouTube" />
       <FaviconLink
         domain={EXTERNAL_SOURCE_DOMAINS.archive}

--- a/apps/web/app/components/setlist/track-rating-overlay.tsx
+++ b/apps/web/app/components/setlist/track-rating-overlay.tsx
@@ -5,12 +5,10 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from "~/components/ui/h
 import { Skeleton } from "~/components/ui/skeleton";
 import { StarRating } from "~/components/ui/star-rating";
 import { useSession } from "~/hooks/use-session";
-import { cn } from "~/lib/utils";
 
 interface TrackRatingOverlayProps {
   track: Track | TrackLight;
   children: React.ReactNode;
-  className?: string;
 }
 
 interface TrackDataResponse {
@@ -25,7 +23,7 @@ interface TrackDataResponse {
   userRating: number | null;
 }
 
-export function TrackRatingOverlay({ track, children, className }: TrackRatingOverlayProps) {
+export function TrackRatingOverlay({ track, children }: TrackRatingOverlayProps) {
   const { user } = useSession();
   const [isOpen, setIsOpen] = useState(false);
   const [data, setData] = useState<TrackDataResponse | null>(null);
@@ -73,7 +71,7 @@ export function TrackRatingOverlay({ track, children, className }: TrackRatingOv
 
   return (
     <HoverCard openDelay={600} closeDelay={200} onOpenChange={setIsOpen}>
-      <HoverCardTrigger asChild className={cn("cursor-pointer", className)}>
+      <HoverCardTrigger asChild className="cursor-pointer">
         {children}
       </HoverCardTrigger>
       <HoverCardContent

--- a/apps/web/app/components/show-date.tsx
+++ b/apps/web/app/components/show-date.tsx
@@ -1,0 +1,21 @@
+import { formatDateShort, formatDateShortMobile } from "~/lib/utils";
+
+interface ShowDateProps {
+  date: string | Date;
+}
+
+/**
+ * Single rendering point for show dates across the app. Outputs `M/D/YYYY`
+ * at sm+ and the compact `M/D/YY` on mobile so narrow tables (songs list,
+ * performance tables) stay readable without overlap. Centralizing here keeps
+ * date formatting consistent everywhere a show date is displayed — change
+ * the format once and every callsite follows.
+ */
+export function ShowDate({ date }: ShowDateProps) {
+  return (
+    <>
+      <span className="hidden sm:inline">{formatDateShort(date)}</span>
+      <span className="sm:hidden">{formatDateShortMobile(date)}</span>
+    </>
+  );
+}

--- a/apps/web/app/components/show-filters-nav.tsx
+++ b/apps/web/app/components/show-filters-nav.tsx
@@ -48,7 +48,7 @@ export function ShowFiltersNav({ basePath, currentURLParameters }: ShowFiltersNa
       <h2 className="text-[10px] font-semibold text-content-text-tertiary uppercase tracking-wide mb-1.5 text-center">
         Filter by Media
       </h2>
-      <div className="grid grid-cols-2 gap-1">
+      <div className="grid grid-cols-4 sm:grid-cols-2 gap-1">
         {FILTER_KEYS.map((key) => {
           const active = currentURLParameters.has(key);
           const next = new URLSearchParams(currentURLParameters);

--- a/apps/web/app/components/show/archive-recordings-card.test.tsx
+++ b/apps/web/app/components/show/archive-recordings-card.test.tsx
@@ -19,10 +19,11 @@ describe("ArchiveRecordingsCard", () => {
   });
 
   // A single recording is auto-picked as primary, rendered in the list,
-  // and embedded in the player below. No "in player below" hint because
-  // there's no ambiguity when only one recording exists.
-  test("renders one recording and embeds the player without the hint", async () => {
-    await setup(
+  // and embedded in the player after the user opens the collapsible
+  // toggle. No "in player below" hint because there's no ambiguity when
+  // only one recording exists.
+  test("renders one recording and embeds the player after expansion without the hint", async () => {
+    const { user } = await setup(
       <ArchiveRecordingsCard
         items={[
           {
@@ -42,6 +43,10 @@ describe("ArchiveRecordingsCard", () => {
     expect(screen.getByText("SBD > DAT")).toBeInTheDocument();
     expect(screen.queryByText("(in player below)")).not.toBeInTheDocument();
 
+    // Player is hidden behind a click-to-expand toggle by default.
+    expect(screen.queryByTestId("ArchiveMusicPlayer")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Play recording/ }));
+
     const player = screen.getByTestId("ArchiveMusicPlayer");
     expect(player).toHaveAttribute("data-identifier", "db2004-12-31.sbd.flac16");
     expect(player).toHaveAttribute("data-bare", "true");
@@ -49,9 +54,9 @@ describe("ArchiveRecordingsCard", () => {
 
   // With multiple recordings the primary (highest scoring — SBD > AUD)
   // gets the "in player below" hint, and only that one is fed to the
-  // embedded player.
+  // embedded player once the user opens the collapsible toggle.
   test("marks the primary recording and embeds only its identifier in the player", async () => {
-    await setup(
+    const { user } = await setup(
       <ArchiveRecordingsCard
         items={[
           {
@@ -76,6 +81,7 @@ describe("ArchiveRecordingsCard", () => {
     const audLink = screen.getByRole("link", { name: "db2004-12-31.aud.flac16" });
     expect(audLink).toBeInTheDocument();
 
+    await user.click(screen.getByRole("button", { name: /Play recording/ }));
     expect(screen.getByTestId("ArchiveMusicPlayer")).toHaveAttribute("data-identifier", "db2004-12-31.sbd.flac16");
   });
 

--- a/apps/web/app/components/show/archive-recordings-card.tsx
+++ b/apps/web/app/components/show/archive-recordings-card.tsx
@@ -1,5 +1,8 @@
 import { type ArchiveDotOrgRecording, pickPrimaryArchiveRecording } from "@bip/domain";
+import { ChevronDown } from "lucide-react";
+import { useState } from "react";
 import ArchiveMusicPlayer from "~/components/player";
+import { cn } from "~/lib/utils";
 import { ExternalSourceCard } from "./external-source-card";
 
 /**
@@ -57,12 +60,36 @@ export function ArchiveRecordingsCard({ items }: ArchiveRecordingsCardProps) {
             );
           })}
         </ul>
-        {primary && (
-          <div className="pt-3 border-t border-white/5">
-            <ArchiveMusicPlayer identifier={primary.identifier} bare />
-          </div>
-        )}
+        {primary && <CollapsiblePlayer identifier={primary.identifier} />}
       </div>
     </ExternalSourceCard>
+  );
+}
+
+/**
+ * Wraps the embedded archive.org player behind a click-to-expand toggle.
+ * Starts collapsed on every viewport because the player is heavy (iframe
+ * + autoload behavior) and most visitors don't engage with it; opening it
+ * is a deliberate "I want to listen" action.
+ */
+function CollapsiblePlayer({ identifier }: { identifier: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="pt-3 border-t border-white/5">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        className="w-full flex items-center justify-between text-sm font-medium text-content-text-secondary hover:text-content-text-primary transition-colors"
+      >
+        <span>{open ? "Hide player" : "Play recording"}</span>
+        <ChevronDown className={cn("h-4 w-4 transition-transform", open && "rotate-180")} />
+      </button>
+      {open && (
+        <div className="mt-3">
+          <ArchiveMusicPlayer identifier={identifier} bare />
+        </div>
+      )}
+    </div>
   );
 }

--- a/apps/web/app/components/show/external-link-card.tsx
+++ b/apps/web/app/components/show/external-link-card.tsx
@@ -33,7 +33,7 @@ export function ExternalLinkCard({ faviconDomain, title, items }: ExternalLinkCa
   if (items.length === 0) return null;
   return (
     <ExternalSourceCard faviconDomain={faviconDomain} title={title}>
-      <ul className="space-y-1 pl-6">
+      <ul className="space-y-0.5 pl-6">
         {items.map(({ url, label }) => (
           <li key={url}>
             <a

--- a/apps/web/app/components/show/external-source-card.tsx
+++ b/apps/web/app/components/show/external-source-card.tsx
@@ -21,9 +21,9 @@ interface ExternalSourceCardProps {
  */
 export function ExternalSourceCard({ faviconDomain, title, children }: ExternalSourceCardProps) {
   return (
-    <div className="bg-black/40 backdrop-blur-xl border border-white/10 rounded-lg p-4">
-      <div className="flex items-center gap-2 mb-2">
-        <img src={faviconSrc(faviconDomain)} alt="" className="h-4 w-4" />
+    <div className="card-premium rounded-lg px-3 py-2">
+      <div className="flex items-center gap-2 mb-1.5">
+        <img src={faviconSrc(faviconDomain)} alt="" className="h-4 w-4 shrink-0" />
         <h4 className="text-sm font-medium text-content-text-secondary">{title}</h4>
       </div>
       {children}

--- a/apps/web/app/components/show/show-photos.tsx
+++ b/apps/web/app/components/show/show-photos.tsx
@@ -6,10 +6,9 @@ import { cn } from "~/lib/utils";
 
 interface ShowPhotosProps {
   photos: ShowFile[];
-  className?: string;
 }
 
-export function ShowPhotos({ photos, className }: ShowPhotosProps) {
+export function ShowPhotos({ photos }: ShowPhotosProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [selectedPhoto, setSelectedPhoto] = useState<ShowFile | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -76,7 +75,7 @@ export function ShowPhotos({ photos, className }: ShowPhotosProps) {
   }
 
   return (
-    <div className={cn("relative group", className)}>
+    <div className="relative group">
       {/* Gradient edges for scroll indication */}
       <div className="absolute left-0 top-0 bottom-2 w-8 bg-gradient-to-r from-background to-transparent z-[5] pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity" />
       <div className="absolute right-0 top-0 bottom-2 w-8 bg-gradient-to-l from-background to-transparent z-[5] pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity" />
@@ -194,9 +193,7 @@ export function ShowPhotos({ photos, className }: ShowPhotosProps) {
           <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black via-black/80 to-transparent p-6 pt-12">
             <div className="flex items-end justify-between">
               <div>
-                {selectedPhoto?.label && (
-                  <p className="text-white font-medium text-lg">{selectedPhoto.label}</p>
-                )}
+                {selectedPhoto?.label && <p className="text-white font-medium text-lg">{selectedPhoto.label}</p>}
                 {selectedPhoto?.source && selectedPhoto.source !== selectedPhoto?.label && (
                   <p className="text-white/60 text-sm mt-0.5">{selectedPhoto.source}</p>
                 )}
@@ -221,14 +218,10 @@ export function ShowPhotos({ photos, className }: ShowPhotosProps) {
                       "flex-shrink-0 rounded-md overflow-hidden transition-all duration-200 border-2",
                       index === selectedIndex
                         ? "border-white scale-100 opacity-100 shadow-lg shadow-white/20"
-                        : "border-white/30 scale-95 opacity-60 hover:opacity-90 hover:scale-100 hover:border-white/50"
+                        : "border-white/30 scale-95 opacity-60 hover:opacity-90 hover:scale-100 hover:border-white/50",
                     )}
                   >
-                    <img
-                      src={photo.thumbnailUrl || photo.url}
-                      alt=""
-                      className="h-14 w-20 object-cover"
-                    />
+                    <img src={photo.thumbnailUrl || photo.url} alt="" className="h-14 w-20 object-cover" />
                   </button>
                 ))}
               </div>

--- a/apps/web/app/components/song/songs-columns.test.tsx
+++ b/apps/web/app/components/song/songs-columns.test.tsx
@@ -137,8 +137,7 @@ describe("getSongsColumns", () => {
   });
 
   // When showFilteredPlays is true, the factory inserts a "Filtered Plays"
-  // column next to Plays showing the scoped count. This is the replacement
-  // for the removed "This Year" column.
+  // column next to Plays showing the count scoped to the active filter.
   test("showFilteredPlays=true: Filtered Plays column renders the scoped count", async () => {
     await setupWithRouter(
       <DataTable
@@ -188,9 +187,9 @@ describe("getSongsColumns", () => {
     await setupWithRouter(<DataTable columns={baseColumns} data={[song]} hideSearch hidePagination />);
 
     // Date text is formatted (not ISO). Regex avoids pinning exact locale format.
-    expect(screen.getByText(/Jun 15, 2024/)).toBeInTheDocument();
+    expect(screen.getByText(/6\/15\/2024/)).toBeInTheDocument();
     // Wrapped in a link to the show
-    const showLink = screen.getByRole("link", { name: /Jun 15, 2024/ });
+    const showLink = screen.getByRole("link", { name: /6\/15\/2024/ });
     expect(showLink).toHaveAttribute("href", "/shows/2024-06-15-the-cap");
     // Venue line is rendered
     expect(screen.getByText(/The Capitol Theatre/)).toBeInTheDocument();
@@ -220,9 +219,9 @@ describe("getSongsColumns", () => {
     });
     await setupWithRouter(<DataTable columns={baseColumns} data={[song]} hideSearch hidePagination />);
 
-    expect(screen.getByText(/Jun 15, 2024/)).toBeInTheDocument();
+    expect(screen.getByText(/6\/15\/2024/)).toBeInTheDocument();
     // No link wraps the date
-    expect(screen.queryByRole("link", { name: /Jun 15, 2024/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /6\/15\/2024/ })).not.toBeInTheDocument();
   });
 
   // First Played cell mirrors Last Played exactly — same date-format +
@@ -236,8 +235,8 @@ describe("getSongsColumns", () => {
     });
     await setupWithRouter(<DataTable columns={baseColumns} data={[song]} hideSearch hidePagination />);
 
-    expect(screen.getByText(/Jul 4, 1995/)).toBeInTheDocument();
-    const showLink = screen.getByRole("link", { name: /Jul 4, 1995/ });
+    expect(screen.getByText(/7\/4\/1995/)).toBeInTheDocument();
+    const showLink = screen.getByRole("link", { name: /7\/4\/1995/ });
     expect(showLink).toHaveAttribute("href", "/shows/1995-07-04-red-rocks");
   });
 
@@ -405,6 +404,111 @@ describe("getSongsColumns", () => {
       .getAllByRole("link")
       .filter((el) => ["Home Again", "Crickets", "Plan B"].includes(el.textContent ?? ""));
     expect(titlesDesc.map((el) => el.textContent)).toEqual(["Crickets", "Plan B", "Home Again"]);
+  });
+
+  // On mobile, the Last Played and First Played dates render in a compact
+  // M/D/YY format so the column fits without overlap. The long format
+  // ("Jun 15, 2024") is preserved at sm+ so desktop users see the full date.
+  // Both formats are present in the DOM, gated by responsive Tailwind classes.
+  test("Last Played cell renders both compact (mobile) and long (desktop) date formats", async () => {
+    const song = makeSong({
+      dateLastPlayed: new Date("2024-06-15"),
+      lastPlayedShow: makeShow({ slug: "2024-06-15-the-cap" }),
+    });
+    await setupWithRouter(<DataTable columns={baseColumns} data={[song]} hideSearch hidePagination />);
+
+    // Long format visible at sm+ (hidden on mobile)
+    const longFormat = screen.getByText(/6\/15\/2024/);
+    expect(longFormat.className).toContain("hidden");
+    expect(longFormat.className).toContain("sm:inline");
+
+    // Compact format visible on mobile (hidden at sm+)
+    const compactFormat = screen.getByText("6/15/24");
+    expect(compactFormat.className).toContain("sm:hidden");
+  });
+
+  // Same dual-format treatment for First Played, mirroring Last Played so
+  // both date columns line up neatly at the same breakpoint.
+  test("First Played cell renders both compact (mobile) and long (desktop) date formats", async () => {
+    const song = makeSong({
+      dateFirstPlayed: new Date("1995-07-04"),
+      firstPlayedShow: makeShow({ id: "show-first", slug: "1995-07-04-red-rocks" }),
+    });
+    await setupWithRouter(<DataTable columns={baseColumns} data={[song]} hideSearch hidePagination />);
+
+    expect(screen.getByText(/7\/4\/1995/).className).toContain("hidden");
+    expect(screen.getByText("7/4/95").className).toContain("sm:hidden");
+  });
+
+  // The venue line beneath Last/First Played dates uses `hidden sm:block`
+  // so the cells collapse to date-only on mobile (matching the perf-table
+  // DateVenueCell pattern). Otherwise the wrapped venue text adds two
+  // extra lines per row on phones for marginal value.
+  test("Last Played venue line is hidden on mobile (hidden sm:block)", async () => {
+    const song = makeSong({
+      dateLastPlayed: new Date("2024-06-15"),
+      lastPlayedShow: makeShow({ slug: "2024-06-15-the-cap" }),
+    });
+    await setupWithRouter(<DataTable columns={baseColumns} data={[song]} hideSearch hidePagination />);
+
+    const venueLine = screen.getByText(/The Capitol Theatre/);
+    expect(venueLine.className).toContain("hidden");
+    expect(venueLine.className).toContain("sm:block");
+  });
+
+  test("First Played venue line is hidden on mobile (hidden sm:block)", async () => {
+    const song = makeSong({
+      dateFirstPlayed: new Date("1995-07-04"),
+      firstPlayedShow: makeShow({
+        id: "show-first",
+        slug: "1995-07-04-red-rocks",
+        venue: {
+          id: "v2",
+          slug: "red-rocks",
+          name: "Red Rocks Amphitheatre",
+          city: "Morrison",
+          state: "CO",
+          country: "USA",
+          createdAt: new Date("2020-01-01"),
+          updatedAt: new Date("2020-01-01"),
+          timesPlayed: 0,
+        },
+      }),
+    });
+    await setupWithRouter(<DataTable columns={baseColumns} data={[song]} hideSearch hidePagination />);
+
+    const venueLine = screen.getByText(/Red Rocks Amphitheatre/);
+    expect(venueLine.className).toContain("hidden");
+    expect(venueLine.className).toContain("sm:block");
+  });
+
+  // Plays and Filtered Plays are short-but-prone-to-overlap headers on
+  // narrow viewports. Both must allow text to wrap (no whitespace-nowrap)
+  // and use leading-tight so the wrapped lines stay compact.
+  test("Plays header allows wrap (whitespace-normal leading-tight)", async () => {
+    await setupWithRouter(<DataTable columns={baseColumns} data={[makeSong()]} hideSearch hidePagination />);
+
+    const playsButton = screen.getByRole("button", { name: /^Plays/i });
+    expect(playsButton.className).toContain("whitespace-normal");
+    expect(playsButton.className).toContain("leading-tight");
+  });
+
+  // When the table is showing both Plays and Filtered Plays, mobile real
+  // estate is too tight for both. The all-time Plays column hides on
+  // mobile so Filtered Plays (the count relevant to the active scope)
+  // gets the room. Desktop continues to show both columns.
+  test("Plays column has meta.hideOnMobile when showFilteredPlays is true", () => {
+    const columns = getSongsColumns({ showFilteredPlays: true });
+    const playsColumn = columns.find((column) => "accessorKey" in column && column.accessorKey === "timesPlayed");
+    expect(playsColumn?.meta?.hideOnMobile).toBe(true);
+  });
+
+  // When Filtered Plays is absent, Plays is the only count column on the
+  // table and must remain visible on mobile.
+  test("Plays column does not hide on mobile when showFilteredPlays is false", () => {
+    const columns = getSongsColumns({ showFilteredPlays: false });
+    const playsColumn = columns.find((column) => "accessorKey" in column && column.accessorKey === "timesPlayed");
+    expect(playsColumn?.meta?.hideOnMobile).toBeFalsy();
   });
 
   // The /songs page shows songs sorted by times played (most played first)

--- a/apps/web/app/components/song/songs-columns.tsx
+++ b/apps/web/app/components/song/songs-columns.tsx
@@ -8,21 +8,16 @@ interface SongWithShows extends Song {
 
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import { Link } from "react-router-dom";
+import { ShowDate } from "~/components/show-date";
 import { Button } from "~/components/ui/button";
 
-const formatDate = (date: Date) => {
-  return new Date(date).toLocaleDateString("en-US", {
-    timeZone: "UTC",
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-};
-
 const getSortIcon = (sortState: false | "asc" | "desc") => {
-  if (sortState === "asc") return <ArrowUp className="ml-2 h-4 w-4 text-brand-primary" />;
-  if (sortState === "desc") return <ArrowDown className="ml-2 h-4 w-4 text-brand-primary" />;
-  return <ArrowUpDown className="ml-2 h-4 w-4" />;
+  // Arrow sits below the label on mobile (the header uses flex-col there) so
+  // we drop the left margin in that layout and bring it back at sm+.
+  const className = "ml-0 sm:ml-2 h-4 w-4";
+  if (sortState === "asc") return <ArrowUp className={`${className} text-brand-primary`} />;
+  if (sortState === "desc") return <ArrowDown className={`${className} text-brand-primary`} />;
+  return <ArrowUpDown className={className} />;
 };
 
 interface GetSongsColumnsOptions {
@@ -44,7 +39,7 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
         <Button
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-          className="h-auto p-0 font-semibold text-left justify-start hover:bg-brand-primary/10 hover:text-brand-primary transition-colors"
+          className="h-auto p-0 font-semibold text-left justify-start hover:bg-brand-primary/10 hover:text-brand-primary transition-colors whitespace-normal leading-tight flex-col items-start gap-0 sm:flex-row sm:items-center sm:gap-2"
         >
           Song Title
           {getSortIcon(column.getIsSorted())}
@@ -56,7 +51,7 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
       return (
         <Link
           to={`/songs/${song.slug}`}
-          className="text-base text-brand-primary hover:text-brand-secondary font-medium"
+          className="inline-block min-w-[10ch] text-base text-brand-primary hover:text-brand-secondary font-medium [overflow-wrap:anywhere]"
         >
           {song.title}
         </Link>
@@ -66,13 +61,16 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
 
   const playsColumn: ColumnDef<SongWithShows> = {
     accessorKey: "timesPlayed",
-    meta: { width: "10%" },
+    // When Filtered Plays is also visible there isn't room for both count
+    // columns on mobile; the all-time count is the less specific of the
+    // two so it drops out at narrow widths.
+    meta: { width: "10%", hideOnMobile: showFilteredPlays },
     header: ({ column }) => {
       return (
         <Button
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-          className="h-auto p-0 font-semibold text-left justify-start hover:bg-brand-primary/10 hover:text-brand-primary transition-colors"
+          className="h-auto p-0 font-semibold text-left justify-start hover:bg-brand-primary/10 hover:text-brand-primary transition-colors whitespace-normal leading-tight flex-col items-start gap-0 sm:flex-row sm:items-center sm:gap-2"
         >
           Plays
           {getSortIcon(column.getIsSorted())}
@@ -97,7 +95,7 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
         <Button
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-          className="h-auto p-0 font-semibold text-left justify-start hover:bg-brand-primary/10 hover:text-brand-primary transition-colors whitespace-normal leading-tight"
+          className="h-auto p-0 font-semibold text-left justify-start hover:bg-brand-primary/10 hover:text-brand-primary transition-colors whitespace-normal leading-tight flex-col items-start gap-0 sm:flex-row sm:items-center sm:gap-2"
         >
           Filtered Plays
           {getSortIcon(column.getIsSorted())}
@@ -131,7 +129,7 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
         <Button
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-          className="h-auto p-0 font-semibold text-left justify-start hover:bg-brand-primary/10 hover:text-brand-primary transition-colors"
+          className="h-auto p-0 font-semibold text-left justify-start hover:bg-brand-primary/10 hover:text-brand-primary transition-colors whitespace-normal leading-tight flex-col items-start gap-0 sm:flex-row sm:items-center sm:gap-2"
         >
           Last Played
           {getSortIcon(column.getIsSorted())}
@@ -148,18 +146,22 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
               to={`/shows/${show.slug}`}
               className="text-brand-primary hover:text-brand-secondary transition-colors"
             >
-              <div>{formatDate(date)}</div>
+              <div>
+                <ShowDate date={date} />
+              </div>
               {show?.venue && (
-                <div className="text-content-text-tertiary text-sm hover:text-content-text-secondary">
+                <div className="text-content-text-tertiary text-sm hover:text-content-text-secondary hidden sm:block">
                   {show.venue.name}, {show.venue.city} {show.venue.state}
                 </div>
               )}
             </Link>
           ) : (
             <div>
-              <div className="text-content-text-secondary">{formatDate(date)}</div>
+              <div className="text-content-text-secondary">
+                <ShowDate date={date} />
+              </div>
               {show?.venue && (
-                <div className="text-content-text-tertiary text-sm">
+                <div className="text-content-text-tertiary text-sm hidden sm:block">
                   {show.venue.name}, {show.venue.city} {show.venue.state}
                 </div>
               )}
@@ -180,7 +182,7 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
         <Button
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-          className="h-auto p-0 font-semibold text-left justify-start hover:bg-brand-primary/10 hover:text-brand-primary transition-colors"
+          className="h-auto p-0 font-semibold text-left justify-start hover:bg-brand-primary/10 hover:text-brand-primary transition-colors whitespace-normal leading-tight flex-col items-start gap-0 sm:flex-row sm:items-center sm:gap-2"
         >
           First Played
           {getSortIcon(column.getIsSorted())}
@@ -197,18 +199,22 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
               to={`/shows/${show.slug}`}
               className="text-brand-primary hover:text-brand-secondary transition-colors"
             >
-              <div>{formatDate(date)}</div>
+              <div>
+                <ShowDate date={date} />
+              </div>
               {show?.venue && (
-                <div className="text-content-text-tertiary text-sm hover:text-content-text-secondary">
+                <div className="text-content-text-tertiary text-sm hover:text-content-text-secondary hidden sm:block">
                   {show.venue.name}, {show.venue.city} {show.venue.state}
                 </div>
               )}
             </Link>
           ) : (
             <div>
-              <div className="text-content-text-secondary">{formatDate(date)}</div>
+              <div className="text-content-text-secondary">
+                <ShowDate date={date} />
+              </div>
               {show?.venue && (
-                <div className="text-content-text-tertiary text-sm">
+                <div className="text-content-text-tertiary text-sm hidden sm:block">
                   {show.venue.name}, {show.venue.city} {show.venue.state}
                 </div>
               )}

--- a/apps/web/app/components/ui/data-table.test.tsx
+++ b/apps/web/app/components/ui/data-table.test.tsx
@@ -208,12 +208,46 @@ describe("DataTable", () => {
     expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
   });
 
-  // Pending: DataTable currently hardcodes column widths by ID
-  // (header.id === "title" etc.), a leaky abstraction. This test pins the
-  // desired behavior — a column's `meta.width` is applied as the header's
-  // CSS width — and should be un-skipped once DataTable reads from
-  // `column.columnDef.meta?.width` instead.
-  test("honors meta.width on column defs", async () => {
+  // Columns marked `meta.hideOnMobile` get `hidden sm:table-cell` on both
+  // the header and body cells so they disappear at narrow viewports without
+  // needing a separate mobile column set. Used for the perf-table Notes
+  // column and other long-text columns that crowd phones.
+  test("hideOnMobile meta adds hidden sm:table-cell to header and body cells", async () => {
+    const columnsWithHidden: ColumnDef<Row>[] = [
+      { accessorKey: "name", header: "Name" },
+      { accessorKey: "count", header: "Count", meta: { hideOnMobile: true } },
+    ];
+
+    await setup(<DataTable columns={columnsWithHidden} data={rows} hideSearch />);
+
+    const countHeader = screen.getByText("Count").closest("th");
+    expect(countHeader?.className).toContain("hidden");
+    expect(countHeader?.className).toContain("sm:table-cell");
+
+    const nameHeader = screen.getByText("Name").closest("th");
+    expect(nameHeader?.className ?? "").not.toContain("hidden");
+
+    const countCell = screen.getByText("3").closest("td");
+    expect(countCell?.className).toContain("hidden");
+    expect(countCell?.className).toContain("sm:table-cell");
+  });
+
+  // The table uses `table-auto` on mobile (lets columns size to content,
+  // avoiding header overlap) and `table-fixed` at sm+ (keeps the
+  // percentage-width sizing predictable on desktop).
+  test("table element uses table-auto on mobile and sm:table-fixed at sm+", async () => {
+    const { container } = await setup(<DataTable columns={basicColumns} data={rows} hideSearch />);
+
+    const tableEl = container.querySelector("table");
+    expect(tableEl?.className).toContain("table-auto");
+    expect(tableEl?.className).toContain("sm:table-fixed");
+  });
+
+  // `meta.width` is exposed as a CSS custom property and only takes effect
+  // at sm+ via a Tailwind class — on mobile the column sizes to content.
+  // Without this gating, desktop-tuned widths would starve other columns
+  // at phone widths (the bug observed on /songs/all-timers and /on-this-day).
+  test("honors meta.width via --col-w + sm:w-[var(--col-w)] on column defs", async () => {
     const columnsWithWidths: ColumnDef<Row>[] = [
       { accessorKey: "name", header: "Name", meta: { width: "60%" } },
       { accessorKey: "count", header: "Count", meta: { width: "40%" } },
@@ -224,7 +258,9 @@ describe("DataTable", () => {
     const nameHeader = screen.getByText("Name").closest("th");
     const countHeader = screen.getByText("Count").closest("th");
 
-    expect(nameHeader?.style.width).toBe("60%");
-    expect(countHeader?.style.width).toBe("40%");
+    expect(nameHeader?.style.getPropertyValue("--col-w")).toBe("60%");
+    expect(countHeader?.style.getPropertyValue("--col-w")).toBe("40%");
+    expect(nameHeader?.className).toContain("sm:w-[var(--col-w)]");
+    expect(countHeader?.className).toContain("sm:w-[var(--col-w)]");
   });
 });

--- a/apps/web/app/components/ui/data-table.tsx
+++ b/apps/web/app/components/ui/data-table.tsx
@@ -17,6 +17,7 @@ declare module "@tanstack/react-table" {
   interface ColumnMeta<TData extends RowData, TValue> {
     width?: string;
     cellClassName?: string;
+    hideOnMobile?: boolean;
   }
 }
 
@@ -105,14 +106,22 @@ export function DataTable<TData, TValue>({
   const paginationBlock = !hasResults ? null : (
     <div className="flex items-center justify-between px-2">
       {!hidePaginationText ? (
-        <div className="text-sm text-content-text-secondary font-medium">
-          {table.getFilteredRowModel().rows.length === 0
-            ? "0 results"
-            : `Showing ${table.getState().pagination.pageIndex * table.getState().pagination.pageSize + 1} to ${Math.min(
-                (table.getState().pagination.pageIndex + 1) * table.getState().pagination.pageSize,
-                table.getFilteredRowModel().rows.length,
-              )} of ${table.getFilteredRowModel().rows.length} results`}
-        </div>
+        (() => {
+          const total = table.getFilteredRowModel().rows.length;
+          if (total === 0) {
+            return <div className="text-sm text-content-text-secondary font-medium">0 results</div>;
+          }
+          const pageSize = table.getState().pagination.pageSize;
+          const pageIndex = table.getState().pagination.pageIndex;
+          const from = pageIndex * pageSize + 1;
+          const to = Math.min((pageIndex + 1) * pageSize, total);
+          return (
+            <div className="text-sm text-content-text-secondary font-medium">
+              <span className="hidden sm:inline">{`Showing ${from} to ${to} of ${total} results`}</span>
+              <span className="sm:hidden">{`${from}–${to} of ${total}`}</span>
+            </div>
+          );
+        })()
       ) : (
         <div />
       )}
@@ -181,18 +190,27 @@ export function DataTable<TData, TValue>({
       {!hidePagination && paginationBlock}
 
       <div className="overflow-x-auto w-full">
-        <Table className="w-full">
+        <Table className="w-full table-auto sm:table-fixed">
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id} className="text-left text-sm text-content-text-secondary">
                 {headerGroup.headers.map((header) => {
+                  const hideOnMobile = header.column.columnDef.meta?.hideOnMobile;
+                  // Width hint applies only at sm+ — on mobile we let
+                  // table-auto size columns to content. Without this,
+                  // desktop-tuned widths (e.g. 180px for the perf-table
+                  // Date column) would starve other columns on phones.
+                  const width = header.column.columnDef.meta?.width;
+                  const widthStyle = width ? ({ "--col-w": width } as React.CSSProperties) : undefined;
                   return (
                     <TableHead
                       key={header.id}
-                      className="p-3 text-sm text-content-text-secondary"
-                      style={{
-                        width: header.column.columnDef.meta?.width,
-                      }}
+                      className={cn(
+                        "px-1.5 py-2 sm:p-3 text-sm text-content-text-secondary align-top",
+                        hideOnMobile && "hidden sm:table-cell",
+                        width && "sm:w-[var(--col-w)]",
+                      )}
+                      style={widthStyle}
                     >
                       {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
                     </TableHead>
@@ -221,7 +239,14 @@ export function DataTable<TData, TValue>({
                   className={`border-t border-glass-border/30 hover:bg-hover-glass ${rowClassName?.(row.original, index) ?? ""}`}
                 >
                   {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id} className={cn("p-3", cell.column.columnDef.meta?.cellClassName)}>
+                    <TableCell
+                      key={cell.id}
+                      className={cn(
+                        "px-1.5 py-2 sm:p-3 align-top break-words",
+                        cell.column.columnDef.meta?.hideOnMobile && "hidden sm:table-cell",
+                        cell.column.columnDef.meta?.cellClassName,
+                      )}
+                    >
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </TableCell>
                   ))}

--- a/apps/web/app/lib/utils.ts
+++ b/apps/web/app/lib/utils.ts
@@ -24,13 +24,41 @@ export function getSafeRedirectUrl(url: string | null): string {
 
 export const ATTENDED_ROW_CLASS = "!border-l-2 !border-l-green-500 bg-green-500/5";
 
-export function formatDateShort(date: string): string {
-  const dateParts = date.split("T")[0].split("-");
-  if (dateParts.length === 3) {
-    const [year, month, day] = dateParts;
-    return `${Number.parseInt(month, 10)}/${Number.parseInt(day, 10)}/${year}`;
+/**
+ * Canonical desktop short date for show-related dates across the app
+ * (year listings, top-rated, songs/all-timers performance tables, song-detail
+ * stat cards). Output is `M/D/YYYY` with no leading zeros.
+ *
+ * Accepts either an ISO-like string ("2024-06-15", "2024-06-15T...") or a
+ * Date object. When a Date is passed, UTC fields drive the output so
+ * dates render the same regardless of the viewer's timezone — historical
+ * shows shouldn't shift to the previous day for users west of UTC.
+ */
+export function formatDateShort(date: string | Date): string {
+  const parts = extractDateParts(date);
+  if (!parts) return typeof date === "string" ? date : "";
+  return `${parts.month}/${parts.day}/${parts.year}`;
+}
+
+/**
+ * Compact mobile-only short date (`M/D/YY`). Used by `<ShowDate>` to render
+ * the same date in less horizontal space on phone-width tables.
+ */
+export function formatDateShortMobile(date: string | Date): string {
+  const parts = extractDateParts(date);
+  if (!parts) return typeof date === "string" ? date : "";
+  const yy = String(parts.year).slice(-2).padStart(2, "0");
+  return `${parts.month}/${parts.day}/${yy}`;
+}
+
+function extractDateParts(date: string | Date): { year: number; month: number; day: number } | null {
+  if (date instanceof Date) {
+    return { year: date.getUTCFullYear(), month: date.getUTCMonth() + 1, day: date.getUTCDate() };
   }
-  return date;
+  const dateParts = date.split("T")[0].split("-");
+  if (dateParts.length !== 3) return null;
+  const [year, month, day] = dateParts;
+  return { year: Number.parseInt(year, 10), month: Number.parseInt(month, 10), day: Number.parseInt(day, 10) };
 }
 
 const MAX_DAYS_PER_MONTH = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
@@ -53,6 +81,17 @@ export function isValidMonthDay(value: string): boolean {
 export function formatMonthDay(monthDay: string): string {
   const [mm, dd] = monthDay.split("-").map(Number);
   const monthName = new Date(2000, mm - 1, dd).toLocaleString("default", { month: "long" });
+  return `${monthName} ${dd}`;
+}
+
+/**
+ * Formats "MM-DD" as "Mon Day" (e.g., "04-04" → "Apr 4"). Used in tight
+ * layouts (mobile prev/next month links) where the full month name doesn't
+ * fit alongside the chevron and sibling links.
+ */
+export function formatMonthDayShort(monthDay: string): string {
+  const [mm, dd] = monthDay.split("-").map(Number);
+  const monthName = new Date(2000, mm - 1, dd).toLocaleString("default", { month: "short" });
   return `${monthName} ${dd}`;
 }
 

--- a/apps/web/app/routes/on-this-day.$monthDay.tsx
+++ b/apps/web/app/routes/on-this-day.$monthDay.tsx
@@ -10,7 +10,7 @@ import type { ShowExternalSources } from "~/components/setlist/show-external-bad
 import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
-import { addDaysYearAgnostic, formatMonthDay, isValidMonthDay } from "~/lib/utils";
+import { addDaysYearAgnostic, formatMonthDay, formatMonthDayShort, isValidMonthDay } from "~/lib/utils";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
 import { computeShowUserData, type ShowUserDataResponse } from "~/server/show-user-data";
@@ -139,7 +139,8 @@ export default function OnThisDay() {
               className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors"
             >
               <ChevronLeft className="h-3 w-3" />
-              <span>{formatMonthDay(previousMonthDay)}</span>
+              <span className="sm:hidden">{formatMonthDayShort(previousMonthDay)}</span>
+              <span className="hidden sm:inline">{formatMonthDay(previousMonthDay)}</span>
             </Link>
             <MonthDayPicker monthDay={monthDay} displayLabel={displayLabel} />
             <Link
@@ -147,7 +148,8 @@ export default function OnThisDay() {
               prefetch="intent"
               className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors"
             >
-              <span>{formatMonthDay(nextMonthDay)}</span>
+              <span className="sm:hidden">{formatMonthDayShort(nextMonthDay)}</span>
+              <span className="hidden sm:inline">{formatMonthDay(nextMonthDay)}</span>
               <ChevronRight className="h-3 w-3" />
             </Link>
           </div>
@@ -202,7 +204,6 @@ export default function OnThisDay() {
             setlists={setlists}
             externalSources={externalSources}
             initialUserData={initialUserData}
-            className="transition-all duration-300 transform hover:scale-[1.01]"
             empty={
               <div className="text-center py-8">
                 <p className="text-content-text-secondary text-lg">No shows on {displayLabel}.</p>

--- a/apps/web/app/routes/shows/$slug.tsx
+++ b/apps/web/app/routes/shows/$slug.tsx
@@ -19,6 +19,7 @@ import type { ShowExternalSources } from "~/components/setlist/show-external-bad
 import { ArchiveRecordingsCard } from "~/components/show/archive-recordings-card";
 import { type ExternalLink, ExternalLinkCard } from "~/components/show/external-link-card";
 import { ShowPhotos } from "~/components/show/show-photos";
+import { ShowDate } from "~/components/show-date";
 import { Button } from "~/components/ui/button";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { useSession } from "~/hooks/use-session";
@@ -260,16 +261,21 @@ export default function Show() {
             <span>Back to shows</span>
           </Link>
         </div>
-        <div className="flex justify-between items-center">
+        <div className="flex justify-between items-center gap-2">
           {adjacentShows.previous ? (
             <Link
               to={`/shows/${adjacentShows.previous.slug}`}
-              className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors"
+              className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors min-w-0"
             >
-              <ChevronLeft className="h-3 w-3" />
-              <span>
-                {formatDateLong(adjacentShows.previous.date)}
-                {adjacentShows.previous.venueName && ` · ${adjacentShows.previous.venueName}`}
+              <ChevronLeft className="h-3 w-3 shrink-0" />
+              <span className="truncate">
+                <span className="hidden sm:inline">{formatDateLong(adjacentShows.previous.date)}</span>
+                <span className="sm:hidden">
+                  <ShowDate date={adjacentShows.previous.date} />
+                </span>
+                {adjacentShows.previous.venueName && (
+                  <span className="hidden sm:inline">{` · ${adjacentShows.previous.venueName}`}</span>
+                )}
               </span>
             </Link>
           ) : (
@@ -277,20 +283,26 @@ export default function Show() {
           )}
           <Link
             to={`/on-this-day/${setlist.show.date.slice(5)}`}
-            className="text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors"
+            className="text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors text-center shrink-0"
           >
-            All shows on {formatMonthDay(setlist.show.date.slice(5))} →
+            <span className="hidden sm:inline">All shows on {formatMonthDay(setlist.show.date.slice(5))} →</span>
+            <span className="sm:hidden">{formatMonthDay(setlist.show.date.slice(5))} →</span>
           </Link>
           {adjacentShows.next ? (
             <Link
               to={`/shows/${adjacentShows.next.slug}`}
-              className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors"
+              className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors min-w-0 justify-end"
             >
-              <span>
-                {formatDateLong(adjacentShows.next.date)}
-                {adjacentShows.next.venueName && ` · ${adjacentShows.next.venueName}`}
+              <span className="truncate">
+                <span className="hidden sm:inline">{formatDateLong(adjacentShows.next.date)}</span>
+                <span className="sm:hidden">
+                  <ShowDate date={adjacentShows.next.date} />
+                </span>
+                {adjacentShows.next.venueName && (
+                  <span className="hidden sm:inline">{` · ${adjacentShows.next.venueName}`}</span>
+                )}
               </span>
-              <ChevronRight className="h-3 w-3" />
+              <ChevronRight className="h-3 w-3 shrink-0" />
             </Link>
           ) : (
             <div />
@@ -298,9 +310,11 @@ export default function Show() {
         </div>
       </div>
 
-      {/* Main content area with responsive grid */}
+      {/* Main content area with responsive grid. On mobile we reorder so
+          users see the setlist, then external/Archive links + track-note
+          highlights, and reviews land at the bottom (long content tail). */}
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
-        {/* Left column: Setlist */}
+        {/* Setlist — always first */}
         <div className="lg:col-span-8">
           <SetlistCard
             key={setlist.show.id}
@@ -310,32 +324,11 @@ export default function Show() {
             showRating={setlist.show.averageRating}
             externalSources={externalSources}
           />
-
-          <div className="mt-6">
-            {reviews && reviews.length === 0 && (
-              <div className="text-center py-8">
-                <p className="text-content-text-secondary">No reviews yet. Be the first to share your thoughts!</p>
-              </div>
-            )}
-            {user && internalUserId && !reviews.some((review: ReviewMinimal) => review.userId === internalUserId) && (
-              <div className="mb-8">
-                <ReviewForm onSubmit={handleReviewSubmit} />
-              </div>
-            )}
-            {reviews && reviews.length > 0 && (
-              <ReviewsList
-                reviews={reviews}
-                currentUserId={internalUserId}
-                onDelete={handleReviewDelete}
-                onUpdate={handleReviewUpdate}
-              />
-            )}
-          </div>
         </div>
 
-        {/* Right column: Highlights and additional content */}
-        <div className="lg:col-span-4">
-          <div className="lg:sticky lg:top-4 space-y-6">
+        {/* Right rail (mobile: sits between setlist and reviews) */}
+        <div className="lg:col-span-4 lg:row-span-2">
+          <div className="lg:sticky lg:top-4 space-y-2">
             <ExternalLinkCard faviconDomain={EXTERNAL_SOURCE_DOMAINS.nugs} title="Official release" items={nugsLinks} />
             <ExternalLinkCard faviconDomain={EXTERNAL_SOURCE_DOMAINS.youtube} title="Video" items={youtubeLinks} />
             <ArchiveRecordingsCard items={archiveRecordings} />
@@ -343,6 +336,29 @@ export default function Show() {
             {/* Highlights panel */}
             <SetlistHighlights setlist={setlist} />
           </div>
+        </div>
+
+        {/* Reviews — desktop: under setlist on left column. mobile: below
+            right rail since list-of-reviews can be long. */}
+        <div className="lg:col-span-8 lg:col-start-1">
+          {reviews && reviews.length === 0 && (
+            <div className="text-center py-8">
+              <p className="text-content-text-secondary">No reviews yet. Be the first to share your thoughts!</p>
+            </div>
+          )}
+          {user && internalUserId && !reviews.some((review: ReviewMinimal) => review.userId === internalUserId) && (
+            <div className="mb-8">
+              <ReviewForm onSubmit={handleReviewSubmit} />
+            </div>
+          )}
+          {reviews && reviews.length > 0 && (
+            <ReviewsList
+              reviews={reviews}
+              currentUserId={internalUserId}
+              onDelete={handleReviewDelete}
+              onUpdate={handleReviewUpdate}
+            />
+          )}
         </div>
       </div>
 

--- a/apps/web/app/routes/shows/year/$year.tsx
+++ b/apps/web/app/routes/shows/year/$year.tsx
@@ -183,6 +183,10 @@ export default function ShowsByYear() {
   // Months with at least one show — drives the Jump-to-Month nav active state.
   const monthsWithShows = useMemo(() => Object.keys(monthCounts).map(Number), [monthCounts]);
 
+  // Jump-to-Month collapses by default on mobile so the long month grid
+  // doesn't push the show list far below the fold; CSS forces it open at sm+.
+  const [jumpToMonthOpen, setJumpToMonthOpen] = useState(false);
+
   // Handle scroll event to show/hide back to top button
   useEffect(() => {
     const handleScroll = () => {
@@ -209,7 +213,9 @@ export default function ShowsByYear() {
           <h1 className="page-heading">SHOWS</h1>
           <div className="absolute top-0 right-0 flex items-start gap-2">
             {!searchQuery && (
-              <ShowFiltersNav basePath={`/shows/year/${year}`} currentURLParameters={currentURLParameters} />
+              <div className="hidden sm:block">
+                <ShowFiltersNav basePath={`/shows/year/${year}`} currentURLParameters={currentURLParameters} />
+              </div>
             )}
             <AdminOnly>
               <Button variant="outline" size="sm" asChild>
@@ -226,6 +232,11 @@ export default function ShowsByYear() {
               <span className="text-content-text-secondary text-lg">Search results for "{searchQuery}"</span>
             )}
           </div>
+          {!searchQuery && (
+            <div className="mt-3 flex justify-center sm:hidden">
+              <ShowFiltersNav basePath={`/shows/year/${year}`} currentURLParameters={currentURLParameters} />
+            </div>
+          )}
         </div>
 
         {/* Navigation - Only show when not searching */}
@@ -240,13 +251,38 @@ export default function ShowsByYear() {
             <div className="card-premium rounded-lg overflow-hidden">
               {/* Month navigation */}
               <div className="px-4 py-3">
-                <h2 className="text-sm font-semibold text-white mb-3 flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setJumpToMonthOpen((open) => !open)}
+                  aria-expanded={jumpToMonthOpen}
+                  className={cn(
+                    "sm:hidden w-full flex items-center gap-2 text-sm font-semibold text-white cursor-pointer select-none",
+                    jumpToMonthOpen ? "mb-3" : "mb-0",
+                  )}
+                >
                   Jump to Month
                   <span className="text-xs font-normal text-content-text-tertiary bg-content-bg-secondary px-2 py-0.5 rounded-full">
-                    {monthsWithShows.length} active
+                    {monthsWithShows.length} months
+                  </span>
+                  <span
+                    className={cn("transition-transform duration-300 ml-2", jumpToMonthOpen ? "rotate-90" : "rotate-0")}
+                    aria-hidden
+                  >
+                    ▶
+                  </span>
+                </button>
+                <h2 className="hidden sm:flex text-sm font-semibold text-white mb-3 items-center gap-2">
+                  Jump to Month
+                  <span className="text-xs font-normal text-content-text-tertiary bg-content-bg-secondary px-2 py-0.5 rounded-full">
+                    {monthsWithShows.length} months
                   </span>
                 </h2>
-                <div className="grid grid-cols-6 sm:grid-cols-12 gap-1.5">
+                <div
+                  className={cn(
+                    "overflow-hidden transition-all duration-300 grid grid-cols-3 sm:grid-cols-12 gap-1.5 sm:!max-h-[1000px] sm:!opacity-100",
+                    jumpToMonthOpen ? "max-h-[1000px] opacity-100" : "max-h-0 opacity-0",
+                  )}
+                >
                   {months.map((month, index) => {
                     const active = monthsWithShows.includes(index);
                     const count = monthCounts[index] ?? 0;
@@ -262,7 +298,7 @@ export default function ShowsByYear() {
                         )}
                       >
                         {month}
-                        {active && count > 0 && <span className="ml-1 opacity-70">({count})</span>}
+                        {active && count > 0 && <span className="ml-1 opacity-70 hidden sm:inline">({count})</span>}
                       </a>
                     );
                   })}
@@ -290,7 +326,6 @@ export default function ShowsByYear() {
                 setlists={setlists}
                 externalSources={externalSources}
                 initialUserData={initialUserData}
-                className="transition-all duration-300 transform hover:scale-[1.01]"
                 groupByMonth={!searchQuery}
                 empty={
                   <div className="text-center py-8">

--- a/apps/web/app/routes/songs/$slug.test.tsx
+++ b/apps/web/app/routes/songs/$slug.test.tsx
@@ -38,9 +38,7 @@ vi.mock("~/hooks/use-serialized-loader-data", () => ({
 // be visible since the unfiltered data has an all-timer.
 vi.mock("~/hooks/use-performance-page-filters", () => ({
   usePerformancePageFilters: vi.fn(() => ({
-    filteredData: [
-      { trackId: "t2", allTimer: false, show: { date: "2024-02-01" }, venue: {} },
-    ],
+    filteredData: [{ trackId: "t2", allTimer: false, show: { date: "2024-02-01" }, venue: {} }],
     isLoading: false,
     selectedYear: "2024",
     selectedEra: "all",
@@ -78,6 +76,7 @@ vi.mock("recharts", () => ({
   YAxis: () => null,
 }));
 
+import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import SongPage from "./$slug";
 
 function renderSongPage() {
@@ -111,5 +110,179 @@ describe("SongPage", () => {
     await user.click(statsTab);
 
     expect(mockClearFilters).toHaveBeenCalled();
+  });
+
+  // The 4 stat cards (Times Played, First Played, Last Played, Most
+  // Common Year) render as a 2x2 grid on mobile and 4x1 at lg+ so phone
+  // users only scroll past two rows of cards instead of four.
+  test("stat grid is 2 columns on mobile, 4 columns on lg", () => {
+    renderSongPage();
+
+    const timesPlayedLabel = screen.getByText(/Times Played/);
+    const grid = timesPlayedLabel.closest("dl");
+    expect(grid?.className).toContain("grid-cols-2");
+    expect(grid?.className).toContain("lg:grid-cols-4");
+    // No single-column stacking on mobile — each row pairs two cards.
+    expect(grid?.className).not.toContain("grid-cols-1");
+  });
+
+  // The First/Last Played stat cards include a venue sublabel (sublabel2).
+  // On mobile that wrapped venue line makes the cards taller than the
+  // viewport allows for the 2x2 grid; we hide it via `hidden sm:block`
+  // so phone users see just the date + label.
+  test("StatBox sublabel2 (venue) is hidden on mobile (hidden sm:block)", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValueOnce({
+      song: {
+        title: "I-Man",
+        slug: "i-man",
+        timesPlayed: 100,
+        dateFirstPlayed: "1997-04-19",
+        dateLastPlayed: null,
+        actualLastPlayedDate: null,
+        firstShowSlug: "1997-04-19-frat-party",
+        lastShowSlug: null,
+        firstVenue: { name: "University of Pennsylvania", city: "Philadelphia", state: "PA" },
+        lastVenue: null,
+        showsSinceLastPlayed: null,
+        history: null,
+        lyrics: null,
+        tabs: null,
+        guitarTabsUrl: null,
+        notes: null,
+        yearlyPlayData: {},
+      },
+      performances: [],
+    });
+    renderSongPage();
+
+    const venueLine = screen.getByText(/University of Pennsylvania, Philadelphia, PA/);
+    expect(venueLine.className).toContain("hidden");
+    expect(venueLine.className).toContain("sm:block");
+  });
+
+  // The TabsList on song-detail clips at narrow widths because there can be
+  // up to 6 tabs (All Performances, All-Timers, Stats, History, Lyrics,
+  // Guitar Tabs). Mobile gets a single <select> dropdown instead while sm+
+  // continues to use the horizontal tab strip.
+  test("song tabs render as a select on mobile (sm:hidden) and tab strip on sm+", () => {
+    renderSongPage();
+
+    const tabList = screen.getByRole("tablist");
+    expect(tabList.className).toContain("hidden");
+    expect(tabList.className).toContain("sm:flex");
+
+    const select = screen.getByLabelText(/song view/i);
+    const wrapper = select.closest("div");
+    expect(wrapper?.className).toContain("sm:hidden");
+  });
+
+  // The "last show" sublabel marks the song as having been played at the
+  // most recent show. The backend computes `showsSinceLastPlayed` as a
+  // strict count of shows AFTER the song's last performance, so 0 = "this
+  // was the last show" and any positive value means there have been more
+  // shows since.
+  test("Last Played sublabel reads 'last show' only when showsSinceLastPlayed is 0", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValueOnce({
+      song: {
+        title: "Shelby Rose",
+        slug: "shelby-rose",
+        timesPlayed: 50,
+        dateFirstPlayed: "2010-01-01",
+        dateLastPlayed: "2026-04-25",
+        actualLastPlayedDate: "2026-04-25",
+        firstShowSlug: "2010-01-01-show",
+        lastShowSlug: "2026-04-25-show",
+        firstVenue: null,
+        lastVenue: null,
+        showsSinceLastPlayed: 0,
+        history: null,
+        lyrics: null,
+        tabs: null,
+        guitarTabsUrl: null,
+        notes: null,
+        yearlyPlayData: {},
+      },
+      performances: [],
+    });
+    renderSongPage();
+    expect(screen.getByText(/last show/i)).toBeInTheDocument();
+  });
+
+  // When at least one show has happened since the song's last performance,
+  // the sublabel should report the count rather than claim "last show".
+  // Singular form for exactly one show after.
+  test("Last Played sublabel reads '1 show ago' when showsSinceLastPlayed is 1", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValueOnce({
+      song: {
+        title: "Shelby Rose",
+        slug: "shelby-rose",
+        timesPlayed: 50,
+        dateFirstPlayed: "2010-01-01",
+        dateLastPlayed: "2026-04-24",
+        actualLastPlayedDate: "2026-04-24",
+        firstShowSlug: "2010-01-01-show",
+        lastShowSlug: "2026-04-24-show",
+        firstVenue: null,
+        lastVenue: null,
+        showsSinceLastPlayed: 1,
+        history: null,
+        lyrics: null,
+        tabs: null,
+        guitarTabsUrl: null,
+        notes: null,
+        yearlyPlayData: {},
+      },
+      performances: [],
+    });
+    renderSongPage();
+    expect(screen.getByText(/1 show ago/)).toBeInTheDocument();
+    expect(screen.queryByText(/last show/i)).not.toBeInTheDocument();
+    // Avoid the "1 shows ago" plural-on-one bug.
+    expect(screen.queryByText(/1 shows ago/)).not.toBeInTheDocument();
+  });
+
+  // Plural form for >1 shows after the song's last performance.
+  test("Last Played sublabel reads 'N shows ago' when showsSinceLastPlayed is greater than 1", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValueOnce({
+      song: {
+        title: "Shelby Rose",
+        slug: "shelby-rose",
+        timesPlayed: 50,
+        dateFirstPlayed: "2010-01-01",
+        dateLastPlayed: "2024-01-01",
+        actualLastPlayedDate: "2024-01-01",
+        firstShowSlug: "2010-01-01-show",
+        lastShowSlug: "2024-01-01-show",
+        firstVenue: null,
+        lastVenue: null,
+        showsSinceLastPlayed: 4,
+        history: null,
+        lyrics: null,
+        tabs: null,
+        guitarTabsUrl: null,
+        notes: null,
+        yearlyPlayData: {},
+      },
+      performances: [],
+    });
+    renderSongPage();
+    expect(screen.getByText(/4 shows ago/)).toBeInTheDocument();
+    expect(screen.queryByText(/last show/i)).not.toBeInTheDocument();
+  });
+
+  // Stat card padding tightens on mobile so the cards aren't bigger than
+  // their content. Headline number also shrinks on mobile so the value
+  // fits on one line within the narrower box.
+  test("StatBox uses compact padding/typography on mobile and full sizing on sm+", () => {
+    renderSongPage();
+
+    const timesPlayedLabel = screen.getByText(/Times Played/);
+    const card = timesPlayedLabel.closest("div[class*='glass-content']");
+    expect(card?.className).toContain("p-2");
+    expect(card?.className).toContain("sm:p-6");
+
+    const value = screen.getByText("100");
+    expect(value.className).toContain("text-xl");
+    expect(value.className).toContain("sm:text-3xl");
   });
 });

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -1,6 +1,6 @@
 import type { SongPageView } from "@bip/domain";
 import { ArrowLeft, BarChart3, FileTextIcon, Flame, GuitarIcon, History, ListMusic, Pencil } from "lucide-react";
-import { useMemo, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 import type { LoaderFunctionArgs } from "react-router";
 import { Link, useSearchParams } from "react-router-dom";
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
@@ -8,6 +8,7 @@ import { AdminOnly } from "~/components/admin/admin-only";
 import { PerformanceTable } from "~/components/performance";
 import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
 import { RatingComponent } from "~/components/rating";
+import { ShowDate } from "~/components/show-date";
 import { Button } from "~/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
@@ -26,19 +27,19 @@ export const loader = publicLoader(async ({ params }: LoaderFunctionArgs): Promi
 
 interface StatBoxProps {
   label: string;
-  value: string | number;
+  value: ReactNode;
   sublabel?: string;
   sublabel2?: string;
 }
 
 function StatBox({ label, value, sublabel, sublabel2 }: StatBoxProps) {
   return (
-    <div className="glass-content p-6 rounded-lg">
+    <div className="glass-content p-2 sm:p-6 rounded-lg h-full">
       <dt className="text-sm font-medium text-content-text-secondary">{label}</dt>
       <dd className="mt-2">
-        <span className="text-3xl font-bold text-content-text-primary">{value}</span>
-        {sublabel && <span className="ml-2 text-sm text-content-text-tertiary">{sublabel}</span>}
-        {sublabel2 && <div className="mt-3 text-sm text-content-text-tertiary">{sublabel2}</div>}
+        <span className="text-xl sm:text-3xl font-bold text-content-text-primary">{value}</span>
+        {sublabel && <div className="mt-1 text-sm text-content-text-tertiary">{sublabel}</div>}
+        {sublabel2 && <div className="mt-3 text-sm text-content-text-tertiary hidden sm:block">{sublabel2}</div>}
       </dd>
     </div>
   );
@@ -99,12 +100,26 @@ export function meta({ data }: { data: SongPageView }) {
   });
 }
 
+/**
+ * Builds the "Last Played" sublabel — "last show" when the song was played
+ * at the most recent show, otherwise "N show(s) ago" with correct
+ * pluralization. The backend's `showsSinceLastPlayed` is a strict count of
+ * shows played AFTER this song's last performance, so 0 = last show.
+ */
+function lastPlayedSublabel(showsSince: number | null | undefined): string | undefined {
+  if (showsSince === null || showsSince === undefined) return undefined;
+  if (showsSince === 0) return "last show";
+  if (showsSince === 1) return "1 show ago";
+  return `${showsSince} shows ago`;
+}
+
 export default function SongPage() {
   const { song, performances: allPerformances } = useSerializedLoaderData<SongPageView>();
   const [searchParams] = useSearchParams();
   const tabParam = searchParams.get("tab");
   const validTabs = ["performances", "all-timers", "stats", "history", "lyrics", "guitar-tabs"];
   const defaultTab = tabParam && validTabs.includes(tabParam) ? tabParam : "performances";
+  const [activeTab, setActiveTab] = useState(defaultTab);
   const {
     filteredData: filteredPerformances,
     isLoading,
@@ -180,23 +195,13 @@ export default function SongPage() {
       </div>
 
       {/* Stats Grid */}
-      <dl className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <StatBox label="Times Played" value={song.timesPlayed} sublabel="total plays" />
+      <dl className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <StatBox label="Times Played" value={song.timesPlayed} />
         {song.firstShowSlug ? (
           <Link to={`/shows/${song.firstShowSlug}`} className="block">
             <StatBox
               label="First Played"
-              value={
-                song.dateFirstPlayed
-                  ? (() => {
-                      const date = new Date(song.dateFirstPlayed);
-                      const month = date.getUTCMonth() + 1;
-                      const day = date.getUTCDate();
-                      const year = date.getUTCFullYear();
-                      return `${month}/${day}/${year}`;
-                    })()
-                  : "Never"
-              }
+              value={song.dateFirstPlayed ? <ShowDate date={song.dateFirstPlayed} /> : "Never"}
               sublabel2={
                 song.firstVenue
                   ? song.firstVenue.city && song.firstVenue.state
@@ -209,17 +214,7 @@ export default function SongPage() {
         ) : (
           <StatBox
             label="First Played"
-            value={
-              song.dateFirstPlayed
-                ? (() => {
-                    const date = new Date(song.dateFirstPlayed);
-                    const month = date.getUTCMonth() + 1;
-                    const day = date.getUTCDate();
-                    const year = date.getUTCFullYear();
-                    return `${month}/${day}/${year}`;
-                  })()
-                : "Never"
-            }
+            value={song.dateFirstPlayed ? <ShowDate date={song.dateFirstPlayed} /> : "Never"}
             sublabel2={
               song.firstVenue
                 ? song.firstVenue.city && song.firstVenue.state
@@ -233,26 +228,8 @@ export default function SongPage() {
           <Link to={`/shows/${song.lastShowSlug}`} className="block">
             <StatBox
               label="Last Played"
-              value={
-                song.actualLastPlayedDate
-                  ? (() => {
-                      const date = new Date(song.actualLastPlayedDate);
-                      const month = date.getUTCMonth() + 1;
-                      const day = date.getUTCDate();
-                      const year = date.getUTCFullYear();
-                      return `${month}/${day}/${year}`;
-                    })()
-                  : "Never"
-              }
-              sublabel={
-                song.actualLastPlayedDate &&
-                song.showsSinceLastPlayed !== null &&
-                song.showsSinceLastPlayed !== undefined
-                  ? song.showsSinceLastPlayed <= 1
-                    ? "last show"
-                    : `${song.showsSinceLastPlayed} shows ago`
-                  : undefined
-              }
+              value={song.actualLastPlayedDate ? <ShowDate date={song.actualLastPlayedDate} /> : "Never"}
+              sublabel={song.actualLastPlayedDate ? lastPlayedSublabel(song.showsSinceLastPlayed) : undefined}
               sublabel2={
                 song.lastVenue
                   ? song.lastVenue.city && song.lastVenue.state
@@ -265,24 +242,8 @@ export default function SongPage() {
         ) : (
           <StatBox
             label="Last Played"
-            value={
-              song.actualLastPlayedDate
-                ? (() => {
-                    const date = new Date(song.actualLastPlayedDate);
-                    const month = date.getUTCMonth() + 1;
-                    const day = date.getUTCDate();
-                    const year = date.getUTCFullYear();
-                    return `${month}/${day}/${year}`;
-                  })()
-                : "Never"
-            }
-            sublabel={
-              song.actualLastPlayedDate && song.showsSinceLastPlayed !== null && song.showsSinceLastPlayed !== undefined
-                ? song.showsSinceLastPlayed <= 1
-                  ? "last show"
-                  : `${song.showsSinceLastPlayed} shows ago`
-                : undefined
-            }
+            value={song.actualLastPlayedDate ? <ShowDate date={song.actualLastPlayedDate} /> : "Never"}
+            sublabel={song.actualLastPlayedDate ? lastPlayedSublabel(song.showsSinceLastPlayed) : undefined}
             sublabel2={
               song.lastVenue
                 ? song.lastVenue.city && song.lastVenue.state
@@ -304,8 +265,36 @@ export default function SongPage() {
         </div>
       )}
 
-      <Tabs defaultValue={defaultTab} className="w-full" onValueChange={() => clearFilters()}>
-        <TabsList className="w-full flex justify-start border-b border-glass-border/30 rounded-none bg-transparent p-0">
+      <Tabs
+        value={activeTab}
+        className="w-full"
+        onValueChange={(value) => {
+          setActiveTab(value);
+          clearFilters();
+        }}
+      >
+        <div className="sm:hidden mb-4">
+          <label htmlFor="song-view-select" className="sr-only">
+            Song view
+          </label>
+          <select
+            id="song-view-select"
+            value={activeTab}
+            onChange={(event) => {
+              setActiveTab(event.target.value);
+              clearFilters();
+            }}
+            className="w-full h-11 px-3 rounded-md bg-glass-bg border border-glass-border text-content-text-primary focus:outline-none focus:ring-1 focus:ring-ring/20"
+          >
+            <option value="performances">All Performances</option>
+            {hasAllTimers && <option value="all-timers">All-Timers</option>}
+            <option value="stats">Stats</option>
+            {song.history && <option value="history">History</option>}
+            {song.lyrics && <option value="lyrics">Lyrics</option>}
+            {(song.tabs || song.guitarTabsUrl) && <option value="guitar-tabs">Guitar Tabs</option>}
+          </select>
+        </div>
+        <TabsList className="w-full hidden sm:flex justify-start border-b border-glass-border/30 rounded-none bg-transparent p-0">
           <TabsTrigger
             value="performances"
             className={cn(

--- a/apps/web/app/routes/songs/_layout.test.tsx
+++ b/apps/web/app/routes/songs/_layout.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, test, vi } from "vitest";
 
@@ -101,5 +101,43 @@ describe("SongsLayout", () => {
     renderAtPath("/songs");
 
     expect(screen.getByTestId("outlet")).toBeInTheDocument();
+  });
+
+  // On mobile, the tab strip is hidden via `sm:flex` (so it does not wrap
+  // and clip the rightmost tab on narrow viewports). A native <select>
+  // dropdown takes its place inside an `sm:hidden` container so users
+  // still have a single-tap way to switch tabs.
+  test("tab strip is hidden on mobile (uses sm:flex), select dropdown is mobile-only", () => {
+    renderAtPath("/songs");
+
+    const tabStrip = screen.getByRole("link", { name: /all songs/i }).closest("div[class*='border-b']");
+    expect(tabStrip?.className).toContain("hidden");
+    expect(tabStrip?.className).toContain("sm:flex");
+
+    // The native select is rendered for mobile; its parent should be sm:hidden
+    const select = screen.getByLabelText(/songs view/i);
+    const wrapper = select.closest("div");
+    expect(wrapper?.className).toContain("sm:hidden");
+  });
+
+  // The mobile select reflects the current tab as its value, so opening
+  // the dropdown shows the user where they are.
+  test("mobile select value reflects the current tab path", () => {
+    renderAtPath("/songs/all-timers");
+
+    const select = screen.getByLabelText(/songs view/i) as HTMLSelectElement;
+    expect(select.value).toBe("/songs/all-timers");
+  });
+
+  // Changing the mobile select navigates to the chosen tab path.
+  test("changing mobile select navigates to the new tab", () => {
+    renderAtPath("/songs");
+
+    const select = screen.getByLabelText(/songs view/i) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "/songs/all-timers" } });
+
+    // The active tab in the desktop strip should now reflect the new path.
+    const allTimersLink = screen.getByRole("link", { name: /all-timers/i });
+    expect(allTimersLink.className).toContain("border-brand-primary");
   });
 });

--- a/apps/web/app/routes/songs/_layout.tsx
+++ b/apps/web/app/routes/songs/_layout.tsx
@@ -1,6 +1,6 @@
 import type { LucideIcon } from "lucide-react";
 import { Calendar, Clock, Flame, History, ListMusic, Plus } from "lucide-react";
-import { Link, Outlet, useLocation } from "react-router-dom";
+import { Link, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { AdminOnly } from "~/components/admin/admin-only";
 import { Button } from "~/components/ui/button";
 import { cn } from "~/lib/utils";
@@ -24,10 +24,11 @@ const TABBED_PATHS = new Set(TABS.map((tab) => tab.path));
 
 export default function SongsLayout() {
   const { pathname } = useLocation();
+  const navigate = useNavigate();
   const showTabs = TABBED_PATHS.has(pathname);
 
   return (
-    <div className="py-8">
+    <div className="py-2 sm:py-3">
       <div className="relative">
         <h1 className="page-heading">SONGS</h1>
         <div className="absolute top-0 right-0 flex items-center gap-3">
@@ -43,27 +44,47 @@ export default function SongsLayout() {
       </div>
 
       {showTabs && (
-        <div className="w-full flex justify-start border-b border-glass-border/30 mb-6">
-          {TABS.map((tab) => {
-            const isActive = pathname === tab.path;
-            const Icon = tab.icon;
-            return (
-              <Link
-                key={tab.path}
-                to={tab.path}
-                className={cn(
-                  "flex items-center gap-2 px-4 py-2 text-sm font-medium",
-                  isActive
-                    ? "border-b-2 border-brand-primary text-content-text-primary"
-                    : "text-content-text-tertiary hover:text-content-text-secondary",
-                )}
-              >
-                <Icon className={cn("h-4 w-4", tab.iconClassName)} />
-                {tab.label}
-              </Link>
-            );
-          })}
-        </div>
+        <>
+          <div className="w-full hidden sm:flex justify-start border-b border-glass-border/30 mb-6">
+            {TABS.map((tab) => {
+              const isActive = pathname === tab.path;
+              const Icon = tab.icon;
+              return (
+                <Link
+                  key={tab.path}
+                  to={tab.path}
+                  className={cn(
+                    "flex items-center gap-2 px-4 py-2 text-sm font-medium",
+                    isActive
+                      ? "border-b-2 border-brand-primary text-content-text-primary"
+                      : "text-content-text-tertiary hover:text-content-text-secondary",
+                  )}
+                >
+                  <Icon className={cn("h-4 w-4", tab.iconClassName)} />
+                  {tab.label}
+                </Link>
+              );
+            })}
+          </div>
+
+          <div className="sm:hidden mb-6">
+            <label htmlFor="songs-view-select" className="sr-only">
+              Songs view
+            </label>
+            <select
+              id="songs-view-select"
+              value={pathname}
+              onChange={(event) => navigate(event.target.value)}
+              className="w-full h-11 px-3 rounded-md bg-glass-bg border border-glass-border text-content-text-primary focus:outline-none focus:ring-1 focus:ring-ring/20"
+            >
+              {TABS.map((tab) => (
+                <option key={tab.path} value={tab.path}>
+                  {tab.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </>
       )}
 
       <Outlet />

--- a/apps/web/app/server/apply-external-source-filters.test.ts
+++ b/apps/web/app/server/apply-external-source-filters.test.ts
@@ -31,7 +31,7 @@ describe("applyExternalSourceFilters", () => {
   test("filters out setlists missing a nugs url when nugs flag is on", () => {
     const setlists = [setlist("astronaut"), setlist("moshi")];
     const externalSources: Record<string, ShowExternalSources> = {
-      astronaut: sources({ nugsUrl: "https://play.nugs.net/release/1" }),
+      astronaut: sources({ nugsUrls: ["https://play.nugs.net/release/1"] }),
       moshi: sources({}),
     };
 
@@ -57,8 +57,8 @@ describe("applyExternalSourceFilters", () => {
   test("requires all active flags (AND) when multiple are set", () => {
     const setlists = [setlist("astronaut"), setlist("moshi"), setlist("basis")];
     const externalSources: Record<string, ShowExternalSources> = {
-      astronaut: sources({ nugsUrl: "n1", archiveUrl: "a1" }),
-      moshi: sources({ nugsUrl: "n2" }),
+      astronaut: sources({ nugsUrls: ["n1"], archiveUrl: "a1" }),
+      moshi: sources({ nugsUrls: ["n2"] }),
       basis: sources({ archiveUrl: "a3" }),
     };
 
@@ -72,7 +72,7 @@ describe("applyExternalSourceFilters", () => {
   test("drops setlists that have no entry in externalSources when a flag is on", () => {
     const setlists = [setlist("astronaut"), setlist("orphan")];
     const externalSources: Record<string, ShowExternalSources> = {
-      astronaut: sources({ nugsUrl: "n1" }),
+      astronaut: sources({ nugsUrls: ["n1"] }),
     };
 
     const result = applyExternalSourceFilters(setlists, externalSources, { nugs: true });

--- a/apps/web/app/server/apply-external-source-filters.ts
+++ b/apps/web/app/server/apply-external-source-filters.ts
@@ -25,7 +25,7 @@ export function applyExternalSourceFilters<T extends Pick<SetlistLight, "show">>
 
   return setlists.filter((setlist) => {
     const sources = externalSources[setlist.show.id];
-    if (flags.nugs && !sources?.nugsUrl) return false;
+    if (flags.nugs && !sources?.nugsUrls?.length) return false;
     if (flags.archive && !sources?.archiveUrl) return false;
     return true;
   });

--- a/apps/web/app/server/show-counts-by-year.test.ts
+++ b/apps/web/app/server/show-counts-by-year.test.ts
@@ -57,8 +57,8 @@ describe("computeShowCountsByYear", () => {
       { date: "2023-06-15", hasPhotos: false, hasYoutube: false },
     ]);
     getReleaseUrlsByDate.mockResolvedValue({
-      "2004-12-31": "https://play.nugs.net/release/1",
-      "2023-06-15": "https://play.nugs.net/release/2",
+      "2004-12-31": ["https://play.nugs.net/release/1"],
+      "2023-06-15": ["https://play.nugs.net/release/2"],
     });
 
     const result = await computeShowCountsByYear({ nugs: true });
@@ -90,8 +90,8 @@ describe("computeShowCountsByYear", () => {
       { date: "2023-06-15", hasPhotos: true, hasYoutube: false }, // missing youtube
     ]);
     getReleaseUrlsByDate.mockResolvedValue({
-      "2004-12-31": "nugs-url",
-      "2023-06-15": "nugs-url",
+      "2004-12-31": ["nugs-url"],
+      "2023-06-15": ["nugs-url"],
     });
     getPrimaryUrlsByDate.mockResolvedValue({
       "2004-12-31": "archive-url",

--- a/apps/web/app/server/show-counts-by-year.ts
+++ b/apps/web/app/server/show-counts-by-year.ts
@@ -25,7 +25,7 @@ export async function computeShowCountsByYear(flags: ShowCountsFilterFlags): Pro
 
   const [showDates, nugsUrlsByDate, archiveUrlsByDate] = await Promise.all([
     services.shows.getShowDatesWithFlags(),
-    needsNugs ? services.nugs.getReleaseUrlsByDate() : Promise.resolve<Record<string, string>>({}),
+    needsNugs ? services.nugs.getReleaseUrlsByDate() : Promise.resolve<Record<string, string[]>>({}),
     needsArchive ? services.archiveDotOrg.getPrimaryUrlsByDate() : Promise.resolve<Record<string, string>>({}),
   ]);
 
@@ -33,7 +33,7 @@ export async function computeShowCountsByYear(flags: ShowCountsFilterFlags): Pro
   for (const show of showDates) {
     if (flags.photos && !show.hasPhotos) continue;
     if (flags.youtube && !show.hasYoutube) continue;
-    if (needsNugs && !nugsUrlsByDate[show.date]) continue;
+    if (needsNugs && !nugsUrlsByDate[show.date]?.length) continue;
     if (needsArchive && !archiveUrlsByDate[show.date]) continue;
 
     const year = Number.parseInt(show.date.slice(0, 4), 10);

--- a/apps/web/app/server/show-external-sources.test.ts
+++ b/apps/web/app/server/show-external-sources.test.ts
@@ -35,7 +35,7 @@ describe("computeShowExternalSources", () => {
   // Shows are keyed by id in the result; nugs/archive URLs lookup by date,
   // youtube URLs lookup by show id — this wiring is the whole point.
   test("maps each show to its resolved URLs by date + show id", async () => {
-    getReleaseUrlsByDate.mockResolvedValue({ "2004-12-31": "https://play.nugs.net/release/1" });
+    getReleaseUrlsByDate.mockResolvedValue({ "2004-12-31": ["https://play.nugs.net/release/1"] });
     getPrimaryUrlsByDate.mockResolvedValue({ "2004-12-31": "https://archive.org/details/db2004" });
     getFirstVideoUrlByShowIds.mockResolvedValue({ "show-nye04": "https://youtube.com/watch?v=aaa" });
 
@@ -43,7 +43,7 @@ describe("computeShowExternalSources", () => {
 
     expect(result).toEqual({
       "show-nye04": {
-        nugsUrl: "https://play.nugs.net/release/1",
+        nugsUrls: ["https://play.nugs.net/release/1"],
         archiveUrl: "https://archive.org/details/db2004",
         youtubeUrl: "https://youtube.com/watch?v=aaa",
       },
@@ -61,7 +61,7 @@ describe("computeShowExternalSources", () => {
     const result = await computeShowExternalSources([{ id: "show-lockn", date: "2019-08-10" }]);
 
     expect(result["show-lockn"]).toEqual({
-      nugsUrl: undefined,
+      nugsUrls: undefined,
       archiveUrl: "https://archive.org/details/db2019",
       youtubeUrl: undefined,
     });
@@ -70,7 +70,7 @@ describe("computeShowExternalSources", () => {
   // Multiple shows in one call share the two catalog fetches but each gets
   // its own per-id youtube lookup — confirms the batching contract.
   test("resolves multiple shows with a single pass through each service", async () => {
-    getReleaseUrlsByDate.mockResolvedValue({ "2004-12-31": "https://play.nugs.net/release/1" });
+    getReleaseUrlsByDate.mockResolvedValue({ "2004-12-31": ["https://play.nugs.net/release/1"] });
     getPrimaryUrlsByDate.mockResolvedValue({ "2019-08-10": "https://archive.org/details/db2019" });
     getFirstVideoUrlByShowIds.mockResolvedValue({
       "show-nye04": "https://youtube.com/watch?v=nye",
@@ -85,9 +85,9 @@ describe("computeShowExternalSources", () => {
     expect(getPrimaryUrlsByDate).toHaveBeenCalledTimes(1);
     expect(getFirstVideoUrlByShowIds).toHaveBeenCalledTimes(1);
     expect(getFirstVideoUrlByShowIds).toHaveBeenCalledWith(["show-nye04", "show-lockn"]);
-    expect(result["show-nye04"].nugsUrl).toBe("https://play.nugs.net/release/1");
+    expect(result["show-nye04"].nugsUrls).toEqual(["https://play.nugs.net/release/1"]);
     expect(result["show-lockn"].archiveUrl).toBe("https://archive.org/details/db2019");
     expect(result["show-nye04"].archiveUrl).toBeUndefined();
-    expect(result["show-lockn"].nugsUrl).toBeUndefined();
+    expect(result["show-lockn"].nugsUrls).toBeUndefined();
   });
 });

--- a/apps/web/app/server/show-external-sources.ts
+++ b/apps/web/app/server/show-external-sources.ts
@@ -34,7 +34,7 @@ export async function computeShowExternalSources(shows: ShowLike[]): Promise<Rec
 
   for (const show of shows) {
     result[show.id] = {
-      nugsUrl: nugsUrlsByDate[show.date],
+      nugsUrls: nugsUrlsByDate[show.date],
       archiveUrl: archiveUrlsByDate[show.date],
       youtubeUrl: youtubeUrlsByShowId[show.id],
     };

--- a/apps/web/app/styles.css
+++ b/apps/web/app/styles.css
@@ -834,13 +834,15 @@
     text-stroke: 1px hsl(var(--brand-primary));
   }
 
-  /* Main page heading class - consistent Tron-style centered headings */
+  /* Main page heading class - consistent Tron-style centered headings.
+     Bottom margin is sized to match the parent layout's padding-top so the
+     heading sits with symmetric vertical breathing room. */
   .page-heading {
     font-size: 2.25rem;
     font-weight: 700;
     font-family: "Audiowide", monospace;
     color: #000;
-    margin-bottom: 2rem;
+    margin-bottom: 0.5rem;
     text-align: center;
     -webkit-text-stroke: 1px hsl(var(--brand-primary));
     text-stroke: 1px hsl(var(--brand-primary));
@@ -849,6 +851,7 @@
   @media (min-width: 768px) {
     .page-heading {
       font-size: 3rem;
+      margin-bottom: 0.75rem;
     }
   }
 

--- a/packages/core/src/shows/nugs-service.ts
+++ b/packages/core/src/shows/nugs-service.ts
@@ -102,18 +102,20 @@ export class NugsService {
   }
 
   /**
-   * Build a date → release-URL map for every show nugs has, merged across
-   * artist catalogs. Exists so listing pages can render the nugs badge with a
-   * real link target via a single Redis read. When the same date exists under
-   * multiple artists, the first one wins (Disco Biscuits comes before
-   * Tractorbeam in {@link NUGS_ARTIST_IDS}, matching the "main act" default).
+   * Build a date → release-URL list map for every show nugs has, merged
+   * across artist catalogs. Exists so listing pages can render nugs badges
+   * with real link targets via a single Redis read. Dates with both a
+   * Disco Biscuits and a Tractorbeam release surface both URLs (in the
+   * {@link NUGS_ARTIST_IDS} order — Disco Biscuits first), so callers can
+   * indicate "more than one release" without a second round-trip.
    */
-  async getReleaseUrlsByDate(): Promise<Record<string, string>> {
+  async getReleaseUrlsByDate(): Promise<Record<string, string[]>> {
     const maps = await Promise.all(this.catalogs.map((c) => c.getAll()));
-    const urls: Record<string, string> = {};
+    const urls: Record<string, string[]> = {};
     for (const map of maps) {
       for (const [date, release] of Object.entries(map)) {
-        if (!urls[date]) urls[date] = release.url;
+        if (!urls[date]) urls[date] = [];
+        urls[date].push(release.url);
       }
     }
     return urls;


### PR DESCRIPTION
## Summary

Mobile responsiveness pass across the shows, songs, and song-detail pages, plus a few related cleanups.

- **Filter chrome** — Filter by Year + Jump to Month default-collapse on mobile; Filter by Media renders as a single row instead of a 2x2 square; counts hide on mobile.
- **/songs table** — tabs collapse into a `<select>` on mobile; full filter block hides behind a "Filters" toggle; sort arrows stack under header text; Plays column hides on mobile when Filtered Plays is showing; song titles use `[overflow-wrap:anywhere]` with a 10ch min-width so long words break cleanly without starving the column.
- **Song detail (/songs/$slug)** — tabs collapse into a `<select>` on mobile; stat cards render as a 2x2 grid with equal heights and tighter padding; venue sublabel hides on mobile; "last show" sublabel renders on its own line and correctly distinguishes 0 / 1 / N shows ago (previously claimed "last show" up to `<= 1`).
- **Performance tables** — Venue folds into the Date cell via new `DateVenueCell`; Notes hides on mobile; Sequence hides on mobile only when the Song column is competing for space; AllTimer flame is flush to the row edge; TrackRatingCell width becomes mobile-fluid.
- **Unified date formatting** — new `<ShowDate>` renders `M/D/YYYY` at sm+ and `M/D/YY` on mobile across /songs, /songs/all-timers, song-detail StatBoxes, and SetlistCards.
- **Show detail (/shows/$slug)** — right rail (Nugs/YouTube/Archive/Highlights) shares one `card-premium` chrome with tighter padding; Archive player is collapsed by default; reviews flow after the right rail on mobile; prev/next nav uses `ShowDate` and hides venue suffix on mobile.
- **/shows/year and /shows/top-rated** — media filters render below the title on mobile; Jump-to-Month grid is 3 cols on mobile.
- **ShowExternalSources** — `nugsUrl` → `nugsUrls[]` so dual-billed nights surface two favicons.
- **DataTable** — `hideOnMobile` column meta + `table-auto` on mobile + sm-gated width hint via `--col-w` CSS variable; pagination text abbreviated on mobile; cells use `break-words` globally.
- **Domain components lose `className` passthrough** (SetlistCard, SetlistList, ShowExternalBadges, ShowPhotos, TrackRatingOverlay) so parent routes can't inject hover/transform behavior. shadcn UI primitives keep theirs.
- **on-this-day** — prev/next month-day links abbreviate to "Apr 4" on mobile.


https://github.com/user-attachments/assets/f44218ee-404b-4583-b52c-9c5ad121e617



## Test plan

- [ ] `make tc` clean
- [ ] `bun run test` clean (357 web tests)
- [ ] At iPhone-SE width, walk through:
  - [ ] `/shows/year/2026` — Filter by Year/Jump to Month start collapsed; media filter is one row below title; Filter-by-Year counts hidden.
  - [ ] `/shows/top-rated` — Filter by Year collapses; Nugs favicon stays square; setlist cards no longer scale on hover.
  - [ ] `/shows/<slug>` — right rail flows after setlist; Archive player is collapsed by default; prev/next dates abbreviated, venue suffix hidden.
  - [ ] `/songs` — `<select>` replaces tabs; "Filters" button collapses filter block; song titles wrap via overflow-wrap:anywhere with a 10ch floor; pagination text reads "1–50 of 1500".
  - [ ] `/songs/all-timers`, `/songs/recent`, `/songs/this-year` — Sequence + Notes hidden; Plays hidden when Filtered Plays present; no horizontal scroll.
  - [ ] `/songs/i-man` — `<select>` replaces tabs; stat cards 2x2 equal-height; venue line hidden; sublabel on its own line; flame column flush; sequence column visible.
  - [ ] `/on-this-day/04-25` — prev/next "Apr" abbreviation; performance table fits without horizontal scroll.
- [ ] At ≥640px, every above flow looks identical to current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
