### PR TITLE
Normalized + all-years toggles on song-detail per-year chart

### DIFF
--- a/apps/web/app/components/song/yearly-play-chart.test.tsx
+++ b/apps/web/app/components/song/yearly-play-chart.test.tsx
@@ -1,0 +1,112 @@
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { YearlyPlayChart } from "./yearly-play-chart";
+
+// Recharts uses ResizeObserver + measured DOM sizes that jsdom doesn't
+// supply. ResponsiveContainer renders nothing under those conditions, which
+// would hide the chart from the test entirely. Stub it to a fixed-size div
+// so the inner LineChart renders deterministically.
+vi.mock("recharts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("recharts")>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 600, height: 300 }}>{children}</div>
+    ),
+  };
+});
+
+describe("YearlyPlayChart", () => {
+  const yearlyPlayData = { 2010: 12, 2011: 8, 2012: 16 };
+  const showsByYear = { 2010: 60, 2011: 80, 2012: 80 };
+
+  // The toggle is a 2-button group styled like the page's existing tabs.
+  // "% of Shows" is the default — normalized view is the more interesting
+  // read for most users since it controls for tour-volume swings.
+  test("renders # Plays and % of Shows toggle buttons with % of Shows selected by default", async () => {
+    await setup(<YearlyPlayChart yearlyPlayData={yearlyPlayData} showsByYear={showsByYear} />);
+
+    const countButton = screen.getByRole("button", { name: /# plays/i });
+    const percentButton = screen.getByRole("button", { name: /% of shows/i });
+
+    expect(countButton).toBeInTheDocument();
+    expect(percentButton).toBeInTheDocument();
+    // aria-pressed reflects which mode is active so screen readers and tests
+    // can both observe the current selection.
+    expect(percentButton).toHaveAttribute("aria-pressed", "true");
+    expect(countButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  // Clicking "Count" flips the toggle state. The visual swap of the chart
+  // series is hard to assert against jsdom + recharts SVG, so we assert the
+  // toggle's pressed state — that's the user-observable contract the test
+  // enforces. The data transform is covered by the helper test.
+  test("clicking # Plays updates the active button", async () => {
+    const { user } = await setup(<YearlyPlayChart yearlyPlayData={yearlyPlayData} showsByYear={showsByYear} />);
+
+    const countButton = screen.getByRole("button", { name: /# plays/i });
+    await user.click(countButton);
+
+    expect(countButton).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: /% of shows/i })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  // Round-trip: clicking back to % of Shows restores the default. Guards
+  // against a one-way toggle bug where clicking the inactive button works
+  // but clicking the now-inactive default button is a no-op.
+  test("clicking % of Shows after # Plays restores % of Shows as active", async () => {
+    const { user } = await setup(<YearlyPlayChart yearlyPlayData={yearlyPlayData} showsByYear={showsByYear} />);
+
+    await user.click(screen.getByRole("button", { name: /# plays/i }));
+    await user.click(screen.getByRole("button", { name: /% of shows/i }));
+
+    expect(screen.getByRole("button", { name: /% of shows/i })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: /# plays/i })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  // The X-axis-scope toggle lets users switch between "All Years" (every
+  // year in the band's touring window since 1995, default) and "Years
+  // Played" (debut year through last-played year, with zero-fills for
+  // skipped years in between so the X axis stays continuous).
+  test("renders Years Played and All Years scope toggle with All Years selected by default", async () => {
+    await setup(<YearlyPlayChart yearlyPlayData={yearlyPlayData} showsByYear={showsByYear} />);
+
+    const playedButton = screen.getByRole("button", { name: /years played/i });
+    const allYearsButton = screen.getByRole("button", { name: /all years/i });
+
+    expect(allYearsButton).toHaveAttribute("aria-pressed", "true");
+    expect(playedButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  // Clicking "Years Played" makes that button the active one. Toggle state
+  // is independent of the units toggle (Count vs %).
+  test("clicking Years Played activates that scope", async () => {
+    const { user } = await setup(<YearlyPlayChart yearlyPlayData={yearlyPlayData} showsByYear={showsByYear} />);
+
+    await user.click(screen.getByRole("button", { name: /years played/i }));
+
+    expect(screen.getByRole("button", { name: /years played/i })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: /all years/i })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  // Round-trip: switching back to All Years restores the default. Symmetric
+  // with the units-toggle round-trip test.
+  test("clicking All Years after Years Played restores All Years as active", async () => {
+    const { user } = await setup(<YearlyPlayChart yearlyPlayData={yearlyPlayData} showsByYear={showsByYear} />);
+
+    await user.click(screen.getByRole("button", { name: /years played/i }));
+    await user.click(screen.getByRole("button", { name: /all years/i }));
+
+    expect(screen.getByRole("button", { name: /all years/i })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: /years played/i })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  // The card title is part of the contract: this is the "Played by Year"
+  // section. Pinned so a future refactor that drops the heading also trips
+  // this test.
+  test("renders the section heading", async () => {
+    await setup(<YearlyPlayChart yearlyPlayData={yearlyPlayData} showsByYear={showsByYear} />);
+    expect(screen.getByText(/played by year/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/song/yearly-play-chart.tsx
+++ b/apps/web/app/components/song/yearly-play-chart.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { START_YEAR } from "~/lib/song-filters";
+import { cn } from "~/lib/utils";
+import {
+  buildYearlyChartData,
+  expandPlayedYears,
+  expandYearlyDataToRange,
+  type YearlyChartMode,
+} from "~/lib/yearly-chart-data";
+
+type YearScope = "played" | "all";
+
+interface YearlyPlayChartProps {
+  yearlyPlayData: Record<number, number>;
+  showsByYear: Record<number, number>;
+}
+
+/**
+ * Per-year plays chart for the song detail page. Toggle between raw counts
+ * and percent-of-shows-that-year — the percent view smooths tour-volume
+ * variance so a "rare" song read isn't conflated with a light touring year.
+ */
+export function YearlyPlayChart({ yearlyPlayData, showsByYear }: YearlyPlayChartProps) {
+  const [mode, setMode] = useState<YearlyChartMode>("percent");
+  const [yearScope, setYearScope] = useState<YearScope>("all");
+
+  const dataInput =
+    yearScope === "all"
+      ? expandYearlyDataToRange(yearlyPlayData, START_YEAR, new Date().getFullYear())
+      : expandPlayedYears(yearlyPlayData);
+  const data = buildYearlyChartData(dataInput, showsByYear, mode);
+  const isPercent = mode === "percent";
+
+  return (
+    <div className="glass-content rounded-lg p-6">
+      <div className="flex items-center justify-between mb-4 gap-3 flex-wrap">
+        <h3 className="text-lg font-semibold text-content-text-primary">Played by Year</h3>
+        <div className="flex items-center flex-wrap gap-y-2">
+          <fieldset className="flex border-0 p-0 m-0">
+            <legend className="sr-only">Chart units</legend>
+            <ToggleButton active={mode === "count"} onClick={() => setMode("count")}>
+              # Plays
+            </ToggleButton>
+            <ToggleButton active={isPercent} onClick={() => setMode("percent")}>
+              % of Shows
+            </ToggleButton>
+          </fieldset>
+          <div className="mx-3 h-5 w-px bg-content-text-tertiary/30" aria-hidden="true" />
+          <fieldset className="flex border-0 p-0 m-0">
+            <legend className="sr-only">Year scope</legend>
+            <ToggleButton active={yearScope === "played"} onClick={() => setYearScope("played")}>
+              Years Played
+            </ToggleButton>
+            <ToggleButton active={yearScope === "all"} onClick={() => setYearScope("all")}>
+              All Years
+            </ToggleButton>
+          </fieldset>
+        </div>
+      </div>
+      <div className="h-80">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 20 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#374151" opacity={0.3} />
+            <XAxis dataKey="year" stroke="#9CA3AF" fontSize={12} />
+            <YAxis
+              stroke="#9CA3AF"
+              fontSize={12}
+              tickFormatter={isPercent ? (v: number) => `${Math.round(v * 100)}%` : undefined}
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: "#1F2937",
+                border: "1px solid #374151",
+                borderRadius: "6px",
+                color: "#F3F4F6",
+              }}
+              labelStyle={{ color: "#F3F4F6" }}
+              formatter={(value: number | undefined) => {
+                const safe = value ?? 0;
+                return isPercent ? [`${Math.round(safe * 100)}%`, "% of Shows"] : [String(safe), "Plays"];
+              }}
+            />
+            <Line
+              type="monotone"
+              dataKey="value"
+              stroke="#8B5CF6"
+              strokeWidth={2}
+              dot={{ fill: "#8B5CF6", strokeWidth: 2, r: 4 }}
+              activeDot={{ r: 6, stroke: "#8B5CF6", strokeWidth: 2 }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+interface ToggleButtonProps {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+function ToggleButton({ active, onClick, children }: ToggleButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={cn(
+        "px-3 py-1.5 text-sm font-medium border-b-2 transition-colors cursor-pointer",
+        active
+          ? "border-brand-primary text-content-text-primary"
+          : "border-transparent text-content-text-tertiary hover:text-content-text-secondary",
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/web/app/lib/song-filters.ts
+++ b/apps/web/app/lib/song-filters.ts
@@ -4,7 +4,7 @@ export interface SongFilterConfig {
   endDate?: Date;
 }
 
-const START_YEAR = 1995;
+export const START_YEAR = 1995;
 
 const yearFilters: Record<string, SongFilterConfig> = Object.fromEntries(
   Array.from({ length: new Date().getFullYear() - START_YEAR + 1 }, (_, i) => {

--- a/apps/web/app/lib/yearly-chart-data.test.ts
+++ b/apps/web/app/lib/yearly-chart-data.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "vitest";
+import { buildYearlyChartData, expandPlayedYears, expandYearlyDataToRange } from "./yearly-chart-data";
+
+describe("buildYearlyChartData", () => {
+  // Count mode is the default rendering: each year's raw play count maps
+  // straight to `value`. Years are sorted ascending so the line chart reads
+  // left-to-right chronologically. Disco Biscuits' "Tractorbeam" — a
+  // long-running staple — exercises the multi-year case.
+  test("count mode returns sorted {year, value} pairs of raw play counts", () => {
+    const yearlyPlayData = { 2010: 12, 2008: 5, 2012: 8 };
+    const showsByYear = { 2008: 60, 2010: 70, 2012: 65 };
+
+    const result = buildYearlyChartData(yearlyPlayData, showsByYear, "count");
+
+    expect(result).toEqual([
+      { year: 2008, value: 5 },
+      { year: 2010, value: 12 },
+      { year: 2012, value: 8 },
+    ]);
+  });
+
+  // Percent mode normalizes by shows-played-that-year. Smooths year-over-year
+  // tour-volume variance so a "rare" song read isn't conflated with a light
+  // touring year. "Above the Waves" is the type of song you'd want to see
+  // normalized.
+  test("percent mode returns plays / showsByYear[year] as a 0-1 decimal", () => {
+    const yearlyPlayData = { 2008: 5, 2010: 14 };
+    const showsByYear = { 2008: 50, 2010: 70 };
+
+    const result = buildYearlyChartData(yearlyPlayData, showsByYear, "percent");
+
+    expect(result).toEqual([
+      { year: 2008, value: 0.1 },
+      { year: 2010, value: 0.2 },
+    ]);
+  });
+
+  // Defensive: if showsByYear is missing a year present in yearlyPlayData
+  // (data drift, partial cache), render 0 in percent mode rather than
+  // dividing by zero or NaN. Per Phase 4 plan, we surface 0 not "no point".
+  test("percent mode renders 0 when showsByYear[year] is missing or zero", () => {
+    const yearlyPlayData = { 2010: 5, 2011: 3, 2012: 7 };
+    const showsByYear = { 2010: 50, 2011: 0 }; // 2011 is zero, 2012 is missing
+
+    const result = buildYearlyChartData(yearlyPlayData, showsByYear, "percent");
+
+    expect(result).toEqual([
+      { year: 2010, value: 0.1 },
+      { year: 2011, value: 0 },
+      { year: 2012, value: 0 },
+    ]);
+  });
+
+  // Empty input: a song that has never been played has no yearly data. The
+  // helper should produce an empty array, not throw and not return a
+  // sentinel year.
+  test("empty yearlyPlayData returns empty array in either mode", () => {
+    expect(buildYearlyChartData({}, {}, "count")).toEqual([]);
+    expect(buildYearlyChartData({}, { 2010: 50 }, "percent")).toEqual([]);
+  });
+
+  // The composer ships year keys as strings (Object.keys / Record<number,
+  // number> are stringified in JS). The helper must coerce keys to numbers
+  // so the chart's XAxis numeric ordering works.
+  test("string year keys are coerced to numbers", () => {
+    const yearlyPlayData = { "2010": 12, "2008": 5 } as unknown as Record<number, number>;
+    const result = buildYearlyChartData(yearlyPlayData, { 2008: 50, 2010: 70 }, "count");
+
+    expect(result[0].year).toBe(2008);
+    expect(typeof result[0].year).toBe("number");
+  });
+});
+
+describe("expandYearlyDataToRange", () => {
+  // The "All Years" toggle on the chart needs every year in the band's
+  // touring window represented, even years where the song wasn't played, so
+  // the X axis scale is consistent across songs. Missing years fill in as
+  // 0 plays.
+  test("fills missing years in [start, end] with 0 plays", () => {
+    const yearlyPlayData = { 2010: 5, 2012: 3 };
+
+    const expanded = expandYearlyDataToRange(yearlyPlayData, 2009, 2013);
+
+    expect(expanded).toEqual({ 2009: 0, 2010: 5, 2011: 0, 2012: 3, 2013: 0 });
+  });
+
+  // Years already populated must not be clobbered by the zero-fill. Pins
+  // the precedence: existing data wins over the default.
+  test("preserves existing year values when filling", () => {
+    const yearlyPlayData = { 2010: 17 };
+    const expanded = expandYearlyDataToRange(yearlyPlayData, 2010, 2010);
+    expect(expanded).toEqual({ 2010: 17 });
+  });
+
+  // Years OUTSIDE the requested range stay in the result. Important
+  // because the song's earliest play might predate START_YEAR (rare but
+  // possible for legacy entries) — we never want to silently drop them.
+  test("keeps years outside [start, end] in the result", () => {
+    const yearlyPlayData = { 1990: 2, 2010: 5 };
+    const expanded = expandYearlyDataToRange(yearlyPlayData, 2009, 2011);
+    expect(expanded).toEqual({ 1990: 2, 2009: 0, 2010: 5, 2011: 0 });
+  });
+
+  // Edge: empty input + range produces a fully-zero map. Lets the chart
+  // render a flat line for songs that haven't been played in the window.
+  test("empty input and a range produces all-zero years", () => {
+    expect(expandYearlyDataToRange({}, 2008, 2010)).toEqual({ 2008: 0, 2009: 0, 2010: 0 });
+  });
+
+  // String year keys (the JSON-serialized shape from the loader) are
+  // coerced to numbers so callers can hand the result back into
+  // buildYearlyChartData without a second normalization pass.
+  test("normalizes string year keys to numbers in the output", () => {
+    const yearlyPlayData = { "2010": 5 } as unknown as Record<number, number>;
+    const expanded = expandYearlyDataToRange(yearlyPlayData, 2010, 2011);
+
+    expect(expanded[2010]).toBe(5);
+    expect(expanded[2011]).toBe(0);
+  });
+});
+
+describe("expandPlayedYears", () => {
+  // The "Years Played" view of the chart shows the range from the song's
+  // earliest play to its latest, with zero-fills for years it skipped in
+  // between. Keeps the X axis continuous so a chart for "Triumph" played
+  // in 2008 and 2012 doesn't visually compress 2008 → 2012 into adjacent
+  // ticks. The min/max are derived from the keys of yearlyPlayData.
+  test("zero-fills years between the earliest and latest played years", () => {
+    const yearlyPlayData = { 2008: 3, 2012: 5 };
+    expect(expandPlayedYears(yearlyPlayData)).toEqual({ 2008: 3, 2009: 0, 2010: 0, 2011: 0, 2012: 5 });
+  });
+
+  // No surprises when the song was played in every consecutive year — the
+  // expansion is a no-op for already-dense data.
+  test("returns the same data when years are already consecutive", () => {
+    const yearlyPlayData = { 2010: 3, 2011: 5, 2012: 7 };
+    expect(expandPlayedYears(yearlyPlayData)).toEqual({ 2010: 3, 2011: 5, 2012: 7 });
+  });
+
+  // A never-played song has no earliest/latest year. The function returns
+  // an empty map rather than throwing on Math.min/max of an empty array.
+  test("returns empty map when yearlyPlayData is empty", () => {
+    expect(expandPlayedYears({})).toEqual({});
+  });
+
+  // Single-year case: min === max, so the result is exactly the input.
+  test("single-year input returns just that year", () => {
+    expect(expandPlayedYears({ 2015: 4 })).toEqual({ 2015: 4 });
+  });
+});

--- a/apps/web/app/lib/yearly-chart-data.ts
+++ b/apps/web/app/lib/yearly-chart-data.ts
@@ -1,0 +1,55 @@
+export type YearlyChartMode = "count" | "percent";
+
+export type YearlyChartPoint = { year: number; value: number };
+
+/**
+ * Builds the data series for the per-year plays chart on the song detail
+ * page. "count" returns raw play counts; "percent" returns plays divided
+ * by the total shows played that year, smoothing tour-volume variance.
+ */
+/**
+ * Returns a copy of `yearlyPlayData` extended to cover every year in
+ * [start, end], with missing years filled as 0. Keys outside the requested
+ * range are preserved untouched. Output keys are normalized to numbers.
+ */
+export function expandYearlyDataToRange(
+  yearlyPlayData: Record<number, number>,
+  start: number,
+  end: number,
+): Record<number, number> {
+  const result: Record<number, number> = {};
+  for (const [yearKey, plays] of Object.entries(yearlyPlayData)) {
+    result[Number.parseInt(yearKey, 10)] = plays;
+  }
+  for (let year = start; year <= end; year++) {
+    if (result[year] === undefined) result[year] = 0;
+  }
+  return result;
+}
+
+/**
+ * Returns a copy of `yearlyPlayData` covering every year from the song's
+ * earliest played year to its latest, with zero-fills for years it skipped.
+ * Keeps the chart's X axis continuous instead of compressing skipped years
+ * into adjacent ticks.
+ */
+export function expandPlayedYears(yearlyPlayData: Record<number, number>): Record<number, number> {
+  const years = Object.keys(yearlyPlayData).map((y) => Number.parseInt(y, 10));
+  if (years.length === 0) return {};
+  return expandYearlyDataToRange(yearlyPlayData, Math.min(...years), Math.max(...years));
+}
+
+export function buildYearlyChartData(
+  yearlyPlayData: Record<number, number>,
+  showsByYear: Record<number, number>,
+  mode: YearlyChartMode,
+): YearlyChartPoint[] {
+  return Object.entries(yearlyPlayData)
+    .map(([yearKey, plays]) => {
+      const year = Number.parseInt(yearKey, 10);
+      if (mode === "count") return { year, value: plays };
+      const denominator = showsByYear[year] ?? 0;
+      return { year, value: denominator > 0 ? plays / denominator : 0 };
+    })
+    .sort((a, b) => a.year - b.year);
+}

--- a/apps/web/app/routes/songs/$slug.test.tsx
+++ b/apps/web/app/routes/songs/$slug.test.tsx
@@ -30,6 +30,7 @@ vi.mock("~/hooks/use-serialized-loader-data", () => ({
       { trackId: "t1", allTimer: true, show: { date: "2024-01-01" }, venue: {} },
       { trackId: "t2", allTimer: false, show: { date: "2024-02-01" }, venue: {} },
     ],
+    showsByYear: {},
   })),
 }));
 
@@ -106,8 +107,8 @@ describe("SongPage", () => {
     const user = userEvent.setup();
     renderSongPage();
 
-    const statsTab = screen.getByRole("tab", { name: /stats/i });
-    await user.click(statsTab);
+    const graphsTab = screen.getByRole("tab", { name: /graphs/i });
+    await user.click(graphsTab);
 
     expect(mockClearFilters).toHaveBeenCalled();
   });
@@ -152,6 +153,7 @@ describe("SongPage", () => {
         yearlyPlayData: {},
       },
       performances: [],
+      showsByYear: {},
     });
     renderSongPage();
 
@@ -203,6 +205,7 @@ describe("SongPage", () => {
         yearlyPlayData: {},
       },
       performances: [],
+      showsByYear: {},
     });
     renderSongPage();
     expect(screen.getByText(/last show/i)).toBeInTheDocument();
@@ -233,6 +236,7 @@ describe("SongPage", () => {
         yearlyPlayData: {},
       },
       performances: [],
+      showsByYear: {},
     });
     renderSongPage();
     expect(screen.getByText(/1 show ago/)).toBeInTheDocument();
@@ -264,6 +268,7 @@ describe("SongPage", () => {
         yearlyPlayData: {},
       },
       performances: [],
+      showsByYear: {},
     });
     renderSongPage();
     expect(screen.getByText(/4 shows ago/)).toBeInTheDocument();

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -3,12 +3,12 @@ import { ArrowLeft, BarChart3, FileTextIcon, Flame, GuitarIcon, History, ListMus
 import { type ReactNode, useMemo, useState } from "react";
 import type { LoaderFunctionArgs } from "react-router";
 import { Link, useSearchParams } from "react-router-dom";
-import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { AdminOnly } from "~/components/admin/admin-only";
 import { PerformanceTable } from "~/components/performance";
 import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
 import { RatingComponent } from "~/components/rating";
 import { ShowDate } from "~/components/show-date";
+import { YearlyPlayChart } from "~/components/song/yearly-play-chart";
 import { Button } from "~/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
@@ -152,7 +152,7 @@ function everyShowsValue(value: number | null | undefined): ReactNode {
 }
 
 export default function SongPage() {
-  const { song, performances: allPerformances } = useSerializedLoaderData<SongPageView>();
+  const { song, performances: allPerformances, showsByYear } = useSerializedLoaderData<SongPageView>();
   const [searchParams] = useSearchParams();
   const tabParam = searchParams.get("tab");
   const validTabs = ["performances", "all-timers", "stats", "history", "lyrics", "guitar-tabs"];
@@ -381,7 +381,7 @@ export default function SongPage() {
             )}
           >
             <BarChart3 className="h-4 w-4" />
-            Stats
+            Graphs
           </TabsTrigger>
           {song.history && (
             <TabsTrigger
@@ -479,48 +479,10 @@ export default function SongPage() {
         </TabsContent>
 
         <TabsContent value="stats" className="mt-6">
-          <div className="glass-content rounded-lg p-6">
-            <h3 className="text-lg font-semibold text-content-text-primary mb-4">Times Played by Year</h3>
-            <div className="h-80">
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart
-                  data={Object.entries(song.yearlyPlayData || {})
-                    .map(([year, count]) => ({
-                      year: Number.parseInt(year, 10),
-                      plays: count as number,
-                    }))
-                    .sort((a, b) => a.year - b.year)}
-                  margin={{
-                    top: 20,
-                    right: 30,
-                    left: 20,
-                    bottom: 20,
-                  }}
-                >
-                  <CartesianGrid strokeDasharray="3 3" stroke="#374151" opacity={0.3} />
-                  <XAxis dataKey="year" stroke="#9CA3AF" fontSize={12} />
-                  <YAxis stroke="#9CA3AF" fontSize={12} />
-                  <Tooltip
-                    contentStyle={{
-                      backgroundColor: "#1F2937",
-                      border: "1px solid #374151",
-                      borderRadius: "6px",
-                      color: "#F3F4F6",
-                    }}
-                    labelStyle={{ color: "#F3F4F6" }}
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="plays"
-                    stroke="#8B5CF6"
-                    strokeWidth={2}
-                    dot={{ fill: "#8B5CF6", strokeWidth: 2, r: 4 }}
-                    activeDot={{ r: 6, stroke: "#8B5CF6", strokeWidth: 2 }}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
-            </div>
-          </div>
+          <YearlyPlayChart
+            yearlyPlayData={(song.yearlyPlayData || {}) as Record<number, number>}
+            showsByYear={showsByYear}
+          />
         </TabsContent>
 
         {song.history && (

--- a/packages/core/src/page-composers/song-page-composer.ts
+++ b/packages/core/src/page-composers/song-page-composer.ts
@@ -176,6 +176,7 @@ export class SongPageComposer {
         longestGapShows,
       },
       performances,
+      showsByYear,
     };
   }
 

--- a/packages/domain/src/views/song-page.ts
+++ b/packages/domain/src/views/song-page.ts
@@ -7,6 +7,7 @@ import type { VenueMinimal } from "../models/venue";
 export type SongPageView = {
   song: Song;
   performances: SongPagePerformance[];
+  showsByYear: Record<number, number>;
 };
 
 export type SongPagePerformance = {


### PR DESCRIPTION
## Summary
- Extracts the song-detail per-year chart into a `YearlyPlayChart` component with two independent toggles
- **# Plays / % of Shows** (default %): % mode divides plays by total shows that year, smoothing tour-volume variance so a "rare" read isn't conflated with a light touring year
- **Years Played / All Years** (default All Years): All Years scopes the X axis to 1995–today; Years Played scopes it to debut–last-played and zero-fills skipped years in between so the axis stays continuous
- Renames the song-detail tab from "Stats" to "Graphs" and the heading from "Times Played by Year" to "Played by Year"


https://github.com/user-attachments/assets/a943f64a-bb77-44cd-a0e7-fbfecfd86cc0



## Test plan
- [ ] `make tc && make test && make lint`
- [ ] `make web` → visit a song's Graphs tab; toggle units and scope, confirm Y-axis switches between integer and percent ticks
- [ ] Visit a song with sparse year coverage and switch to Years Played — confirm gap years render as zeros instead of compressing distant years into adjacent ticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
