### PR TITLE
Tri-state media filters on /shows/year

### DIFF
--- a/apps/web/app/components/show-filters-nav.test.tsx
+++ b/apps/web/app/components/show-filters-nav.test.tsx
@@ -22,21 +22,33 @@ describe("ShowFiltersNav", () => {
     expect(screen.getByRole("link", { name: /archive/i })).toBeInTheDocument();
   });
 
-  // When a filter isn't active, clicking its link should add `=true` to the
-  // URL — matching the existing FilterNav.parameters convention.
-  test("inactive toggle link adds ?photos=true", async () => {
+  // First click on an empty filter advances to positive — the URL gains
+  // `?photos=yes` (the canonical positive serialization).
+  test("empty toggle link advances to ?photos=yes", async () => {
     await setupWithRouter(<ShowFiltersNav basePath="/shows/year/2024" currentURLParameters={new URLSearchParams()} />);
 
     const link = screen.getByRole("link", { name: /photos/i });
     const href = link.getAttribute("href") ?? "";
-    expect(paramsOf(href).get("photos")).toBe("true");
+    expect(paramsOf(href).get("photos")).toBe("yes");
   });
 
-  // When a filter is already active, clicking its link should remove it —
-  // so every button is a two-way toggle.
-  test("active toggle link removes the filter", async () => {
+  // Second click on an already-positive filter advances to negative —
+  // expresses "only shows WITHOUT photos".
+  test("positive toggle link advances to ?photos=no", async () => {
     await setupWithRouter(
-      <ShowFiltersNav basePath="/shows/year/2024" currentURLParameters={new URLSearchParams("photos=true")} />,
+      <ShowFiltersNav basePath="/shows/year/2024" currentURLParameters={new URLSearchParams("photos=yes")} />,
+    );
+
+    const link = screen.getByRole("link", { name: /photos/i });
+    const href = link.getAttribute("href") ?? "";
+    expect(paramsOf(href).get("photos")).toBe("no");
+  });
+
+  // Third click clears the filter — completes the cycle empty → positive →
+  // negative → empty so users can return to the unfiltered state by clicking.
+  test("negative toggle link clears the filter", async () => {
+    await setupWithRouter(
+      <ShowFiltersNav basePath="/shows/year/2024" currentURLParameters={new URLSearchParams("photos=no")} />,
     );
 
     const link = screen.getByRole("link", { name: /photos/i });
@@ -44,26 +56,36 @@ describe("ShowFiltersNav", () => {
     expect(paramsOf(href).has("photos")).toBe(false);
   });
 
-  // Toggling one filter must leave other active filters intact — the
-  // Filter-by-Year nav already preserves ?q= similarly.
-  test("toggling one filter preserves the others", async () => {
+  // `?photos=true` reads as positive (the parser is permissive about the
+  // value), so its toggle advances to `?photos=no` — the same path any
+  // positive-state filter takes when clicked.
+  test("?photos=true reads as positive and advances to ?photos=no", async () => {
     await setupWithRouter(
-      <ShowFiltersNav
-        basePath="/shows/year/2024"
-        currentURLParameters={new URLSearchParams("photos=true&nugs=true")}
-      />,
+      <ShowFiltersNav basePath="/shows/year/2024" currentURLParameters={new URLSearchParams("photos=true")} />,
+    );
+
+    const link = screen.getByRole("link", { name: /photos/i });
+    const href = link.getAttribute("href") ?? "";
+    expect(paramsOf(href).get("photos")).toBe("no");
+  });
+
+  // Toggling one filter must leave other active filters intact, including
+  // mixed positive/negative combinations across siblings.
+  test("toggling one filter preserves mixed positive/negative siblings", async () => {
+    await setupWithRouter(
+      <ShowFiltersNav basePath="/shows/year/2024" currentURLParameters={new URLSearchParams("photos=yes&nugs=no")} />,
     );
 
     const youtubeLink = screen.getByRole("link", { name: /youtube/i });
     const href = youtubeLink.getAttribute("href") ?? "";
     const next = paramsOf(href);
-    expect(next.get("photos")).toBe("true");
-    expect(next.get("nugs")).toBe("true");
-    expect(next.get("youtube")).toBe("true");
+    expect(next.get("photos")).toBe("yes");
+    expect(next.get("nugs")).toBe("no");
+    expect(next.get("youtube")).toBe("yes");
   });
 
-  // Non-filter query params (e.g. the legacy `?q=`) must survive a toggle
-  // click so users don't lose unrelated state.
+  // Non-filter query params (e.g. `?q=` from external search links) must
+  // survive a toggle click so users don't lose unrelated state.
   test("preserves unrelated query params", async () => {
     await setupWithRouter(
       <ShowFiltersNav basePath="/shows/year/2024" currentURLParameters={new URLSearchParams("q=camden")} />,
@@ -72,5 +94,17 @@ describe("ShowFiltersNav", () => {
     const link = screen.getByRole("link", { name: /photos/i });
     const href = link.getAttribute("href") ?? "";
     expect(paramsOf(href).get("q")).toBe("camden");
+  });
+
+  // Negative state announces "excluded" via aria-label so screen-reader
+  // users can tell positive and negative apart — neither has visual icon
+  // text and the strikethrough is purely decorative.
+  test("negative toggle has an excluded aria-label", async () => {
+    await setupWithRouter(
+      <ShowFiltersNav basePath="/shows/year/2024" currentURLParameters={new URLSearchParams("archive=no")} />,
+    );
+
+    const link = screen.getByRole("link", { name: /archive/i });
+    expect(link.getAttribute("aria-label")).toMatch(/exclud/i);
   });
 });

--- a/apps/web/app/components/show-filters-nav.tsx
+++ b/apps/web/app/components/show-filters-nav.tsx
@@ -1,14 +1,12 @@
 import { Camera } from "lucide-react";
-import { Link } from "react-router-dom";
+import { TriStateFilterButton } from "~/components/tri-state-filter-button";
 import { EXTERNAL_SOURCE_DOMAINS, faviconSrc } from "~/lib/favicon";
-import { cn } from "~/lib/utils";
+import { parseTriState, TRI_STATE_NEXT, writeTriState } from "~/lib/tri-state-filter";
 
 /**
- * The URL param names for the four external-source filters. Values are the
- * literal string `"true"` to match the convention established by
- * {@link FilterNav.parameters}, where presence (not value) drives behavior.
- * Order matches the badge strip in SetlistCard so filter buttons and the
- * per-row indicators read the same way.
+ * The URL param names for the four external-source filters. Order matches
+ * the badge strip in SetlistCard so filter buttons and the per-row
+ * indicators read the same way.
  */
 const FILTER_KEYS = ["nugs", "youtube", "archive", "photos"] as const;
 type FilterKey = (typeof FILTER_KEYS)[number];
@@ -36,11 +34,10 @@ interface ShowFiltersNavProps {
 }
 
 /**
- * Compact vertical filter stack for the year route header. Each toggle adds
- * or removes a `nugs|youtube|archive|photos=true` param so the loader can
- * stack them with AND logic. Other params (including `q=`) pass through
- * unchanged. Rendered in the page's top-right so it stays out of the way
- * of the main show list but is always visible for quick filtering.
+ * Tri-state filter stack for the year route header. Each toggle cycles
+ * empty → positive → negative → empty so users can express both "must have
+ * media X" and "must NOT have media X" in the same URL. Other params
+ * (including `q=`) pass through unchanged.
  */
 export function ShowFiltersNav({ basePath, currentURLParameters }: ShowFiltersNavProps) {
   return (
@@ -50,38 +47,30 @@ export function ShowFiltersNav({ basePath, currentURLParameters }: ShowFiltersNa
       </h2>
       <div className="grid grid-cols-4 sm:grid-cols-2 gap-1">
         {FILTER_KEYS.map((key) => {
-          const active = currentURLParameters.has(key);
+          const state = parseTriState(currentURLParameters.get(key));
           const next = new URLSearchParams(currentURLParameters);
-          if (active) next.delete(key);
-          else next.set(key, "true");
+          writeTriState(next, key, TRI_STATE_NEXT[state]);
           const search = next.toString();
 
           return (
-            <Link
+            <TriStateFilterButton
               key={key}
-              to={{ pathname: basePath, search: search ? `?${search}` : "" }}
-              className={cn(
-                "px-2 py-1 text-xs font-medium rounded-md transition-all duration-200 flex items-center gap-1.5",
-                active
-                  ? "text-white bg-content-bg-tertiary border border-brand-primary/50"
-                  : "text-content-text-secondary bg-content-bg-secondary hover:bg-content-bg-tertiary hover:text-white border border-transparent",
-              )}
-            >
-              {FILTER_FAVICON_DOMAINS[key] ? (
-                <img
-                  src={faviconSrc(FILTER_FAVICON_DOMAINS[key] as string)}
-                  alt=""
-                  aria-hidden="true"
-                  className="h-3.5 w-3.5"
-                />
-              ) : (
-                <Camera className="h-3.5 w-3.5" aria-hidden="true" />
-              )}
-              {FILTER_LABELS[key]}
-            </Link>
+              state={state}
+              label={FILTER_LABELS[key]}
+              href={`${basePath}${search ? `?${search}` : ""}`}
+              icon={<FilterFavicon filterKey={key} />}
+            />
           );
         })}
       </div>
     </div>
   );
+}
+
+function FilterFavicon({ filterKey }: { filterKey: FilterKey }) {
+  const domain = FILTER_FAVICON_DOMAINS[filterKey];
+  if (domain) {
+    return <img src={faviconSrc(domain)} alt="" aria-hidden="true" className="h-3.5 w-3.5" />;
+  }
+  return <Camera className="h-3.5 w-3.5" aria-hidden="true" />;
 }

--- a/apps/web/app/components/tri-state-filter-button.test.tsx
+++ b/apps/web/app/components/tri-state-filter-button.test.tsx
@@ -1,0 +1,86 @@
+import { setupWithRouter } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { TriStateFilterButton } from "./tri-state-filter-button";
+
+const baseProps = {
+  label: "Archive",
+  href: "/shows/year/2024?archive=yes",
+  icon: <span data-testid="icon">icon</span>,
+};
+
+describe("TriStateFilterButton", () => {
+  // Label and icon are always rendered regardless of state — the only thing
+  // state changes is styling and the aria-label phrasing.
+  test("renders label and icon", async () => {
+    await setupWithRouter(<TriStateFilterButton {...baseProps} state="empty" />);
+
+    expect(screen.getByText("Archive")).toBeInTheDocument();
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+  });
+
+  // The href flows straight through to the underlying Link so the parent
+  // owns the cycle (empty→positive→negative→empty); the button doesn't
+  // compute it.
+  test("uses the provided href verbatim", async () => {
+    await setupWithRouter(<TriStateFilterButton {...baseProps} state="positive" />);
+
+    const link = screen.getByRole("link", { name: /archive/i });
+    expect(link.getAttribute("href")).toBe("/shows/year/2024?archive=yes");
+  });
+
+  // Empty-state aria-label tells screen reader users the filter is off and
+  // what clicking does — preserves accessibility parity with the visual cue
+  // (border style) sighted users get.
+  test("empty state announces 'not filtered, click to require'", async () => {
+    await setupWithRouter(<TriStateFilterButton {...baseProps} state="empty" />);
+
+    const link = screen.getByRole("link", { name: /archive/i });
+    expect(link.getAttribute("aria-label")).toMatch(/not filtered/i);
+    expect(link.getAttribute("aria-label")).toMatch(/click to require/i);
+  });
+
+  // Positive-state aria-label distinguishes "included" from "excluded" —
+  // a key accessibility requirement since the only visual difference is
+  // border color.
+  test("positive state announces 'currently included, click to exclude'", async () => {
+    await setupWithRouter(<TriStateFilterButton {...baseProps} state="positive" />);
+
+    const link = screen.getByRole("link", { name: /archive/i });
+    expect(link.getAttribute("aria-label")).toMatch(/currently included/i);
+    expect(link.getAttribute("aria-label")).toMatch(/click to exclude/i);
+  });
+
+  // Negative-state aria-label closes the cycle: clicking returns to empty.
+  test("negative state announces 'currently excluded, click to clear'", async () => {
+    await setupWithRouter(<TriStateFilterButton {...baseProps} state="negative" />);
+
+    const link = screen.getByRole("link", { name: /archive/i });
+    expect(link.getAttribute("aria-label")).toMatch(/currently excluded/i);
+    expect(link.getAttribute("aria-label")).toMatch(/click to clear/i);
+  });
+
+  // Negative state wraps the icon in a strikethrough overlay so the icon
+  // visually reads as "excluded". The overlay is the only `.rotate-45`
+  // element rendered, so its presence is a clean signal.
+  test("negative state wraps the icon with a strikethrough overlay", async () => {
+    const { unmount } = await setupWithRouter(<TriStateFilterButton {...baseProps} state="negative" />);
+    expect(document.querySelector(".rotate-45")).not.toBeNull();
+    unmount();
+
+    await setupWithRouter(<TriStateFilterButton {...baseProps} state="empty" />);
+    expect(document.querySelector(".rotate-45")).toBeNull();
+  });
+
+  // Each state applies a distinct border class — empty is the only state
+  // without a colored border. These are the visual cues sighted users get
+  // to tell the three states apart.
+  test.each([
+    ["empty", "border-transparent"],
+    ["positive", "border-brand-primary"],
+    ["negative", "border-red-500"],
+  ] as const)("%s state has %s border class", async (state, expectedClass) => {
+    await setupWithRouter(<TriStateFilterButton {...baseProps} state={state} />);
+    expect(screen.getByRole("link").className).toContain(expectedClass);
+  });
+});

--- a/apps/web/app/components/tri-state-filter-button.tsx
+++ b/apps/web/app/components/tri-state-filter-button.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import type { TriState } from "~/lib/tri-state-filter";
+import { cn } from "~/lib/utils";
+
+interface TriStateFilterButtonProps {
+  /** Current state of the filter — drives styling and aria-label phrasing. */
+  state: TriState;
+  /** Visible button text — also used inside the aria-label. */
+  label: string;
+  /** Icon node rendered to the left of the label. The negative state wraps
+   * this in a strikethrough overlay; the icon itself stays unchanged. */
+  icon: ReactNode;
+  /** Destination link for the button click — typically the current path with
+   * the filter param advanced one step in the cycle. */
+  href: string;
+}
+
+const STATE_DESCRIPTION: Record<TriState, string> = {
+  empty: "not filtered",
+  positive: "currently included",
+  negative: "currently excluded",
+};
+
+const NEXT_DESCRIPTION: Record<TriState, string> = {
+  empty: "click to require",
+  positive: "click to exclude",
+  negative: "click to clear",
+};
+
+/**
+ * One button in a tri-state filter strip. Centralizes the empty / positive
+ * / negative className branches and the strikethrough overlay so callers
+ * only own the cycle decision (which state comes next) and the icon choice.
+ */
+export function TriStateFilterButton({ state, label, icon, href }: TriStateFilterButtonProps) {
+  return (
+    <Link
+      to={href}
+      aria-label={`${label} filter — ${STATE_DESCRIPTION[state]}, ${NEXT_DESCRIPTION[state]}`}
+      className={cn(
+        "px-2 py-1 text-xs font-medium rounded-md transition-all duration-200 flex items-center gap-1.5 border",
+        state === "positive" && "text-white bg-content-bg-tertiary border-brand-primary/50",
+        state === "negative" && "text-white bg-red-600/10 border-red-500/50",
+        state === "empty" &&
+          "text-content-text-secondary bg-content-bg-secondary hover:bg-content-bg-tertiary hover:text-white border-transparent",
+      )}
+    >
+      <FilterIcon state={state}>{icon}</FilterIcon>
+      {label}
+    </Link>
+  );
+}
+
+/**
+ * Wraps an icon in a diagonal strikethrough overlay for the negative state.
+ * In other states the icon renders unchanged so all three buttons keep the
+ * same visual rhythm.
+ */
+function FilterIcon({ state, children }: { state: TriState; children: ReactNode }) {
+  if (state !== "negative") return <>{children}</>;
+
+  return (
+    <span className="relative inline-flex h-3.5 w-3.5 items-center justify-center" aria-hidden="true">
+      {children}
+      <span className="absolute inset-0 flex items-center justify-center">
+        <span className="block h-[2px] w-full rotate-45 bg-white shadow-[0_0_0_1px_rgba(0,0,0,0.5)]" />
+      </span>
+    </span>
+  );
+}

--- a/apps/web/app/lib/tri-state-filter.test.ts
+++ b/apps/web/app/lib/tri-state-filter.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+import { parseTriState, TRI_STATE_NEXT, writeTriState } from "~/lib/tri-state-filter";
+
+describe("parseTriState", () => {
+  // Missing key in URLSearchParams.get() returns null — that's the empty state.
+  test("returns empty when value is null", () => {
+    expect(parseTriState(null)).toBe("empty");
+  });
+
+  // The canonical positive serialization.
+  test("returns positive for 'yes'", () => {
+    expect(parseTriState("yes")).toBe("positive");
+  });
+
+  // The only string that means negative — anything else with a value reads positive.
+  test("returns negative for 'no'", () => {
+    expect(parseTriState("no")).toBe("negative");
+  });
+
+  // Permissive positive parsing: bare-key `?archive` (URLSearchParams.get
+  // returns ""), `?archive=true`, and any non-"no" value all read as positive.
+  // Lets shared/bookmarked URLs that omit the value or use other truthy
+  // strings still narrow the show list.
+  test.each(["true", "", "1", "anything"])("returns positive for non-'no' value %p", (value) => {
+    expect(parseTriState(value)).toBe("positive");
+  });
+});
+
+describe("writeTriState", () => {
+  // Empty state must remove the key entirely so URLs stay clean and old
+  // presence-checks (if any survive) don't read a stale value as positive.
+  test("empty deletes the key", () => {
+    const params = new URLSearchParams("archive=yes&nugs=no");
+    writeTriState(params, "archive", "empty");
+    expect(params.has("archive")).toBe(false);
+    expect(params.get("nugs")).toBe("no");
+  });
+
+  // Positive writes the canonical "yes" value.
+  test("positive sets value to 'yes'", () => {
+    const params = new URLSearchParams();
+    writeTriState(params, "archive", "positive");
+    expect(params.get("archive")).toBe("yes");
+  });
+
+  // Negative writes the canonical "no" value.
+  test("negative sets value to 'no'", () => {
+    const params = new URLSearchParams();
+    writeTriState(params, "archive", "negative");
+    expect(params.get("archive")).toBe("no");
+  });
+
+  // Re-writing an already-set key replaces (not duplicates) the value, so
+  // cycling between states leaves a single canonical entry.
+  test("overwrites an existing value", () => {
+    const params = new URLSearchParams("archive=yes");
+    writeTriState(params, "archive", "negative");
+    expect(params.getAll("archive")).toEqual(["no"]);
+  });
+});
+
+describe("TRI_STATE_NEXT", () => {
+  // The cycle the user requested: empty → positive → negative → empty.
+  // Locking this down protects the click-handler in show-filters-nav from
+  // accidental reorderings.
+  test("cycles empty → positive → negative → empty", () => {
+    expect(TRI_STATE_NEXT.empty).toBe("positive");
+    expect(TRI_STATE_NEXT.positive).toBe("negative");
+    expect(TRI_STATE_NEXT.negative).toBe("empty");
+  });
+});

--- a/apps/web/app/lib/tri-state-filter.ts
+++ b/apps/web/app/lib/tri-state-filter.ts
@@ -1,0 +1,63 @@
+/**
+ * Tri-state for the year-page media filters: each toggle cycles
+ * empty → positive → negative → empty so users can express both
+ * "must have media X" and "must NOT have media X" in the same URL.
+ */
+export type TriState = "empty" | "positive" | "negative";
+
+/**
+ * The click cycle. Lives here (not inline in the component) so loader,
+ * counts helper, and component all agree on the order.
+ */
+export const TRI_STATE_NEXT: Record<TriState, TriState> = {
+  empty: "positive",
+  positive: "negative",
+  negative: "empty",
+};
+
+/**
+ * Read a tri-state value from a `URLSearchParams.get()` result. Anything
+ * other than literal `"no"` reads as positive — including bare-key `?key`
+ * (which `.get()` returns as `""`) and `?key=true`. Permissive on purpose
+ * so externally shared URLs that omit the value still narrow the show list.
+ */
+export function parseTriState(value: string | null): TriState {
+  if (value === null) return "empty";
+  if (value === "no") return "negative";
+  return "positive";
+}
+
+/**
+ * Mutate `params` so the given filter key reflects `state`. Empty deletes
+ * the key entirely; positive/negative write the canonical `"yes"` / `"no"`.
+ */
+export function writeTriState(params: URLSearchParams, key: string, state: TriState): void {
+  if (state === "empty") {
+    params.delete(key);
+  } else if (state === "positive") {
+    params.set(key, "yes");
+  } else {
+    params.set(key, "no");
+  }
+}
+
+/**
+ * Convert a tri-state to the `boolean | undefined` shape used by the core
+ * `SetlistFilter` for `hasPhotos` / `hasYoutube`.
+ *   empty → undefined (no filter)
+ *   positive → true (must have)
+ *   negative → false (must NOT have)
+ */
+export function triStateToBoolean(state: TriState): boolean | undefined {
+  if (state === "empty") return undefined;
+  return state === "positive";
+}
+
+/** True when at least one flag is in a non-empty state. */
+export function isAnyTriStateActive(flags: Record<string, TriState | undefined>): boolean {
+  for (const key in flags) {
+    const value = flags[key];
+    if (value && value !== "empty") return true;
+  }
+  return false;
+}

--- a/apps/web/app/routes/shows/year/$year.tsx
+++ b/apps/web/app/routes/shows/year/$year.tsx
@@ -13,6 +13,7 @@ import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
 import { logger } from "~/lib/logger";
 import { getShowsMeta } from "~/lib/seo";
+import { parseTriState, type TriState, triStateToBoolean } from "~/lib/tri-state-filter";
 import { cn } from "~/lib/utils";
 import { applyExternalSourceFilters } from "~/server/apply-external-source-filters";
 import { services } from "~/server/services";
@@ -27,7 +28,7 @@ interface LoaderData {
   externalSources: Record<string, ShowExternalSources>;
   showCountsByYear: Record<number, number>;
   monthCounts: Record<number, number>;
-  filters: { photos: boolean; youtube: boolean; nugs: boolean; archive: boolean };
+  filters: { photos: TriState; youtube: TriState; nugs: TriState; archive: TriState };
   initialUserData: ShowUserDataResponse;
 }
 
@@ -70,10 +71,10 @@ export const loader = publicLoader(async ({ request, params, context }): Promise
   const searchQuery = url.searchParams.get("q") || undefined;
 
   const filters = {
-    photos: url.searchParams.has("photos"),
-    youtube: url.searchParams.has("youtube"),
-    nugs: url.searchParams.has("nugs"),
-    archive: url.searchParams.has("archive"),
+    photos: parseTriState(url.searchParams.get("photos")),
+    youtube: parseTriState(url.searchParams.get("youtube")),
+    nugs: parseTriState(url.searchParams.get("nugs")),
+    archive: parseTriState(url.searchParams.get("archive")),
   };
   const emptyCounts: Record<number, number> = {};
 
@@ -122,8 +123,8 @@ export const loader = publicLoader(async ({ request, params, context }): Promise
     return await services.setlists.findManyLight({
       filters: {
         year: yearInt,
-        hasPhotos: filters.photos || undefined,
-        hasYoutube: filters.youtube || undefined,
+        hasPhotos: triStateToBoolean(filters.photos),
+        hasYoutube: triStateToBoolean(filters.youtube),
       },
       sort: [{ field: "date", direction: sortDirection }],
     });

--- a/apps/web/app/server/apply-external-source-filters.test.ts
+++ b/apps/web/app/server/apply-external-source-filters.test.ts
@@ -14,12 +14,13 @@ function sources(partial: Partial<ShowExternalSources>): ShowExternalSources {
 
 describe("applyExternalSourceFilters", () => {
   // No filter flags active → input passes through untouched. The year loader
-  // uses this helper unconditionally, so the no-op path has to be cheap.
+  // uses this helper unconditionally, so the no-op path has to be cheap and
+  // return-by-reference (preserves React Query reference equality downstream).
   test("returns setlists unchanged when no filters are active", () => {
-    const setlists = [setlist("astronaut"), setlist("moshi")];
+    const setlists = [setlist("astronaut"), setlist("basis")];
     const externalSources: Record<string, ShowExternalSources> = {
       astronaut: sources({}),
-      moshi: sources({}),
+      basis: sources({}),
     };
 
     const result = applyExternalSourceFilters(setlists, externalSources, {});
@@ -27,56 +28,136 @@ describe("applyExternalSourceFilters", () => {
     expect(result).toBe(setlists);
   });
 
-  // nugs flag drops any setlist whose externalSources has no nugsUrl.
-  test("filters out setlists missing a nugs url when nugs flag is on", () => {
-    const setlists = [setlist("astronaut"), setlist("moshi")];
+  // "empty" tri-state is equivalent to the flag being absent — the helper
+  // must treat an explicit `"empty"` the same as not passing the key.
+  test("treats empty tri-state as no filter", () => {
+    const setlists = [setlist("astronaut"), setlist("basis")];
+    const externalSources: Record<string, ShowExternalSources> = {
+      astronaut: sources({}),
+      basis: sources({}),
+    };
+
+    const result = applyExternalSourceFilters(setlists, externalSources, {
+      nugs: "empty",
+      archive: "empty",
+    });
+
+    expect(result).toBe(setlists);
+  });
+
+  // Positive nugs keeps only shows that DO have a nugs url.
+  test("nugs=positive keeps only shows with a nugs url", () => {
+    const setlists = [setlist("astronaut"), setlist("basis")];
     const externalSources: Record<string, ShowExternalSources> = {
       astronaut: sources({ nugsUrls: ["https://play.nugs.net/release/1"] }),
-      moshi: sources({}),
+      basis: sources({}),
     };
 
-    const result = applyExternalSourceFilters(setlists, externalSources, { nugs: true });
+    const result = applyExternalSourceFilters(setlists, externalSources, { nugs: "positive" });
 
     expect(result.map((s: { show: { id: string } }) => s.show.id)).toEqual(["astronaut"]);
   });
 
-  // archive flag drops setlists lacking archiveUrl — mirrors nugs behavior.
-  test("filters out setlists missing an archive url when archive flag is on", () => {
-    const setlists = [setlist("astronaut"), setlist("moshi")];
+  // Negative nugs is the opposite — keep only shows without a nugs url.
+  // Without this branch, "shows that have archive but NOT nugs" can't be expressed.
+  test("nugs=negative keeps only shows without a nugs url", () => {
+    const setlists = [setlist("astronaut"), setlist("basis")];
+    const externalSources: Record<string, ShowExternalSources> = {
+      astronaut: sources({ nugsUrls: ["https://play.nugs.net/release/1"] }),
+      basis: sources({}),
+    };
+
+    const result = applyExternalSourceFilters(setlists, externalSources, { nugs: "negative" });
+
+    expect(result.map((s: { show: { id: string } }) => s.show.id)).toEqual(["basis"]);
+  });
+
+  // Positive archive — same shape as positive nugs but for archive.org links.
+  test("archive=positive keeps only shows with an archive url", () => {
+    const setlists = [setlist("astronaut"), setlist("basis")];
     const externalSources: Record<string, ShowExternalSources> = {
       astronaut: sources({ archiveUrl: "https://archive.org/details/db" }),
-      moshi: sources({}),
+      basis: sources({}),
     };
 
-    const result = applyExternalSourceFilters(setlists, externalSources, { archive: true });
+    const result = applyExternalSourceFilters(setlists, externalSources, { archive: "positive" });
 
     expect(result.map((s: { show: { id: string } }) => s.show.id)).toEqual(["astronaut"]);
   });
 
-  // nugs + archive combine with AND — a show must have both links to survive.
-  test("requires all active flags (AND) when multiple are set", () => {
-    const setlists = [setlist("astronaut"), setlist("moshi"), setlist("basis")];
+  // Negative archive — keep only shows without an archive url.
+  test("archive=negative keeps only shows without an archive url", () => {
+    const setlists = [setlist("astronaut"), setlist("basis")];
+    const externalSources: Record<string, ShowExternalSources> = {
+      astronaut: sources({ archiveUrl: "https://archive.org/details/db" }),
+      basis: sources({}),
+    };
+
+    const result = applyExternalSourceFilters(setlists, externalSources, { archive: "negative" });
+
+    expect(result.map((s: { show: { id: string } }) => s.show.id)).toEqual(["basis"]);
+  });
+
+  // The headline use case from the user request: "shows that have archive but
+  // NOT nugs". Mixed positive + negative across the two flags must AND together.
+  test("archive=positive + nugs=negative keeps only shows with archive and no nugs", () => {
+    const setlists = [
+      setlist("crystal-ball"),
+      setlist("basis-for-a-day"),
+      setlist("munchkin-invasion"),
+      setlist("plan-b"),
+    ];
+    const externalSources: Record<string, ShowExternalSources> = {
+      "crystal-ball": sources({ archiveUrl: "a1" }), // archive yes, nugs no → keep
+      "basis-for-a-day": sources({ archiveUrl: "a2", nugsUrls: ["n2"] }), // both → drop (has nugs)
+      "munchkin-invasion": sources({ nugsUrls: ["n3"] }), // nugs only → drop (no archive)
+      "plan-b": sources({}), // neither → drop (no archive)
+    };
+
+    const result = applyExternalSourceFilters(setlists, externalSources, {
+      archive: "positive",
+      nugs: "negative",
+    });
+
+    expect(result.map((s: { show: { id: string } }) => s.show.id)).toEqual(["crystal-ball"]);
+  });
+
+  // Two positives combine with AND — a show must have both links to survive
+  // the filter (mirrors the per-show predicate's short-circuit semantics).
+  test("positive + positive combine with AND", () => {
+    const setlists = [setlist("astronaut"), setlist("basis"), setlist("crystal-ball")];
     const externalSources: Record<string, ShowExternalSources> = {
       astronaut: sources({ nugsUrls: ["n1"], archiveUrl: "a1" }),
-      moshi: sources({ nugsUrls: ["n2"] }),
-      basis: sources({ archiveUrl: "a3" }),
+      basis: sources({ nugsUrls: ["n2"] }),
+      "crystal-ball": sources({ archiveUrl: "a3" }),
     };
 
-    const result = applyExternalSourceFilters(setlists, externalSources, { nugs: true, archive: true });
+    const result = applyExternalSourceFilters(setlists, externalSources, {
+      nugs: "positive",
+      archive: "positive",
+    });
 
     expect(result.map((s: { show: { id: string } }) => s.show.id)).toEqual(["astronaut"]);
   });
 
-  // A show missing from the externalSources map fails every external-source
-  // filter — treat missing as "no link found".
-  test("drops setlists that have no entry in externalSources when a flag is on", () => {
+  // A show missing from the externalSources map has no links → fails any
+  // positive filter, satisfies any negative filter.
+  test("missing entry in externalSources counts as no link", () => {
     const setlists = [setlist("astronaut"), setlist("orphan")];
     const externalSources: Record<string, ShowExternalSources> = {
       astronaut: sources({ nugsUrls: ["n1"] }),
     };
 
-    const result = applyExternalSourceFilters(setlists, externalSources, { nugs: true });
+    expect(
+      applyExternalSourceFilters(setlists, externalSources, { nugs: "positive" }).map(
+        (s: { show: { id: string } }) => s.show.id,
+      ),
+    ).toEqual(["astronaut"]);
 
-    expect(result.map((s: { show: { id: string } }) => s.show.id)).toEqual(["astronaut"]);
+    expect(
+      applyExternalSourceFilters(setlists, externalSources, { nugs: "negative" }).map(
+        (s: { show: { id: string } }) => s.show.id,
+      ),
+    ).toEqual(["orphan"]);
   });
 });

--- a/apps/web/app/server/apply-external-source-filters.ts
+++ b/apps/web/app/server/apply-external-source-filters.ts
@@ -1,32 +1,47 @@
 import type { SetlistLight } from "@bip/domain";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
+import type { TriState } from "~/lib/tri-state-filter";
 
 /**
- * Flags for the external-source filters that are NOT queryable in Prisma
- * (nugs/archive live in Redis catalogs). Photo and YouTube filters live on
- * the denormalized show counts and are applied in the DB query, not here.
+ * Tri-state flags for the external-source filters that are NOT queryable in
+ * Prisma (nugs/archive live in Redis catalogs). Photo and YouTube filters
+ * live on the denormalized show counts and are applied in the DB query.
+ *
+ * - "positive" → keep only setlists with the source
+ * - "negative" → keep only setlists without the source
+ * - "empty" / undefined → no filter
  */
 export interface ExternalSourceFilterFlags {
-  nugs?: boolean;
-  archive?: boolean;
+  nugs?: TriState;
+  archive?: TriState;
+}
+
+function isActive(state: TriState | undefined): boolean {
+  return state === "positive" || state === "negative";
 }
 
 /**
- * Drop setlists whose resolved external sources don't include the links
- * required by the active flags. Returns the input reference unchanged when
- * no flag is set so callers can use it unconditionally on every request.
+ * Drop setlists whose resolved external sources don't match the active
+ * flags. Returns the input reference unchanged when no flag is active so
+ * callers can use it unconditionally on every request without breaking
+ * downstream reference equality.
  */
 export function applyExternalSourceFilters<T extends Pick<SetlistLight, "show">>(
   setlists: T[],
   externalSources: Record<string, ShowExternalSources>,
   flags: ExternalSourceFilterFlags,
 ): T[] {
-  if (!flags.nugs && !flags.archive) return setlists;
+  if (!isActive(flags.nugs) && !isActive(flags.archive)) return setlists;
 
   return setlists.filter((setlist) => {
     const sources = externalSources[setlist.show.id];
-    if (flags.nugs && !sources?.nugsUrls?.length) return false;
-    if (flags.archive && !sources?.archiveUrl) return false;
+    const hasNugs = Boolean(sources?.nugsUrls?.length);
+    const hasArchive = Boolean(sources?.archiveUrl);
+
+    if (flags.nugs === "positive" && !hasNugs) return false;
+    if (flags.nugs === "negative" && hasNugs) return false;
+    if (flags.archive === "positive" && !hasArchive) return false;
+    if (flags.archive === "negative" && hasArchive) return false;
     return true;
   });
 }

--- a/apps/web/app/server/show-counts-by-year.test.ts
+++ b/apps/web/app/server/show-counts-by-year.test.ts
@@ -36,21 +36,35 @@ describe("computeShowCountsByYear", () => {
     expect(result).toEqual({ 2004: 2, 2023: 1 });
   });
 
-  // Photo filter uses the denormalized flag — no catalog lookups needed.
-  test("counts only shows with photos when photos flag is on", async () => {
+  // Positive photos filter — denormalized flag, no catalog lookups needed.
+  test("photos=positive counts only shows with photos", async () => {
     getShowDatesWithFlags.mockResolvedValue([
       { date: "2004-06-01", hasPhotos: false, hasYoutube: false },
       { date: "2004-12-31", hasPhotos: true, hasYoutube: false },
       { date: "2023-06-15", hasPhotos: true, hasYoutube: false },
     ]);
 
-    const result = await computeShowCountsByYear({ photos: true });
+    const result = await computeShowCountsByYear({ photos: "positive" });
 
     expect(result).toEqual({ 2004: 1, 2023: 1 });
   });
 
-  // Nugs filter intersects show dates with the nugs catalog (one Redis read).
-  test("counts only shows present in the nugs catalog when nugs flag is on", async () => {
+  // Negative photos — the inverse. Required for the user's "shows without
+  // photos in 2004" use case from the year-page sidebar.
+  test("photos=negative counts only shows without photos", async () => {
+    getShowDatesWithFlags.mockResolvedValue([
+      { date: "2004-06-01", hasPhotos: false, hasYoutube: false },
+      { date: "2004-12-31", hasPhotos: true, hasYoutube: false },
+      { date: "2023-06-15", hasPhotos: true, hasYoutube: false },
+    ]);
+
+    const result = await computeShowCountsByYear({ photos: "negative" });
+
+    expect(result).toEqual({ 2004: 1 });
+  });
+
+  // Positive nugs intersects show dates with the nugs catalog (one Redis read).
+  test("nugs=positive counts only shows present in the nugs catalog", async () => {
     getShowDatesWithFlags.mockResolvedValue([
       { date: "2004-12-31", hasPhotos: false, hasYoutube: false },
       { date: "2019-08-10", hasPhotos: false, hasYoutube: false },
@@ -61,29 +75,56 @@ describe("computeShowCountsByYear", () => {
       "2023-06-15": ["https://play.nugs.net/release/2"],
     });
 
-    const result = await computeShowCountsByYear({ nugs: true });
+    const result = await computeShowCountsByYear({ nugs: "positive" });
 
     expect(result).toEqual({ 2004: 1, 2023: 1 });
   });
 
-  // Archive filter mirrors nugs but uses the archive.org catalog.
-  test("counts only shows present in the archive catalog when archive flag is on", async () => {
+  // Negative nugs — keep only shows NOT in the catalog. Crucially the
+  // catalog must be fetched for the negative branch too: we can't decide
+  // "not in nugs" without knowing which dates are in nugs.
+  test("nugs=negative counts only shows missing from the nugs catalog", async () => {
     getShowDatesWithFlags.mockResolvedValue([
       { date: "2004-12-31", hasPhotos: false, hasYoutube: false },
       { date: "2019-08-10", hasPhotos: false, hasYoutube: false },
+      { date: "2023-06-15", hasPhotos: false, hasYoutube: false },
     ]);
-    getPrimaryUrlsByDate.mockResolvedValue({
-      "2019-08-10": "https://archive.org/details/db2019",
+    getReleaseUrlsByDate.mockResolvedValue({
+      "2004-12-31": ["https://play.nugs.net/release/1"],
     });
 
-    const result = await computeShowCountsByYear({ archive: true });
+    const result = await computeShowCountsByYear({ nugs: "negative" });
 
-    expect(result).toEqual({ 2019: 1 });
+    expect(getReleaseUrlsByDate).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ 2019: 1, 2023: 1 });
   });
 
-  // All flags combine with AND — a show needs to pass every active filter to
-  // be counted. Covers the worst-case "stacked filters" path end-to-end.
-  test("combines flags with AND across photos/youtube/nugs/archive", async () => {
+  // Mixed positive + negative: the user's headline use case at the year-bucket
+  // level. Counts shows with archive AND without nugs.
+  test("archive=positive + nugs=negative counts shows with archive but no nugs", async () => {
+    getShowDatesWithFlags.mockResolvedValue([
+      { date: "2004-06-01", hasPhotos: false, hasYoutube: false }, // archive yes, nugs no → keep
+      { date: "2004-12-31", hasPhotos: false, hasYoutube: false }, // archive yes, nugs yes → drop
+      { date: "2019-08-10", hasPhotos: false, hasYoutube: false }, // archive no, nugs no → drop
+      { date: "2023-06-15", hasPhotos: false, hasYoutube: false }, // archive no, nugs yes → drop
+    ]);
+    getReleaseUrlsByDate.mockResolvedValue({
+      "2004-12-31": ["nugs"],
+      "2023-06-15": ["nugs"],
+    });
+    getPrimaryUrlsByDate.mockResolvedValue({
+      "2004-06-01": "archive",
+      "2004-12-31": "archive",
+    });
+
+    const result = await computeShowCountsByYear({ archive: "positive", nugs: "negative" });
+
+    expect(result).toEqual({ 2004: 1 });
+  });
+
+  // All flags positive combine with AND — every active filter must match
+  // for a show to be counted in its year bucket.
+  test("all positives combine with AND across photos/youtube/nugs/archive", async () => {
     getShowDatesWithFlags.mockResolvedValue([
       { date: "2004-12-31", hasPhotos: true, hasYoutube: true }, // in both catalogs
       { date: "2019-08-10", hasPhotos: true, hasYoutube: true }, // not in nugs
@@ -99,13 +140,34 @@ describe("computeShowCountsByYear", () => {
     });
 
     const result = await computeShowCountsByYear({
-      photos: true,
-      youtube: true,
-      nugs: true,
-      archive: true,
+      photos: "positive",
+      youtube: "positive",
+      nugs: "positive",
+      archive: "positive",
     });
 
     expect(result).toEqual({ 2004: 1 });
+  });
+
+  // Empty tri-state must behave identically to the flag being absent — no
+  // catalog reads, no filtering. Protects callers that pass through whatever
+  // state they parsed from the URL without normalizing first.
+  test("empty tri-state behaves like no filter", async () => {
+    getShowDatesWithFlags.mockResolvedValue([
+      { date: "2004-06-01", hasPhotos: false, hasYoutube: false },
+      { date: "2023-06-15", hasPhotos: true, hasYoutube: false },
+    ]);
+
+    const result = await computeShowCountsByYear({
+      photos: "empty",
+      youtube: "empty",
+      nugs: "empty",
+      archive: "empty",
+    });
+
+    expect(getReleaseUrlsByDate).not.toHaveBeenCalled();
+    expect(getPrimaryUrlsByDate).not.toHaveBeenCalled();
+    expect(result).toEqual({ 2004: 1, 2023: 1 });
   });
 
   // Years with zero matching shows don't appear in the result map, so the
@@ -116,7 +178,7 @@ describe("computeShowCountsByYear", () => {
       { date: "2023-06-15", hasPhotos: true, hasYoutube: false },
     ]);
 
-    const result = await computeShowCountsByYear({ photos: true });
+    const result = await computeShowCountsByYear({ photos: "positive" });
 
     expect(result).toEqual({ 2023: 1 });
     expect(result[2004]).toBeUndefined();

--- a/apps/web/app/server/show-counts-by-year.ts
+++ b/apps/web/app/server/show-counts-by-year.ts
@@ -1,14 +1,21 @@
+import type { TriState } from "~/lib/tri-state-filter";
 import { services } from "~/server/services";
 
 /**
- * Filter flags accepted by {@link computeShowCountsByYear}. Mirrors the
- * toggle set in the year-page filter bar. All active flags combine with AND.
+ * Tri-state filter flags for {@link computeShowCountsByYear}. Mirrors the
+ * toggle set in the year-page filter bar — each filter can be positive
+ * (must have media), negative (must NOT have media), or empty (don't filter).
+ * All non-empty flags combine with AND.
  */
 export interface ShowCountsFilterFlags {
-  photos?: boolean;
-  youtube?: boolean;
-  nugs?: boolean;
-  archive?: boolean;
+  photos?: TriState;
+  youtube?: TriState;
+  nugs?: TriState;
+  archive?: TriState;
+}
+
+function isActive(state: TriState | undefined): boolean {
+  return state === "positive" || state === "negative";
 }
 
 /**
@@ -17,11 +24,13 @@ export interface ShowCountsFilterFlags {
  *
  * One DB read (all show dates + denormalized flags) plus at most two Redis
  * reads (nugs/archive catalogs, each a full date-keyed map) — work is flat
- * regardless of how many years exist.
+ * regardless of how many years exist. Both positive and negative tri-state
+ * branches need the catalog: deciding "not in nugs" requires knowing which
+ * dates are in nugs.
  */
 export async function computeShowCountsByYear(flags: ShowCountsFilterFlags): Promise<Record<number, number>> {
-  const needsNugs = Boolean(flags.nugs);
-  const needsArchive = Boolean(flags.archive);
+  const needsNugs = isActive(flags.nugs);
+  const needsArchive = isActive(flags.archive);
 
   const [showDates, nugsUrlsByDate, archiveUrlsByDate] = await Promise.all([
     services.shows.getShowDatesWithFlags(),
@@ -31,10 +40,18 @@ export async function computeShowCountsByYear(flags: ShowCountsFilterFlags): Pro
 
   const counts: Record<number, number> = {};
   for (const show of showDates) {
-    if (flags.photos && !show.hasPhotos) continue;
-    if (flags.youtube && !show.hasYoutube) continue;
-    if (needsNugs && !nugsUrlsByDate[show.date]?.length) continue;
-    if (needsArchive && !archiveUrlsByDate[show.date]) continue;
+    if (flags.photos === "positive" && !show.hasPhotos) continue;
+    if (flags.photos === "negative" && show.hasPhotos) continue;
+    if (flags.youtube === "positive" && !show.hasYoutube) continue;
+    if (flags.youtube === "negative" && show.hasYoutube) continue;
+
+    const hasNugs = Boolean(nugsUrlsByDate[show.date]?.length);
+    if (flags.nugs === "positive" && !hasNugs) continue;
+    if (flags.nugs === "negative" && hasNugs) continue;
+
+    const hasArchive = Boolean(archiveUrlsByDate[show.date]);
+    if (flags.archive === "positive" && !hasArchive) continue;
+    if (flags.archive === "negative" && hasArchive) continue;
 
     const year = Number.parseInt(show.date.slice(0, 4), 10);
     counts[year] = (counts[year] ?? 0) + 1;

--- a/packages/core/src/setlists/setlist-service.test.ts
+++ b/packages/core/src/setlists/setlist-service.test.ts
@@ -26,7 +26,8 @@ describe("SetlistService.findManyLight", () => {
     expect(call.where.date).toEqual({ endsWith: "-04-04" });
   });
 
-  // Existing year filter still works (gte/lt range) — no regression
+  // Year filter expands to a half-open date range (gte first day, lt next
+  // year's first day) so it works with the string-shaped date column.
   test("applies gte/lt date filter when year is provided", async () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never);
@@ -50,9 +51,9 @@ describe("SetlistService.findManyLight", () => {
     expect(call.where.date).toBeUndefined();
   });
 
-  // hasYoutube maps to showYoutubesCount > 0 — same pattern as hasPhotos but
-  // targets the denormalized YouTube count on the Show model.
-  test("applies showYoutubesCount > 0 when hasYoutube filter is true", async () => {
+  // hasYoutube=true maps to showYoutubesCount > 0 — same pattern as hasPhotos
+  // but targets the denormalized YouTube count on the Show model.
+  test("applies showYoutubesCount > 0 when hasYoutube is true", async () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never);
 
@@ -64,9 +65,38 @@ describe("SetlistService.findManyLight", () => {
     expect(call.where.showYoutubesCount).toEqual({ gt: 0 });
   });
 
-  // Without the flag set, the where-clause must not constrain showYoutubesCount
-  // so shows without YouTube videos remain in the results.
-  test("omits showYoutubesCount filter when hasYoutube is not set", async () => {
+  // hasYoutube=false is the negative tri-state branch — caller is asking for
+  // shows that explicitly DO NOT have a YouTube video. Maps to showYoutubesCount = 0
+  // rather than skipping the filter (which is the `undefined` case).
+  test("applies showYoutubesCount = 0 when hasYoutube is false", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never);
+
+    await service.findManyLight({
+      filters: { year: 2024, hasYoutube: false },
+    });
+
+    const call = db.show.findMany.mock.calls[0][0];
+    expect(call.where.showYoutubesCount).toEqual({ equals: 0 });
+  });
+
+  // hasPhotos=false — same negative branch on the photos column. Drives the
+  // "shows without photos" filter from the year-page UI.
+  test("applies showPhotosCount = 0 when hasPhotos is false", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never);
+
+    await service.findManyLight({
+      filters: { year: 2024, hasPhotos: false },
+    });
+
+    const call = db.show.findMany.mock.calls[0][0];
+    expect(call.where.showPhotosCount).toEqual({ equals: 0 });
+  });
+
+  // Without the flag set (undefined), the where-clause must not constrain
+  // either count column so all shows remain in the results.
+  test("omits photos/youtube filters when hasPhotos and hasYoutube are undefined", async () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never);
 
@@ -74,21 +104,23 @@ describe("SetlistService.findManyLight", () => {
 
     const call = db.show.findMany.mock.calls[0][0];
     expect(call.where.showYoutubesCount).toBeUndefined();
+    expect(call.where.showPhotosCount).toBeUndefined();
   });
 
   // hasPhotos and hasYoutube combine as AND when both are active — lets the
-  // filter bar stack Photos+YouTube on the year route.
-  test("stacks hasPhotos and hasYoutube filters", async () => {
+  // filter bar stack Photos+YouTube on the year route. Includes a positive
+  // and negative mix to cover the cross-product.
+  test("stacks hasPhotos=true with hasYoutube=false", async () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never);
 
     await service.findManyLight({
-      filters: { year: 2024, hasPhotos: true, hasYoutube: true },
+      filters: { year: 2024, hasPhotos: true, hasYoutube: false },
     });
 
     const call = db.show.findMany.mock.calls[0][0];
     expect(call.where.showPhotosCount).toEqual({ gt: 0 });
-    expect(call.where.showYoutubesCount).toEqual({ gt: 0 });
+    expect(call.where.showYoutubesCount).toEqual({ equals: 0 });
   });
 });
 

--- a/packages/core/src/setlists/setlist-service.ts
+++ b/packages/core/src/setlists/setlist-service.ts
@@ -3,6 +3,12 @@ import type { DbAnnotation, DbClient, DbShow, DbSong, DbTrack, DbVenue } from ".
 import { buildOrderByClause } from "../_shared/database/query-utils";
 import type { PaginationOptions, SortOptions } from "../_shared/database/types";
 
+/**
+ * Filter options for setlist queries. The `hasPhotos` / `hasYoutube` flags
+ * are tri-state: `true` requires the media, `false` requires its absence,
+ * and `undefined` skips the filter. Drives the year-page tri-state media
+ * toggles where users can include OR exclude shows by media presence.
+ */
 export type SetlistFilter = {
   year?: number;
   monthDay?: string;
@@ -10,6 +16,15 @@ export type SetlistFilter = {
   hasPhotos?: boolean;
   hasYoutube?: boolean;
 };
+
+/**
+ * Translate a tri-state media filter into a Prisma numeric where-clause for
+ * a denormalized count column (showPhotosCount, showYoutubesCount).
+ */
+function countFilter(flag: boolean | undefined) {
+  if (flag === undefined) return undefined;
+  return flag ? { gt: 0 } : { equals: 0 };
+}
 
 type DbTrackLight = {
   id: string;
@@ -356,8 +371,8 @@ export class SetlistService {
                 lt: `${year + 1}-01-01`,
               }
             : undefined,
-        showPhotosCount: hasPhotos ? { gt: 0 } : undefined,
-        showYoutubesCount: hasYoutube ? { gt: 0 } : undefined,
+        showPhotosCount: countFilter(hasPhotos),
+        showYoutubesCount: countFilter(hasYoutube),
       },
       orderBy,
       skip,
@@ -420,8 +435,8 @@ export class SetlistService {
                 lt: `${year + 1}-01-01`,
               }
             : undefined,
-        showPhotosCount: hasPhotos ? { gt: 0 } : undefined,
-        showYoutubesCount: hasYoutube ? { gt: 0 } : undefined,
+        showPhotosCount: countFilter(hasPhotos),
+        showYoutubesCount: countFilter(hasYoutube),
       },
       orderBy,
       skip,


### PR DESCRIPTION
## Summary

You can now  look for shows that have and don't have certain media. For instance, now I know that there are 2 shows with youtube links but have neither nugs nor archive links. Which is odd and interesting. (my personal use case: I plan to use this in the future to find shows that have archive and no nugs)

- Each of the four media filter buttons (Photos, YouTube, Nugs, Archive) now cycles **empty → positive → negative → empty** on click, so users can express both "must have media X" and "must NOT have media X" — e.g. `?archive=yes&nugs=no` for shows with archive but no nugs.
- `findManyLight` (Prisma) accepts tri-state for `hasPhotos`/`hasYoutube`: `true → { gt: 0 }`, `false → { equals: 0 }`, `undefined → omit`. `applyExternalSourceFilters` and `computeShowCountsByYear` apply the same semantics for the Redis-backed nugs/archive flags.
- Permissive parsing keeps existing shared/bookmarked URLs working: bare `?archive`, `?archive=true`, and any non-`"no"` value all read as positive.


https://github.com/user-attachments/assets/ae32e247-12cb-4e6a-b226-6deb2b1f9be3



## Test plan
- [ ] `make tc` passes
- [ ] `make test` passes (38 new/amended tests across 5 files; full suite 482 passing)
- [ ] On `/shows/year/2024`, click Archive once → URL gains `?archive=yes`, list narrows to shows with archive.org links
- [ ] Click Archive again → URL becomes `?archive=no`, button shows red border + strikethrough on icon, list shows only shows without archive
- [ ] Click Archive a third time → URL clears, button returns to empty state
- [ ] Headline combo: `?archive=yes&nugs=no` shows only shows with archive AND no nugs
- [ ] Filter-by-Year sidebar counts update consistently with active tri-state filters
- [ ] Backwards compat: `/shows/year/2024?archive&photos=true` renders both as positive

🤖 Generated with [Claude Code](https://claude.com/claude-code)