### PR TITLE
Show ordering, track gap denormalization, and song-detail Gap/Last Played columns

### DIFF
--- a/apps/web/app/components/performance/performance-columns.test.tsx
+++ b/apps/web/app/components/performance/performance-columns.test.tsx
@@ -34,6 +34,8 @@ function makePerformance(overrides: Partial<SongPagePerformance> = {}): SongPage
     annotations: [],
     set: "S1",
     position: 3,
+    gap: 5,
+    previousPerformanceShowId: "prev-show",
     tags: {},
     ...overrides,
   };
@@ -196,6 +198,167 @@ describe("createPerformanceColumns", () => {
     expect(sequenceHeader?.querySelector("button")).toBeNull();
   });
 
+  // Column order on the song-detail performances table reads as a
+  // narrative: when did this happen (Date) → how rare was it (Gap) → when
+  // was the last time before that (Last Played) → which set was it (Set) →
+  // what came around it (Sequence). Pinning the order so future column
+  // additions don't accidentally reshuffle this flow.
+  test("column order is Date, Gap, Last Played, Set, Sequence", async () => {
+    const columns = createPerformanceColumns(defaultOptions);
+    await setup(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
+
+    const headers = Array.from(document.querySelectorAll("th"))
+      .map((th) => th.textContent?.trim() ?? "")
+      .filter(Boolean);
+    const dateIdx = headers.findIndex((h) => h.startsWith("Date"));
+    const gapIdx = headers.findIndex((h) => h.startsWith("Gap"));
+    const lastPlayedIdx = headers.findIndex((h) => h.startsWith("Last Played"));
+    const setIdx = headers.findIndex((h) => h.startsWith("Set") && !h.startsWith("Sequence"));
+    const seqIdx = headers.findIndex((h) => h.startsWith("Sequence"));
+    expect(dateIdx).toBeGreaterThan(-1);
+    expect(gapIdx).toBeGreaterThan(dateIdx);
+    expect(lastPlayedIdx).toBeGreaterThan(gapIdx);
+    expect(setIdx).toBeGreaterThan(lastPlayedIdx);
+    expect(seqIdx).toBeGreaterThan(setIdx);
+  });
+
+  // A normal (non-debut, non-this-show) row renders the integer gap so users
+  // can read "X shows since last play" directly.
+  test("Gap column renders integer for normal rows", async () => {
+    const columns = createPerformanceColumns(defaultOptions);
+    const performances = [makePerformance({ trackId: "t-cassidy", gap: 12, previousPerformanceShowId: "prev-1" })];
+    await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+
+    expect(screen.getByText("12")).toBeInTheDocument();
+  });
+
+  // A debut performance has gap=null and no earlier-position row in the same
+  // show, so we render a Star icon (not a number) to mark it visually as the
+  // song's first ever appearance.
+  test("Gap column renders Star icon for debut rows (gap=null, no earlier same-show row)", async () => {
+    const columns = createPerformanceColumns(defaultOptions);
+    const performances = [
+      makePerformance({
+        trackId: "t-debut",
+        show: { id: "show-debut", slug: "2010-01-01-debut", date: "2010-01-01", venueId: "v", countForStats: true },
+        position: 1,
+        gap: null,
+        previousPerformanceShowId: null,
+      }),
+    ];
+    const { container } = await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+
+    expect(container.querySelectorAll(".lucide-star").length).toBe(1);
+  });
+
+  // When a song is played twice in the same show, Phase 1 stores the SAME
+  // gap on both tracks (the gap to the previous *show* the song was played).
+  // The repeat is identified at render time by checking for an earlier-
+  // position track in the same show, and gets a RotateCcw icon instead of
+  // a number to flag the within-show repeat.
+  test("Gap column renders RotateCcw icon for within-show repeats", async () => {
+    const columns = createPerformanceColumns(defaultOptions);
+    const sharedShow = {
+      id: "show-repeat",
+      slug: "2012-08-15-camp",
+      date: "2012-08-15",
+      venueId: "v",
+      countForStats: true,
+    };
+    const performances = [
+      makePerformance({ trackId: "t-first", show: sharedShow, position: 3, gap: 5, previousPerformanceShowId: "p" }),
+      makePerformance({ trackId: "t-repeat", show: sharedShow, position: 8, gap: 5, previousPerformanceShowId: "p" }),
+    ];
+    const { container } = await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+
+    // Exactly one rotate-ccw icon — the second occurrence; the first
+    // occurrence still renders the integer 5.
+    expect(container.querySelectorAll(".lucide-rotate-ccw").length).toBe(1);
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  // The Last Played column shows the date of the song's prior performance
+  // (sourced from Phase 1's Track.previousPerformanceShowId join) and links
+  // to that show. When sorted by Gap (or any non-date order), this column
+  // gives users back the chronological context the Date column otherwise
+  // provides at a glance.
+  test("Last Played column renders linked date for non-debut rows", async () => {
+    const columns = createPerformanceColumns(defaultOptions);
+    const performances = [
+      makePerformance({
+        trackId: "t-with-prior",
+        gap: 12,
+        previousPerformanceShowId: "prev-show",
+        previousShow: { slug: "2018-02-14-bowery", date: "2018-02-14" },
+      }),
+    ];
+    await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+
+    const link = screen.getByRole("link", { name: /2\/14\/2018/ });
+    expect(link).toHaveAttribute("href", "/shows/2018-02-14-bowery");
+  });
+
+  // Debuts have no prior performance, so the Last Played cell renders an
+  // em-dash placeholder — same convention as the Set column's empty state.
+  test("Last Played column shows em-dash for debut rows", async () => {
+    const columns = createPerformanceColumns(defaultOptions);
+    const performances = [
+      makePerformance({
+        trackId: "t-debut",
+        gap: null,
+        previousPerformanceShowId: null,
+        previousShow: undefined,
+      }),
+    ];
+    const { container } = await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+
+    // The cell sits between Set and Gap in the header order, so we look up
+    // the third td in the row (after Date and Set). Rather than rely on
+    // brittle positional indexing, check the row text contains the dash.
+    expect(container.textContent).toContain("—");
+  });
+
+  // Gap column is sortable — header renders inside a button with a sort
+  // indicator icon, just like Date and Rating.
+  test("Gap column is sortable", async () => {
+    const columns = createPerformanceColumns(defaultOptions);
+    await setup(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
+
+    const gapHeader = screen.getByText("Gap").closest("button");
+    expect(gapHeader).not.toBeNull();
+    expect(gapHeader?.querySelector("svg")).not.toBeNull();
+  });
+}); // end of createPerformanceColumns
+
+// Sort comparator unit tests target the exported gapSortingFn directly so
+// the rarity-first ordering rules can be verified without spinning up a
+// full DataTable.
+describe("gapSortingFn", () => {
+  // Ascending order surfaces debuts (gap=null) FIRST since a debut is the
+  // rarest possible event; then non-null gaps in numeric ascending order.
+  // Tied gaps fall back to show date so all rows from the same show
+  // cluster (including within-show repeats), then to track position as
+  // the final tiebreak.
+  test("ascending: debut first, then numeric, date tiebreak, position final tiebreak", async () => {
+    const { gapSortingFn } = await import("./performance-columns");
+    const fakeRow = (gap: number | null, date: string, position: number) =>
+      ({ original: { gap, position, show: { date } } }) as unknown as Parameters<typeof gapSortingFn>[0];
+
+    // Primary: debut < non-null gap.
+    expect(gapSortingFn(fakeRow(null, "2024-01-01", 5), fakeRow(0, "2024-01-01", 1))).toBeLessThan(0);
+    // Primary: smaller gap < larger gap.
+    expect(gapSortingFn(fakeRow(0, "2024-01-01", 1), fakeRow(3, "2024-01-01", 1))).toBeLessThan(0);
+    // Secondary: tied gap, earlier date sorts first.
+    expect(gapSortingFn(fakeRow(5, "2018-06-01", 1), fakeRow(5, "2024-08-15", 1))).toBeLessThan(0);
+    expect(gapSortingFn(fakeRow(5, "2024-08-15", 1), fakeRow(5, "2018-06-01", 1))).toBeGreaterThan(0);
+    // Tertiary: tied gap AND tied date (within-show repeat), position breaks.
+    expect(gapSortingFn(fakeRow(5, "2012-08-15", 3), fakeRow(5, "2012-08-15", 8))).toBeLessThan(0);
+    // Two debuts at different shows still respect date tiebreak.
+    expect(gapSortingFn(fakeRow(null, "2010-01-01", 1), fakeRow(null, "2012-01-01", 1))).toBeLessThan(0);
+  });
+});
+
+describe("createPerformanceColumns extras", () => {
   // Columns that need constrained widths (like the narrow allTimer flame
   // icon and the Set label) set explicit meta.width. Other columns auto-size
   // to avoid wasted space.

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -1,10 +1,50 @@
 import { compareByShowDate, type SongPagePerformance } from "@bip/domain";
-import { type Column, type ColumnDef, createColumnHelper } from "@tanstack/react-table";
-import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon, Flame } from "lucide-react";
+import { type Column, type ColumnDef, createColumnHelper, type Row } from "@tanstack/react-table";
+import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon, Flame, RotateCcw, Star } from "lucide-react";
+import type { ReactElement } from "react";
 import { ShowDate } from "~/components/show-date";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "~/components/ui/tooltip";
 import { CombinedNotes } from "./combined-notes";
 import { DateVenueCell } from "./date-venue-cell";
 import { TrackRatingCell } from "./track-rating-cell";
+
+/**
+ * Wraps a small status icon (★ debut, ↺ this-show repeat) in a tooltip so
+ * users can hover/tap to learn what the icon means without crowding the cell.
+ */
+function GapIcon({ icon, label }: { icon: ReactElement; label: string }) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span role="img" aria-label={label}>
+            {icon}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>{label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+/**
+ * Sort comparator for the Gap column. Debuts (gap=null) sort first because a
+ * debut is the rarest possible event; remaining rows sort by gap ascending.
+ * Ties break by show date so all rows from the same show — including
+ * within-show repeats, which share both gap and date — cluster together;
+ * track position is the final tiebreak so within-show repeats stay in
+ * setlist order relative to each other.
+ */
+export function gapSortingFn(a: Row<SongPagePerformance>, b: Row<SongPagePerformance>): number {
+  const aGap = a.original.gap;
+  const bGap = b.original.gap;
+  const aKey = aGap == null ? Number.NEGATIVE_INFINITY : aGap;
+  const bKey = bGap == null ? Number.NEGATIVE_INFINITY : bGap;
+  if (aKey !== bKey) return aKey - bKey;
+  const dateCmp = compareByShowDate(a.original, b.original);
+  if (dateCmp !== 0) return dateCmp;
+  return (a.original.position ?? 0) - (b.original.position ?? 0);
+}
 
 interface PerformanceColumnOptions {
   showSongColumn?: boolean;
@@ -101,6 +141,52 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
               date={<ShowDate date={date} />}
               venue={{ name: venue?.name, city: venue?.city, state: venue?.state }}
             />
+          </a>
+        );
+      },
+    }) as ColumnDef<SongPagePerformance, unknown>,
+    columnHelper.accessor((row) => row.gap ?? Number.NEGATIVE_INFINITY, {
+      id: "gap",
+      meta: { width: "64px" },
+      header: ({ column }) => <SortableHeader column={column} label="Gap" />,
+      enableSorting: true,
+      sortingFn: gapSortingFn,
+      cell: (info) => {
+        const row = info.row.original;
+        const allRows = info.table.getCoreRowModel().rows;
+        // Within-show repeat: another row exists in the same show with an
+        // earlier track position. Phase 1 stores the same gap on both tracks
+        // of a within-show repeat, so the icon — not the gap value — is what
+        // distinguishes the repeat from its first occurrence.
+        const isRepeat = allRows.some(
+          (other) => other.original.show.id === row.show.id && (other.original.position ?? 0) < (row.position ?? 0),
+        );
+
+        if (isRepeat) {
+          return <GapIcon icon={<RotateCcw className="h-4 w-4 text-content-text-secondary" />} label="Same Show" />;
+        }
+
+        if (row.gap == null) {
+          return <GapIcon icon={<Star className="h-4 w-4 text-content-text-secondary" />} label="Debut" />;
+        }
+
+        return <span className="text-content-text-secondary tabular-nums">{row.gap}</span>;
+      },
+    }) as ColumnDef<SongPagePerformance, unknown>,
+    columnHelper.accessor((row) => row.previousShow?.date ?? "", {
+      id: "lastPlayed",
+      meta: { width: "110px", hideOnMobile: true },
+      header: ({ column }) => <SortableHeader column={column} label="Last Played" />,
+      enableSorting: true,
+      sortingFn: "alphanumeric",
+      cell: (info) => {
+        const previousShow = info.row.original.previousShow;
+        if (!previousShow) {
+          return <span className="text-content-text-tertiary">—</span>;
+        }
+        return (
+          <a href={`/shows/${previousShow.slug}`} className="text-base text-brand-primary hover:text-brand-secondary">
+            <ShowDate date={previousShow.date} />
           </a>
         );
       },

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -1,4 +1,4 @@
-import type { SongPageView } from "@bip/domain";
+import { compareByShowDate, type SongPageView } from "@bip/domain";
 import { ArrowLeft, BarChart3, FileTextIcon, Flame, GuitarIcon, History, ListMusic, Pencil } from "lucide-react";
 import { type ReactNode, useMemo, useState } from "react";
 import type { LoaderFunctionArgs } from "react-router";
@@ -375,9 +375,7 @@ export default function SongPage() {
           <TabsContent value="all-timers" className="mt-6 space-y-8">
             {/* Featured cards for performances with notes */}
             {(() => {
-              const withNotes = filteredAllTimers
-                .filter((p) => p.notes)
-                .sort((a, b) => new Date(b.show.date).getTime() - new Date(a.show.date).getTime());
+              const withNotes = filteredAllTimers.filter((p) => p.notes).sort((a, b) => compareByShowDate(b, a));
 
               return (
                 withNotes.length > 0 && (

--- a/apps/web/app/routes/users/$username.tsx
+++ b/apps/web/app/routes/users/$username.tsx
@@ -1,3 +1,4 @@
+import { compareByShowDate } from "@bip/domain";
 import { CalendarDays, Edit, MessageSquare, Star, Users } from "lucide-react";
 import type { LoaderFunctionArgs, MetaFunction } from "react-router-dom";
 import { Link, useLoaderData } from "react-router-dom";
@@ -78,9 +79,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const totalRatings = showRatingsCount + trackRatingsCount;
 
   // Calculate first and last show dates
-  const sortedAttendances = userAttendances.sort(
-    (a, b) => new Date(a.show.date).getTime() - new Date(b.show.date).getTime(),
-  );
+  const sortedAttendances = userAttendances.sort(compareByShowDate);
   const firstShow = sortedAttendances[0]?.show || null;
   const lastShow = sortedAttendances[sortedAttendances.length - 1]?.show || null;
 

--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -20,6 +20,7 @@ import { Prisma } from "@prisma/client";
 import { CacheInvalidationService, CacheService } from "../src/_shared/cache";
 import prisma from "../src/_shared/prisma/client";
 import { RedisService } from "../src/_shared/redis";
+import { StatsService } from "../src/stats/stats-service";
 import { createTestLogger } from "../src/_shared/test-logger";
 
 const MCP_URL = process.env.MCP_URL ?? "https://discobiscuits.net/mcp";
@@ -325,11 +326,19 @@ async function syncMissingShows(): Promise<void> {
   const redis = redisUrl ? new RedisService(redisUrl, logger) : null;
   const cache = redis ? new CacheService(redis, logger) : null;
   const cacheInvalidation = cache ? new CacheInvalidationService(cache, logger) : null;
+  // StatsService is wired without a cache here — the script never reads
+  // cached aggregates, only triggers the post-batch gap rebuild.
+  const statsService = new StatsService(prisma, cache ?? undefined);
   if (redis) await redis.connect();
 
   // Track every show whose row materially changed this run — used at the end
   // to invalidate the per-slug show.data + setlist.data cache entries.
   const changedSlugs = new Set<string>();
+  // The earliest date of any show INSERTED this run (drift updates don't
+  // shift gap math). Scopes the post-batch gap rebuild — pre-this-date
+  // chains are unaffected. ISO YYYY-MM-DD strings compare lexicographically
+  // the same as chronologically, so `<` works directly.
+  let earliestInsertedDate: string | null = null;
   let songsChanged = false;
 
   const stats: SyncStats = {
@@ -589,6 +598,10 @@ async function syncMissingShows(): Promise<void> {
             }
           }
           changedSlugs.add(slug);
+          const showDate = String(show.date);
+          if (earliestInsertedDate === null || showDate < earliestInsertedDate) {
+            earliestInsertedDate = showDate;
+          }
           stats.showsCreated++;
           stats.tracksCreated += trackCount;
           console.log(`  ✅ ${slug} (${trackCount} tracks, venue=${venueId ? "✓" : "—"})`);
@@ -612,6 +625,20 @@ async function syncMissingShows(): Promise<void> {
       if (songsChanged) await cacheInvalidation.invalidateSongCaches();
     } else if (!isDryRun && !cacheInvalidation && (changedSlugs.size > 0 || songsChanged)) {
       console.warn("⚠️  REDIS_URL not set; skipping cache invalidation. Cached pages may show stale data until TTL expires or you restart the app.");
+    }
+
+    // Rebuild Track.gap + Song.* aggregates once for the whole batch. Bulk
+    // operation — a single rebuild covering the earliest inserted date is
+    // cheaper than N per-show rebuilds, and it captures every chain that
+    // could have shifted as a result of these inserts.
+    if (!isDryRun && earliestInsertedDate !== null) {
+      console.log(`📐 Rebuilding gaps + song stats since ${earliestInsertedDate}`);
+      try {
+        await statsService.rebuildGapsAndSongStatsSince(earliestInsertedDate);
+      } catch (err) {
+        console.error("  ❌ stats rebuild failed:", err);
+        stats.errors++;
+      }
     }
 
     printSummary(stats, isDryRun);

--- a/packages/core/src/_shared/cache/cache-invalidation-service.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.ts
@@ -50,8 +50,18 @@ export class CacheInvalidationService {
     await Promise.all([
       this.cache.delPattern(CacheKeys.shows.allLists()),
       this.cache.delPattern("home:*"), // Invalidate all home page caches
+      this.cache.del(CacheKeys.stats.showsByYear()), // shows-per-year aggregate is tied to the show catalog
       this.cloudflareCache?.purgeYearListings(),
     ]);
+  }
+
+  /**
+   * Invalidate the cross-domain shows-by-year aggregate. Standalone hook
+   * for callers that mutate shows without going through the listing flow.
+   */
+  async invalidateStatsShowsByYear(): Promise<void> {
+    this.logger.info("Invalidating stats:shows-by-year");
+    await this.cache.del(CacheKeys.stats.showsByYear());
   }
 
   /**

--- a/packages/core/src/_shared/prisma/migrations/20260508182000_add_track_gap/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260508182000_add_track_gap/migration.sql
@@ -1,0 +1,187 @@
+-- Adds denormalized gap + previous-performance pointer to tracks. The gap
+-- column stores the count of shows strictly between this performance and
+-- the song's prior performance. NULL gap means either a debut OR a track on
+-- a show with count_for_stats=false (soundcheck/radio/cancelled/etc) which
+-- is invisible to the stats walk.
+--
+-- Ordering rules used here and in the matching service code:
+--   1. show.date ASC
+--   2. show.day_order ASC NULLS LAST  (tiebreaker for same-date shows)
+--   3. track.position ASC             (tiebreaker within a show)
+--   4. show.id                        (final stable tiebreaker for unset day_order)
+--
+-- Stats rules:
+--   * The "shows between" denominator counts only count_for_stats=true shows.
+--   * count_for_stats=false shows can POINT AT a prior count_for_stats=true
+--     performance via gap+prev (so someone viewing a soundcheck row sees
+--     "last really played N shows ago"), but they are NEVER pointed at —
+--     the next count_for_stats=true performance walks back past them to
+--     the prior count_for_stats=true performance. This is implemented as
+--     two passes below: pass 1 handles stats-shows via LAG over the
+--     stats-only chain; pass 2 handles non-stats-shows via LATERAL lookup
+--     of the most recent prior stats-show.
+--   * Song.timesPlayed / dateFirstPlayed / dateLastPlayed / yearlyPlayData
+--     are recomputed below to exclude count_for_stats=false shows.
+
+ALTER TABLE "tracks"
+  ADD COLUMN "gap" INTEGER,
+  ADD COLUMN "previous_performance_show_id" UUID;
+
+ALTER TABLE "tracks"
+  ADD CONSTRAINT "fk_tracks_previous_performance_show_id"
+  FOREIGN KEY ("previous_performance_show_id")
+  REFERENCES "shows"("id")
+  ON DELETE NO ACTION
+  ON UPDATE NO ACTION;
+
+-- =========================================================================
+-- Track.gap + Track.previous_performance_show_id backfill (two passes)
+-- =========================================================================
+
+-- Pass 1: count_for_stats=true tracks. LAG over the stats-only chain gives
+-- each (song, stats-show) its prior stats-show. Within-show repeats share
+-- via DISTINCT ON.
+WITH first_per_show AS (
+  SELECT DISTINCT ON (t.song_id, t.show_id)
+    t.song_id,
+    t.show_id,
+    s.date AS show_date,
+    LAG(t.show_id) OVER w  AS prev_show_id,
+    LAG(s.date)    OVER w  AS prev_show_date
+  FROM tracks t
+  JOIN shows s ON s.id = t.show_id
+  WHERE s.count_for_stats = TRUE
+  WINDOW w AS (
+    PARTITION BY t.song_id
+    ORDER BY s.date, s.day_order NULLS LAST, t.position, s.id
+  )
+  ORDER BY t.song_id, t.show_id, s.date, s.day_order NULLS LAST, t.position, s.id
+),
+gap_per_show AS (
+  SELECT
+    fps.song_id,
+    fps.show_id,
+    fps.prev_show_id,
+    CASE
+      WHEN fps.prev_show_date IS NULL THEN NULL
+      ELSE (
+        SELECT COUNT(*)::INTEGER
+        FROM shows s2
+        WHERE s2.date > fps.prev_show_date
+          AND s2.date < fps.show_date
+          AND s2.count_for_stats = TRUE
+      )
+    END AS gap
+  FROM first_per_show fps
+)
+UPDATE tracks t
+   SET gap = gps.gap,
+       previous_performance_show_id = gps.prev_show_id
+  FROM gap_per_show gps
+ WHERE gps.song_id = t.song_id
+   AND gps.show_id = t.show_id;
+
+-- Pass 2: count_for_stats=false tracks. For each (song, non-stats-show)
+-- find the most recent prior count_for_stats=true performance of the same
+-- song via LATERAL. Gap = stats-shows strictly between those two dates.
+WITH non_stats_perfs AS (
+  SELECT DISTINCT t.song_id, t.show_id, s.date AS show_date, s.day_order, s.id AS sid
+  FROM tracks t
+  JOIN shows s ON s.id = t.show_id
+  WHERE s.count_for_stats = FALSE
+),
+stats_perfs AS (
+  SELECT DISTINCT t.song_id, t.show_id, s.date AS show_date, s.day_order, s.id AS sid
+  FROM tracks t
+  JOIN shows s ON s.id = t.show_id
+  WHERE s.count_for_stats = TRUE
+),
+prev_per_perf AS (
+  SELECT
+    nsp.song_id,
+    nsp.show_id,
+    nsp.show_date,
+    prev.prev_show_id,
+    prev.prev_show_date
+  FROM non_stats_perfs nsp
+  LEFT JOIN LATERAL (
+    SELECT sp.show_id AS prev_show_id, sp.show_date AS prev_show_date
+    FROM stats_perfs sp
+    WHERE sp.song_id = nsp.song_id
+      AND ROW(sp.show_date, COALESCE(sp.day_order, 2147483647), sp.sid)
+        < ROW(nsp.show_date, COALESCE(nsp.day_order, 2147483647), nsp.sid)
+    ORDER BY sp.show_date DESC, COALESCE(sp.day_order, 2147483647) DESC, sp.sid DESC
+    LIMIT 1
+  ) prev ON TRUE
+),
+gap_for_non_stats AS (
+  SELECT
+    ppp.song_id,
+    ppp.show_id,
+    ppp.prev_show_id,
+    CASE
+      WHEN ppp.prev_show_date IS NULL THEN NULL
+      ELSE (
+        SELECT COUNT(*)::INTEGER
+        FROM shows s2
+        WHERE s2.date > ppp.prev_show_date
+          AND s2.date < ppp.show_date
+          AND s2.count_for_stats = TRUE
+      )
+    END AS gap
+  FROM prev_per_perf ppp
+)
+UPDATE tracks t
+   SET gap = gns.gap,
+       previous_performance_show_id = gns.prev_show_id
+  FROM gap_for_non_stats gns
+ WHERE gns.song_id = t.song_id
+   AND gns.show_id = t.show_id;
+
+-- =========================================================================
+-- Song stats recompute — timesPlayed, dateFirstPlayed, dateLastPlayed,
+-- yearlyPlayData. All four exclude count_for_stats=false shows.
+-- This must stay in sync with SongService.updateSongStatistics().
+-- =========================================================================
+
+WITH song_show AS (
+  -- One row per (song_id, show_id) for shows that count toward stats.
+  SELECT DISTINCT t.song_id, t.show_id, s.date::date AS show_date
+  FROM tracks t
+  JOIN shows s ON s.id = t.show_id
+  WHERE s.count_for_stats = TRUE
+),
+song_yearly AS (
+  -- {year: count} aggregated per song, as a JSONB object.
+  SELECT
+    song_id,
+    COALESCE(
+      jsonb_object_agg(year::text, cnt) FILTER (WHERE year IS NOT NULL),
+      '{}'::jsonb
+    ) AS yearly
+  FROM (
+    SELECT song_id, EXTRACT(YEAR FROM show_date)::int AS year, COUNT(*)::int AS cnt
+    FROM song_show
+    GROUP BY song_id, EXTRACT(YEAR FROM show_date)
+  ) y
+  GROUP BY song_id
+),
+song_agg AS (
+  SELECT
+    ss.song_id,
+    COUNT(DISTINCT ss.show_id)::int AS times_played,
+    MIN(ss.show_date)               AS date_first_played,
+    MAX(ss.show_date)               AS date_last_played
+  FROM song_show ss
+  GROUP BY ss.song_id
+)
+UPDATE songs sg SET
+  times_played      = COALESCE(sa.times_played, 0),
+  date_first_played = sa.date_first_played,
+  date_last_played  = sa.date_last_played,
+  yearly_play_data  = COALESCE(sy.yearly, '{}'::jsonb),
+  updated_at        = NOW()
+FROM songs sg2
+LEFT JOIN song_agg sa  ON sa.song_id = sg2.id
+LEFT JOIN song_yearly sy ON sy.song_id = sg2.id
+WHERE sg.id = sg2.id;

--- a/packages/core/src/_shared/prisma/schema.prisma
+++ b/packages/core/src/_shared/prisma/schema.prisma
@@ -339,6 +339,7 @@ model Show {
   band              Band?                    @relation(fields: [bandId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_shows_bands_band_id")
   venue             Venue?                   @relation(fields: [venueId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_shows_venues_venue_id")
   tracks            Track[]
+  previousPerformanceTracks Track[]            @relation("TrackPreviousPerformance")
   segueRuns         SegueRun[]
   files             ShowToFile[]
 
@@ -474,9 +475,12 @@ model Track {
   ratingsCount    Int                      @default(0) @map("ratings_count")
   searchText      String?                  @map("search_text") @db.Text
   searchVector    Unsupported("tsvector")? @map("search_vector")
+  gap                       Int?
+  previousPerformanceShowId String?         @map("previous_performance_show_id") @db.Uuid
   annotations     Annotation[]
   show            Show                     @relation(fields: [showId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_tracks_shows_show_id")
   song            Song                     @relation(fields: [songId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_tracks_songs_song_id")
+  previousPerformanceShow   Show?           @relation("TrackPreviousPerformance", fields: [previousPerformanceShowId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_tracks_previous_performance_show_id")
 
   @@index([likesCount])
   @@index([nextTrackId])

--- a/packages/core/src/_shared/services.ts
+++ b/packages/core/src/_shared/services.ts
@@ -16,6 +16,7 @@ import { ShowService } from "../shows/show-service";
 import { TourDatesService } from "../shows/tour-dates-service";
 import { YoutubeService } from "../shows/youtube-service";
 import { SongService } from "../songs/song-service";
+import { StatsService } from "../stats/stats-service";
 import { TrackService } from "../tracks/track-service";
 import { UserService } from "../users/user-service";
 import { VenueService } from "../venues/venue-service";
@@ -30,6 +31,7 @@ export interface Services {
   blogPosts: BlogPostService;
   shows: ShowService;
   songs: SongService;
+  stats: StatsService;
   tracks: TrackService;
   setlists: SetlistService;
   venues: VenueService;
@@ -59,13 +61,17 @@ export function createServices(container: ServiceContainer): Services {
 
   // Create core services
   const songService = new SongService(container.db, container.logger);
+  // StatsService is constructed first so ShowService can hand it the
+  // post-mutation rebuild dependency.
+  const statsService = new StatsService(container.db, container.cache);
 
   return {
     annotations: new AnnotationService(container.db, container.logger, container.cacheInvalidation),
     authors: new AuthorService(container.db, container.logger),
     blogPosts: new BlogPostService(container.db, container.redis, container.logger),
-    shows: new ShowService(container.db, container.logger, container.cacheInvalidation),
+    shows: new ShowService(container.db, container.logger, container.cacheInvalidation, statsService),
     songs: songService,
+    stats: statsService,
     tracks: new TrackService(container.db, container.logger, container.cacheInvalidation),
     setlists: new SetlistService(container.db),
     venues: new VenueService(container.db, container.logger),

--- a/packages/core/src/_shared/track-gap.test.ts
+++ b/packages/core/src/_shared/track-gap.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from "vitest";
+import {
+  computeSongStats,
+  computeTrackGaps,
+  sortTracksForGapWalk,
+  type TrackForGapWalk,
+} from "./track-gap";
+
+function track(opts: Partial<TrackForGapWalk> & Pick<TrackForGapWalk, "trackId" | "showId" | "showDate">): TrackForGapWalk {
+  return {
+    dayOrder: null,
+    showCountForStats: true,
+    position: 1,
+    ...opts,
+  };
+}
+
+describe("sortTracksForGapWalk", () => {
+  // Different dates: chronological order wins.
+  test("orders by date when dates differ", () => {
+    const sorted = sortTracksForGapWalk([
+      track({ trackId: "later", showId: "B", showDate: "2010-06-01" }),
+      track({ trackId: "earlier", showId: "A", showDate: "2010-01-01" }),
+    ]);
+    expect(sorted.map((t) => t.trackId)).toEqual(["earlier", "later"]);
+  });
+
+  // Same date: explicit dayOrder breaks the tie. NULL sorts LAST in ASC.
+  test("breaks same-date ties with dayOrder ascending, NULLs last", () => {
+    const sorted = sortTracksForGapWalk([
+      track({ trackId: "null-order", showId: "C", showDate: "2010-03-26", dayOrder: null }),
+      track({ trackId: "second", showId: "B", showDate: "2010-03-26", dayOrder: 2 }),
+      track({ trackId: "first", showId: "A", showDate: "2010-03-26", dayOrder: 1 }),
+    ]);
+    expect(sorted.map((t) => t.trackId)).toEqual(["first", "second", "null-order"]);
+  });
+
+  // Within-show ordering: same showId means same date and same dayOrder, so
+  // position breaks the tie. Used for songs played twice in one show.
+  test("within a show, position breaks ties", () => {
+    const sorted = sortTracksForGapWalk([
+      track({ trackId: "encore", showId: "X", showDate: "2010-03-26", position: 8 }),
+      track({ trackId: "opener", showId: "X", showDate: "2010-03-26", position: 1 }),
+    ]);
+    expect(sorted.map((t) => t.trackId)).toEqual(["opener", "encore"]);
+  });
+
+  // Both NULL dayOrder on the same date: showId is the final tiebreaker for
+  // stable ordering.
+  test("falls back to showId when both dayOrders are null", () => {
+    const sorted = sortTracksForGapWalk([
+      track({ trackId: "second", showId: "show-z", showDate: "1995-12-01" }),
+      track({ trackId: "first", showId: "show-a", showDate: "1995-12-01" }),
+    ]);
+    expect(sorted.map((t) => t.trackId)).toEqual(["first", "second"]);
+  });
+});
+
+describe("computeTrackGaps", () => {
+  // First-ever performance: gap=null, prev=null. Renders as "Debut".
+  test("debut: single track gets gap=null and prev=null", () => {
+    const tracks = [track({ trackId: "t1", showId: "show-A", showDate: "1998-04-15" })];
+    const results = computeTrackGaps(tracks, ["1998-04-15"]);
+    expect(results).toEqual([{ trackId: "t1", gap: null, previousPerformanceShowId: null }]);
+  });
+
+  // Back-to-back: song played at consecutive shows → gap=0 on the second.
+  test("back-to-back shows produce gap=0", () => {
+    const tracks = sortTracksForGapWalk([
+      track({ trackId: "t1", showId: "A", showDate: "2001-06-01" }),
+      track({ trackId: "t2", showId: "B", showDate: "2001-06-02" }),
+    ]);
+    const results = computeTrackGaps(tracks, ["2001-06-01", "2001-06-02"]);
+    expect(results).toEqual([
+      { trackId: "t1", gap: null, previousPerformanceShowId: null },
+      { trackId: "t2", gap: 0, previousPerformanceShowId: "A" },
+    ]);
+  });
+
+  // Three unrelated shows between performances → gap counts shows strictly
+  // between (exclusive bounds).
+  test("N shows between: gap counts shows strictly between performances", () => {
+    const tracks = sortTracksForGapWalk([
+      track({ trackId: "t1", showId: "A", showDate: "2003-10-10" }),
+      track({ trackId: "t2", showId: "E", showDate: "2003-10-20" }),
+    ]);
+    const statsShows = ["2003-10-10", "2003-10-12", "2003-10-15", "2003-10-18", "2003-10-20"];
+    const results = computeTrackGaps(tracks, statsShows);
+    expect(results).toEqual([
+      { trackId: "t1", gap: null, previousPerformanceShowId: null },
+      { trackId: "t2", gap: 3, previousPerformanceShowId: "A" },
+    ]);
+  });
+
+  // Within-show repeat: both tracks share gap+prev computed against the
+  // song's prior *show*, not against the earlier track in this show. The
+  // "this show" repeat marker is a render-time concern.
+  test("within-show repeat: both tracks share gap+prev from prior show", () => {
+    const tracks = sortTracksForGapWalk([
+      track({ trackId: "t1", showId: "A", showDate: "2005-02-01" }),
+      track({ trackId: "t2a", showId: "B", showDate: "2005-02-05", position: 3 }),
+      track({ trackId: "t2b", showId: "B", showDate: "2005-02-05", position: 8 }),
+    ]);
+    const statsShows = ["2005-02-01", "2005-02-03", "2005-02-05"];
+    const results = computeTrackGaps(tracks, statsShows);
+    expect(results).toEqual([
+      { trackId: "t1", gap: null, previousPerformanceShowId: null },
+      { trackId: "t2a", gap: 1, previousPerformanceShowId: "A" },
+      { trackId: "t2b", gap: 1, previousPerformanceShowId: "A" },
+    ]);
+  });
+
+  // count_for_stats=false tracks get a gap value pointing at the prior real
+  // performance, but they DO NOT advance the "last performance" cursor —
+  // the next stats-show walks back past them.
+  test("count_for_stats=false: track points at prior stats-show; never pointed at", () => {
+    const tracks = sortTracksForGapWalk([
+      track({ trackId: "t-A", showId: "A", showDate: "2010-06-01" }),
+      track({ trackId: "t-SC", showId: "SC", showDate: "2010-06-10", showCountForStats: false }),
+      track({ trackId: "t-B", showId: "B", showDate: "2010-06-15" }),
+    ]);
+    const statsShows = ["2010-06-01", "2010-06-15"];
+    const results = computeTrackGaps(tracks, statsShows);
+    expect(results).toEqual([
+      { trackId: "t-A", gap: null, previousPerformanceShowId: null },
+      // SC points at A, even though SC doesn't count for stats.
+      { trackId: "t-SC", gap: 0, previousPerformanceShowId: "A" },
+      // B walks back to A, NOT to SC. Stats shows between A and B = 0.
+      { trackId: "t-B", gap: 0, previousPerformanceShowId: "A" },
+    ]);
+  });
+
+  // Same-date pair where the song is played at both shows — dayOrder
+  // tiebreaker determines which is "first" for gap purposes. The earlier
+  // (day_order=1) is the song's debut on that date, gap=0 on day_order=2.
+  test("same-date pair: dayOrder=1 is treated as the earlier show", () => {
+    const tracks = sortTracksForGapWalk([
+      track({ trackId: "t-after", showId: "after", showDate: "2010-03-26", dayOrder: 2 }),
+      track({ trackId: "t-fest", showId: "fest", showDate: "2010-03-26", dayOrder: 1 }),
+    ]);
+    const statsShows = ["2010-03-26", "2010-03-26"];
+    const results = computeTrackGaps(tracks, statsShows);
+    expect(results).toEqual([
+      { trackId: "t-fest", gap: null, previousPerformanceShowId: null },
+      { trackId: "t-after", gap: 0, previousPerformanceShowId: "fest" },
+    ]);
+  });
+});
+
+describe("computeSongStats", () => {
+  // Empty stats-track list → all-zero/null aggregates.
+  test("no stats tracks: returns zero/null defaults", () => {
+    expect(computeSongStats([])).toEqual({
+      timesPlayed: 0,
+      dateFirstPlayed: null,
+      dateLastPlayed: null,
+      yearlyPlayData: {},
+    });
+  });
+
+  // timesPlayed counts UNIQUE shows: a song played twice in one show
+  // counts once.
+  test("timesPlayed counts unique shows", () => {
+    const stats = computeSongStats([
+      { showId: "A", showDate: "2010-01-01" },
+      { showId: "A", showDate: "2010-01-01" }, // within-show repeat
+      { showId: "B", showDate: "2010-06-01" },
+    ]);
+    expect(stats.timesPlayed).toBe(2);
+  });
+
+  // First/last played track the chronological extremes.
+  test("dateFirst/LastPlayed track chronological extremes", () => {
+    const stats = computeSongStats([
+      { showId: "B", showDate: "2010-06-01" },
+      { showId: "A", showDate: "2010-01-01" },
+      { showId: "C", showDate: "2010-12-01" },
+    ]);
+    expect(stats.dateFirstPlayed?.toISOString().slice(0, 10)).toBe("2010-01-01");
+    expect(stats.dateLastPlayed?.toISOString().slice(0, 10)).toBe("2010-12-01");
+  });
+
+  // yearlyPlayData buckets unique-shows by year.
+  test("yearlyPlayData buckets unique shows by year", () => {
+    const stats = computeSongStats([
+      { showId: "A", showDate: "1999-04-15" },
+      { showId: "B", showDate: "2001-08-15" },
+      { showId: "C", showDate: "2001-12-31" },
+      { showId: "D", showDate: "2010-06-01" },
+    ]);
+    expect(stats.yearlyPlayData).toEqual({ "1999": 1, "2001": 2, "2010": 1 });
+  });
+});

--- a/packages/core/src/_shared/track-gap.ts
+++ b/packages/core/src/_shared/track-gap.ts
@@ -1,0 +1,178 @@
+/**
+ * Pure-function gap walk. Single source of truth for the algorithm that
+ * produces `Track.gap` + `Track.previousPerformanceShowId` for one song
+ * and the corresponding `Song.timesPlayed` / `dateFirst/LastPlayed` /
+ * `yearlyPlayData` aggregates. Used by:
+ *   * SongService.updateSongStatistics (one song)
+ *   * StatsService.rebuildAffectedSongsSince (many songs)
+ *
+ * No DB access here — callers fetch the data, hand it in, and write the
+ * results back. Pure functions are unit-tested without any Prisma mocking.
+ */
+
+/**
+ * Track input shape for the gap walk. Pulled from the joined track + show
+ * row, projecting only the fields the algorithm needs.
+ */
+export type TrackForGapWalk = {
+  trackId: string;
+  showId: string;
+  /** ISO YYYY-MM-DD string (lex-sorts chronologically). */
+  showDate: string;
+  dayOrder: number | null;
+  showCountForStats: boolean;
+  /** Position of this track within its show, used as a tiebreaker. */
+  position: number;
+};
+
+export type GapResult = {
+  trackId: string;
+  gap: number | null;
+  previousPerformanceShowId: string | null;
+};
+
+export type SongStatsAggregate = {
+  timesPlayed: number;
+  dateFirstPlayed: Date | null;
+  dateLastPlayed: Date | null;
+  yearlyPlayData: Record<string, number>;
+};
+
+/**
+ * Sort tracks chronologically with the canonical same-date tiebreakers
+ * (date → dayOrder NULLS LAST → position → showId). Returns a new array
+ * — input is not mutated.
+ */
+export function sortTracksForGapWalk(tracks: TrackForGapWalk[]): TrackForGapWalk[] {
+  const compare = (a: TrackForGapWalk, b: TrackForGapWalk): number => {
+    if (a.showDate !== b.showDate) return a.showDate < b.showDate ? -1 : 1;
+    const aOrder = a.dayOrder ?? Number.MAX_SAFE_INTEGER;
+    const bOrder = b.dayOrder ?? Number.MAX_SAFE_INTEGER;
+    if (aOrder !== bOrder) return aOrder - bOrder;
+    if (a.position !== b.position) return a.position - b.position;
+    return a.showId < b.showId ? -1 : a.showId > b.showId ? 1 : 0;
+  };
+  return [...tracks].sort(compare);
+}
+
+/**
+ * First index where `dates[i] > target` — i.e., the first date strictly
+ * greater. `dates` MUST be sorted ASC.
+ */
+function firstIndexGreaterThan(dates: string[], target: string): number {
+  let lo = 0;
+  let hi = dates.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (dates[mid] > target) hi = mid;
+    else lo = mid + 1;
+  }
+  return lo;
+}
+
+/**
+ * First index where `dates[i] >= target`. `dates` MUST be sorted ASC.
+ */
+function firstIndexGreaterOrEqual(dates: string[], target: string): number {
+  let lo = 0;
+  let hi = dates.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (dates[mid] >= target) hi = mid;
+    else lo = mid + 1;
+  }
+  return lo;
+}
+
+/**
+ * Walk a song's pre-sorted tracks and compute per-track gap +
+ * previousPerformanceShowId. The walk only updates the "last performance"
+ * cursor on count_for_stats=true shows — non-stats tracks (soundchecks,
+ * radio sessions, etc.) get a gap value pointing at the prior stats-show
+ * but never act as a "prev" for later tracks.
+ *
+ * `statsShowDates` is the chronologically-sorted list of show dates
+ * where count_for_stats=true. The "shows between" denominator counts
+ * dates strictly between the prior performance date and this one — done
+ * via binary search so the walk is O(N tracks · log M dates) rather than
+ * the naive O(N · M).
+ */
+export function computeTrackGaps(
+  sortedTracks: TrackForGapWalk[],
+  statsShowDates: string[],
+): GapResult[] {
+  const results: GapResult[] = [];
+  let lastShowDate: string | null = null;
+  let lastShowId: string | null = null;
+  let currentShowId: string | null = null;
+  let currentShowGap: number | null = null;
+  let currentShowPrevId: string | null = null;
+
+  for (const track of sortedTracks) {
+    if (track.showId !== currentShowId) {
+      // New show for this song — recompute gap+prev relative to the most
+      // recent prior count_for_stats=true performance.
+      if (lastShowDate === null) {
+        currentShowGap = null;
+        currentShowPrevId = null;
+      } else {
+        // Count dates strictly between (lastShowDate, track.showDate):
+        //   * indices [0, leftBound)        → dates <= lastShowDate
+        //   * indices [leftBound, rightBound) → lastShowDate < d < track.showDate  ← what we want
+        //   * indices [rightBound, end)     → dates >= track.showDate
+        // Clamp at 0: a same-date pair (lastShowDate == track.showDate)
+        // produces leftBound > rightBound; the actual count is 0.
+        const leftBound = firstIndexGreaterThan(statsShowDates, lastShowDate);
+        const rightBound = firstIndexGreaterOrEqual(statsShowDates, track.showDate);
+        currentShowGap = Math.max(0, rightBound - leftBound);
+        currentShowPrevId = lastShowId;
+      }
+      currentShowId = track.showId;
+      // Only count_for_stats=true shows advance the "last performance" cursor.
+      if (track.showCountForStats) {
+        lastShowDate = track.showDate;
+        lastShowId = track.showId;
+      }
+    }
+    results.push({
+      trackId: track.trackId,
+      gap: currentShowGap,
+      previousPerformanceShowId: currentShowPrevId,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Aggregate Song.* from a song's count_for_stats=true tracks. Counts
+ * unique shows (a song played twice in one show counts once) and bins
+ * by year for the yearly play data graph.
+ */
+export function computeSongStats(
+  statsTracks: { showId: string; showDate: string }[],
+): SongStatsAggregate {
+  const uniqueShowDates: string[] = [];
+  const seen = new Set<string>();
+  for (const t of statsTracks) {
+    if (seen.has(t.showId)) continue;
+    seen.add(t.showId);
+    uniqueShowDates.push(t.showDate);
+  }
+  uniqueShowDates.sort();
+
+  const yearlyPlayData: Record<string, number> = {};
+  for (const d of uniqueShowDates) {
+    const year = new Date(d).getFullYear().toString();
+    yearlyPlayData[year] = (yearlyPlayData[year] || 0) + 1;
+  }
+
+  return {
+    timesPlayed: uniqueShowDates.length,
+    dateFirstPlayed: uniqueShowDates[0] ? new Date(uniqueShowDates[0]) : null,
+    dateLastPlayed: uniqueShowDates[uniqueShowDates.length - 1]
+      ? new Date(uniqueShowDates[uniqueShowDates.length - 1])
+      : null,
+    yearlyPlayData,
+  };
+}

--- a/packages/core/src/page-composers/song-page-composer.test.ts
+++ b/packages/core/src/page-composers/song-page-composer.test.ts
@@ -15,7 +15,14 @@ import {
 function makePerformance(overrides: Partial<SongPagePerformance> = {}): SongPagePerformance {
   return {
     trackId: "track-1",
-    show: { id: "show-1", slug: "2024-06-15", date: "2024-06-15", venueId: "venue-1", dayOrder: null, countForStats: true },
+    show: {
+      id: "show-1",
+      slug: "2024-06-15",
+      date: "2024-06-15",
+      venueId: "venue-1",
+      dayOrder: null,
+      countForStats: true,
+    },
     set: "S1",
     position: 3,
     segue: null,
@@ -70,6 +77,10 @@ function makeDto(overrides: Partial<PerformanceDto> = {}): PerformanceDto {
     average_rating: 4.5,
     ratings_count: 12,
     note: null,
+    gap: null,
+    previous_performance_show_id: null,
+    previous_show_slug: null,
+    previous_show_date: null,
     // Next/Prev track segues
     next_track_segue: null,
     prev_track_segue: null,
@@ -299,6 +310,22 @@ describe("transformToSongPagePerformanceView", () => {
   // current impl). Documented quirk: `|| undefined` means `0` values also
   // become `undefined`, which is fine for rating/ratingsCount but worth
   // pinning so the behavior is explicit.
+  // Phase 1 of the stats expansion denormalized gap onto Track. The
+  // composer must surface gap and previousPerformanceShowId on the view so
+  // the song-detail performances table can render the Gap column without
+  // an extra query per row.
+  test("maps gap and previous_performance_show_id through to the view", () => {
+    const debutView = transformToSongPagePerformanceView(makeDto({ gap: null, previous_performance_show_id: null }));
+    expect(debutView.gap).toBeNull();
+    expect(debutView.previousPerformanceShowId).toBeNull();
+
+    const subsequentView = transformToSongPagePerformanceView(
+      makeDto({ gap: 7, previous_performance_show_id: "prior-show-id" }),
+    );
+    expect(subsequentView.gap).toBe(7);
+    expect(subsequentView.previousPerformanceShowId).toBe("prior-show-id");
+  });
+
   test("null rating, ratings_count, and note all map to undefined", () => {
     const view = transformToSongPagePerformanceView(
       makeDto({ average_rating: null as never, ratings_count: null as never, note: null }),

--- a/packages/core/src/page-composers/song-page-composer.ts
+++ b/packages/core/src/page-composers/song-page-composer.ts
@@ -363,7 +363,11 @@ export class SongPageComposer {
         tracks.all_timer,
         tracks.average_rating,
         tracks.ratings_count,
-        tracks.note
+        tracks.note,
+        tracks.gap,
+        tracks.previous_performance_show_id,
+        prevShows.slug as previous_show_slug,
+        prevShows.date as previous_show_date
         ${songColumns},
         nextTracks.segue as next_track_segue,
         prevTracks.segue as prev_track_segue,
@@ -386,6 +390,7 @@ export class SongPageComposer {
         AND prevTracks.position = tracks.position - 1
         AND prevTracks.set = tracks.set
       LEFT JOIN songs prevSongs ON prevTracks.song_id = prevSongs.id
+      LEFT JOIN shows prevShows ON tracks.previous_performance_show_id = prevShows.id
       WHERE ${options.whereClause}
       ORDER BY ${showOrderBySql("shows", "DESC")}, tracks.set, tracks.position
     `;
@@ -564,6 +569,12 @@ export function transformToSongPagePerformanceView(row: PerformanceDto): SongPag
     position: row.position,
     cover: row.song_cover ?? undefined,
     authorId: row.song_author_id ?? null,
+    gap: row.gap,
+    previousPerformanceShowId: row.previous_performance_show_id,
+    previousShow:
+      row.previous_show_slug && row.previous_show_date
+        ? { slug: row.previous_show_slug, date: row.previous_show_date }
+        : undefined,
   };
 }
 
@@ -593,6 +604,10 @@ export type PerformanceDto = {
   average_rating: number;
   ratings_count: number;
   note: string | null;
+  gap: number | null;
+  previous_performance_show_id: string | null;
+  previous_show_slug: string | null;
+  previous_show_date: string | null;
 
   // Next/Prev track fields
   next_track_segue: string | null;

--- a/packages/core/src/shows/show-service.test.ts
+++ b/packages/core/src/shows/show-service.test.ts
@@ -1,15 +1,62 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, type Mock, test, vi } from "vitest";
+import type { CacheInvalidationService } from "../_shared/cache";
+import type { StatsService } from "../stats/stats-service";
 import { ShowService } from "./show-service";
 
 // Minimal logger stub — show-service only calls `.info`
 const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+
+// Cache invalidation stub — write-path tests don't reach into it but the
+// constructor requires a real-shaped service. Cast at the boundary so we
+// don't have to enumerate every method.
+function makeCacheInvalidationStub(): CacheInvalidationService {
+  return {
+    invalidateShow: vi.fn(),
+    invalidateShowListings: vi.fn(),
+    invalidateShowComprehensive: vi.fn(),
+    invalidateSongCaches: vi.fn(),
+    invalidateAllTimers: vi.fn(),
+  } as unknown as CacheInvalidationService;
+}
+
+// Stats stub — preserves the Mock type on `rebuildGapsAndSongStatsSince`
+// so test assertions like `expect(stats.rebuildGapsAndSongStatsSince).toHaveBeenCalledWith(...)`
+// stay typed, while still accepted as a StatsService at the constructor.
+function makeStatsStub(): StatsService & { rebuildGapsAndSongStatsSince: Mock } {
+  return {
+    rebuildGapsAndSongStatsSince: vi.fn().mockResolvedValue(undefined),
+  } as unknown as StatsService & { rebuildGapsAndSongStatsSince: Mock };
+}
 
 function makeMockDb() {
   return {
     show: {
       findMany: vi.fn().mockResolvedValue([]),
       findUnique: vi.fn(),
+      create: vi.fn().mockResolvedValue({
+        id: "show-id",
+        slug: "1999-12-31-test",
+        date: "1999-12-31",
+        venueId: null,
+        bandId: null,
+        notes: null,
+        relistenUrl: null,
+        legacyId: null,
+        likesCount: 0,
+        averageRating: 0,
+        ratingsCount: 0,
+        showPhotosCount: 0,
+        showYoutubesCount: 0,
+        reviewsCount: 0,
+        countForStats: true,
+        dayOrder: null,
+        searchText: null,
+        searchVector: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
       update: vi.fn(),
+      delete: vi.fn().mockResolvedValue({}),
     },
     venue: {
       findUnique: vi.fn().mockResolvedValue(null),
@@ -33,7 +80,7 @@ describe("ShowService.getShowDatesWithFlags", () => {
       { date: "2019-08-10", showPhotosCount: 0, showYoutubesCount: 2 },
       { date: "2023-06-15", showPhotosCount: 7, showYoutubesCount: 3 },
     ]);
-    const service = new ShowService(db as never, logger);
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), makeStatsStub());
 
     const result = await service.getShowDatesWithFlags();
 
@@ -48,7 +95,7 @@ describe("ShowService.getShowDatesWithFlags", () => {
   // toggle change on the year page, so keep it narrow.
   test("selects only the fields needed for bucketing", async () => {
     const db = makeMockDb();
-    const service = new ShowService(db as never, logger);
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), makeStatsStub());
 
     await service.getShowDatesWithFlags();
 
@@ -89,7 +136,7 @@ describe("ShowService.reorderByDate", () => {
       id: args.where.id,
       dayOrder: args.data.dayOrder,
     }));
-    const service = new ShowService(db as never, logger);
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), makeStatsStub());
 
     await service.reorderByDate("2017-07-22", ["show-a", "show-b", "show-c"]);
 
@@ -113,7 +160,7 @@ describe("ShowService.reorderByDate", () => {
       { id: "good-id", date: "2017-07-22" },
       { id: "wrong-date-id", date: "2018-12-31" },
     ]);
-    const service = new ShowService(db as never, logger);
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), makeStatsStub());
 
     await expect(service.reorderByDate("2017-07-22", ["good-id", "wrong-date-id"])).rejects.toThrow(
       /not on date 2017-07-22/,
@@ -125,7 +172,7 @@ describe("ShowService.reorderByDate", () => {
   test("throws when any supplied id is not found", async () => {
     const db = makeMockDb();
     db.show.findMany.mockResolvedValue([{ id: "found-id", date: "2017-07-22" }]);
-    const service = new ShowService(db as never, logger);
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), makeStatsStub());
 
     await expect(service.reorderByDate("2017-07-22", ["found-id", "missing-id"])).rejects.toThrow();
     expect(db.$transaction).not.toHaveBeenCalled();
@@ -161,11 +208,117 @@ describe("ShowService.update countForStats", () => {
       showYoutubesCount: 0,
       reviewsCount: 0,
     });
-    const service = new ShowService(db as never, logger);
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), makeStatsStub());
 
     await service.update("2017-07-22-soundcheck", { date: "2017-07-22", countForStats: false });
 
     const updateArgs = db.show.update.mock.calls[0][0];
     expect(updateArgs.data.countForStats).toBe(false);
+  });
+});
+
+describe("ShowService — gap rebuild on mutation", () => {
+  // Adding a new show changes the universe of count_for_stats=true shows,
+  // which ripples to gap chains for songs whose performances span the new
+  // show's date — even songs that weren't played at the new show. The
+  // rebuild is scoped to tracks at or after the new show's date so the
+  // common "today's show" case stays cheap (no pre-existing tracks at
+  // that date).
+  test("create() rebuilds gaps from the new show's date forward", async () => {
+    const db = makeMockDb();
+    const stats = makeStatsStub();
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), stats);
+    const rebuild = stats.rebuildGapsAndSongStatsSince;
+
+    await service.create({ date: "1999-12-31" });
+
+    expect(rebuild).toHaveBeenCalledWith("1999-12-31");
+  });
+
+  // Updating a show's date moves it in the timeline. Rebuild from the
+  // earlier of the old and new dates so chains spanning either side are
+  // recomputed.
+  test("update() with later date uses the original (earlier) date as sinceDate", async () => {
+    const db = makeMockDb();
+    db.show.findUnique.mockResolvedValueOnce({ id: "show-id", date: "1999-12-31", venueId: null });
+    db.show.update.mockResolvedValue({
+      id: "show-id",
+      slug: "1999-12-31-test",
+      date: "2000-01-15",
+      venueId: null,
+      bandId: null,
+      notes: null,
+      relistenUrl: null,
+      legacyId: null,
+      likesCount: 0,
+      averageRating: 0,
+      ratingsCount: 0,
+      showPhotosCount: 0,
+      showYoutubesCount: 0,
+      reviewsCount: 0,
+      countForStats: true,
+      dayOrder: null,
+      searchText: null,
+      searchVector: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const stats = makeStatsStub();
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), stats);
+    const rebuild = stats.rebuildGapsAndSongStatsSince;
+
+    await service.update("1999-12-31-test", { date: "2000-01-15" });
+
+    expect(rebuild).toHaveBeenCalledWith("1999-12-31");
+  });
+
+  // Editing a show without changing its date doesn't affect any gap chain
+  // (notes / relistenUrl don't enter the gap algorithm). Skip the rebuild.
+  test("update() without a date change does not invoke rebuild", async () => {
+    const db = makeMockDb();
+    db.show.findUnique.mockResolvedValueOnce({ id: "show-id", date: "1999-12-31", venueId: null });
+    db.show.update.mockResolvedValue({
+      id: "show-id",
+      slug: "1999-12-31-test",
+      date: "1999-12-31",
+      venueId: null,
+      bandId: null,
+      notes: "edited",
+      relistenUrl: null,
+      legacyId: null,
+      likesCount: 0,
+      averageRating: 0,
+      ratingsCount: 0,
+      showPhotosCount: 0,
+      showYoutubesCount: 0,
+      reviewsCount: 0,
+      countForStats: true,
+      dayOrder: null,
+      searchText: null,
+      searchVector: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const stats = makeStatsStub();
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), stats);
+    const rebuild = stats.rebuildGapsAndSongStatsSince;
+
+    await service.update("1999-12-31-test", { date: "1999-12-31", notes: "edited" });
+
+    expect(rebuild).not.toHaveBeenCalled();
+  });
+
+  // Deleting a count_for_stats=true show shrinks the denominator for
+  // chains that span its date — rebuild from that date forward.
+  test("delete() rebuilds gaps from the deleted show's date forward", async () => {
+    const db = makeMockDb();
+    db.show.findUnique.mockResolvedValueOnce({ slug: "1999-12-31-test", date: "1999-12-31" });
+    const stats = makeStatsStub();
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), stats);
+    const rebuild = stats.rebuildGapsAndSongStatsSince;
+
+    await service.delete("show-id");
+
+    expect(rebuild).toHaveBeenCalledWith("1999-12-31");
   });
 });

--- a/packages/core/src/shows/show-service.ts
+++ b/packages/core/src/shows/show-service.ts
@@ -13,6 +13,7 @@ import {
   showOrderTuple,
 } from "../_shared/show-ordering";
 import { slugify } from "../_shared/utils/slugify";
+import type { StatsService } from "../stats/stats-service";
 
 export interface ShowFilter {
   year?: number;
@@ -68,7 +69,14 @@ export class ShowService {
   constructor(
     protected readonly db: DbClient,
     protected readonly logger: Logger,
-    protected readonly cacheInvalidation?: CacheInvalidationService,
+    protected readonly cacheInvalidation: CacheInvalidationService,
+    /**
+     * Triggered after every show mutation (create/update/delete) to keep
+     * Track.gap and Song.* aggregates consistent — the universe of
+     * count_for_stats=true shows changes whenever a show is mutated, which
+     * ripples to chains spanning the affected date.
+     */
+    protected readonly stats: StatsService,
   ) {}
 
   private async generateShowSlug(date: string, venueId?: string): Promise<string> {
@@ -342,9 +350,15 @@ export class ShowService {
     const show = mapShowToDomainEntity(result);
 
     // Invalidate show listing caches (new show affects listings)
-    if (this.cacheInvalidation) {
-      await this.cacheInvalidation.invalidateShowListings();
-    }
+    await this.cacheInvalidation.invalidateShowListings();
+
+    // Adding a count_for_stats=true show changes the "shows between"
+    // denominator for songs whose chains span this date — rebuild gaps
+    // for tracks at or after this show. A brand-new show has no tracks
+    // yet (tracks come later via TrackService) so this is typically a
+    // no-op; the cost only kicks in if the new show is in the past and
+    // tracks already exist there (rare).
+    await this.stats.rebuildGapsAndSongStatsSince(String(data.date));
 
     return show;
   }
@@ -389,19 +403,25 @@ export class ShowService {
 
     const show = mapShowToDomainEntity(result);
 
-    // Invalidate caches
-    if (this.cacheInvalidation) {
-      if (newSlug && newSlug !== slug) {
-        // Slug changed - invalidate both old and new
-        await Promise.all([
-          this.cacheInvalidation.invalidateShow(slug), // old slug
-          this.cacheInvalidation.invalidateShow(newSlug), // new slug
-          this.cacheInvalidation.invalidateShowListings(),
-        ]);
-      } else {
-        // Regular update - invalidate current show and listings
-        await this.cacheInvalidation.invalidateShowComprehensive(currentShow.id, slug);
-      }
+    if (newSlug && newSlug !== slug) {
+      // Slug changed - invalidate both old and new
+      await Promise.all([
+        this.cacheInvalidation.invalidateShow(slug), // old slug
+        this.cacheInvalidation.invalidateShow(newSlug), // new slug
+        this.cacheInvalidation.invalidateShowListings(),
+      ]);
+    } else {
+      await this.cacheInvalidation.invalidateShowComprehensive(currentShow.id, slug);
+    }
+
+    // Show edits that move the show in time (or later: count_for_stats /
+    // day_order toggles) can change the gap denominator. Rebuild from the
+    // earlier of the old and new dates so chains spanning either side are
+    // recomputed. Skip when the date didn't change — notes / relistenUrl /
+    // venue edits don't affect gap.
+    if (data.date && String(data.date) !== currentShow.date) {
+      const sinceDate = String(data.date) < currentShow.date ? String(data.date) : currentShow.date;
+      await this.stats.rebuildGapsAndSongStatsSince(sinceDate);
     }
 
     return show;
@@ -444,26 +464,31 @@ export class ShowService {
       ),
     );
 
-    if (this.cacheInvalidation) {
-      await this.cacheInvalidation.invalidateShowListings();
-    }
+    await this.cacheInvalidation.invalidateShowListings();
   }
 
   async delete(id: string): Promise<boolean> {
     try {
-      // Get show data before deletion for cache invalidation
+      // Capture slug + date before deletion — slug for cache invalidation,
+      // date for the stats rebuild scope.
       const show = await this.db.show.findUnique({
         where: { id },
-        select: { slug: true },
+        select: { slug: true, date: true },
       });
 
       await this.db.show.delete({
         where: { id },
       });
 
-      // Invalidate caches
-      if (this.cacheInvalidation && show?.slug) {
+      if (show?.slug) {
         await this.cacheInvalidation.invalidateShowComprehensive(id, show.slug);
+      }
+
+      // Removing a stats-show shrinks the "shows between" denominator for
+      // chains that span its date. Rebuild from the deleted show's date
+      // forward — earlier chains are unaffected.
+      if (show?.date) {
+        await this.stats.rebuildGapsAndSongStatsSince(show.date);
       }
 
       return true;

--- a/packages/core/src/songs/song-service.test.ts
+++ b/packages/core/src/songs/song-service.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, test, vi } from "vitest";
+import { SongService } from "./song-service";
+
+// Minimal logger stub — song-service only calls these methods on logger
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+
+type MockTrack = {
+  id: string;
+  songId: string;
+  showId: string;
+  position: number;
+  show: { id: string; date: string; dayOrder: number | null; countForStats: boolean };
+};
+
+type MockShow = { date: string };
+
+function makeMockDb(opts: { tracks: MockTrack[]; statsShows: MockShow[] }) {
+  return {
+    track: {
+      findMany: vi.fn().mockResolvedValue(opts.tracks),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    song: {
+      update: vi.fn().mockResolvedValue({}),
+    },
+    show: {
+      // Service queries with `where: { countForStats: true }` to compute the
+      // "shows between" denominator. Tests mock this to return only the
+      // count_for_stats=true shows.
+      findMany: vi.fn().mockResolvedValue(opts.statsShows),
+    },
+  };
+}
+
+/**
+ * Capture every gap+previousPerformanceShowId write produced by
+ * updateSongStatistics into a `{trackId: {gap, previousPerformanceShowId}}` map
+ * so individual test assertions stay readable.
+ */
+function capturedTrackUpdates(db: ReturnType<typeof makeMockDb>) {
+  const out: Record<string, { gap: number | null; previousPerformanceShowId: string | null }> = {};
+  for (const call of db.track.update.mock.calls) {
+    const [{ where, data }] = call;
+    out[where.id] = {
+      gap: data.gap ?? null,
+      previousPerformanceShowId: data.previousPerformanceShowId ?? null,
+    };
+  }
+  return out;
+}
+
+/** Convenience builder for the show object on a mock track. */
+function show(id: string, date: string, opts: { dayOrder?: number | null; countForStats?: boolean } = {}) {
+  return {
+    id,
+    date,
+    dayOrder: opts.dayOrder ?? null,
+    countForStats: opts.countForStats ?? true,
+  };
+}
+
+describe("SongService.updateSongStatistics — gap denormalization", () => {
+  // A song's first-ever performance has no prior occurrence, so gap is NULL
+  // (renders as "Debut") and previousPerformanceShowId is NULL.
+  test("debut: single track gets gap=null and previousPerformanceShowId=null", async () => {
+    const db = makeMockDb({
+      tracks: [
+        { id: "track-1", songId: "song-basis", showId: "show-A", position: 1, show: show("show-A", "1998-04-15") },
+      ],
+      statsShows: [{ date: "1998-04-15" }],
+    });
+    const service = new SongService(db as never, logger);
+
+    await service.updateSongStatistics("song-basis");
+
+    expect(capturedTrackUpdates(db)).toEqual({
+      "track-1": { gap: null, previousPerformanceShowId: null },
+    });
+  });
+
+  // Two consecutive shows with no other shows in between → gap=0 on the
+  // second performance. previousPerformanceShowId points at the first show.
+  test("back-to-back: gap=0 when song was played at the immediately previous show", async () => {
+    const db = makeMockDb({
+      tracks: [
+        { id: "track-1", songId: "song-munchkin", showId: "show-A", position: 1, show: show("show-A", "2001-06-01") },
+        { id: "track-2", songId: "song-munchkin", showId: "show-B", position: 1, show: show("show-B", "2001-06-02") },
+      ],
+      statsShows: [{ date: "2001-06-01" }, { date: "2001-06-02" }],
+    });
+    const service = new SongService(db as never, logger);
+
+    await service.updateSongStatistics("song-munchkin");
+
+    expect(capturedTrackUpdates(db)).toEqual({
+      "track-1": { gap: null, previousPerformanceShowId: null },
+      "track-2": { gap: 0, previousPerformanceShowId: "show-A" },
+    });
+  });
+
+  // Three unrelated shows sit between the two performances of Spaga.
+  // gap should equal the count of shows strictly between (exclusive bounds).
+  test("N shows between: gap counts shows strictly between performances", async () => {
+    const db = makeMockDb({
+      tracks: [
+        { id: "track-1", songId: "song-spaga", showId: "show-A", position: 2, show: show("show-A", "2003-10-10") },
+        { id: "track-2", songId: "song-spaga", showId: "show-E", position: 5, show: show("show-E", "2003-10-20") },
+      ],
+      statsShows: [
+        { date: "2003-10-10" }, // show A — bound, excluded
+        { date: "2003-10-12" }, // unrelated
+        { date: "2003-10-15" }, // unrelated
+        { date: "2003-10-18" }, // unrelated
+        { date: "2003-10-20" }, // show E — bound, excluded
+      ],
+    });
+    const service = new SongService(db as never, logger);
+
+    await service.updateSongStatistics("song-spaga");
+
+    expect(capturedTrackUpdates(db)).toEqual({
+      "track-1": { gap: null, previousPerformanceShowId: null },
+      "track-2": { gap: 3, previousPerformanceShowId: "show-A" },
+    });
+  });
+
+  // When a song is played twice in the same show, both tracks share the
+  // gap+prevShowId computed against the song's prior *show*, not against
+  // the earlier track in this show. The "this show" repeat marker is a
+  // render-time concern (computed from the loaded setlist).
+  test("within-show repeat: both tracks share gap and previousPerformanceShowId from the prior show", async () => {
+    const db = makeMockDb({
+      tracks: [
+        { id: "track-1", songId: "song-mrdon", showId: "show-A", position: 1, show: show("show-A", "2005-02-01") },
+        // Two tracks of Mr. Don in show B — both are "new show" relative to A
+        { id: "track-2a", songId: "song-mrdon", showId: "show-B", position: 3, show: show("show-B", "2005-02-05") },
+        { id: "track-2b", songId: "song-mrdon", showId: "show-B", position: 8, show: show("show-B", "2005-02-05") },
+      ],
+      statsShows: [
+        { date: "2005-02-01" },
+        { date: "2005-02-03" }, // unrelated → between A and B
+        { date: "2005-02-05" },
+      ],
+    });
+    const service = new SongService(db as never, logger);
+
+    await service.updateSongStatistics("song-mrdon");
+
+    expect(capturedTrackUpdates(db)).toEqual({
+      "track-1": { gap: null, previousPerformanceShowId: null },
+      "track-2a": { gap: 1, previousPerformanceShowId: "show-A" },
+      "track-2b": { gap: 1, previousPerformanceShowId: "show-A" },
+    });
+  });
+
+  // A song with no tracks at all (e.g., after all its tracks were deleted)
+  // should reset song stats and not attempt any track.update calls.
+  test("no tracks: resets song stats and writes no track gap rows", async () => {
+    const db = makeMockDb({ tracks: [], statsShows: [] });
+    const service = new SongService(db as never, logger);
+
+    await service.updateSongStatistics("song-crystalball");
+
+    expect(db.track.update).not.toHaveBeenCalled();
+    expect(db.song.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "song-crystalball" },
+        data: expect.objectContaining({
+          timesPlayed: 0,
+          dateFirstPlayed: null,
+          dateLastPlayed: null,
+        }),
+      }),
+    );
+  });
+
+  // Tracks on a count_for_stats=false show (soundcheck, radio session,
+  // cancelled stub, late-night Tractorbeam set) DO get a gap value — it
+  // points back at the most recent count_for_stats=true performance, so a
+  // user viewing the soundcheck setlist sees "this song was last really
+  // played N stats-shows ago at show X". But the soundcheck itself is
+  // never POINTED AT by a later stats-show — the next stats-performance
+  // walks back past it to the prior stats-show. timesPlayed and the other
+  // song-level stats still exclude these shows.
+  test("count_for_stats=false: track points at prior stats-show; never pointed at", async () => {
+    const db = makeMockDb({
+      tracks: [
+        { id: "track-A", songId: "song-shem", showId: "show-A", position: 1, show: show("show-A", "2010-06-01") },
+        // Soundcheck at show-SC. Should point at show-A (the prior real
+        // performance), but not advance the lastShow tracker.
+        {
+          id: "track-SC",
+          songId: "song-shem",
+          showId: "show-SC",
+          position: 1,
+          show: show("show-SC", "2010-06-10", { countForStats: false }),
+        },
+        // show-B is the next real performance. Its prev should still be
+        // show-A (not show-SC), and gap is the count of stats-shows
+        // strictly between A and B (zero — SC doesn't count).
+        { id: "track-B", songId: "song-shem", showId: "show-B", position: 1, show: show("show-B", "2010-06-15") },
+      ],
+      // Only count_for_stats=true shows in the denominator.
+      statsShows: [{ date: "2010-06-01" }, { date: "2010-06-15" }],
+    });
+    const service = new SongService(db as never, logger);
+
+    await service.updateSongStatistics("song-shem");
+
+    expect(capturedTrackUpdates(db)).toEqual({
+      "track-A": { gap: null, previousPerformanceShowId: null },
+      // SC points at A; no stats-shows between 2010-06-01 and 2010-06-10.
+      "track-SC": { gap: 0, previousPerformanceShowId: "show-A" },
+      // B walks back to A (skipping SC); no stats-shows between A and B.
+      "track-B": { gap: 0, previousPerformanceShowId: "show-A" },
+    });
+    // timesPlayed = 2 (A + B). The soundcheck doesn't count.
+    expect(db.song.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ timesPlayed: 2 }),
+      }),
+    );
+  });
+
+  // When two shows share a date, dayOrder determines which is "first" for
+  // gap purposes. The mock service receives tracks pre-sorted by Prisma's
+  // (date, dayOrder, position, id) ORDER BY, so the test mimics that.
+  test("same-date pair: dayOrder=1 is treated as the earlier show", async () => {
+    const db = makeMockDb({
+      tracks: [
+        // Earlier show on 2010-03-26 (Bicentennial Park, day_order=1)
+        {
+          id: "track-1",
+          songId: "song-helicopters",
+          showId: "show-fest",
+          position: 1,
+          show: show("show-fest", "2010-03-26", { dayOrder: 1 }),
+        },
+        // Later show on 2010-03-26 (Tractorbeam after-party, day_order=2)
+        {
+          id: "track-2",
+          songId: "song-helicopters",
+          showId: "show-after",
+          position: 1,
+          show: show("show-after", "2010-03-26", { dayOrder: 2 }),
+        },
+      ],
+      // Both shows count toward the denominator (the user only opted-out
+      // some Tractorbeam sets, not all).
+      statsShows: [{ date: "2010-03-26" }, { date: "2010-03-26" }],
+    });
+    const service = new SongService(db as never, logger);
+
+    await service.updateSongStatistics("song-helicopters");
+
+    // Earlier show is the debut, after-party gap=0 with prev pointing at it.
+    expect(capturedTrackUpdates(db)).toEqual({
+      "track-1": { gap: null, previousPerformanceShowId: null },
+      "track-2": { gap: 0, previousPerformanceShowId: "show-fest" },
+    });
+  });
+});

--- a/packages/core/src/songs/song-service.ts
+++ b/packages/core/src/songs/song-service.ts
@@ -2,7 +2,8 @@ import type { Logger, Song, TrendingSong } from "@bip/domain";
 import type { DbClient, DbSong } from "../_shared/database/models";
 import { buildOrderByClause, buildWhereClause } from "../_shared/database/query-utils";
 import type { FilterCondition, QueryOptions } from "../_shared/database/types";
-import { SHOW_ORDER_DESC, STATS_SHOWS_WHERE } from "../_shared/show-ordering";
+import { SHOW_ORDER_DESC, STATS_SHOWS_WHERE, TRACK_BY_SHOW_ORDER_ASC } from "../_shared/show-ordering";
+import { computeSongStats, computeTrackGaps, sortTracksForGapWalk, type TrackForGapWalk } from "../_shared/track-gap";
 import { slugify } from "../_shared/utils/slugify";
 
 export interface SongFilter {
@@ -321,26 +322,33 @@ export class SongService {
   }
 
   /**
-   * Recalculate and update statistics for a specific song based on its tracks
+   * Recalculate denormalized stats for a specific song: per-track gap +
+   * previousPerformanceShowId, and Song.timesPlayed / dateFirst/LastPlayed /
+   * yearlyPlayData. Algorithm lives in pure functions in `_shared/track-gap.ts`
+   * so it's unit-tested without DB mocks; this method is a thin wrapper that
+   * fetches data, runs the pure functions, and writes results.
+   *
+   * Stats rules:
+   *  - Shows with `countForStats=false` (soundchecks, radio sessions, cancelled
+   *    stubs, late-night Tractorbeam sets) are excluded from `timesPlayed` /
+   *    `dateFirst/LastPlayed` / `yearlyPlayData`.
+   *  - Tracks on those shows get a gap pointing at the prior stats-show (so
+   *    the soundcheck row reads "last really played N shows ago") but never
+   *    act as a `prev` for later tracks — the next stats-performance walks
+   *    back past them.
    */
   async updateSongStatistics(songId: string): Promise<void> {
-    // Get all unique shows for this song (count shows, not individual tracks)
-    const uniqueShows = await this.db.track.findMany({
+    const tracks = await this.db.track.findMany({
       where: { songId },
-      distinct: ["showId"],
       include: {
         show: {
-          select: { date: true },
+          select: { id: true, date: true, dayOrder: true, countForStats: true },
         },
       },
-      orderBy: {
-        show: {
-          date: "asc",
-        },
-      },
+      orderBy: TRACK_BY_SHOW_ORDER_ASC,
     });
 
-    if (uniqueShows.length === 0) {
+    if (tracks.length === 0) {
       // No tracks, reset statistics
       await this.db.song.update({
         where: { id: songId },
@@ -354,30 +362,55 @@ export class SongService {
       return;
     }
 
-    // Calculate statistics based on unique shows
-    const timesPlayed = uniqueShows.length;
-    const firstShow = uniqueShows[0];
-    const lastShow = uniqueShows[uniqueShows.length - 1];
-
-    // Build yearly play data (count unique shows per year)
-    const yearlyPlayData: Record<string, number> = {};
-    uniqueShows.forEach((track) => {
-      if (track.show?.date) {
-        const year = new Date(track.show.date).getFullYear().toString();
-        yearlyPlayData[year] = (yearlyPlayData[year] || 0) + 1;
-      }
+    // Universe of stats-show dates feeds the "shows between" denominator.
+    const statsShows = await this.db.show.findMany({
+      where: STATS_SHOWS_WHERE,
+      select: { date: true },
+      orderBy: { date: "asc" },
     });
 
-    // Update the song
-    await this.db.song.update({
-      where: { id: songId },
-      data: {
-        timesPlayed,
-        dateFirstPlayed: firstShow.show?.date ? new Date(firstShow.show.date) : null,
-        dateLastPlayed: lastShow.show?.date ? new Date(lastShow.show.date) : null,
-        yearlyPlayData: yearlyPlayData,
-        updatedAt: new Date(),
-      },
+    const walkInput: TrackForGapWalk[] = tracks.flatMap((t) => {
+      // Drop tracks whose show row failed to join (shouldn't happen — FK
+      // is enforced — but the include's type is `show: Show | null`).
+      if (!t.show) return [];
+      return [
+        {
+          trackId: t.id,
+          showId: t.show.id,
+          showDate: t.show.date,
+          dayOrder: t.show.dayOrder,
+          showCountForStats: t.show.countForStats,
+          position: t.position,
+        },
+      ];
     });
+
+    const sortedTracks = sortTracksForGapWalk(walkInput);
+    const gapResults = computeTrackGaps(
+      sortedTracks,
+      statsShows.map((s) => s.date),
+    );
+    const songStats = computeSongStats(
+      walkInput.filter((t) => t.showCountForStats).map((t) => ({ showId: t.showId, showDate: t.showDate })),
+    );
+
+    await Promise.all([
+      ...gapResults.map((g) =>
+        this.db.track.update({
+          where: { id: g.trackId },
+          data: { gap: g.gap, previousPerformanceShowId: g.previousPerformanceShowId },
+        }),
+      ),
+      this.db.song.update({
+        where: { id: songId },
+        data: {
+          timesPlayed: songStats.timesPlayed,
+          dateFirstPlayed: songStats.dateFirstPlayed,
+          dateLastPlayed: songStats.dateLastPlayed,
+          yearlyPlayData: songStats.yearlyPlayData,
+          updatedAt: new Date(),
+        },
+      }),
+    ]);
   }
 }

--- a/packages/core/src/stats/stats-service.test.ts
+++ b/packages/core/src/stats/stats-service.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "vitest";
+import { songStatsChanged } from "./stats-service";
+
+const baseFresh = {
+  timesPlayed: 3,
+  dateFirstPlayed: new Date("2010-01-01"),
+  dateLastPlayed: new Date("2012-06-15"),
+  yearlyPlayData: { "2010": 1, "2011": 1, "2012": 1 },
+};
+
+describe("songStatsChanged", () => {
+  // Identical values must not trigger a write — this is the whole reason
+  // diff-before-write exists.
+  test("returns false when current row exactly matches the freshly-computed aggregate", () => {
+    const current = {
+      timesPlayed: 3,
+      dateFirstPlayed: new Date("2010-01-01"),
+      dateLastPlayed: new Date("2012-06-15"),
+      yearlyPlayData: { "2010": 1, "2011": 1, "2012": 1 },
+    };
+    expect(songStatsChanged(current, baseFresh)).toBe(false);
+  });
+
+  // Counter changed → must write. The cheapest possible diff hit.
+  test("returns true when timesPlayed changed", () => {
+    const current = { ...baseFresh, timesPlayed: 2 };
+    expect(songStatsChanged(current, baseFresh)).toBe(true);
+  });
+
+  // Date objects with the same wall-clock value must compare equal — we
+  // diff via getTime(), not reference equality, so two `new Date(...)`
+  // calls for the same date don't spuriously trigger a write.
+  test("returns false for distinct Date instances representing the same moment", () => {
+    const current = {
+      timesPlayed: 3,
+      dateFirstPlayed: new Date("2010-01-01"),
+      dateLastPlayed: new Date("2012-06-15"),
+      yearlyPlayData: { "2010": 1, "2011": 1, "2012": 1 },
+    };
+    expect(songStatsChanged(current, baseFresh)).toBe(false);
+  });
+
+  // Date moved → must write. Latest play could shift earlier (delete) or
+  // later (new performance).
+  test("returns true when dateLastPlayed shifted", () => {
+    const current = { ...baseFresh, dateLastPlayed: new Date("2012-06-14") };
+    expect(songStatsChanged(current, baseFresh)).toBe(true);
+  });
+
+  // Null ↔ Date transitions: a song going from never-played to debut, or
+  // having every track removed.
+  test("returns true when one date is null and the other is set", () => {
+    const current = { ...baseFresh, dateFirstPlayed: null };
+    expect(songStatsChanged(current, baseFresh)).toBe(true);
+  });
+
+  test("returns false when both dates are null", () => {
+    const empty = {
+      timesPlayed: 0,
+      dateFirstPlayed: null,
+      dateLastPlayed: null,
+      yearlyPlayData: {},
+    };
+    expect(songStatsChanged(empty, empty)).toBe(false);
+  });
+
+  // jsonb doesn't preserve insertion order on round-trip, so the comparator
+  // must normalize before comparing — otherwise every song would diff dirty
+  // forever and we'd write every row on every rebuild.
+  test("returns false when yearlyPlayData differs only by key order", () => {
+    const current = {
+      ...baseFresh,
+      yearlyPlayData: { "2012": 1, "2010": 1, "2011": 1 },
+    };
+    expect(songStatsChanged(current, baseFresh)).toBe(false);
+  });
+
+  // A real change in the year buckets — a play moved from one year to
+  // another, or a count changed.
+  test("returns true when a yearlyPlayData count differs", () => {
+    const current = {
+      ...baseFresh,
+      yearlyPlayData: { "2010": 1, "2011": 2, "2012": 1 },
+    };
+    expect(songStatsChanged(current, baseFresh)).toBe(true);
+  });
+
+  // Adding or removing a year bucket entirely.
+  test("returns true when yearlyPlayData has a different set of years", () => {
+    const current = {
+      ...baseFresh,
+      yearlyPlayData: { "2010": 1, "2011": 1 },
+    };
+    expect(songStatsChanged(current, baseFresh)).toBe(true);
+  });
+
+  // Prisma's JsonValue can be null for a column that was never set.
+  // Guard against treating `null` as an empty object accidentally — a
+  // null vs `{}` is an actual change worth writing.
+  test("returns true when current yearlyPlayData is null and fresh has data", () => {
+    const current = { ...baseFresh, yearlyPlayData: null as unknown };
+    expect(songStatsChanged(current, baseFresh)).toBe(true);
+  });
+});

--- a/packages/core/src/stats/stats-service.ts
+++ b/packages/core/src/stats/stats-service.ts
@@ -1,0 +1,265 @@
+import { CacheKeys } from "@bip/domain";
+import type { CacheService } from "../_shared/cache/cache-service";
+import type { DbClient } from "../_shared/database/models";
+import { STATS_SHOWS_WHERE, statsShowsSql, TRACK_BY_SHOW_ORDER_ASC } from "../_shared/show-ordering";
+import {
+  computeSongStats,
+  computeTrackGaps,
+  type GapResult,
+  sortTracksForGapWalk,
+  type TrackForGapWalk,
+} from "../_shared/track-gap";
+
+const ONE_DAY_SECONDS = 86400;
+
+/**
+ * Cross-domain aggregates that span shows and songs and back rarity /
+ * normalization features (per-year graph denominator, "shows since debut",
+ * etc.). Producers are lazy: first reader after invalidation pays the
+ * compute cost; everyone else hits Redis.
+ *
+ * Also owns the denormalized-stats rebuild path. Adding/editing/deleting a
+ * show changes the universe of `count_for_stats=true` shows, which ripples
+ * to `Track.gap` for songs whose performance chains span the changed show's
+ * date — even songs that weren't played at the changed show. The rebuild
+ * walks every track and recomputes `Track.gap`, `Track.previousPerformanceShowId`,
+ * `Song.timesPlayed`, `Song.dateFirstPlayed`, `Song.dateLastPlayed`, and
+ * `Song.yearlyPlayData` against the current show set.
+ */
+export class StatsService {
+  constructor(
+    private readonly db: DbClient,
+    /**
+     * Optional. Required for cached read paths like `getShowsByYear()`,
+     * not for the rebuild path. The sync-missing-shows script wires this
+     * service without a cache (no Redis when REDIS_URL is unset locally),
+     * so the rebuild stays usable in script contexts.
+     */
+    private readonly cache?: CacheService,
+  ) {}
+
+  /**
+   * Returns `{[year]: showCount}` for every year that has at least one
+   * show. Used by the song-detail "% of Shows" graph and the rarity stat
+   * cards. Invalidated by show mutations via CacheInvalidationService.
+   */
+  async getShowsByYear(): Promise<Record<number, number>> {
+    if (!this.cache) {
+      throw new Error("StatsService.getShowsByYear() requires a cache; constructed without one");
+    }
+    return this.cache.getOrSet(
+      CacheKeys.stats.showsByYear(),
+      async () => {
+        const rows = await this.db.$queryRaw<Array<{ year: number; count: bigint }>>`
+          SELECT date_part('year', date::date)::int AS year, COUNT(*) AS count
+          FROM shows
+          WHERE date IS NOT NULL
+            AND ${statsShowsSql("shows")}
+          GROUP BY 1
+          ORDER BY 1
+        `;
+        const out: Record<number, number> = {};
+        for (const row of rows) {
+          out[row.year] = Number(row.count);
+        }
+        return out;
+      },
+      { ttl: ONE_DAY_SECONDS },
+    );
+  }
+
+  /**
+   * Recompute Track.gap + Track.previousPerformanceShowId for every track
+   * at a show on or after `sinceDate`, and Song.timesPlayed /
+   * dateFirstPlayed / dateLastPlayed / yearlyPlayData for every song with
+   * at least one such track. Called after any show mutation (create /
+   * update / delete) — adding or removing a count_for_stats=true show
+   * changes the "shows between" denominator for chains spanning that date.
+   * Pre-`sinceDate` tracks are not touched: their universe of prior shows
+   * is unchanged because the mutated show is later than them.
+   *
+   * Implementation: fetch affected ids, stats-show dates, all tracks for
+   * affected songs, and current Song.* aggregates in parallel; run the
+   * pure-function gap walk per song; diff the computed values against
+   * what's already in the DB and write only the rows that actually
+   * changed. Writes dominate this path's runtime, so skipping unchanged
+   * rows is the lever that matters.
+   */
+  async rebuildGapsAndSongStatsSince(sinceDate: string): Promise<void> {
+    const affected = await this.db.track.findMany({
+      where: { show: { date: { gte: sinceDate } } },
+      select: { songId: true },
+      distinct: ["songId"],
+    });
+    if (affected.length === 0) return;
+    const affectedSongIds = affected.map((a) => a.songId);
+
+    const [statsShows, allTracks, currentSongs] = await Promise.all([
+      this.db.show.findMany({
+        where: STATS_SHOWS_WHERE,
+        select: { date: true },
+        orderBy: { date: "asc" },
+      }),
+      this.db.track.findMany({
+        where: { songId: { in: affectedSongIds } },
+        include: {
+          show: { select: { id: true, date: true, dayOrder: true, countForStats: true } },
+        },
+        orderBy: TRACK_BY_SHOW_ORDER_ASC,
+      }),
+      this.db.song.findMany({
+        where: { id: { in: affectedSongIds } },
+        select: {
+          id: true,
+          timesPlayed: true,
+          dateFirstPlayed: true,
+          dateLastPlayed: true,
+          yearlyPlayData: true,
+        },
+      }),
+    ]);
+    const statsShowDates = statsShows.map((s) => s.date);
+    const currentSongById = new Map(currentSongs.map((s) => [s.id, s]));
+
+    const tracksBySong = new Map<string, typeof allTracks>();
+    for (const t of allTracks) {
+      const arr = tracksBySong.get(t.songId);
+      if (arr) arr.push(t);
+      else tracksBySong.set(t.songId, [t]);
+    }
+
+    const changedGapResults: GapResult[] = [];
+    const changedSongUpdates: Array<{ songId: string; stats: ReturnType<typeof computeSongStats> }> = [];
+
+    for (const [songId, songTracks] of tracksBySong) {
+      const walkInput: TrackForGapWalk[] = songTracks.flatMap((t) => {
+        if (!t.show) return [];
+        return [
+          {
+            trackId: t.id,
+            showId: t.show.id,
+            showDate: t.show.date,
+            dayOrder: t.show.dayOrder,
+            showCountForStats: t.show.countForStats,
+            position: t.position,
+          },
+        ];
+      });
+      const sortedTracks = sortTracksForGapWalk(walkInput);
+      const gapResults = computeTrackGaps(sortedTracks, statsShowDates);
+
+      // Diff each computed (gap, prevId) against the current row. Tracks
+      // before sinceDate can't change, but they're cheap to check and the
+      // filter is the whole point.
+      const trackById = new Map(songTracks.map((t) => [t.id, t]));
+      for (const r of gapResults) {
+        const existing = trackById.get(r.trackId);
+        if (!existing) continue;
+        if (existing.gap !== r.gap || existing.previousPerformanceShowId !== r.previousPerformanceShowId) {
+          changedGapResults.push(r);
+        }
+      }
+
+      const songStats = computeSongStats(
+        walkInput.filter((t) => t.showCountForStats).map((t) => ({ showId: t.showId, showDate: t.showDate })),
+      );
+      const current = currentSongById.get(songId);
+      if (!current || songStatsChanged(current, songStats)) {
+        changedSongUpdates.push({ songId, stats: songStats });
+      }
+    }
+
+    await Promise.all([this.bulkUpdateTrackGaps(changedGapResults), this.bulkUpdateSongStats(changedSongUpdates)]);
+  }
+
+  /**
+   * Apply N song-stat updates to N songs in a single round-trip via UNNEST
+   * over five parallel arrays. Same trick as `bulkUpdateTrackGaps`.
+   */
+  private async bulkUpdateSongStats(
+    updates: Array<{ songId: string; stats: ReturnType<typeof computeSongStats> }>,
+  ): Promise<void> {
+    if (updates.length === 0) return;
+    const songIds = updates.map((u) => u.songId);
+    const timesPlayed = updates.map((u) => u.stats.timesPlayed);
+    const dateFirstPlayed = updates.map((u) => u.stats.dateFirstPlayed);
+    const dateLastPlayed = updates.map((u) => u.stats.dateLastPlayed);
+    const yearlyPlayData = updates.map((u) => JSON.stringify(u.stats.yearlyPlayData));
+    await this.db.$executeRaw`
+      UPDATE songs s
+         SET times_played      = u.times_played,
+             date_first_played = u.date_first_played,
+             date_last_played  = u.date_last_played,
+             yearly_play_data  = u.yearly_play_data::jsonb,
+             updated_at        = NOW()
+        FROM (
+          SELECT
+            UNNEST(${songIds}::uuid[])           AS song_id,
+            UNNEST(${timesPlayed}::int[])        AS times_played,
+            UNNEST(${dateFirstPlayed}::date[])   AS date_first_played,
+            UNNEST(${dateLastPlayed}::date[])    AS date_last_played,
+            UNNEST(${yearlyPlayData}::text[])    AS yearly_play_data
+        ) AS u
+       WHERE s.id = u.song_id
+    `;
+  }
+
+  /**
+   * Apply N gap+prev updates to N tracks in a single round-trip. Passes
+   * three parallel arrays as scalar parameters and uses `UNNEST` to turn
+   * them into rows — sidesteps Postgres's per-statement parameter limit
+   * (which a `(VALUES (...), (...), ...)` form would blow through at
+   * thousands of rows) while keeping us to one network round-trip.
+   * Pure values list, no business logic.
+   */
+  private async bulkUpdateTrackGaps(gapResults: GapResult[]): Promise<void> {
+    if (gapResults.length === 0) return;
+    const trackIds = gapResults.map((g) => g.trackId);
+    const gaps = gapResults.map((g) => g.gap);
+    const previousShowIds = gapResults.map((g) => g.previousPerformanceShowId);
+    await this.db.$executeRaw`
+      UPDATE tracks t
+         SET gap = u.gap,
+             previous_performance_show_id = u.previous_show_id
+        FROM (
+          SELECT
+            UNNEST(${trackIds}::uuid[])        AS track_id,
+            UNNEST(${gaps}::int[])             AS gap,
+            UNNEST(${previousShowIds}::uuid[]) AS previous_show_id
+        ) AS u
+       WHERE t.id = u.track_id
+    `;
+  }
+}
+
+/**
+ * True iff the freshly-computed song aggregate differs from what's on the
+ * row already. Date comparison goes through getTime() so two Date objects
+ * with the same wall-clock value compare equal; yearlyPlayData compares
+ * via a stable key-sorted serialization (Postgres jsonb doesn't preserve
+ * insertion order on round-trip).
+ */
+export function songStatsChanged(
+  current: {
+    timesPlayed: number;
+    dateFirstPlayed: Date | null;
+    dateLastPlayed: Date | null;
+    yearlyPlayData: unknown;
+  },
+  fresh: ReturnType<typeof computeSongStats>,
+): boolean {
+  if (current.timesPlayed !== fresh.timesPlayed) return true;
+  if (dateMs(current.dateFirstPlayed) !== dateMs(fresh.dateFirstPlayed)) return true;
+  if (dateMs(current.dateLastPlayed) !== dateMs(fresh.dateLastPlayed)) return true;
+  return stableYearlyJson(current.yearlyPlayData) !== stableYearlyJson(fresh.yearlyPlayData);
+}
+
+function dateMs(d: Date | null): number | null {
+  return d ? d.getTime() : null;
+}
+
+function stableYearlyJson(value: unknown): string {
+  if (!value || typeof value !== "object") return "[]";
+  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return JSON.stringify(entries);
+}

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -93,6 +93,15 @@ export const CacheKeys = {
     /** Recent setlists for home page (limit + sort direction) */
     recentSetlists: (limit: number) => `home:recent-setlists:${limit}`,
   },
+
+  /**
+   * Cross-domain stats cache keys (denormalized aggregates that span shows
+   * and songs and back rarity/normalization features).
+   */
+  stats: {
+    /** Map of `{year: showCount}` for the entire show catalog. */
+    showsByYear: () => "stats:shows-by-year",
+  },
 } as const;
 
 /**

--- a/packages/domain/src/views/song-page.ts
+++ b/packages/domain/src/views/song-page.ts
@@ -27,6 +27,9 @@ export type SongPagePerformance = {
   songSlug?: string;
   cover?: boolean;
   authorId?: string | null;
+  gap?: number | null;
+  previousPerformanceShowId?: string | null;
+  previousShow?: { slug: string; date: string };
   tags?: {
     setOpener?: boolean;
     setCloser?: boolean;


### PR DESCRIPTION
## Why

Users can now see how long it has between each time a song has been played and what the last played date. At first I hadn't added the "last played date" but this is useful when sorting by gap.


https://github.com/user-attachments/assets/a622756a-ee65-496c-a397-c38cde527879



## Summary

- Adds **count_for_stats** and **day_order** to shows so non-canonical sets (late-night Tractorbeam, soundchecks, etc.) can be excluded from stats and same-date shows have a deterministic order. Includes an admin UI to edit both.
- Denormalizes **Track.gap** and **Track.previousPerformanceShowId** with a one-shot SQL backfill and an incremental rebuild that runs on show create/update/delete. Eliminates per-row gap queries on every page that renders setlists.
- Adds a **Gap** column and a paired **Last Played** column to the song-detail performances table at `/songs/:slug`. ★ marks debuts; ↺ marks within-show repeats. Sort puts debuts first, then ascending gap, with date and position tiebreaks via the canonical `compareByShowDate`.
- Standardizes a few ad-hoc `Date.getTime()` sorts on `compareByShowDate` so dayOrder/id tiebreak rules stay consistent across the app.
- Cleans up dead code and lint warnings touched along the way.


## Test plan

- [ ] `make tc && make test && make lint` clean.
- [ ] `make web` and visit a debut-heavy song, a stalwart, and a song with a within-show repeat on `/songs/:slug` — confirm ★, ↺, integers, and that sort by Gap clusters same-show repeats.
- [ ] Confirm Last Played column links to the prior show and is hidden on mobile.
- [ ] Admin: edit a show's `countForStats` and `dayOrder` — verify gap recompute fires and downstream pages reflect the change.
- [ ] Spot-check `/users/:username` first/last show dates and `/songs/:slug` all-timers ordering after the `compareByShowDate` swap.
- [ ] On staging, confirm the migration's automatic backfill populates `tracks.gap` and `tracks.previous_performance_show_id` for the full catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)