### PR TITLE
Gap-chart view on SetlistCard + ~17x perf win on setlist queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ migrate:
 	cd packages/core && bun prisma:migrate:dev
 
 migrate-create:
-	cd packages/core && bun prisma:migrate:create
+	@if [ -z "$(NAME)" ]; then echo "Usage: make migrate-create NAME=add_foo_index" && exit 1; fi
+	cd packages/core && bun prisma:migrate:create -- --name $(NAME)
 
 migrate-baseline:
 	cd packages/core && bun prisma:migrate:baseline

--- a/apps/web/app/components/gap-icon.tsx
+++ b/apps/web/app/components/gap-icon.tsx
@@ -1,0 +1,22 @@
+import type { ReactElement } from "react";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "~/components/ui/tooltip";
+
+/**
+ * Wraps a small status icon (★ debut, ↺ this-show repeat) in a tooltip so
+ * users can hover/tap to learn what the icon means without crowding the cell.
+ * Shared by the song-detail performances table and the setlist gap-chart view.
+ */
+export function GapIcon({ icon, label }: { icon: ReactElement; label: string }) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span role="img" aria-label={label}>
+            {icon}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>{label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -1,31 +1,12 @@
 import { compareByShowDate, type SongPagePerformance } from "@bip/domain";
 import { type Column, type ColumnDef, createColumnHelper, type Row } from "@tanstack/react-table";
 import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon, Flame, RotateCcw, Star } from "lucide-react";
-import type { ReactElement } from "react";
+import { GapIcon } from "~/components/gap-icon";
+import { formatSetLabel } from "~/components/setlist/set-label";
 import { ShowDate } from "~/components/show-date";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "~/components/ui/tooltip";
 import { CombinedNotes } from "./combined-notes";
 import { DateVenueCell } from "./date-venue-cell";
 import { TrackRatingCell } from "./track-rating-cell";
-
-/**
- * Wraps a small status icon (★ debut, ↺ this-show repeat) in a tooltip so
- * users can hover/tap to learn what the icon means without crowding the cell.
- */
-function GapIcon({ icon, label }: { icon: ReactElement; label: string }) {
-  return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span role="img" aria-label={label}>
-            {icon}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent>{label}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
 
 /**
  * Sort comparator for the Gap column. Debuts (gap=null) sort first because a
@@ -197,11 +178,10 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       enableSorting: false,
       cell: (info) => {
         const set = info.getValue();
-        return set ? (
-          <span className="text-content-text-secondary">{set}</span>
-        ) : (
-          <span className="text-content-text-tertiary">—</span>
-        );
+        if (!set) return <span className="text-content-text-tertiary">—</span>;
+        // Cross-show table — we don't know the encore count of any one
+        // show, so single-encore collapse (E1 → E) is left off here.
+        return <span className="text-content-text-secondary">{formatSetLabel(set)}</span>;
       },
     }) as ColumnDef<SongPagePerformance, unknown>,
     columnHelper.accessor(

--- a/apps/web/app/components/setlist/set-label.test.ts
+++ b/apps/web/app/components/setlist/set-label.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest";
+import { countDistinctEncores, formatSetLabel } from "./set-label";
+
+describe("formatSetLabel", () => {
+  // S-prefixed regular sets drop the "S" because the column header (or
+  // surrounding context) already says "Set". Lock down the common cases.
+  test("drops the S prefix from regular sets", () => {
+    expect(formatSetLabel("S1")).toBe("1");
+    expect(formatSetLabel("S2")).toBe("2");
+    expect(formatSetLabel("S10")).toBe("10");
+  });
+
+  // Lowercase is normalized via toUpperCase before pattern matching so the
+  // helper is forgiving of input variation from older data or different
+  // entry surfaces.
+  test("normalizes lowercase set labels", () => {
+    expect(formatSetLabel("s1")).toBe("1");
+    expect(formatSetLabel("e1", { encoresInSet: 2 })).toBe("E1");
+  });
+
+  // Without the encore-count hint, encores keep their numeric label so the
+  // caller never accidentally collapses E1 → E in a multi-encore show.
+  test("keeps the encore numeral when encoresInSet is omitted", () => {
+    expect(formatSetLabel("E1")).toBe("E1");
+    expect(formatSetLabel("E2")).toBe("E2");
+  });
+
+  // The single-encore collapse is the whole reason for the encoresInSet
+  // hint — when a setlist has exactly one encore, "E1" reads cleaner as
+  // a bare "E" because the "1" can't be contrasted with anything.
+  test("collapses E1 → E only when encoresInSet === 1", () => {
+    expect(formatSetLabel("E1", { encoresInSet: 1 })).toBe("E");
+    expect(formatSetLabel("E2", { encoresInSet: 1 })).toBe("E"); // E2 alone? Still "E" — the count, not the value, drives collapse.
+    expect(formatSetLabel("E1", { encoresInSet: 2 })).toBe("E1");
+    expect(formatSetLabel("E1", { encoresInSet: 0 })).toBe("E1"); // boundary: count !== 1, no collapse
+  });
+
+  // Anything that isn't a recognized set/encore pattern (Soundcheck, empty
+  // strings, future labels we haven't seen) passes through verbatim so the
+  // helper never silently mangles unfamiliar input.
+  test("returns non-set/non-encore values verbatim", () => {
+    expect(formatSetLabel("Soundcheck")).toBe("Soundcheck");
+    expect(formatSetLabel("")).toBe("");
+    expect(formatSetLabel("???")).toBe("???");
+  });
+});
+
+describe("countDistinctEncores", () => {
+  // Counts unique encore labels regardless of how many tracks share each
+  // encore. Two tracks both labeled E1 still report "1 distinct encore".
+  test("counts unique encore labels, not encore tracks", () => {
+    expect(
+      countDistinctEncores([
+        { set: "E1" },
+        { set: "E1" },
+        { set: "E1" },
+      ]),
+    ).toBe(1);
+  });
+
+  // Mixed-set rows: only encores contribute. Regular sets are ignored so
+  // the result is safe to feed straight into `formatSetLabel({encoresInSet})`.
+  test("ignores non-encore rows", () => {
+    expect(
+      countDistinctEncores([
+        { set: "S1" },
+        { set: "S2" },
+        { set: "E1" },
+        { set: "E2" },
+      ]),
+    ).toBe(2);
+  });
+
+  // Empty list = 0 distinct encores. The collapse branch in formatSetLabel
+  // only fires on === 1, so an empty list correctly leaves any encore label
+  // (which couldn't exist in this scenario anyway) un-collapsed.
+  test("returns 0 for an empty list", () => {
+    expect(countDistinctEncores([])).toBe(0);
+  });
+
+  // Lowercase encore labels still count toward the distinct set so callers
+  // don't have to pre-normalize input.
+  test("normalizes lowercase encore labels for de-duplication", () => {
+    expect(countDistinctEncores([{ set: "e1" }, { set: "E1" }])).toBe(1);
+  });
+});

--- a/apps/web/app/components/setlist/set-label.ts
+++ b/apps/web/app/components/setlist/set-label.ts
@@ -1,0 +1,34 @@
+/**
+ * Compact display of a track's `set` value across any table that shows a
+ * Set column. Drops the "S" prefix on regular sets ("S1" → "1") because the
+ * column header already says "Set". Encores keep their letter; if the
+ * caller knows the surrounding setlist has only one encore (single-show
+ * tables), pass `encoresInSet: 1` to collapse "E1" → "E". Anything else
+ * (e.g. "Soundcheck") renders verbatim.
+ *
+ * @param raw The raw set label as stored on the Track row.
+ * @param opts.encoresInSet Optional count of distinct encores that share
+ *   the same setlist as this track. Only meaningful when the caller knows
+ *   the full setlist (e.g. SetlistTable); cross-show tables omit it.
+ */
+export function formatSetLabel(raw: string, opts?: { encoresInSet?: number }): string {
+  const upper = raw.toUpperCase();
+  if (/^S\d+$/.test(upper)) return upper.slice(1);
+  if (/^E\d+$/.test(upper)) {
+    return opts?.encoresInSet === 1 ? "E" : upper;
+  }
+  return raw;
+}
+
+/**
+ * Counts distinct encore labels in a flat track list. Use the result as
+ * `encoresInSet` for {@link formatSetLabel} when you have the whole setlist
+ * in scope (e.g. inside SetlistTable's Set column cell renderer).
+ */
+export function countDistinctEncores(rows: ReadonlyArray<{ set: string }>): number {
+  const encores = new Set<string>();
+  for (const r of rows) {
+    if (/^E\d+$/i.test(r.set)) encores.add(r.set.toUpperCase());
+  }
+  return encores.size;
+}

--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -76,12 +76,17 @@ function makeSetlist(overrides: { showDate?: string } = {}): SetlistLight {
             allTimer: false,
             averageRating: null,
             ratingsCount: 0,
+            gap: null,
+            previousPerformanceShowId: null,
+            previousPerformanceShow: null,
             song: { id: "song-1", title: "Basis for a Day", slug: "basis-for-a-day" },
           },
         ],
       },
     ],
     annotations: [],
+    averageSongGap: null,
+    medianSongGap: null,
   };
 }
 
@@ -219,5 +224,96 @@ describe("SetlistCard", () => {
     );
     const header = screen.getByTestId("setlist-card-header");
     expect(header.className).toMatch(/\bpy-1\b/);
+  });
+
+  // The setlist/gap chart toggle lives inside the body, paired with the
+  // "Average song gap" label on the same line. Default view is setlist
+  // (the existing flow text), preserving today's first-paint.
+  test("renders setlist/gap chart toggle inside body, defaulting to setlist view", async () => {
+    await setupWithRouter(
+      <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={null} />,
+    );
+    const body = screen.getByTestId("setlist-card-body");
+    const setlistButton = screen.getByRole("button", { name: /^setlist$/i });
+    const gapChartButton = screen.getByRole("button", { name: /gap chart/i });
+    expect(body.contains(setlistButton)).toBe(true);
+    expect(body.contains(gapChartButton)).toBe(true);
+    // Default = setlist view: flow text is rendered, SetlistTable is not.
+    expect(screen.getByText("Basis for a Day")).toBeInTheDocument();
+  });
+
+  // Clicking "gap chart" swaps to the table view. Existence of the
+  // SetlistTable column headers (Set/Song/Last Played/Gap) is the signal.
+  test("clicking gap chart swaps to the table view", async () => {
+    const user = userEvent.setup();
+    await setupWithRouter(
+      <SetlistCard
+        setlist={{ ...makeSetlist(), averageSongGap: 7.5, medianSongGap: 6 }}
+        userAttendance={null}
+        userRating={null}
+        showRating={null}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /gap chart/i }));
+    // Average gap formats to one decimal place — terse, matches the rest
+    // of the rarity stat presentation on the song-detail page.
+    expect(screen.getByText(/Average \/ Median song gap:\s*7\.5\s*\/\s*6\.0/)).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Last Played" })).toBeInTheDocument();
+  });
+
+  // The average gap summary lives BELOW the setlist text on the same row
+  // as the setlist/gap-chart toggle. Renders for every caller — show page
+  // and list pages alike — so users always see the rarity number.
+  test("setlist view renders the average gap summary below the setlist", async () => {
+    await setupWithRouter(
+      <SetlistCard
+        setlist={{ ...makeSetlist(), averageSongGap: 7.5, medianSongGap: 6 }}
+        userAttendance={null}
+        userRating={null}
+        showRating={null}
+      />,
+    );
+    const summary = screen.getByText(/Average \/ Median song gap:\s*7\.5\s*\/\s*6\.0/);
+    const trackText = screen.getByText("Basis for a Day");
+    // DOM order: track text comes before the summary line. compareDocumentPosition
+    // returns DOCUMENT_POSITION_FOLLOWING (4) when `summary` follows `trackText`.
+    expect(trackText.compareDocumentPosition(summary)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  // List-page regression (year, top-rated, on-this-day, venue, home): without
+  // an onViewChange callback, toggling stays purely local — no URL mutation,
+  // no leaked state to sibling cards. This covers the contract that every
+  // list-page caller relies on by omitting the prop.
+  test("toggling without onViewChange does not invoke any URL writer", async () => {
+    const user = userEvent.setup();
+    const onViewChange = vi.fn();
+    await setupWithRouter(
+      <SetlistCard
+        setlist={{ ...makeSetlist(), averageSongGap: 7.5, medianSongGap: 6 }}
+        userAttendance={null}
+        userRating={null}
+        showRating={null}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /gap chart/i }));
+    // The card flipped views (table renders), but no callback was invoked
+    // because none was passed — the only way list pages preserve local state.
+    expect(screen.getByRole("columnheader", { name: "Last Played" })).toBeInTheDocument();
+    expect(onViewChange).not.toHaveBeenCalled();
+  });
+
+  // averageSongGap=null happens for all-debut/all-repeat shows. The summary
+  // line should be omitted entirely (not "Average song gap: —") so the
+  // toggle row stays clean on shows where the number isn't meaningful.
+  test("setlist view omits the average summary when averageSongGap is null", async () => {
+    await setupWithRouter(
+      <SetlistCard
+        setlist={{ ...makeSetlist(), averageSongGap: null }}
+        userAttendance={null}
+        userRating={null}
+        showRating={null}
+      />,
+    );
+    expect(screen.queryByText(/song gap/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -11,8 +11,12 @@ import { useSession } from "~/hooks/use-session";
 import { useAttendanceMutation } from "~/hooks/use-show-user-data";
 import { cn } from "~/lib/utils";
 import { AnniversaryBadge } from "./anniversary-badge";
+import { SetlistTable } from "./setlist-table";
+import { SetlistViewControl } from "./setlist-view-control";
 import { ShowExternalBadges, type ShowExternalSources } from "./show-external-badges";
 import { TrackRatingOverlay } from "./track-rating-overlay";
+
+export type SetlistView = "setlist" | "gap-chart";
 
 interface SetlistCardProps {
   setlist: Setlist | SetlistLight;
@@ -26,6 +30,18 @@ interface SetlistCardProps {
    * ignored so they keep working without toggling the card.
    */
   collapsible?: boolean;
+  /**
+   * Initial view for the setlist/gap-chart toggle. Defaults to "setlist".
+   * The /shows/:slug route reads `?view=gap-chart` and passes it here so a
+   * shared link round-trips into the table view.
+   */
+  defaultView?: SetlistView;
+  /**
+   * Called whenever the user flips the toggle. Wired only on /shows/:slug
+   * to round-trip `?view=gap-chart` through the URL; list pages omit this
+   * so toggling stays local to each card.
+   */
+  onViewChange?: (view: SetlistView) => void;
 }
 
 function SetlistCardComponent({
@@ -35,7 +51,14 @@ function SetlistCardComponent({
   showRating,
   externalSources,
   collapsible = false,
+  defaultView = "setlist",
+  onViewChange,
 }: SetlistCardProps) {
+  const [view, setView] = useState<SetlistView>(defaultView);
+  function changeView(next: SetlistView) {
+    setView(next);
+    onViewChange?.(next);
+  }
   const { user } = useSession();
   const [displayedRating, setDisplayedRating] = useState<number>(showRating ?? setlist.show.averageRating ?? 0);
   const [displayedCount, setDisplayedCount] = useState<number>(setlist.show.ratingsCount ?? 0);
@@ -317,59 +340,81 @@ function SetlistCardComponent({
               />
             )}
 
-            <div className="space-y-2 md:space-y-4">
-              {setlist.sets.map((set, setIndex) => (
-                <span
-                  key={setlist.show.id + set.label}
-                  className="inline-block w-full md:flex md:gap-4 md:items-baseline"
-                >
-                  <span className="inline text-base font-medium text-content-text-tertiary">{set.label}</span>
-                  <span className="inline ml-2 md:ml-0 md:flex-1">
-                    {set.tracks.map((track, i) => (
-                      <span key={track.id} className="inline">
-                        <TrackRatingOverlay track={track}>
-                          <span
-                            className={cn(
-                              "relative text-brand-primary hover:text-brand-secondary hover:underline transition-colors text-base",
-                              track.allTimer && "font-medium",
-                            )}
-                          >
-                            {track.allTimer && (
-                              <Flame className="h-3 w-3 md:h-4 md:w-4 inline-block mr-1 transform -translate-y-0.5 text-orange-500" />
-                            )}
-                            <Link to={`/songs/${track.song?.slug}`}>{track.song?.title}</Link>
-                            {trackAnnotationMap.has(track.id) && (
-                              <sup className="text-brand-secondary ml-0.5 font-medium text-xs">
-                                {trackAnnotationMap.get(track.id)?.map((index, i) => (
-                                  <span key={index} className={i > 0 ? "ml-1" : ""}>
-                                    {index}
-                                  </span>
-                                ))}
-                              </sup>
-                            )}
-                          </span>
-                        </TrackRatingOverlay>
-                        {i < set.tracks.length - 1 && (
-                          <span className="text-content-text-secondary mx-1 font-medium text-base">
-                            {track.segue ? " > " : ", "}
-                          </span>
-                        )}
-                      </span>
-                    ))}
-                  </span>
-                  {setIndex < setlist.sets.length - 1 && <span className="hidden"> </span>}
-                </span>
-              ))}
-            </div>
-
-            {orderedAnnotations.length > 0 && (
-              <div className="mt-6 pt-4 border-t border-glass-border/30 space-y-2">
-                {orderedAnnotations.map((annotation) => (
-                  <div key={`annotation-${annotation.index}`} className="text-sm text-content-text-secondary">
-                    <sup className="text-brand-secondary">{annotation.index}</sup> {annotation.desc}
-                  </div>
-                ))}
+            {view === "gap-chart" ? (
+              <div className="space-y-2">
+                <SetlistViewControl
+                  view={view}
+                  onChange={changeView}
+                  averageSongGap={setlist.averageSongGap}
+                  medianSongGap={setlist.medianSongGap}
+                />
+                <SetlistTable tracks={setlist.sets.flatMap((s) => s.tracks)} />
               </div>
+            ) : (
+              <>
+                <div className="space-y-2 md:space-y-4">
+                  {setlist.sets.map((set, setIndex) => (
+                    <span
+                      key={setlist.show.id + set.label}
+                      className="inline-block w-full md:flex md:gap-4 md:items-baseline"
+                    >
+                      <span className="inline text-base font-medium text-content-text-tertiary">{set.label}</span>
+                      <span className="inline ml-2 md:ml-0 md:flex-1">
+                        {set.tracks.map((track, i) => (
+                          <span key={track.id} className="inline">
+                            <TrackRatingOverlay track={track}>
+                              <span
+                                className={cn(
+                                  "relative text-brand-primary hover:text-brand-secondary hover:underline transition-colors text-base",
+                                  track.allTimer && "font-medium",
+                                )}
+                              >
+                                {track.allTimer && (
+                                  <Flame className="h-3 w-3 md:h-4 md:w-4 inline-block mr-1 transform -translate-y-0.5 text-orange-500" />
+                                )}
+                                <Link to={`/songs/${track.song?.slug}`}>{track.song?.title}</Link>
+                                {trackAnnotationMap.has(track.id) && (
+                                  <sup className="text-brand-secondary ml-0.5 font-medium text-xs">
+                                    {trackAnnotationMap.get(track.id)?.map((index, i) => (
+                                      <span key={index} className={i > 0 ? "ml-1" : ""}>
+                                        {index}
+                                      </span>
+                                    ))}
+                                  </sup>
+                                )}
+                              </span>
+                            </TrackRatingOverlay>
+                            {i < set.tracks.length - 1 && (
+                              <span className="text-content-text-secondary mx-1 font-medium text-base">
+                                {track.segue ? " > " : ", "}
+                              </span>
+                            )}
+                          </span>
+                        ))}
+                      </span>
+                      {setIndex < setlist.sets.length - 1 && <span className="hidden"> </span>}
+                    </span>
+                  ))}
+                </div>
+
+                {orderedAnnotations.length > 0 && (
+                  <div className="mt-6 pt-4 border-t border-glass-border/30 space-y-2">
+                    {orderedAnnotations.map((annotation) => (
+                      <div key={`annotation-${annotation.index}`} className="text-sm text-content-text-secondary">
+                        <sup className="text-brand-secondary">{annotation.index}</sup> {annotation.desc}
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <div className="mt-4">
+                  <SetlistViewControl
+                    view={view}
+                    onChange={changeView}
+                    averageSongGap={setlist.averageSongGap}
+                    medianSongGap={setlist.medianSongGap}
+                  />
+                </div>
+              </>
             )}
           </CardContent>
         </div>

--- a/apps/web/app/components/setlist/setlist-columns.test.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.test.tsx
@@ -1,0 +1,355 @@
+import type { TrackLight } from "@bip/domain";
+import { flexRender, getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
+import { setupWithRouter } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test } from "vitest";
+import { createSetlistColumns, type SetlistTableRow } from "./setlist-columns";
+
+function makeTrack(overrides: Partial<TrackLight> & { songId: string; position: number }): SetlistTableRow {
+  return {
+    id: `t-${overrides.position}`,
+    showId: "show-1",
+    songId: overrides.songId,
+    set: overrides.set ?? "S1",
+    position: overrides.position,
+    segue: overrides.segue ?? null,
+    likesCount: 0,
+    note: null,
+    allTimer: false,
+    averageRating: null,
+    ratingsCount: 0,
+    gap: overrides.gap ?? null,
+    previousPerformanceShowId: overrides.previousPerformanceShowId ?? null,
+    previousPerformanceShow: overrides.previousPerformanceShow ?? null,
+    song: overrides.song ?? { id: overrides.songId, title: "Tractorbeam", slug: "tractorbeam" },
+  };
+}
+
+// Renders the column definitions through a real table so we exercise the cell
+// callbacks against TanStack's row model — same render pattern the production
+// SetlistTable will use.
+async function renderTable(rows: SetlistTableRow[]) {
+  function Harness() {
+    const table = useReactTable({
+      data: rows,
+      columns: createSetlistColumns(),
+      getCoreRowModel: getCoreRowModel(),
+      getSortedRowModel: getSortedRowModel(),
+    });
+    return (
+      <table>
+        <thead>
+          <tr>
+            {table.getHeaderGroups()[0].headers.map((h) => (
+              <th key={h.id}>{flexRender(h.column.columnDef.header, h.getContext())}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((r) => (
+            <tr key={r.id}>
+              {r.getVisibleCells().map((c) => (
+                <td key={c.id}>{flexRender(c.column.columnDef.cell, c.getContext())}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+  return setupWithRouter(<Harness />);
+}
+
+describe("createSetlistColumns", () => {
+  // Column order: Set, Track #, Song, Gap, Last Played. Track sits between
+  // Set and Song; Gap sits next to Song so the rarity number reads as
+  // "Song / Gap" before the user's eye jumps to the older Last Played
+  // date. Locking the order so a future rearrangement is a deliberate edit.
+  test("returns columns in order [Set, Track, Song, Gap, Last Played]", () => {
+    const columns = createSetlistColumns();
+    expect(columns.map((c) => c.id)).toEqual(["set", "track", "song", "gap", "lastPlayed"]);
+  });
+
+  // Sortable columns: Set, Track #, Gap, Last Played. Set and Track # share
+  // the canonical "set order then position" comparator (sorting either way
+  // produces the same render); Last Played sorts by previous-show date;
+  // Gap sorts numerically with debuts/repeats kept at the extremes. Song
+  // is intentionally not sortable (alphabetizing it would scramble the
+  // setlist's narrative).
+  test("Set, Track, Gap, and Last Played are sortable; Song is not", () => {
+    const columns = createSetlistColumns();
+    const sortable = new Map(columns.map((c) => [c.id, c.enableSorting]));
+    expect(sortable.get("set")).toBe(true);
+    expect(sortable.get("track")).toBe(true);
+    expect(sortable.get("gap")).toBe(true);
+    expect(sortable.get("lastPlayed")).toBe(true);
+    expect(sortable.get("song")).toBe(false);
+  });
+
+  // When sorted by Set (the default), only the first row of each set group
+  // shows the set label — subsequent rows in the same set leave the cell
+  // blank to make the grouping visually obvious. Other sorts (Gap, Last
+  // Played) interleave sets, so every row keeps its label.
+  test("hides repeated set labels when sorted by Set", async () => {
+    await renderTable([
+      makeTrack({ songId: "a", position: 1, set: "S1", song: { id: "a", title: "Tractorbeam", slug: "x" } }),
+      makeTrack({ songId: "b", position: 2, set: "S1", song: { id: "b", title: "Above the Waves", slug: "y" } }),
+      makeTrack({ songId: "c", position: 3, set: "S2", song: { id: "c", title: "Confrontation", slug: "z" } }),
+      makeTrack({ songId: "d", position: 4, set: "S2", song: { id: "d", title: "Crickets", slug: "w" } }),
+    ]);
+    // Default sort is on the harness's input order; explicitly clicking
+    // the Set header puts the table into "sorted by set" mode.
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /^Set$/i }));
+    const setCells = screen.getAllByRole("cell").filter((_, i) => i % 5 === 0);
+    expect(setCells.map((c) => c.textContent)).toEqual(["1", "", "2", ""]);
+  });
+
+  // Other sorts mix set values together (an asc-by-gap may go S2, S1, E1, S1),
+  // so blanking would lose the per-row context. Every row labels its set
+  // when the active sort isn't the Set column.
+  test("shows the set label on every row when sorted by Gap", async () => {
+    const user = userEvent.setup();
+    await renderTable([
+      makeTrack({ songId: "a", position: 1, set: "S1", gap: 10, song: { id: "a", title: "Tractorbeam", slug: "x" } }),
+      makeTrack({ songId: "b", position: 2, set: "S1", gap: 5, song: { id: "b", title: "Above the Waves", slug: "y" } }),
+      makeTrack({ songId: "c", position: 3, set: "S2", gap: 20, song: { id: "c", title: "Confrontation", slug: "z" } }),
+    ]);
+    await user.click(screen.getByRole("button", { name: /Gap/i }));
+    const setCells = screen.getAllByRole("cell").filter((_, i) => i % 5 === 0);
+    // After asc-by-gap: gap=5 (S1), gap=10 (S1), gap=20 (S2). Every row
+    // displays its set label.
+    expect(setCells.map((c) => c.textContent)).toEqual(["1", "1", "2"]);
+  });
+
+  // Sort by Last Played (asc) reorders rows by the previous performance
+  // date. Lexicographic compare on YYYY-MM-DD keeps it correct without a
+  // Date parse. Debuts (no previous show) sort to one end consistently.
+  test("sorting by Last Played reorders by previous-show date", async () => {
+    const user = userEvent.setup();
+    await renderTable([
+      makeTrack({
+        songId: "c",
+        position: 1,
+        set: "S1",
+        previousPerformanceShow: { date: "2024-08-01", slug: "newer" },
+        song: { id: "c", title: "Crickets", slug: "c" },
+      }),
+      makeTrack({
+        songId: "a",
+        position: 2,
+        set: "S1",
+        previousPerformanceShow: { date: "2024-01-15", slug: "older" },
+        song: { id: "a", title: "Tractorbeam", slug: "x" },
+      }),
+      makeTrack({
+        songId: "b",
+        position: 3,
+        set: "S1",
+        previousPerformanceShow: { date: "2024-05-10", slug: "middle" },
+        song: { id: "b", title: "Above the Waves", slug: "y" },
+      }),
+    ]);
+    await user.click(screen.getByRole("button", { name: /Last Played/i }));
+    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 5 === 2);
+    expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
+      "Tractorbeam",
+      "Above the Waves",
+      "Crickets",
+    ]);
+  });
+
+  // Sort by Gap (asc) puts the smallest non-null gap first; debuts (null)
+  // sort consistently at one end so the user can also use desc to find
+  // them. Numeric compare, not string.
+  test("sorting by Gap reorders by gap value ascending", async () => {
+    const user = userEvent.setup();
+    await renderTable([
+      makeTrack({ songId: "c", position: 1, set: "S1", gap: 50, song: { id: "c", title: "Crickets", slug: "c" } }),
+      makeTrack({
+        songId: "a",
+        position: 2,
+        set: "S1",
+        gap: 5,
+        song: { id: "a", title: "Tractorbeam", slug: "x" },
+      }),
+      makeTrack({
+        songId: "b",
+        position: 3,
+        set: "S1",
+        gap: 12,
+        song: { id: "b", title: "Above the Waves", slug: "y" },
+      }),
+    ]);
+    await user.click(screen.getByRole("button", { name: /Gap/i }));
+    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 5 === 2);
+    expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
+      "Tractorbeam",
+      "Above the Waves",
+      "Crickets",
+    ]);
+  });
+
+  // Track number resets per set so each set/encore reads "1, 2, 3, …"
+  // independent of the cumulative position in the show.
+  test("renders Track # 1-indexed within each set/encore", async () => {
+    await renderTable([
+      makeTrack({ songId: "a", position: 1, set: "S1", song: { id: "a", title: "Tractorbeam", slug: "x" } }),
+      makeTrack({ songId: "b", position: 2, set: "S1", song: { id: "b", title: "Above the Waves", slug: "y" } }),
+      makeTrack({ songId: "c", position: 3, set: "S2", song: { id: "c", title: "Confrontation", slug: "z" } }),
+      makeTrack({ songId: "d", position: 4, set: "E1", song: { id: "d", title: "Crickets", slug: "w" } }),
+    ]);
+    const cells = screen.getAllByRole("cell");
+    // Each row produces 5 cells; cells[1], cells[6], cells[11], cells[16] are Track #.
+    expect(cells[1].textContent).toBe("1");
+    expect(cells[6].textContent).toBe("2");
+    expect(cells[11].textContent).toBe("1");
+    expect(cells[16].textContent).toBe("1");
+  });
+
+  // Set column drops the "S" prefix (S1 → 1, S2 → 2, etc.) — the column
+  // header already says "Set" so the redundant letter just adds visual
+  // noise. Encores still need a marker, so E1/E2 keep theirs (or collapse
+  // to a bare "E" when there's only one).
+  test("renders S-set labels as bare numbers", async () => {
+    await renderTable([
+      makeTrack({ songId: "a", position: 1, set: "S1", song: { id: "a", title: "Above the Waves", slug: "x" } }),
+      makeTrack({ songId: "b", position: 2, set: "S2", song: { id: "b", title: "Tempest", slug: "t" } }),
+    ]);
+    const cells = screen.getAllByRole("cell");
+    // 5 cells per row; cells[0] = Set of row 0, cells[5] = Set of row 1.
+    expect(cells[0].textContent).toBe("1");
+    expect(cells[5].textContent).toBe("2");
+  });
+
+  // Single encore collapses E1 → E because there's no second encore to
+  // disambiguate against. Multi-encore shows keep E1/E2 so the rows tell
+  // the user which encore came first.
+  test("renders a single encore as 'E' but keeps E1/E2 when multiple encores exist", async () => {
+    await renderTable([
+      makeTrack({ songId: "a", position: 1, set: "S1", song: { id: "a", title: "Tractorbeam", slug: "t" } }),
+      makeTrack({ songId: "b", position: 2, set: "E1", song: { id: "b", title: "Crickets", slug: "c" } }),
+    ]);
+    const singleCells = screen.getAllByRole("cell");
+    // 5 cells per row; cells[0] = Set row 0, cells[5] = Set row 1.
+    expect(singleCells[0].textContent).toBe("1");
+    expect(singleCells[5].textContent).toBe("E");
+
+    // Re-render with two encores to confirm we keep the numbering.
+    document.body.innerHTML = "";
+    await renderTable([
+      makeTrack({ songId: "a", position: 1, set: "E1", song: { id: "a", title: "Munchkin Invasion", slug: "m" } }),
+      makeTrack({ songId: "b", position: 2, set: "E2", song: { id: "b", title: "Spaga", slug: "s" } }),
+    ]);
+    const multiCells = screen.getAllByRole("cell");
+    expect(multiCells[0].textContent).toBe("E1");
+    expect(multiCells[5].textContent).toBe("E2");
+  });
+
+  // Normal row: gap renders as the integer; Last Played renders the prior
+  // show's date as a link to that show. This is the common case.
+  test("renders gap value and Last Played link for a normal row", async () => {
+    await renderTable([
+      makeTrack({
+        songId: "song-a",
+        position: 2,
+        gap: 12,
+        previousPerformanceShowId: "prev-show",
+        previousPerformanceShow: { date: "2024-06-15", slug: "2024-06-15-some-venue" },
+        song: { id: "song-a", title: "Above the Waves", slug: "above-the-waves" },
+      }),
+    ]);
+    expect(screen.getByText("12")).toBeInTheDocument();
+    const links = screen.getAllByRole("link");
+    const lastPlayedLink = links.find((a) => a.getAttribute("href") === "/shows/2024-06-15-some-venue");
+    expect(lastPlayedLink).toBeDefined();
+  });
+
+  // Debut row (gap=null): ★ icon with "Debut" tooltip in the Gap column,
+  // em-dash placeholder in Last Played because there's no prior show to link
+  // to. Mirrors the song-detail performances table treatment.
+  test("renders ★ Debut for gap=null and em-dash in Last Played", async () => {
+    await renderTable([
+      makeTrack({
+        songId: "song-debut",
+        position: 1,
+        gap: null,
+        song: { id: "song-debut", title: "Munchkin Invasion", slug: "munchkin-invasion" },
+      }),
+    ]);
+    expect(screen.getByLabelText("Debut")).toBeInTheDocument();
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+
+  // Within-show repeat: same songId appears at an earlier position in the
+  // table. Phase 1 stores the same gap on both tracks of a within-show
+  // repeat, so the icon — not the value — is what distinguishes the repeat
+  // from its first occurrence.
+  test("renders ↺ This Show for a within-show repeat", async () => {
+    await renderTable([
+      makeTrack({
+        songId: "song-repeated",
+        position: 2,
+        gap: 5,
+        previousPerformanceShowId: "prev",
+        previousPerformanceShow: { date: "2024-05-01", slug: "2024-05-01-venue" },
+        song: { id: "song-repeated", title: "Tempest", slug: "tempest" },
+      }),
+      makeTrack({
+        songId: "song-repeated",
+        position: 5,
+        gap: 5,
+        previousPerformanceShowId: "prev",
+        previousPerformanceShow: { date: "2024-05-01", slug: "2024-05-01-venue" },
+        song: { id: "song-repeated", title: "Tempest", slug: "tempest" },
+      }),
+    ]);
+    expect(screen.getByLabelText("This Show")).toBeInTheDocument();
+  });
+
+  // Segue indicator carries over from the flow view: a track whose `segue`
+  // is truthy gets a trailing ">" so the table preserves the same flow
+  // information ("Tractorbeam > Above the Waves") readers already know.
+  // Non-segue rows render the song title alone (no trailing punctuation —
+  // the table row separator already does that job).
+  test("renders > after segueing tracks and nothing after non-segueing tracks", async () => {
+    await renderTable([
+      makeTrack({
+        songId: "song-segue",
+        position: 1,
+        gap: 5,
+        segue: ">",
+        song: { id: "song-segue", title: "Tractorbeam", slug: "tractorbeam" },
+      }),
+      makeTrack({
+        songId: "song-end",
+        position: 2,
+        gap: 10,
+        segue: null,
+        song: { id: "song-end", title: "Crickets", slug: "crickets" },
+      }),
+    ]);
+    const segueCell = screen.getByRole("link", { name: "Tractorbeam" }).parentElement;
+    expect(segueCell?.textContent).toMatch(/Tractorbeam\s*>/);
+    const endCell = screen.getByRole("link", { name: "Crickets" }).parentElement;
+    expect(endCell?.textContent).toBe("Crickets");
+  });
+
+  // Song cell links to the song detail route so users can pivot from a
+  // setlist row to that song's full history.
+  test("Song cell links to /songs/<slug>", async () => {
+    await renderTable([
+      makeTrack({
+        songId: "song-confrontation",
+        position: 1,
+        gap: 30,
+        previousPerformanceShowId: "prev",
+        previousPerformanceShow: { date: "2024-04-20", slug: "2024-04-20" },
+        song: { id: "song-confrontation", title: "Confrontation", slug: "confrontation" },
+      }),
+    ]);
+    const link = screen.getByRole("link", { name: "Confrontation" });
+    expect(link).toHaveAttribute("href", "/songs/confrontation");
+  });
+});

--- a/apps/web/app/components/setlist/setlist-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.tsx
@@ -1,0 +1,197 @@
+import type { TrackLight } from "@bip/domain";
+import { type Column, type ColumnDef, createColumnHelper } from "@tanstack/react-table";
+import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon, RotateCcw, Star } from "lucide-react";
+import { GapIcon } from "~/components/gap-icon";
+import { ShowDate } from "~/components/show-date";
+import { countDistinctEncores, formatSetLabel } from "./set-label";
+
+/**
+ * Row shape consumed by the gap-chart table. A SetlistTableRow is a TrackLight
+ * (with the Phase 5 gap+previousPerformanceShow fields) and is intentionally
+ * narrowed from the full Setlist tree so the column factory doesn't depend on
+ * Set/Show/Venue context.
+ */
+export type SetlistTableRow = TrackLight;
+
+/**
+ * Numeric sort key for a set label. Mirrors the server-side composer so the
+ * client default sort matches the order the loader already produced. Sets
+ * before encores; soundcheck before everything; unknowns at the end.
+ */
+function setSortKey(label: string): number {
+  const upper = label.toUpperCase();
+  if (label.toLowerCase() === "soundcheck") return 0;
+  if (upper === "S1") return 10;
+  if (upper === "S2") return 20;
+  if (upper === "S3") return 30;
+  if (upper === "S4") return 40;
+  if (upper === "E1") return 50;
+  if (upper === "E2") return 60;
+  if (upper === "E3") return 70;
+  return 999;
+}
+
+/**
+ * Sort comparator shared by the Set and Track columns. Both produce the
+ * same ordering — set bucket first, then track position within the set —
+ * because sorting on either should restore the canonical narrative order
+ * the composer already returns.
+ */
+function compareBySetThenPosition(a: SetlistTableRow, b: SetlistTableRow): number {
+  const setDiff = setSortKey(a.set) - setSortKey(b.set);
+  if (setDiff !== 0) return setDiff;
+  return a.position - b.position;
+}
+
+function SortableHeader({ column, label }: { column: Column<SetlistTableRow, unknown>; label: string }) {
+  if (!column.getCanSort()) return <span>{label}</span>;
+  return (
+    <button
+      type="button"
+      className="cursor-pointer select-none hover:text-content-text-primary text-left"
+      onClick={() => column.toggleSorting()}
+    >
+      <span className={column.getIsSorted() ? "text-content-text-primary font-semibold" : ""}>{label}</span>
+      <span className={column.getIsSorted() ? "text-brand-primary ml-1" : "ml-1"}>
+        {column.getIsSorted() === "asc" ? (
+          <ArrowUpIcon className="h-4 w-4 inline" />
+        ) : column.getIsSorted() === "desc" ? (
+          <ArrowDownIcon className="h-4 w-4 inline" />
+        ) : (
+          <ArrowUpDown className="h-4 w-4 inline" />
+        )}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * Columns for the SetlistCard "gap chart" view. Order is locked at
+ * [Set, Track #, Song, Gap, Last Played]. Within-show repeats are detected
+ * from the row's table context — a track whose songId already appeared at
+ * an earlier position in the same render.
+ */
+export function createSetlistColumns(): ColumnDef<SetlistTableRow, unknown>[] {
+  const columnHelper = createColumnHelper<SetlistTableRow>();
+
+  return [
+    columnHelper.accessor("set", {
+      id: "set",
+      header: ({ column }) => <SortableHeader column={column} label="Set" />,
+      meta: { width: "48px" },
+      enableSorting: true,
+      sortingFn: (a, b) => compareBySetThenPosition(a.original, b.original),
+      cell: (info) => {
+        const raw = info.getValue();
+        const encoresInSet = countDistinctEncores(info.table.getCoreRowModel().rows.map((r) => r.original));
+        // When the active sort IS the Set column, runs of same-set rows
+        // cluster together — show the label only on the first row of each
+        // run so the grouping is visually obvious. Other sorts (Gap, Last
+        // Played) interleave sets and need every row labeled.
+        const sorting = info.table.getState().sorting;
+        const groupBySet = sorting.length > 0 && sorting[0].id === "set";
+        if (groupBySet) {
+          const sortedRows = info.table.getSortedRowModel().rows;
+          const idx = sortedRows.findIndex((r) => r.id === info.row.id);
+          if (idx > 0 && sortedRows[idx - 1].original.set === info.row.original.set) {
+            return null;
+          }
+        }
+        return <span className="text-content-text-secondary">{formatSetLabel(raw, { encoresInSet })}</span>;
+      },
+    }) as ColumnDef<SetlistTableRow, unknown>,
+    columnHelper.display({
+      id: "track",
+      header: ({ column }) => <SortableHeader column={column} label="Track" />,
+      // Drops on narrow viewports — the Set column already orients the row,
+      // and a tiny "Track #" column would steal width from Song on mobile.
+      meta: { width: "56px", hideOnMobile: true },
+      enableSorting: true,
+      // Track # = position-within-set, computed at render time from the
+      // unsorted row model. The comparator falls through to the same
+      // set+position order as the Set column, so sorting either restores
+      // the canonical narrative.
+      sortingFn: (a, b) => compareBySetThenPosition(a.original, b.original),
+      cell: (info) => {
+        const row = info.row.original;
+        const allRows = info.table.getCoreRowModel().rows;
+        const trackNumber =
+          allRows.filter((r) => r.original.set === row.set && r.original.position < row.position).length + 1;
+        return <span className="text-content-text-secondary tabular-nums">{trackNumber}</span>;
+      },
+    }) as ColumnDef<SetlistTableRow, unknown>,
+    columnHelper.accessor((row) => row.song?.title ?? "", {
+      id: "song",
+      header: "Song",
+      enableSorting: false,
+      cell: (info) => {
+        const title = info.getValue() as string;
+        const slug = info.row.original.song?.slug;
+        const segue = info.row.original.segue;
+        const titleNode = slug ? (
+          <a href={`/songs/${slug}`} className="text-base text-brand-primary hover:text-brand-secondary font-medium">
+            {title}
+          </a>
+        ) : (
+          <span className="text-content-text-secondary">{title}</span>
+        );
+        // Preserve the flow view's segue marker so "Tractorbeam > Above the
+        // Waves" still reads as a continuous run inside the table.
+        return (
+          <>
+            {titleNode}
+            {segue && <span className="text-content-text-secondary ml-1 font-medium">&gt;</span>}
+          </>
+        );
+      },
+    }) as ColumnDef<SetlistTableRow, unknown>,
+    columnHelper.accessor((row) => row.gap ?? Number.POSITIVE_INFINITY, {
+      id: "gap",
+      header: ({ column }) => <SortableHeader column={column} label="Gap" />,
+      meta: { width: "64px" },
+      enableSorting: true,
+      // Numeric ascending; debuts (gap=null) become +∞ so they cluster at
+      // the end on asc and at the start on desc. Within-show repeats share
+      // their first occurrence's gap by Phase 1 design — sort treats them
+      // as equal and the icon (not the value) tells the story per row.
+      sortingFn: "basic",
+      // First click sorts ascending. TanStack auto-flips to desc-first for
+      // numeric accessors; force asc so "smallest gap first" matches the
+      // mental model "what was the rarest play in this show."
+      sortDescFirst: false,
+      cell: (info) => {
+        const row = info.row.original;
+        const allRows = info.table.getCoreRowModel().rows;
+        const isRepeat = allRows.some(
+          (other) => other.original.songId === row.songId && other.original.position < row.position,
+        );
+        if (isRepeat) {
+          return <GapIcon icon={<RotateCcw className="h-4 w-4 text-content-text-secondary" />} label="This Show" />;
+        }
+        if (row.gap == null) {
+          return <GapIcon icon={<Star className="h-4 w-4 text-content-text-secondary" />} label="Debut" />;
+        }
+        return <span className="text-content-text-secondary tabular-nums">{row.gap}</span>;
+      },
+    }) as ColumnDef<SetlistTableRow, unknown>,
+    columnHelper.accessor((row) => row.previousPerformanceShow?.date ?? "", {
+      id: "lastPlayed",
+      header: ({ column }) => <SortableHeader column={column} label="Last Played" />,
+      meta: { width: "140px" },
+      enableSorting: true,
+      // YYYY-MM-DD strings sort lexicographically the same as chronologically,
+      // so the default alphanumeric comparator is correct here. Empty strings
+      // (debuts) sort to the start ascending, end descending.
+      sortingFn: "alphanumeric",
+      cell: (info) => {
+        const prev = info.row.original.previousPerformanceShow;
+        if (!prev) return <span className="text-content-text-tertiary">—</span>;
+        return (
+          <a href={`/shows/${prev.slug}`} className="text-base text-brand-primary hover:text-brand-secondary">
+            <ShowDate date={prev.date} />
+          </a>
+        );
+      },
+    }) as ColumnDef<SetlistTableRow, unknown>,
+  ];
+}

--- a/apps/web/app/components/setlist/setlist-list.test.tsx
+++ b/apps/web/app/components/setlist/setlist-list.test.tsx
@@ -73,12 +73,17 @@ function makeSetlist(id: string, title: string, averageRating: number | null = 4
             allTimer: false,
             averageRating: null,
             ratingsCount: 0,
+            gap: null,
+            previousPerformanceShowId: null,
+            previousPerformanceShow: null,
             song: { id: "song-1", title, slug: title.toLowerCase().replace(/\s+/g, "-") },
           },
         ],
       },
     ],
     annotations: [],
+    averageSongGap: null,
+    medianSongGap: null,
   };
 }
 

--- a/apps/web/app/components/setlist/setlist-table.test.tsx
+++ b/apps/web/app/components/setlist/setlist-table.test.tsx
@@ -1,0 +1,97 @@
+import type { TrackLight } from "@bip/domain";
+import { setupWithRouter } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { SetlistTable } from "./setlist-table";
+
+function makeTrack(overrides: Partial<TrackLight> & { songId: string; position: number }): TrackLight {
+  return {
+    id: `t-${overrides.position}`,
+    showId: "show-1",
+    songId: overrides.songId,
+    set: overrides.set ?? "S1",
+    position: overrides.position,
+    segue: null,
+    likesCount: 0,
+    note: null,
+    allTimer: false,
+    averageRating: null,
+    ratingsCount: 0,
+    gap: overrides.gap ?? null,
+    previousPerformanceShowId: overrides.previousPerformanceShowId ?? null,
+    previousPerformanceShow: overrides.previousPerformanceShow ?? null,
+    song: overrides.song ?? { id: overrides.songId, title: "Tractorbeam", slug: "tractorbeam" },
+  };
+}
+
+describe("SetlistTable", () => {
+  // Default sort = set order then position. The composer already returns
+  // rows in this order; SetlistTable applies the matching initial sort so
+  // that rendering through DataTable (which would otherwise leave rows in
+  // input order) preserves the canonical narrative even after the user has
+  // toggled into a different sort and back via the column headers.
+  test("default sort puts S1 before S2 before E1, with tracks in position order", async () => {
+    await setupWithRouter(
+      <SetlistTable
+        tracks={[
+          makeTrack({
+            songId: "c",
+            position: 30,
+            set: "E1",
+            song: { id: "c", title: "Crickets", slug: "c" },
+          }),
+          makeTrack({
+            songId: "b",
+            position: 12,
+            set: "S2",
+            song: { id: "b", title: "Tempest", slug: "t" },
+          }),
+          makeTrack({
+            songId: "a",
+            position: 1,
+            set: "S1",
+            song: { id: "a", title: "Tractorbeam", slug: "x" },
+          }),
+          makeTrack({
+            songId: "a2",
+            position: 2,
+            set: "S1",
+            song: { id: "a2", title: "Above the Waves", slug: "y" },
+          }),
+        ]}
+      />,
+    );
+    const cells = screen.getAllByRole("cell").filter((_, i) => i % 5 === 2);
+    expect(cells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
+      "Tractorbeam",
+      "Above the Waves",
+      "Tempest",
+      "Crickets",
+    ]);
+  });
+
+  // Sanity: each track row appears in the rendered table body so callers
+  // know SetlistTable is handing the data through to DataTable + columns.
+  test("renders a row per track", async () => {
+    await setupWithRouter(
+      <SetlistTable
+        tracks={[
+          makeTrack({
+            songId: "a",
+            position: 1,
+            gap: 5,
+            song: { id: "a", title: "Above the Waves", slug: "above-the-waves" },
+          }),
+          makeTrack({
+            songId: "b",
+            position: 2,
+            gap: 10,
+            song: { id: "b", title: "Confrontation", slug: "confrontation" },
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByRole("link", { name: "Above the Waves" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Confrontation" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/setlist/setlist-table.tsx
+++ b/apps/web/app/components/setlist/setlist-table.tsx
@@ -1,0 +1,31 @@
+import type { TrackLight } from "@bip/domain";
+import { useMemo } from "react";
+import { DataTable } from "~/components/ui/data-table";
+import { createSetlistColumns } from "./setlist-columns";
+
+interface SetlistTableProps {
+  tracks: TrackLight[];
+}
+
+/**
+ * Tabular "gap chart" rendering of a setlist. Pairs the column factory with
+ * the shared DataTable shell. The average-song-gap summary line lives in
+ * SetlistViewControl (rendered by SetlistCard above and below the table)
+ * so it can sit on the same row as the setlist/gap-chart toggle.
+ */
+export function SetlistTable({ tracks }: SetlistTableProps) {
+  const columns = useMemo(() => createSetlistColumns(), []);
+  return (
+    <DataTable
+      columns={columns}
+      data={tracks}
+      hideSearch
+      hidePagination
+      hidePaginationText
+      // Set+position is the canonical order the composer already returns.
+      // Pinning it as initial sort means clicking a header to sort then
+      // clicking back to "Set" restores the canonical narrative.
+      initialSorting={[{ id: "set", desc: false }]}
+    />
+  );
+}

--- a/apps/web/app/components/setlist/setlist-view-control.tsx
+++ b/apps/web/app/components/setlist/setlist-view-control.tsx
@@ -1,0 +1,63 @@
+import { cn } from "~/lib/utils";
+import type { SetlistView } from "./setlist-card";
+
+interface SetlistViewControlProps {
+  view: SetlistView;
+  onChange: (next: SetlistView) => void;
+  averageSongGap: number | null;
+  medianSongGap: number | null;
+}
+
+/**
+ * Toggle for setlist ↔ gap chart, paired on the same row with the
+ * "Average song gap" summary so the two pieces of meta-information stay
+ * visually grouped. Used both above and below the gap-chart table; the
+ * setlist view renders a single instance below the flow text.
+ */
+export function SetlistViewControl({
+  view,
+  onChange,
+  averageSongGap,
+  medianSongGap,
+}: SetlistViewControlProps) {
+  return (
+    <div className="flex items-center justify-between gap-3 text-sm">
+      <div className="inline-flex items-center">
+        <button
+          type="button"
+          aria-pressed={view === "setlist"}
+          onClick={() => onChange("setlist")}
+          className={cn(
+            "px-2 py-1 border-b-2 transition-colors cursor-pointer",
+            view === "setlist"
+              ? "border-brand-primary text-content-text-primary"
+              : "border-transparent text-content-text-tertiary hover:text-content-text-secondary",
+          )}
+        >
+          setlist
+        </button>
+        <button
+          type="button"
+          aria-pressed={view === "gap-chart"}
+          onClick={() => onChange("gap-chart")}
+          className={cn(
+            "px-2 py-1 border-b-2 transition-colors cursor-pointer",
+            view === "gap-chart"
+              ? "border-brand-primary text-content-text-primary"
+              : "border-transparent text-content-text-tertiary hover:text-content-text-secondary",
+          )}
+        >
+          gap chart
+        </button>
+      </div>
+      {averageSongGap !== null && medianSongGap !== null && (
+        // text-right tucks the wrapped numbers under the right edge when
+        // narrow viewports force "Average / Median song gap:" onto its own
+        // line — keeps the numbers anchored where the eye expects them.
+        <span className="text-content-text-secondary text-right">
+          Average / Median song gap: {averageSongGap.toFixed(1)} / {medianSongGap.toFixed(1)}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/hooks/use-setlist-view.test.tsx
+++ b/apps/web/app/hooks/use-setlist-view.test.tsx
@@ -1,0 +1,59 @@
+import { setupWithRouter } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { describe, expect, test } from "vitest";
+import { useSetlistView } from "./use-setlist-view";
+
+// Tiny harness — render the hook's view + a button to flip it, plus the
+// current URL search string so we can assert round-trip behavior.
+function Harness() {
+  const [view, setView] = useSetlistView();
+  const location = useLocation();
+  return (
+    <>
+      <div data-testid="view">{view}</div>
+      <div data-testid="search">{location.search}</div>
+      <button type="button" onClick={() => setView("gap-chart")}>
+        to-gap
+      </button>
+      <button type="button" onClick={() => setView("setlist")}>
+        to-setlist
+      </button>
+    </>
+  );
+}
+
+describe("useSetlistView", () => {
+  // Default view comes from the absence of ?view= in the URL — preserves
+  // today's first-paint (flow text) on the show page.
+  test("defaults to setlist when no view param is set", async () => {
+    await setupWithRouter(<Harness />);
+    expect(screen.getByTestId("view").textContent).toBe("setlist");
+  });
+
+  // Reading ?view=gap-chart lets a shared link land directly in the table
+  // view without an extra click.
+  test("reads ?view=gap-chart from the URL on mount", () => {
+    render(
+      <MemoryRouter initialEntries={["/shows/2024-07-26?view=gap-chart"]}>
+        <Harness />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("view").textContent).toBe("gap-chart");
+  });
+
+  // Setting the view writes ?view=gap-chart so the URL is shareable; setting
+  // back to setlist drops the param entirely instead of leaving ?view=setlist
+  // hanging around (cleaner default state).
+  test("setting to gap-chart writes the param; setting to setlist drops it", async () => {
+    const user = userEvent.setup();
+    await setupWithRouter(<Harness />);
+
+    await user.click(screen.getByText("to-gap"));
+    expect(screen.getByTestId("search").textContent).toBe("?view=gap-chart");
+
+    await user.click(screen.getByText("to-setlist"));
+    expect(screen.getByTestId("search").textContent).toBe("");
+  });
+});

--- a/apps/web/app/hooks/use-setlist-view.ts
+++ b/apps/web/app/hooks/use-setlist-view.ts
@@ -1,0 +1,34 @@
+import { useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
+import type { SetlistView } from "~/components/setlist/setlist-card";
+
+/**
+ * URL-syncs the SetlistCard's setlist/gap-chart toggle on /shows/:slug.
+ * Reads `?view=gap-chart` on mount and writes the param when the user
+ * flips the toggle. Setting back to "setlist" drops the param so the
+ * default state has a clean URL. List pages skip this hook so toggling
+ * stays local per card.
+ */
+export function useSetlistView(): [SetlistView, (next: SetlistView) => void] {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const view: SetlistView = searchParams.get("view") === "gap-chart" ? "gap-chart" : "setlist";
+
+  const setView = useCallback(
+    (next: SetlistView) => {
+      setSearchParams(
+        (prev) => {
+          if (next === "gap-chart") {
+            prev.set("view", "gap-chart");
+          } else {
+            prev.delete("view");
+          }
+          return prev;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  return [view, setView];
+}

--- a/apps/web/app/routes/shows/$slug.tsx
+++ b/apps/web/app/routes/shows/$slug.tsx
@@ -23,6 +23,7 @@ import { ShowDate } from "~/components/show-date";
 import { Button } from "~/components/ui/button";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { useSession } from "~/hooks/use-session";
+import { useSetlistView } from "~/hooks/use-setlist-view";
 import { useShowUserData } from "~/hooks/use-show-user-data";
 import { type Context, publicLoader } from "~/lib/base-loaders";
 import { notFound } from "~/lib/errors";
@@ -152,6 +153,7 @@ export default function Show() {
   } = useSerializedLoaderData<ShowLoaderData>();
   const { user } = useSession();
   const revalidator = useRevalidator();
+  const [setlistView, setSetlistView] = useSetlistView();
   const { userRatingMap } = useShowUserData([setlist.show.id]);
   const userRating = userRatingMap.get(setlist.show.id) ?? null;
 
@@ -254,17 +256,17 @@ export default function Show() {
       <div className="space-y-2">
         <div className="flex justify-start">
           <Link
-            to="/shows"
+            to={`/shows/year/${setlist.show.date.slice(0, 4)}`}
             className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors"
           >
             <ArrowLeft className="h-3 w-3" />
-            <span>Back to shows</span>
+            <span>Back to {setlist.show.date.slice(0, 4)} shows</span>
           </Link>
         </div>
         <div className="flex justify-between items-center gap-2">
           {adjacentShows.previous ? (
             <Link
-              to={`/shows/${adjacentShows.previous.slug}`}
+              to={`/shows/${adjacentShows.previous.slug}${setlistView === "gap-chart" ? "?view=gap-chart" : ""}`}
               className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors min-w-0"
             >
               <ChevronLeft className="h-3 w-3 shrink-0" />
@@ -290,7 +292,7 @@ export default function Show() {
           </Link>
           {adjacentShows.next ? (
             <Link
-              to={`/shows/${adjacentShows.next.slug}`}
+              to={`/shows/${adjacentShows.next.slug}${setlistView === "gap-chart" ? "?view=gap-chart" : ""}`}
               className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors min-w-0 justify-end"
             >
               <span className="truncate">
@@ -323,6 +325,8 @@ export default function Show() {
             userRating={userRating}
             showRating={setlist.show.averageRating}
             externalSources={externalSources}
+            defaultView={setlistView}
+            onViewChange={setSetlistView}
           />
           {/* Note when count_for_stats=false (soundchecks, radio sessions,
               cancelled stubs, late-night Tractorbeam sets). Yellow accent on

--- a/packages/core/scripts/sync-missing-shows.test.ts
+++ b/packages/core/scripts/sync-missing-shows.test.ts
@@ -3,6 +3,7 @@ import {
   buildShowCreateInput,
   buildSongCreateInput,
   buildTrackCreateInputs,
+  buildShowDriftUpdate,
   buildVenueCreateInput,
   collectSongSlugs,
   collectVenueKeys,
@@ -386,14 +387,20 @@ describe("matchVenue", () => {
     expect(matchVenue(candidates, { name: "Fox Theatre", city: "Atlanta", state: "GA" })).toBeNull();
   });
 
-  // Two candidates tie on name + city + state: ambiguous, return null to stay
-  // safe (extremely rare in practice, but correctness > optimism).
-  test("returns null when multiple candidates match (ambiguous)", () => {
+  // Two candidates tie on name + city + state: prod actually has duplicate
+  // venue rows for some venues (e.g. Higher Ground / South Burlington / VT
+  // exists as both `higher-ground` and `the-new-higher-ground`). Returning
+  // null here used to leave shows with `venueId = NULL`, which made the show
+  // page 404 because the loader requires a venue. Tiebreak deterministically
+  // on lex-min slug so re-runs always pick the same canonical row.
+  test("breaks ties deterministically by lex-min slug when multiple candidates match", () => {
     const candidates: McpSearchVenueResult[] = [
-      { slug: "fox-theatre-a", name: "Fox Theatre", city: "Boulder", state: "CO" },
-      { slug: "fox-theatre-b", name: "Fox Theatre", city: "Boulder", state: "CO" },
+      { slug: "the-new-higher-ground", name: "Higher Ground", city: "South Burlington", state: "VT" },
+      { slug: "higher-ground", name: "Higher Ground", city: "South Burlington", state: "VT" },
     ];
-    expect(matchVenue(candidates, { name: "Fox Theatre", city: "Boulder", state: "CO" })).toBeNull();
+    expect(
+      matchVenue(candidates, { name: "Higher Ground", city: "South Burlington", state: "VT" }),
+    ).toBe("higher-ground");
   });
 
   // Regression for the Brooklyn Bowl Las Vegas bug: search_venues returned
@@ -410,6 +417,99 @@ describe("matchVenue", () => {
     expect(matchVenue(candidates, { name: "Brooklyn Bowl Las Vegas", city: "Las Vegas", state: "NV" })).toBe(
       "brooklyn-bowl-las-vegas",
     );
+  });
+});
+
+// buildShowDriftUpdate computes the patch to apply to an existing local show
+// row. Two independent triggers: aggregate drift (rating/notes/relisten) AND
+// venue back-fill (local landed with venueId=NULL under an older sync, but the
+// venue is now resolvable). Either one alone must yield an update; neither
+// means we skip the write entirely so re-runs stay idempotent.
+describe("buildShowDriftUpdate", () => {
+  const remote: McpShow = {
+    slug: "2025-11-15-brooklyn-steel-brooklyn-ny",
+    date: "2025-11-15",
+    venueName: "Brooklyn Steel",
+    venueCity: "Brooklyn",
+    averageRating: 3.7,
+    ratingsCount: 12,
+    notes: null,
+    relistenUrl: null,
+  };
+  const localInSync = {
+    averageRating: 3.7,
+    ratingsCount: 12,
+    notes: null,
+    relistenUrl: null,
+    venueId: "venue-brooklyn-steel-uuid",
+  };
+
+  // Nothing drifted, venue already linked: no patch — caller must skip the
+  // UPDATE entirely so re-runs don't churn updatedAt for unchanged rows.
+  test("returns null when aggregates match and venue is already linked", () => {
+    expect(buildShowDriftUpdate(localInSync, remote, "venue-brooklyn-steel-uuid")).toBeNull();
+  });
+
+  // Pure aggregate drift, venue unchanged: patch contains the four mirrored
+  // fields and does NOT touch venueId (avoid clobbering with same value).
+  test("emits aggregate fields when ratingsCount drifts", () => {
+    const patch = buildShowDriftUpdate({ ...localInSync, ratingsCount: 11 }, remote, "venue-brooklyn-steel-uuid");
+    expect(patch).toEqual({
+      averageRating: 3.7,
+      ratingsCount: 12,
+      notes: null,
+      relistenUrl: null,
+    });
+  });
+
+  // The Bug B fix: a show that landed with venueId=NULL under an older buggy
+  // sync (e.g. 2025-11-15-brooklyn-steel-brooklyn-ny) must self-heal on the
+  // next run when venue resolution now succeeds. Patch must include venueId.
+  test("emits venueId when local has null venue and remote venue resolves", () => {
+    const localMissingVenue = { ...localInSync, venueId: null };
+    const patch = buildShowDriftUpdate(localMissingVenue, remote, "venue-brooklyn-steel-uuid");
+    expect(patch).toEqual({ venueId: "venue-brooklyn-steel-uuid" });
+  });
+
+  // Combined case: aggregates drifted AND venue needs back-fill. Patch
+  // must carry both — single UPDATE round-trip, not two.
+  test("combines aggregate drift and venue back-fill into one patch", () => {
+    const patch = buildShowDriftUpdate(
+      { ...localInSync, ratingsCount: 11, venueId: null },
+      remote,
+      "venue-brooklyn-steel-uuid",
+    );
+    expect(patch).toEqual({
+      averageRating: 3.7,
+      ratingsCount: 12,
+      notes: null,
+      relistenUrl: null,
+      venueId: "venue-brooklyn-steel-uuid",
+    });
+  });
+
+  // Local is missing venue, but resolution still failed (e.g. unmatched search):
+  // no venue back-fill patch component. If aggregates also match, return null
+  // so we don't churn updatedAt on a show we can't fix yet.
+  test("returns null when local has null venue but resolution also failed and aggregates match", () => {
+    expect(buildShowDriftUpdate({ ...localInSync, venueId: null }, remote, null)).toBeNull();
+  });
+
+  // Local already has a venueId; never overwrite even if resolution returns a
+  // different slug. The rename/dedupe path is a separate workflow — drift sync
+  // is conservative.
+  test("never overwrites an already-set venueId", () => {
+    const patch = buildShowDriftUpdate(
+      { ...localInSync, venueId: "existing-venue-uuid", ratingsCount: 11 },
+      remote,
+      "different-venue-uuid",
+    );
+    expect(patch).toEqual({
+      averageRating: 3.7,
+      ratingsCount: 12,
+      notes: null,
+      relistenUrl: null,
+    });
   });
 });
 

--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -169,8 +169,13 @@ export function matchVenue(
       (c.city ?? "").toLowerCase() === wantCity &&
       (c.state ?? "").toLowerCase() === wantState,
   );
+  if (matches.length === 0) return null;
   if (matches.length === 1) return matches[0]?.slug ?? null;
-  return null;
+  // True duplicates on prod (same name + city + state across multiple Venue
+  // rows, e.g. Higher Ground / South Burlington / VT). Tiebreak deterministically
+  // on lex-min slug — re-runs always pick the same canonical row, and any
+  // later prod-side dedupe just re-points us at the survivor.
+  return matches.map((c) => c.slug).sort()[0] ?? null;
 }
 
 export function buildShowCreateInput(
@@ -211,6 +216,51 @@ export function showNeedsUpdate(local: LocalShowAggregates, remote: McpShow): bo
   const ra = remote.averageRating;
   if (la === null || ra === null) return la !== ra;
   return Math.abs(la - ra) > AVERAGE_RATING_TOLERANCE;
+}
+
+// Shape-minimal local row for the drift-update path. Includes venueId so we
+// can detect shows that landed without a venue under an older sync version
+// and back-fill them once resolution succeeds.
+export interface LocalShowForDrift extends LocalShowAggregates {
+  venueId: string | null;
+}
+
+// Patch returned by buildShowDriftUpdate. Empty object means "skip" (handled
+// by returning null). venueId is only present when local was null and
+// resolution succeeded — we never overwrite an already-set venueId from the
+// drift path; rename/merge is a separate concern.
+export interface ShowDriftUpdate {
+  averageRating?: number | null;
+  ratingsCount?: number;
+  notes?: string | null;
+  relistenUrl?: string | null;
+  venueId?: string | null;
+}
+
+/**
+ * Compute the patch to apply to an already-local show row. Two independent
+ * triggers: aggregate drift (rating/notes/relistenUrl/ratingsCount) and venue
+ * back-fill (local venueId is null but the venue is now resolvable). Returns
+ * null when nothing changed so callers can skip the UPDATE entirely and keep
+ * re-runs idempotent.
+ */
+export function buildShowDriftUpdate(
+  local: LocalShowForDrift,
+  remote: McpShow,
+  resolvedVenueId: string | null,
+): ShowDriftUpdate | null {
+  const aggregatesDrift = showNeedsUpdate(local, remote);
+  const venueDrift = local.venueId === null && resolvedVenueId !== null;
+  if (!aggregatesDrift && !venueDrift) return null;
+  const update: ShowDriftUpdate = {};
+  if (aggregatesDrift) {
+    update.averageRating = remote.averageRating;
+    update.ratingsCount = remote.ratingsCount;
+    update.notes = remote.notes;
+    update.relistenUrl = remote.relistenUrl;
+  }
+  if (venueDrift) update.venueId = resolvedVenueId;
+  return update;
 }
 
 export function buildSongCreateInput(song: McpSong, now: Date): Prisma.SongUncheckedCreateInput {
@@ -400,64 +450,68 @@ async function syncMissingShows(): Promise<void> {
     }
     const remoteBySlug = new Map<string, McpShow>(remoteFullShows.map((s) => [s.slug, s]));
 
-    // Step 2c: partition into missing-locally vs already-local.
+    // Step 2c: partition into missing-locally vs already-local. We pull venueId
+    // for existing rows so the drift-update branch can back-fill venues that
+    // landed NULL under an older sync (caused 404s on /shows/:slug).
     const existingLocal = await db.show.findMany({
       where: { slug: { in: realSlugs } },
-      select: { id: true, slug: true, averageRating: true, ratingsCount: true, notes: true, relistenUrl: true },
+      select: {
+        id: true,
+        slug: true,
+        averageRating: true,
+        ratingsCount: true,
+        notes: true,
+        relistenUrl: true,
+        venueId: true,
+      },
     });
     const existingBySlug = new Map(existingLocal.map((s) => [s.slug, s]));
     stats.showsAlreadyLocal = existingBySlug.size;
     const missingShows = remoteFullShows.filter((s) => !existingBySlug.has(s.slug));
     const existingRemoteShows = remoteFullShows.filter((s) => existingBySlug.has(s.slug));
-    console.log(`📥 ${missingShows.length} missing locally (${stats.showsAlreadyLocal} already present)`);
+    // Existing shows whose venue we still need to resolve so the drift loop
+    // can back-fill venueId. Their setlists MUST be fetched alongside missing
+    // shows so we know the (name, city, state) tuple to search by.
+    const needsVenueSlugs = existingLocal.filter((s) => s.venueId === null).map((s) => s.slug);
+    console.log(`📥 ${missingShows.length} missing locally (${stats.showsAlreadyLocal} already present, ${needsVenueSlugs.length} need venue back-fill)`);
 
-    // Step 2d: drift-detection update loop for existing local shows. Only
-    // rewrites the four aggregate fields we mirror from prod; does NOT touch
-    // tracks, songs, or venues for already-local shows.
-    for (const remote of existingRemoteShows) {
-      const local = existingBySlug.get(remote.slug);
-      if (!local) continue;
-      if (!showNeedsUpdate(local, remote)) {
-        stats.showsUnchanged++;
-        continue;
+    if (missingShows.length === 0 && needsVenueSlugs.length === 0) {
+      // Pure aggregate-drift run: do the simple update loop and bail out.
+      for (const remote of existingRemoteShows) {
+        const local = existingBySlug.get(remote.slug);
+        if (!local) continue;
+        const patch = buildShowDriftUpdate(local, remote, local.venueId);
+        if (patch === null) {
+          stats.showsUnchanged++;
+          continue;
+        }
+        if (isDryRun) {
+          console.log(`  🔄 ${remote.slug} would update ${JSON.stringify(patch)} (dry run)`);
+          stats.showsUpdated++;
+          continue;
+        }
+        try {
+          await db.show.update({ where: { slug: remote.slug }, data: { ...patch, updatedAt: now } });
+          changedSlugs.add(remote.slug);
+          stats.showsUpdated++;
+          console.log(`  🔄 ${remote.slug} ${JSON.stringify(patch)}`);
+        } catch (err) {
+          console.error(`  ❌ failed to update show ${remote.slug}:`, err);
+          stats.errors++;
+        }
       }
-      if (isDryRun) {
-        console.log(`  🔄 ${remote.slug} would update (rating ${local.averageRating}→${remote.averageRating}, count ${local.ratingsCount}→${remote.ratingsCount}) (dry run)`);
-        stats.showsUpdated++;
-        continue;
-      }
-      try {
-        await db.show.update({
-          where: { slug: remote.slug },
-          data: {
-            averageRating: remote.averageRating,
-            ratingsCount: remote.ratingsCount,
-            notes: remote.notes,
-            relistenUrl: remote.relistenUrl,
-            updatedAt: now,
-          },
-        });
-        changedSlugs.add(remote.slug);
-        stats.showsUpdated++;
-        console.log(`  🔄 ${remote.slug} (rating ${local.averageRating}→${remote.averageRating}, count ${local.ratingsCount}→${remote.ratingsCount})`);
-      } catch (err) {
-        console.error(`  ❌ failed to update show ${remote.slug}:`, err);
-        stats.errors++;
-      }
-    }
-    console.log(`📊 Existing shows: ${stats.showsUpdated} updated, ${stats.showsUnchanged} unchanged`);
-
-    if (missingShows.length === 0) {
+      console.log(`📊 Existing shows: ${stats.showsUpdated} updated, ${stats.showsUnchanged} unchanged`);
       printSummary(stats, isDryRun);
       return;
     }
 
-    // Step 3: fetch setlists for the missing shows in a single batch.
-    const missingSlugs = missingShows.map((s) => s.slug);
+    // Step 3: fetch setlists for missing shows AND existing shows that need
+    // venue back-fill, in one batched call.
+    const setlistFetchSlugs = [...missingShows.map((s) => s.slug), ...needsVenueSlugs];
     const { setlists, errors: setlistErrors } = await mcpCall<{
       setlists: McpSetlist[];
       errors?: Array<{ slug: string; error: string }>;
-    }>("get_setlists", { showSlugs: missingSlugs });
+    }>("get_setlists", { showSlugs: setlistFetchSlugs });
     if (setlistErrors?.length) {
       console.warn(`⚠️  ${setlistErrors.length} setlist fetch errors:`, setlistErrors);
       stats.errors += setlistErrors.length;
@@ -524,6 +578,43 @@ async function syncMissingShows(): Promise<void> {
         }
       }
     }
+
+    // Step 5b: drift-update existing local shows. Runs AFTER venue resolution
+    // so shows that landed with venueId=NULL under an older sync version can
+    // self-heal — their patch will include venueId once the (name, city, state)
+    // tuple resolves. Aggregate-only drift (rating/notes/relistenUrl) lands
+    // here too.
+    for (const remote of existingRemoteShows) {
+      const local = existingBySlug.get(remote.slug);
+      if (!local) continue;
+      const setlist = setlistBySlug.get(remote.slug);
+      const venueKey = setlist?.venue?.name
+        ? `${setlist.venue.name}|${setlist.venue.city ?? ""}|${setlist.venue.state ?? ""}`
+        : null;
+      const venueSlug = venueKey ? venueKeyToSlug.get(venueKey) : null;
+      const resolvedVenueId = venueSlug ? venueSlugToId.get(venueSlug) ?? null : null;
+      const patch = buildShowDriftUpdate(local, remote, resolvedVenueId);
+      if (patch === null) {
+        stats.showsUnchanged++;
+        continue;
+      }
+      if (isDryRun) {
+        console.log(`  🔄 ${remote.slug} would update ${JSON.stringify(patch)} (dry run)`);
+        stats.showsUpdated++;
+        continue;
+      }
+      try {
+        await db.show.update({ where: { slug: remote.slug }, data: { ...patch, updatedAt: now } });
+        changedSlugs.add(remote.slug);
+        if (patch.venueId) stats.venuesLinked++;
+        stats.showsUpdated++;
+        console.log(`  🔄 ${remote.slug} ${JSON.stringify(patch)}`);
+      } catch (err) {
+        console.error(`  ❌ failed to update show ${remote.slug}:`, err);
+        stats.errors++;
+      }
+    }
+    console.log(`📊 Existing shows: ${stats.showsUpdated} updated, ${stats.showsUnchanged} unchanged`);
 
     // Step 6: resolve songs (local + remote) into an id map the track builder
     // can consume. Songs already in the DB reuse their existing id; new songs

--- a/packages/core/src/_shared/prisma/migrations/20260510140801_add_track_song_id_and_annotation_track_id_indexes/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260510140801_add_track_song_id_and_annotation_track_id_indexes/migration.sql
@@ -1,0 +1,8 @@
+-- CreateIndex
+CREATE INDEX "annotations_track_id_idx" ON "annotations"("track_id");
+
+-- CreateIndex
+CREATE INDEX "tracks_song_id_idx" ON "tracks"("song_id");
+
+-- CreateIndex
+CREATE INDEX "tracks_previous_performance_show_id_idx" ON "tracks"("previous_performance_show_id");

--- a/packages/core/src/_shared/prisma/schema.prisma
+++ b/packages/core/src/_shared/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  previewFeatures = ["relationJoins"]
 }
 
 datasource db {
@@ -42,6 +43,7 @@ model Annotation {
   updatedAt DateTime @map("updated_at") @db.Timestamp(6)
   track     Track    @relation(fields: [trackId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_annotations_tracks_track_id")
 
+  @@index([trackId])
   @@map("annotations")
 }
 
@@ -485,6 +487,9 @@ model Track {
   @@index([likesCount])
   @@index([nextTrackId])
   @@index([previousTrackId])
+  @@index([songId])
+  @@index([previousPerformanceShowId])
+  @@index([showId, set, position], map: "tracks_show_set_position_idx")
   @@map("tracks")
 }
 

--- a/packages/core/src/setlists/setlist-service.test.ts
+++ b/packages/core/src/setlists/setlist-service.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test, vi } from "vitest";
-import { SetlistService } from "./setlist-service";
+import { computeAverageSongGap, computeMedianSongGap, SetlistService } from "./setlist-service";
 
 // Minimal mock DbClient — only the paths used by tests
 function makeMockDb() {
   return {
     show: {
       findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue(null),
       count: vi.fn().mockResolvedValue(0),
     },
   };
@@ -121,6 +122,243 @@ describe("SetlistService.findManyLight", () => {
     const call = db.show.findMany.mock.calls[0][0];
     expect(call.where.showPhotosCount).toEqual({ gt: 0 });
     expect(call.where.showYoutubesCount).toEqual({ equals: 0 });
+  });
+});
+
+describe("computeAverageSongGap", () => {
+  // Standard case: average of two real-gap tracks. Debut (gap=null) is
+  // excluded from both numerator and denominator so it doesn't drag the
+  // average down to "we never played this".
+  test("averages real gaps and ignores debuts", () => {
+    const tracks = [
+      { songId: "a", position: 1, gap: null }, // Tractorbeam debut
+      { songId: "b", position: 2, gap: 5 }, // Above the Waves
+      { songId: "c", position: 3, gap: 10 }, // Confrontation
+    ];
+    expect(computeAverageSongGap(tracks)).toBe(7.5);
+  });
+
+  // Within-show repeat: a song that appears twice in the same show carries the
+  // gap of its earlier in-show occurrence (recompute writes the same value to
+  // both rows). Including the repeat would double-count the same song's
+  // recency, so the second occurrence is excluded by (songId already seen).
+  test("excludes within-show repeats by songId", () => {
+    const tracks = [
+      { songId: "a", position: 1, gap: null }, // Munchkin Invasion debut
+      { songId: "b", position: 2, gap: 5 }, // Tempest
+      { songId: "c", position: 3, gap: 10 }, // Mindless Dribble
+      { songId: "b", position: 4, gap: 5 }, // Tempest reprise — same songId, drop
+    ];
+    expect(computeAverageSongGap(tracks)).toBe(7.5);
+  });
+
+  // All debuts (or all repeats of debuts) means there's no meaningful gap to
+  // average — return null so the UI can hide the summary line entirely.
+  test("returns null when no eligible tracks remain", () => {
+    const tracks = [
+      { songId: "a", position: 1, gap: null }, // Crickets debut
+      { songId: "b", position: 2, gap: null }, // Spaga debut
+    ];
+    expect(computeAverageSongGap(tracks)).toBeNull();
+  });
+});
+
+describe("computeMedianSongGap", () => {
+  // Odd-length eligible list: median is the middle value after sorting.
+  // 5 / 10 / 30 → median = 10. Surfaces "what's the typical gap" without
+  // an outlier dragging it like the average can.
+  test("returns the middle value for an odd-count eligible list", () => {
+    const tracks = [
+      { songId: "a", position: 1, gap: 30 }, // Tractorbeam
+      { songId: "b", position: 2, gap: 5 }, // Above the Waves
+      { songId: "c", position: 3, gap: 10 }, // Confrontation
+    ];
+    expect(computeMedianSongGap(tracks)).toBe(10);
+  });
+
+  // Even-length eligible list: median is the mean of the two middle values
+  // after sorting. 5 / 10 / 20 / 30 → middles are 10 and 20 → 15.
+  test("averages the two middle values for an even-count eligible list", () => {
+    const tracks = [
+      { songId: "a", position: 1, gap: 30 }, // Crickets
+      { songId: "b", position: 2, gap: 5 }, // Munchkin Invasion
+      { songId: "c", position: 3, gap: 20 }, // Spaga
+      { songId: "d", position: 4, gap: 10 }, // Tempest
+    ];
+    expect(computeMedianSongGap(tracks)).toBe(15);
+  });
+
+  // Same exclusion rules as the average: debuts (gap=null) and within-show
+  // repeats (songId already seen at an earlier position) are dropped before
+  // sorting. Without this, a repeated song would distort the middle value.
+  test("excludes debuts and within-show repeats before computing", () => {
+    const tracks = [
+      { songId: "a", position: 1, gap: null }, // Mindless Dribble debut — drop
+      { songId: "b", position: 2, gap: 5 }, // Tempest
+      { songId: "c", position: 3, gap: 10 }, // Spaga
+      { songId: "d", position: 4, gap: 30 }, // Crickets
+      { songId: "b", position: 5, gap: 5 }, // Tempest reprise — drop
+    ];
+    // Eligible gaps after exclusions: [5, 10, 30] → median = 10.
+    expect(computeMedianSongGap(tracks)).toBe(10);
+  });
+
+  // No eligible tracks (all debuts or all repeats) → null, so the UI can
+  // hide the summary line entirely.
+  test("returns null when no eligible tracks remain", () => {
+    const tracks = [
+      { songId: "a", position: 1, gap: null }, // Tractorbeam debut
+      { songId: "b", position: 2, gap: null }, // Above the Waves debut
+    ];
+    expect(computeMedianSongGap(tracks)).toBeNull();
+  });
+});
+
+describe("SetlistService.findByShowSlug", () => {
+  // The setlist payload powers the gap-chart view (Phase 5). It needs the
+  // prior-show date+slug for the "Last Played" column, so the query must
+  // include the previousPerformanceShow relation with date+slug only (no full
+  // show payload — keeps the response compact).
+  test("includes previousPerformanceShow date+slug on tracks", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never);
+
+    await service.findByShowSlug("2024-07-26-red-rocks-amphitheatre-morrison-co");
+
+    const call = db.show.findUnique.mock.calls[0][0];
+    expect(call.include.tracks.include.previousPerformanceShow).toEqual({
+      select: { date: true, slug: true },
+    });
+  });
+
+  // The setlist domain object exposes averageSongGap so SetlistTable can
+  // render the summary without recomputing client-side. Tracks come back from
+  // Prisma with `gap` already populated (Phase 1 denormalization).
+  test("returns averageSongGap derived from tracks", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never);
+    db.show.findUnique.mockResolvedValue({
+      id: "show-1",
+      slug: "2024-07-26",
+      date: "2024-07-26",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      venueId: "v-1",
+      bandId: "b-1",
+      tracks: [
+        // Tractorbeam debut — gap=null
+        {
+          id: "t-1",
+          showId: "show-1",
+          songId: "song-a",
+          set: "S1",
+          position: 1,
+          segue: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          likesCount: 0,
+          slug: "t-1",
+          note: null,
+          allTimer: false,
+          previousTrackId: null,
+          nextTrackId: null,
+          averageRating: 0,
+          ratingsCount: 0,
+          gap: null,
+          previousPerformanceShowId: null,
+          previousPerformanceShow: null,
+          song: null,
+          annotations: [],
+        },
+        // Above the Waves — gap=5
+        {
+          id: "t-2",
+          showId: "show-1",
+          songId: "song-b",
+          set: "S1",
+          position: 2,
+          segue: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          likesCount: 0,
+          slug: "t-2",
+          note: null,
+          allTimer: false,
+          previousTrackId: null,
+          nextTrackId: null,
+          averageRating: 0,
+          ratingsCount: 0,
+          gap: 5,
+          previousPerformanceShowId: "prev-show-1",
+          previousPerformanceShow: { date: "2024-06-15", slug: "2024-06-15-some-venue" },
+          song: null,
+          annotations: [],
+        },
+        // Confrontation — gap=10
+        {
+          id: "t-3",
+          showId: "show-1",
+          songId: "song-c",
+          set: "S1",
+          position: 3,
+          segue: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          likesCount: 0,
+          slug: "t-3",
+          note: null,
+          allTimer: false,
+          previousTrackId: null,
+          nextTrackId: null,
+          averageRating: 0,
+          ratingsCount: 0,
+          gap: 10,
+          previousPerformanceShowId: "prev-show-2",
+          previousPerformanceShow: { date: "2024-04-20", slug: "2024-04-20-other-venue" },
+          song: null,
+          annotations: [],
+        },
+      ],
+      venue: {
+        id: "v-1",
+        name: "Red Rocks",
+        slug: "red-rocks",
+        city: "Morrison",
+        country: "US",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    const setlist = await service.findByShowSlug("2024-07-26");
+
+    expect(setlist?.averageSongGap).toBe(7.5);
+    // Tracks pass through gap and the resolved prev-show pointer for the table.
+    const tracks = setlist?.sets.flatMap((s) => s.tracks) ?? [];
+    expect(tracks.find((t) => t.id === "t-1")?.gap).toBeNull();
+    expect(tracks.find((t) => t.id === "t-2")?.gap).toBe(5);
+    expect(tracks.find((t) => t.id === "t-2")?.previousPerformanceShow).toEqual({
+      date: "2024-06-15",
+      slug: "2024-06-15-some-venue",
+    });
+  });
+});
+
+describe("SetlistService.findManyLight", () => {
+  // findManyLight powers the list pages (year, top-rated, etc.). The gap-chart
+  // toggle on those pages needs the same prior-show pointer + averageSongGap.
+  test("includes previousPerformanceShow date+slug on tracks", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never);
+
+    await service.findManyLight({ filters: { year: 2024 } });
+
+    const call = db.show.findMany.mock.calls[0][0];
+    expect(call.include.tracks.select.previousPerformanceShow).toEqual({
+      select: { date: true, slug: true },
+    });
+    expect(call.include.tracks.select.gap).toBe(true);
+    expect(call.include.tracks.select.previousPerformanceShowId).toBe(true);
   });
 });
 

--- a/packages/core/src/setlists/setlist-service.ts
+++ b/packages/core/src/setlists/setlist-service.ts
@@ -38,9 +38,70 @@ type DbTrackLight = {
   allTimer: boolean | null;
   averageRating: number | null;
   ratingsCount: number;
+  gap: number | null;
+  previousPerformanceShowId: string | null;
+  previousPerformanceShow: { date: string; slug: string | null } | null;
   song: { id: string; title: string; slug: string } | null;
   annotations: DbAnnotation[];
 };
+
+/**
+ * Eligible gap values for setlist-level aggregations. Excludes debuts (gap
+ * is null — no prior performance to compare against) and within-show
+ * repeats (a song's second appearance in the same show carries the same
+ * gap as its first; counting it would double-weight that song's recency).
+ * Shared by the average and median computations so both apply identical
+ * exclusion rules.
+ */
+function eligibleGapsForAggregation(
+  tracks: ReadonlyArray<{ songId: string; position: number; gap: number | null }>,
+): number[] {
+  const seenSongIds = new Set<string>();
+  const eligible: number[] = [];
+  const ordered = [...tracks].sort((a, b) => a.position - b.position);
+  for (const t of ordered) {
+    if (t.gap === null) continue;
+    if (seenSongIds.has(t.songId)) continue;
+    seenSongIds.add(t.songId);
+    eligible.push(t.gap);
+  }
+  return eligible;
+}
+
+/**
+ * Arithmetic mean of `track.gap` across a setlist's tracks. Returns null
+ * when no eligible tracks remain so the gap-chart UI can hide the summary.
+ */
+export function computeAverageSongGap(
+  tracks: ReadonlyArray<{ songId: string; position: number; gap: number | null }>,
+): number | null {
+  const eligible = eligibleGapsForAggregation(tracks);
+  if (eligible.length === 0) return null;
+  const sum = eligible.reduce((acc, v) => acc + v, 0);
+  return sum / eligible.length;
+}
+
+/**
+ * Median of `track.gap` across a setlist's tracks. Resists outliers (one
+ * very-high-gap rarity won't drag the typical-gap signal up the way the
+ * average does), so it pairs with the average to give users both the
+ * typical and the central-tendency view.
+ */
+export function computeMedianSongGap(
+  tracks: ReadonlyArray<{ songId: string; position: number; gap: number | null }>,
+): number | null {
+  const sorted = eligibleGapsForAggregation(tracks).sort((a, b) => a - b);
+  if (sorted.length === 0) return null;
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function previousPerformanceShowFromDb(
+  prev: { date: string; slug: string | null } | null,
+): { date: string; slug: string } | null {
+  if (!prev || !prev.slug) return null;
+  return { date: String(prev.date), slug: prev.slug };
+}
 
 // Mapper functions
 function mapShowToDomainEntity(dbShow: DbShow): Show {
@@ -78,13 +139,19 @@ function mapAnnotationToDomainEntity(dbAnnotation: DbAnnotation): Annotation {
   };
 }
 
-function mapTrackToDomainEntity(dbTrack: DbTrack & { song: DbSong | null }): Track {
-  const { createdAt, updatedAt, slug, ...rest } = dbTrack;
+function mapTrackToDomainEntity(
+  dbTrack: DbTrack & {
+    song: DbSong | null;
+    previousPerformanceShow?: { date: string; slug: string | null } | null;
+  },
+): Track {
+  const { createdAt, updatedAt, slug, previousPerformanceShow, ...rest } = dbTrack;
   return {
     ...rest,
     slug: slug ?? "",
     createdAt: new Date(createdAt),
     updatedAt: new Date(updatedAt),
+    previousPerformanceShow: previousPerformanceShowFromDb(previousPerformanceShow ?? null),
     song: dbTrack.song
       ? {
           id: dbTrack.song.id,
@@ -148,7 +215,11 @@ function getSetSortOrder(setLabel: string): number {
 
 function mapSetlistToDomainEntity(
   show: DbShow & {
-    tracks: (DbTrack & { song: DbSong | null; annotations: DbAnnotation[] })[];
+    tracks: (DbTrack & {
+      song: DbSong | null;
+      annotations: DbAnnotation[];
+      previousPerformanceShow?: { date: string; slug: string | null } | null;
+    })[];
     venue: DbVenue;
   },
 ): Setlist {
@@ -187,6 +258,8 @@ function mapSetlistToDomainEntity(
     venue: mapVenueToDomainEntity(show.venue),
     sets,
     annotations: tracks.flatMap((t) => t.annotations ?? []).map((a) => mapAnnotationToDomainEntity(a)),
+    averageSongGap: computeAverageSongGap(tracks),
+    medianSongGap: computeMedianSongGap(tracks),
   };
 }
 
@@ -203,6 +276,9 @@ function mapTrackLightToDomainEntity(track: DbTrackLight): TrackLight {
     allTimer: track.allTimer,
     averageRating: track.averageRating,
     ratingsCount: track.ratingsCount,
+    gap: track.gap,
+    previousPerformanceShowId: track.previousPerformanceShowId,
+    previousPerformanceShow: previousPerformanceShowFromDb(track.previousPerformanceShow),
     song: track.song ?? undefined,
   };
 }
@@ -243,6 +319,8 @@ function mapSetlistLightToDomainEntity(
     venue: mapVenueToDomainEntity(show.venue),
     sets,
     annotations: tracks.flatMap((t) => t.annotations ?? []).map((a) => mapAnnotationToDomainEntity(a)),
+    averageSongGap: computeAverageSongGap(tracks),
+    medianSongGap: computeMedianSongGap(tracks),
   };
 }
 
@@ -252,11 +330,13 @@ export class SetlistService {
   async findByShowId(id: string): Promise<Setlist | null> {
     const show = await this.db.show.findUnique({
       where: { id },
+      relationLoadStrategy: "join",
       include: {
         tracks: {
           include: {
             song: true,
             annotations: true,
+            previousPerformanceShow: { select: { date: true, slug: true } },
           },
         },
         venue: true,
@@ -274,11 +354,13 @@ export class SetlistService {
   async findByShowSlug(slug: string): Promise<Setlist | null> {
     const result = await this.db.show.findUnique({
       where: { slug },
+      relationLoadStrategy: "join",
       include: {
         tracks: {
           include: {
             song: true,
             annotations: true,
+            previousPerformanceShow: { select: { date: true, slug: true } },
           },
         },
         venue: true,
@@ -324,11 +406,16 @@ export class SetlistService {
       orderBy,
       skip,
       take,
+      // Single LATERAL-joined query instead of 5 batched roundtrips. With
+      // 100 shows × ~25 tracks each + relations, the per-roundtrip latency
+      // dominates the page load on un-cached routes (top-rated etc).
+      relationLoadStrategy: "join",
       include: {
         tracks: {
           include: {
             song: true,
             annotations: true,
+            previousPerformanceShow: { select: { date: true, slug: true } },
           },
         },
         venue: true,
@@ -384,11 +471,13 @@ export class SetlistService {
       orderBy,
       skip,
       take,
+      relationLoadStrategy: "join",
       include: {
         tracks: {
           include: {
             song: true,
             annotations: true,
+            previousPerformanceShow: { select: { date: true, slug: true } },
           },
         },
         venue: true,
@@ -448,6 +537,7 @@ export class SetlistService {
       orderBy,
       skip,
       take,
+      relationLoadStrategy: "join",
       include: {
         tracks: {
           select: {
@@ -462,6 +552,9 @@ export class SetlistService {
             allTimer: true,
             averageRating: true,
             ratingsCount: true,
+            gap: true,
+            previousPerformanceShowId: true,
+            previousPerformanceShow: { select: { date: true, slug: true } },
             song: {
               select: {
                 id: true,

--- a/packages/core/src/tracks/track-service.ts
+++ b/packages/core/src/tracks/track-service.ts
@@ -12,14 +12,19 @@ type DbTrackWithSongAndAnnotations = DbTrack & {
 };
 
 // Mapper functions
-function mapTrackToDomainEntity(dbTrack: DbTrack): Track {
-  const { slug, createdAt, updatedAt, ...rest } = dbTrack;
+function mapTrackToDomainEntity(
+  dbTrack: DbTrack & { previousPerformanceShow?: { date: string; slug: string | null } | null },
+): Track {
+  const { slug, createdAt, updatedAt, previousPerformanceShow, ...rest } = dbTrack;
 
   return {
     ...rest,
     slug: slug || "",
     createdAt: new Date(createdAt),
     updatedAt: new Date(updatedAt),
+    previousPerformanceShow: previousPerformanceShow?.slug
+      ? { date: String(previousPerformanceShow.date), slug: previousPerformanceShow.slug }
+      : null,
   };
 }
 

--- a/packages/domain/src/models/setlist.ts
+++ b/packages/domain/src/models/setlist.ts
@@ -14,6 +14,8 @@ export type Setlist = {
   venue: Venue;
   sets: Set[];
   annotations: Annotation[];
+  averageSongGap: number | null;
+  medianSongGap: number | null;
 };
 
 export type SetLight = {
@@ -27,4 +29,6 @@ export type SetlistLight = {
   venue: Venue;
   sets: SetLight[];
   annotations: Annotation[];
+  averageSongGap: number | null;
+  medianSongGap: number | null;
 };

--- a/packages/domain/src/models/track.ts
+++ b/packages/domain/src/models/track.ts
@@ -2,6 +2,13 @@ import { z } from "zod";
 import { annotationSchema } from "./annotation";
 import { songSchema } from "./song";
 
+const previousPerformanceShowSchema = z
+  .object({
+    date: z.string(),
+    slug: z.string(),
+  })
+  .nullable();
+
 export const trackSchema = z.object({
   id: z.string().uuid(),
   showId: z.string().uuid(),
@@ -19,6 +26,9 @@ export const trackSchema = z.object({
   nextTrackId: z.string().uuid().nullable(),
   averageRating: z.number().default(0.0).nullable(),
   ratingsCount: z.number().default(0),
+  gap: z.number().nullable(),
+  previousPerformanceShowId: z.string().uuid().nullable(),
+  previousPerformanceShow: previousPerformanceShowSchema,
   song: songSchema.optional(),
   annotations: z.array(annotationSchema).optional(),
 });
@@ -55,6 +65,9 @@ export const trackLightSchema = z.object({
   allTimer: z.boolean().nullable().default(false),
   averageRating: z.number().default(0.0).nullable(),
   ratingsCount: z.number().default(0),
+  gap: z.number().nullable(),
+  previousPerformanceShowId: z.string().uuid().nullable(),
+  previousPerformanceShow: previousPerformanceShowSchema,
   song: songLightSchema.optional(),
 });
 


### PR DESCRIPTION
## Why

Every `SetlistCard` now has a toggle between the existing setlist text and a new gap-chart table view. The table shows each song along with its gap (number of shows since it was last played) and the date it was last played, plus the show's average and median song gap. The toggle and summary live on every card on every page, so the data is one click away wherever a setlist is rendered.

These signals belong on every `SetlistCard`, not just `/shows/:slug` — but pulling per-track gap data into list pages was a regression. Top-rated jumped from ~470ms → ~950ms once the new joins were added. Switching to Prisma's `relationLoadStrategy: "join"` collapsed five batched roundtrips into one LATERAL-joined SQL and dropped top-rated to ~57ms — faster than the pre-PR baseline. List pages now carry richer data AND load faster.

A few smaller things tagged along: missing indexes, a Prisma schema/DB drift on an existing index, "Back to shows" linking to the year you were browsing instead of the index, set labels reading "1, 2, E" instead of "S1, S2, E1", and a `make migrate-create NAME=…` fix so the target stops hanging in non-TTY contexts (which kept orphaning Prisma processes that held the migration advisory lock).


https://github.com/user-attachments/assets/9d7257e7-407e-45f5-b50c-d3959fa9e290



## What this means for users

- Toggle any setlist into a sortable gap chart: Set / Track / Song / Gap / Last Played, plus the show's average and median song gap.
- Share `/shows/<slug>?view=gap-chart` and the recipient lands directly in the table.
- Toggle one card on a year page; other cards keep the default setlist view.
- Prev/next show navigation preserves the active view.
- List pages (top-rated especially) load noticeably faster.
- "Back to shows" returns you to the year you were browsing.

## Test plan

- [ ] `/shows/<slug>`: toggle setlist ↔ gap chart, confirm sortable columns and the average + median summary on the toggle row. URL gains/drops `?view=gap-chart`.
- [ ] Hard-load `/shows/<slug>?view=gap-chart` → mounts directly into table view.
- [ ] Prev/next on a show in gap-chart view → next show opens in gap-chart view.
- [ ] `/shows/year/2024`: expand a card, toggle one to gap chart — other cards stay in setlist view; URL unchanged.
- [ ] All-Timers / Top-Rated: collapsed cards do not show the toggle until expanded.
- [ ] Sort by Gap (asc-first), Last Played, Set. When sorted by Set, repeated labels collapse to blank for runs.
- [ ] Mobile (375px): table scrolls; Track # column hidden; "Average / Median song gap" wraps with numbers right-aligned.
- [ ] Single-encore show renders Set as "E"; multi-encore renders "E1"/"E2".
- [ ] `make tc && make test && make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
