### PR TITLE
Add filtered rarity columns to /songs and Filtered Gap to song detail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,12 @@ Any code that orders or filters shows/tracks chronologically MUST use the helper
 
 Use `SHOW_ORDER_ASC` / `SHOW_ORDER_DESC` for Prisma `orderBy`, `showOrderBySql` for raw SQL, `TRACK_BY_SHOW_ORDER_ASC` for ordering tracks by their show, `statsShowsSql` / `STATS_SHOWS_WHERE` for the count_for_stats=true predicate, and `compareByShowDate` for in-memory sorts.
 
+## Commit and PR Messages
+
+Describe the final before→after change as the user will see it, not the development process or intermediate iterations. Be pithy. Lead with the user-visible change.
+
+If a change involves a particularly tricky technical detail or a non-obvious design decision the reviewer should know about, put it in a separate section at the end of the PR description (not in the lead). Skip that section entirely when the change is straightforward.
+
 ## CRITICAL: Don't Guess
 
 **NEVER guess field names, function signatures, or code structure.** Always look at the actual files first. This applies to database fields, function parameters, API endpoints, file paths, configuration keys — anything with a definitive answer in the codebase.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,12 @@ This is a **monorepo** using **pnpm workspaces** with **Bun** as the runtime:
 - Never commit secrets or API keys
 - Use `doppler run --` prefix for commands that need environment variables
 
+## Show Ordering
+
+Any code that orders or filters shows/tracks chronologically MUST use the helpers in `packages/core/src/_shared/show-ordering.ts` (or `compareByShowDate` from `packages/domain/src/show-ordering.ts` for in-memory work). Never write `orderBy: { date: 'asc' }` directly — same-day shows have a `dayOrder` column (NULLS LAST) plus track-position tiebreakers, and the helpers centralize that logic so it stays consistent across SQL, Prisma, and JS.
+
+Use `SHOW_ORDER_ASC` / `SHOW_ORDER_DESC` for Prisma `orderBy`, `showOrderBySql` for raw SQL, `TRACK_BY_SHOW_ORDER_ASC` for ordering tracks by their show, `statsShowsSql` / `STATS_SHOWS_WHERE` for the count_for_stats=true predicate, and `compareByShowDate` for in-memory sorts.
+
 ## CRITICAL: Don't Guess
 
 **NEVER guess field names, function signatures, or code structure.** Always look at the actual files first. This applies to database fields, function parameters, API endpoints, file paths, configuration keys — anything with a definitive answer in the codebase.

--- a/apps/web/app/components/performance/performance-columns.test.tsx
+++ b/apps/web/app/components/performance/performance-columns.test.tsx
@@ -120,6 +120,82 @@ describe("createPerformanceColumns", () => {
     expect(ids).not.toContain("lastPlayed");
   });
 
+  // Filtered Gap appears only when a server-narrowing filter is active —
+  // the column has no meaning otherwise (it would just duplicate Gap).
+  test("Filtered Gap column is absent by default", () => {
+    const columns = createPerformanceColumns(defaultOptions);
+    const ids = columns.map((c) => ("id" in c ? c.id : undefined));
+    expect(ids).not.toContain("filteredGap");
+  });
+
+  // When narrowing is active, Filtered Gap renders immediately after the
+  // all-time Gap column so the two read as a paired comparison.
+  test("Filtered Gap column is present when hasNarrowingFilter is true", () => {
+    const columns = createPerformanceColumns({ ...defaultOptions, hasNarrowingFilter: true });
+    const ids = columns.map((c) => ("id" in c ? c.id : undefined));
+    const gapIdx = ids.indexOf("gap");
+    const filteredGapIdx = ids.indexOf("filteredGap");
+    expect(filteredGapIdx).toBeGreaterThan(-1);
+    expect(filteredGapIdx).toBe(gapIdx + 1);
+  });
+
+  // Filtered Gap rides on the same `showGapColumns` gate as Gap. On
+  // mixed-song surfaces (all-timers, on-this-day) the entire gap family
+  // hides regardless of whether the filter is narrowing.
+  test("Filtered Gap column is hidden when showGapColumns is false even with hasNarrowingFilter", () => {
+    const columns = createPerformanceColumns({
+      ...defaultOptions,
+      showGapColumns: false,
+      hasNarrowingFilter: true,
+    });
+    const ids = columns.map((c) => ("id" in c ? c.id : undefined));
+    expect(ids).not.toContain("filteredGap");
+  });
+
+  // Cell rendering mirrors the all-time Gap column: ★ for debut of the
+  // filtered set (filteredGap == null), ↺ for the second occurrence within
+  // the same show, integer otherwise.
+  test("Filtered Gap cell renders Star icon for filteredGap=null debut", async () => {
+    const performances = [makePerformance({ trackId: "t-debut", filteredGap: null, position: 1 })];
+    const columns = createPerformanceColumns({ ...defaultOptions, hasNarrowingFilter: true });
+    const { container } = await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    // Two stars expected: the all-time Gap column treats this row the same
+    // way (its gap field defaulted to 5 from makePerformance, so the Gap
+    // cell renders a number, not a star). Filtered Gap renders the star.
+    expect(container.querySelectorAll(".lucide-star").length).toBe(1);
+  });
+
+  test("Filtered Gap cell renders rotate icon for within-show repeat", async () => {
+    const performances = [
+      makePerformance({
+        trackId: "t-first",
+        filteredGap: 3,
+        position: 2,
+        show: { id: "s-1", slug: "2024-06-15", date: "2024-06-15", venueId: "v", countForStats: true },
+      }),
+      makePerformance({
+        trackId: "t-repeat",
+        filteredGap: 3,
+        position: 7,
+        show: { id: "s-1", slug: "2024-06-15", date: "2024-06-15", venueId: "v", countForStats: true },
+      }),
+    ];
+    const columns = createPerformanceColumns({ ...defaultOptions, hasNarrowingFilter: true });
+    const { container } = await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    // Within-show repeats render ↺ in both Gap AND Filtered Gap columns on
+    // the second row — two `.lucide-rotate-ccw` icons total.
+    expect(container.querySelectorAll(".lucide-rotate-ccw").length).toBe(2);
+  });
+
+  test("Filtered Gap cell renders the numeric value when not a debut or repeat", async () => {
+    const performances = [makePerformance({ trackId: "t-1", filteredGap: 7, position: 1 })];
+    const columns = createPerformanceColumns({ ...defaultOptions, hasNarrowingFilter: true });
+    await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    // The Gap column renders 5 (from makePerformance default); Filtered Gap
+    // renders 7. Looking for "7" is unambiguous since the all-time Gap is 5.
+    expect(screen.getByText("7")).toBeInTheDocument();
+  });
+
   // The Song column only appears on /songs/all-timers where performances
   // span multiple songs. On /songs/$slug (single song), it's omitted.
   test("Song column present when showSongColumn is true, absent otherwise", async () => {
@@ -270,8 +346,8 @@ describe("createPerformanceColumns", () => {
     expect(container.querySelectorAll(".lucide-star").length).toBe(1);
   });
 
-  // When a song is played twice in the same show, Phase 1 stores the SAME
-  // gap on both tracks (the gap to the previous *show* the song was played).
+  // When a song is played twice in the same show, both tracks carry the
+  // SAME gap value (the gap to the previous *show* the song was played).
   // The repeat is identified at render time by checking for an earlier-
   // position track in the same show, and gets a RotateCcw icon instead of
   // a number to flag the within-show repeat.
@@ -297,8 +373,8 @@ describe("createPerformanceColumns", () => {
   });
 
   // The Last Played column shows the date of the song's prior performance
-  // (sourced from Phase 1's Track.previousPerformanceShowId join) and links
-  // to that show. When sorted by Gap (or any non-date order), this column
+  // (sourced from the Track.previousPerformanceShowId join) and links to
+  // that show. When sorted by Gap (or any non-date order), this column
   // gives users back the chronological context the Date column otherwise
   // provides at a glance.
   test("Last Played column renders linked date for non-debut rows", async () => {

--- a/apps/web/app/components/performance/performance-columns.test.tsx
+++ b/apps/web/app/components/performance/performance-columns.test.tsx
@@ -101,6 +101,25 @@ describe("createPerformanceColumns", () => {
     expect(sequenceColumn?.meta?.hideOnMobile).toBeFalsy();
   });
 
+  // Gap and Last Played are per-song signals — they only make sense when
+  // every row of the table refers to the same song. On surfaces that mix
+  // songs (`/songs/all-timers`, `/on-this-day/:monthDay`), the columns
+  // become noise and the caller passes `showGapColumns={false}` to hide
+  // both at once.
+  test("Gap and Last Played columns are present by default", () => {
+    const columns = createPerformanceColumns(defaultOptions);
+    const ids = columns.map((c) => ("id" in c ? c.id : undefined));
+    expect(ids).toContain("gap");
+    expect(ids).toContain("lastPlayed");
+  });
+
+  test("Gap and Last Played columns are absent when showGapColumns is false", () => {
+    const columns = createPerformanceColumns({ ...defaultOptions, showGapColumns: false });
+    const ids = columns.map((c) => ("id" in c ? c.id : undefined));
+    expect(ids).not.toContain("gap");
+    expect(ids).not.toContain("lastPlayed");
+  });
+
   // The Song column only appears on /songs/all-timers where performances
   // span multiple songs. On /songs/$slug (single song), it's omitted.
   test("Song column present when showSongColumn is true, absent otherwise", async () => {

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -1,6 +1,6 @@
 import { compareByShowDate, type SongPagePerformance } from "@bip/domain";
 import { type Column, type ColumnDef, createColumnHelper, type Row } from "@tanstack/react-table";
-import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon, Flame, RotateCcw, Star } from "lucide-react";
+import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon, Filter, Flame, RotateCcw, Star } from "lucide-react";
 import { GapIcon } from "~/components/gap-icon";
 import { formatSetLabel } from "~/components/setlist/set-label";
 import { ShowDate } from "~/components/show-date";
@@ -9,22 +9,57 @@ import { DateVenueCell } from "./date-venue-cell";
 import { TrackRatingCell } from "./track-rating-cell";
 
 /**
- * Sort comparator for the Gap column. Debuts (gap=null) sort first because a
- * debut is the rarest possible event; remaining rows sort by gap ascending.
- * Ties break by show date so all rows from the same show — including
- * within-show repeats, which share both gap and date — cluster together;
- * track position is the final tiebreak so within-show repeats stay in
- * setlist order relative to each other.
+ * Sort comparator for any gap-flavored column. Debuts (gap=null) sort first
+ * because a debut is the rarest possible event; remaining rows sort by gap
+ * ascending. Ties break by show date so all rows from the same show —
+ * including within-show repeats, which share both gap and date — cluster
+ * together; track position is the final tiebreak so within-show repeats
+ * stay in setlist order relative to each other.
+ *
+ * Parameterized by `key` so the same comparator drives both Gap (`gap`)
+ * and Filtered Gap (`filteredGap`).
  */
-export function gapSortingFn(a: Row<SongPagePerformance>, b: Row<SongPagePerformance>): number {
-  const aGap = a.original.gap;
-  const bGap = b.original.gap;
-  const aKey = aGap == null ? Number.NEGATIVE_INFINITY : aGap;
-  const bKey = bGap == null ? Number.NEGATIVE_INFINITY : bGap;
-  if (aKey !== bKey) return aKey - bKey;
-  const dateCmp = compareByShowDate(a.original, b.original);
-  if (dateCmp !== 0) return dateCmp;
-  return (a.original.position ?? 0) - (b.original.position ?? 0);
+function makeGapSortingFn(key: "gap" | "filteredGap") {
+  return (a: Row<SongPagePerformance>, b: Row<SongPagePerformance>): number => {
+    const aGap = a.original[key];
+    const bGap = b.original[key];
+    const aKey = aGap == null ? Number.NEGATIVE_INFINITY : aGap;
+    const bKey = bGap == null ? Number.NEGATIVE_INFINITY : bGap;
+    if (aKey !== bKey) return aKey - bKey;
+    const dateCmp = compareByShowDate(a.original, b.original);
+    if (dateCmp !== 0) return dateCmp;
+    return (a.original.position ?? 0) - (b.original.position ?? 0);
+  };
+}
+
+export const gapSortingFn = makeGapSortingFn("gap");
+export const filteredGapSortingFn = makeGapSortingFn("filteredGap");
+
+/**
+ * Shared cell renderer for Gap and Filtered Gap. Same icon semantics: ★
+ * for a debut (null), ↺ for the second occurrence within the same show,
+ * tabular number otherwise.
+ */
+function renderGapCell({ value, isRepeat }: { value: number | null | undefined; isRepeat: boolean }) {
+  if (isRepeat) {
+    return <GapIcon icon={<RotateCcw className="h-4 w-4 text-content-text-secondary" />} label="Same Show" />;
+  }
+  if (value == null) {
+    return <GapIcon icon={<Star className="h-4 w-4 text-content-text-secondary" />} label="Debut" />;
+  }
+  return <span className="text-content-text-secondary tabular-nums">{value}</span>;
+}
+
+/**
+ * Detects whether `row` is the second-or-later occurrence of its song
+ * within the same show. The gap and filtered-gap values themselves are
+ * shared across within-show repeats, so the icon — not the number —
+ * distinguishes the repeat from its first occurrence.
+ */
+function isWithinShowRepeat(row: SongPagePerformance, allRows: Array<{ original: SongPagePerformance }>): boolean {
+  return allRows.some(
+    (other) => other.original.show.id === row.show.id && (other.original.position ?? 0) < (row.position ?? 0),
+  );
 }
 
 interface PerformanceColumnOptions {
@@ -35,22 +70,34 @@ interface PerformanceColumnOptions {
    * (all-timers, on-this-day), pass `false` to hide both. Defaults true.
    */
   showGapColumns?: boolean;
+  /**
+   * When true, render the Filtered Gap column alongside the all-time Gap.
+   * The route sets this from `hasNarrowingFilter` so the column only
+   * appears when the filtered set differs from all-time.
+   */
+  hasNarrowingFilter?: boolean;
   songTitle?: string;
   userRatingMap: Map<string, number>;
   isAuthenticated: boolean;
 }
 
-function SortableHeader({ column, label }: { column: Column<SongPagePerformance, unknown>; label: string }) {
+function SortableHeader({
+  column,
+  label,
+}: {
+  column: Column<SongPagePerformance, unknown>;
+  label: string | React.ReactNode;
+}) {
   if (!column.getCanSort()) return <span>{label}</span>;
 
   return (
     <button
       type="button"
-      className="cursor-pointer select-none hover:text-content-text-primary w-full text-left"
+      className="cursor-pointer select-none hover:text-content-text-primary w-full text-left flex items-start gap-1"
       onClick={() => column.toggleSorting()}
     >
       <span className={column.getIsSorted() ? "text-content-text-primary font-semibold" : ""}>{label}</span>
-      <span className={column.getIsSorted() ? "text-brand-primary ml-1" : "ml-1"}>
+      <span className={column.getIsSorted() ? "text-brand-primary" : ""}>
         {column.getIsSorted() === "asc" ? (
           <ArrowUpIcon className="h-4 w-4 inline" />
         ) : column.getIsSorted() === "desc" ? (
@@ -64,7 +111,15 @@ function SortableHeader({ column, label }: { column: Column<SongPagePerformance,
 }
 
 export function createPerformanceColumns(options: PerformanceColumnOptions): ColumnDef<SongPagePerformance, unknown>[] {
-  const { showSongColumn, showAllTimerColumn, showGapColumns, songTitle, userRatingMap, isAuthenticated } = options;
+  const {
+    showSongColumn,
+    showAllTimerColumn,
+    showGapColumns,
+    hasNarrowingFilter,
+    songTitle,
+    userRatingMap,
+    isAuthenticated,
+  } = options;
   const includeGapColumns = showGapColumns !== false;
   const columnHelper = createColumnHelper<SongPagePerformance>();
   const columns: ColumnDef<SongPagePerformance, unknown>[] = [];
@@ -144,26 +199,43 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
         sortingFn: gapSortingFn,
         cell: (info) => {
           const row = info.row.original;
-          const allRows = info.table.getCoreRowModel().rows;
-          // Within-show repeat: another row exists in the same show with an
-          // earlier track position. Phase 1 stores the same gap on both tracks
-          // of a within-show repeat, so the icon — not the gap value — is what
-          // distinguishes the repeat from its first occurrence.
-          const isRepeat = allRows.some(
-            (other) => other.original.show.id === row.show.id && (other.original.position ?? 0) < (row.position ?? 0),
-          );
-
-          if (isRepeat) {
-            return <GapIcon icon={<RotateCcw className="h-4 w-4 text-content-text-secondary" />} label="Same Show" />;
-          }
-
-          if (row.gap == null) {
-            return <GapIcon icon={<Star className="h-4 w-4 text-content-text-secondary" />} label="Debut" />;
-          }
-
-          return <span className="text-content-text-secondary tabular-nums">{row.gap}</span>;
+          return renderGapCell({
+            value: row.gap,
+            isRepeat: isWithinShowRepeat(row, info.table.getCoreRowModel().rows),
+          });
         },
       }) as ColumnDef<SongPagePerformance, unknown>,
+    );
+    if (hasNarrowingFilter) {
+      columns.push(
+        columnHelper.accessor((row) => row.filteredGap ?? Number.NEGATIVE_INFINITY, {
+          id: "filteredGap",
+          meta: { width: "72px" },
+          header: ({ column }) => (
+            <SortableHeader
+              column={column}
+              label={
+                <span className="inline-flex items-center gap-1">
+                  <Filter className="h-3 w-3" aria-hidden="true" />
+                  <span className="sr-only">Filtered</span>
+                  Gap
+                </span>
+              }
+            />
+          ),
+          enableSorting: true,
+          sortingFn: filteredGapSortingFn,
+          cell: (info) => {
+            const row = info.row.original;
+            return renderGapCell({
+              value: row.filteredGap,
+              isRepeat: isWithinShowRepeat(row, info.table.getCoreRowModel().rows),
+            });
+          },
+        }) as ColumnDef<SongPagePerformance, unknown>,
+      );
+    }
+    columns.push(
       columnHelper.accessor((row) => row.previousShow?.date ?? "", {
         id: "lastPlayed",
         meta: { width: "110px", hideOnMobile: true },

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -30,6 +30,11 @@ export function gapSortingFn(a: Row<SongPagePerformance>, b: Row<SongPagePerform
 interface PerformanceColumnOptions {
   showSongColumn?: boolean;
   showAllTimerColumn?: boolean;
+  /**
+   * Gap + Last Played are per-song signals. On surfaces that mix songs
+   * (all-timers, on-this-day), pass `false` to hide both. Defaults true.
+   */
+  showGapColumns?: boolean;
   songTitle?: string;
   userRatingMap: Map<string, number>;
   isAuthenticated: boolean;
@@ -59,7 +64,8 @@ function SortableHeader({ column, label }: { column: Column<SongPagePerformance,
 }
 
 export function createPerformanceColumns(options: PerformanceColumnOptions): ColumnDef<SongPagePerformance, unknown>[] {
-  const { showSongColumn, showAllTimerColumn, songTitle, userRatingMap, isAuthenticated } = options;
+  const { showSongColumn, showAllTimerColumn, showGapColumns, songTitle, userRatingMap, isAuthenticated } = options;
+  const includeGapColumns = showGapColumns !== false;
   const columnHelper = createColumnHelper<SongPagePerformance>();
   const columns: ColumnDef<SongPagePerformance, unknown>[] = [];
 
@@ -126,52 +132,60 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
         );
       },
     }) as ColumnDef<SongPagePerformance, unknown>,
-    columnHelper.accessor((row) => row.gap ?? Number.NEGATIVE_INFINITY, {
-      id: "gap",
-      meta: { width: "64px" },
-      header: ({ column }) => <SortableHeader column={column} label="Gap" />,
-      enableSorting: true,
-      sortingFn: gapSortingFn,
-      cell: (info) => {
-        const row = info.row.original;
-        const allRows = info.table.getCoreRowModel().rows;
-        // Within-show repeat: another row exists in the same show with an
-        // earlier track position. Phase 1 stores the same gap on both tracks
-        // of a within-show repeat, so the icon — not the gap value — is what
-        // distinguishes the repeat from its first occurrence.
-        const isRepeat = allRows.some(
-          (other) => other.original.show.id === row.show.id && (other.original.position ?? 0) < (row.position ?? 0),
-        );
+  );
 
-        if (isRepeat) {
-          return <GapIcon icon={<RotateCcw className="h-4 w-4 text-content-text-secondary" />} label="Same Show" />;
-        }
+  if (includeGapColumns) {
+    columns.push(
+      columnHelper.accessor((row) => row.gap ?? Number.NEGATIVE_INFINITY, {
+        id: "gap",
+        meta: { width: "64px" },
+        header: ({ column }) => <SortableHeader column={column} label="Gap" />,
+        enableSorting: true,
+        sortingFn: gapSortingFn,
+        cell: (info) => {
+          const row = info.row.original;
+          const allRows = info.table.getCoreRowModel().rows;
+          // Within-show repeat: another row exists in the same show with an
+          // earlier track position. Phase 1 stores the same gap on both tracks
+          // of a within-show repeat, so the icon — not the gap value — is what
+          // distinguishes the repeat from its first occurrence.
+          const isRepeat = allRows.some(
+            (other) => other.original.show.id === row.show.id && (other.original.position ?? 0) < (row.position ?? 0),
+          );
 
-        if (row.gap == null) {
-          return <GapIcon icon={<Star className="h-4 w-4 text-content-text-secondary" />} label="Debut" />;
-        }
+          if (isRepeat) {
+            return <GapIcon icon={<RotateCcw className="h-4 w-4 text-content-text-secondary" />} label="Same Show" />;
+          }
 
-        return <span className="text-content-text-secondary tabular-nums">{row.gap}</span>;
-      },
-    }) as ColumnDef<SongPagePerformance, unknown>,
-    columnHelper.accessor((row) => row.previousShow?.date ?? "", {
-      id: "lastPlayed",
-      meta: { width: "110px", hideOnMobile: true },
-      header: ({ column }) => <SortableHeader column={column} label="Last Played" />,
-      enableSorting: true,
-      sortingFn: "alphanumeric",
-      cell: (info) => {
-        const previousShow = info.row.original.previousShow;
-        if (!previousShow) {
-          return <span className="text-content-text-tertiary">—</span>;
-        }
-        return (
-          <a href={`/shows/${previousShow.slug}`} className="text-base text-brand-primary hover:text-brand-secondary">
-            <ShowDate date={previousShow.date} />
-          </a>
-        );
-      },
-    }) as ColumnDef<SongPagePerformance, unknown>,
+          if (row.gap == null) {
+            return <GapIcon icon={<Star className="h-4 w-4 text-content-text-secondary" />} label="Debut" />;
+          }
+
+          return <span className="text-content-text-secondary tabular-nums">{row.gap}</span>;
+        },
+      }) as ColumnDef<SongPagePerformance, unknown>,
+      columnHelper.accessor((row) => row.previousShow?.date ?? "", {
+        id: "lastPlayed",
+        meta: { width: "110px", hideOnMobile: true },
+        header: ({ column }) => <SortableHeader column={column} label="Last Played" />,
+        enableSorting: true,
+        sortingFn: "alphanumeric",
+        cell: (info) => {
+          const previousShow = info.row.original.previousShow;
+          if (!previousShow) {
+            return <span className="text-content-text-tertiary">—</span>;
+          }
+          return (
+            <a href={`/shows/${previousShow.slug}`} className="text-base text-brand-primary hover:text-brand-secondary">
+              <ShowDate date={previousShow.date} />
+            </a>
+          );
+        },
+      }) as ColumnDef<SongPagePerformance, unknown>,
+    );
+  }
+
+  columns.push(
     columnHelper.accessor("set", {
       header: "Set",
       meta: { width: "48px" },

--- a/apps/web/app/components/performance/performance-filter-controls.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Filter } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import { AuthorSearch } from "~/components/author/author-search";
 import { SelectFilter } from "~/components/ui/filters";
@@ -80,6 +80,7 @@ export function PerformanceFilterControls({
         aria-expanded={mobileOpen}
       >
         <span className="flex items-center gap-2">
+          <Filter className="h-4 w-4" aria-hidden="true" />
           Filters
           {activeFilterCount > 0 && (
             <span className="px-2 py-0.5 rounded-full bg-brand-primary/20 text-brand-primary text-xs">

--- a/apps/web/app/components/performance/performance-table.tsx
+++ b/apps/web/app/components/performance/performance-table.tsx
@@ -15,6 +15,12 @@ interface PerformanceTableProps {
   showSongColumn?: boolean;
   showAllTimerColumn?: boolean;
   showGapColumns?: boolean;
+  /**
+   * When true, render the Filtered Gap column. Route is responsible for
+   * deriving this from its server-narrowing filter state (timeRange,
+   * attended, toggles) — `searchText` does not count.
+   */
+  hasNarrowingFilter?: boolean;
   headerContent?: ReactNode;
   isLoading?: boolean;
   pageSize?: number;
@@ -31,6 +37,7 @@ export function PerformanceTable({
   showSongColumn,
   showAllTimerColumn,
   showGapColumns,
+  hasNarrowingFilter,
   headerContent,
   isLoading,
   pageSize,
@@ -63,11 +70,12 @@ export function PerformanceTable({
         showSongColumn,
         showAllTimerColumn,
         showGapColumns,
+        hasNarrowingFilter,
         songTitle,
         userRatingMap,
         isAuthenticated,
       }),
-    [showSongColumn, showAllTimerColumn, showGapColumns, songTitle, userRatingMap, isAuthenticated],
+    [showSongColumn, showAllTimerColumn, showGapColumns, hasNarrowingFilter, songTitle, userRatingMap, isAuthenticated],
   );
 
   return (

--- a/apps/web/app/components/performance/performance-table.tsx
+++ b/apps/web/app/components/performance/performance-table.tsx
@@ -14,6 +14,7 @@ interface PerformanceTableProps {
   songTitle?: string;
   showSongColumn?: boolean;
   showAllTimerColumn?: boolean;
+  showGapColumns?: boolean;
   headerContent?: ReactNode;
   isLoading?: boolean;
   pageSize?: number;
@@ -29,6 +30,7 @@ export function PerformanceTable({
   songTitle,
   showSongColumn,
   showAllTimerColumn,
+  showGapColumns,
   headerContent,
   isLoading,
   pageSize,
@@ -56,8 +58,16 @@ export function PerformanceTable({
   const { userRatingMap } = useTrackUserRatings(trackIds);
 
   const columns = useMemo(
-    () => createPerformanceColumns({ showSongColumn, showAllTimerColumn, songTitle, userRatingMap, isAuthenticated }),
-    [showSongColumn, showAllTimerColumn, songTitle, userRatingMap, isAuthenticated],
+    () =>
+      createPerformanceColumns({
+        showSongColumn,
+        showAllTimerColumn,
+        showGapColumns,
+        songTitle,
+        userRatingMap,
+        isAuthenticated,
+      }),
+    [showSongColumn, showAllTimerColumn, showGapColumns, songTitle, userRatingMap, isAuthenticated],
   );
 
   return (

--- a/apps/web/app/components/setlist/setlist-columns.test.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.test.tsx
@@ -283,9 +283,9 @@ describe("createSetlistColumns", () => {
   });
 
   // Within-show repeat: same songId appears at an earlier position in the
-  // table. Phase 1 stores the same gap on both tracks of a within-show
-  // repeat, so the icon — not the value — is what distinguishes the repeat
-  // from its first occurrence.
+  // table. Both occurrences share the same gap value, so the icon — not
+  // the number — is what distinguishes the repeat from its first
+  // occurrence.
   test("renders ↺ This Show for a within-show repeat", async () => {
     await renderTable([
       makeTrack({

--- a/apps/web/app/components/setlist/setlist-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.tsx
@@ -6,10 +6,9 @@ import { ShowDate } from "~/components/show-date";
 import { countDistinctEncores, formatSetLabel } from "./set-label";
 
 /**
- * Row shape consumed by the gap-chart table. A SetlistTableRow is a TrackLight
- * (with the Phase 5 gap+previousPerformanceShow fields) and is intentionally
- * narrowed from the full Setlist tree so the column factory doesn't depend on
- * Set/Show/Venue context.
+ * Row shape consumed by the gap-chart table. Narrowed from the full Setlist
+ * tree so the column factory doesn't depend on Set/Show/Venue context —
+ * just a TrackLight with the denormalized gap + previous-performance fields.
  */
 export type SetlistTableRow = TrackLight;
 
@@ -152,8 +151,8 @@ export function createSetlistColumns(): ColumnDef<SetlistTableRow, unknown>[] {
       enableSorting: true,
       // Numeric ascending; debuts (gap=null) become +∞ so they cluster at
       // the end on asc and at the start on desc. Within-show repeats share
-      // their first occurrence's gap by Phase 1 design — sort treats them
-      // as equal and the icon (not the value) tells the story per row.
+      // their first occurrence's gap value — sort treats them as equal and
+      // the icon (not the value) tells the story per row.
       sortingFn: "basic",
       // First click sorts ascending. TanStack auto-flips to desc-first for
       // numeric accessors; force asc so "smallest gap first" matches the

--- a/apps/web/app/components/show-date.tsx
+++ b/apps/web/app/components/show-date.tsx
@@ -2,6 +2,12 @@ import { formatDateShort, formatDateShortMobile } from "~/lib/utils";
 
 interface ShowDateProps {
   date: string | Date;
+  /**
+   * Render the compact `M/D/YY` form at all viewport sizes instead of
+   * only on mobile. For dense surfaces where the four-digit year would
+   * wrap the cell.
+   */
+  compact?: boolean;
 }
 
 /**
@@ -11,7 +17,8 @@ interface ShowDateProps {
  * date formatting consistent everywhere a show date is displayed — change
  * the format once and every callsite follows.
  */
-export function ShowDate({ date }: ShowDateProps) {
+export function ShowDate({ date, compact }: ShowDateProps) {
+  if (compact) return <span>{formatDateShortMobile(date)}</span>;
   return (
     <>
       <span className="hidden sm:inline">{formatDateShort(date)}</span>

--- a/apps/web/app/components/song/songs-columns.test.tsx
+++ b/apps/web/app/components/song/songs-columns.test.tsx
@@ -141,7 +141,84 @@ describe("getSongsColumns", () => {
       />,
     );
 
-    expect(screen.queryByRole("button", { name: /Filtered Plays/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Filtered\s*Plays/i })).not.toBeInTheDocument();
+  });
+
+  // The three filtered rarity columns ride on the same `showFilteredPlays`
+  // gate as Filtered Plays. They mirror Current Gap / Since Debut / Avg Gap,
+  // computed against the active filter scope. Hidden by default so they
+  // don't duplicate the all-time columns when no filter narrows the data.
+  test("showFilteredPlays=false: filtered rarity columns are not rendered", async () => {
+    await setupWithRouter(
+      <DataTable
+        columns={baseColumns}
+        data={[
+          makeSong({
+            filteredTimesPlayed: 3,
+            filteredShowsSinceLastPlayed: 9,
+            filteredPercentSinceDebut: 0.42,
+            filteredAverageShowsPerPlay: 2.4,
+          }),
+        ]}
+        hideSearch
+        hidePagination
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /Filtered Current Gap/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Filtered Since Debut/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Filtered Avg Gap/i })).not.toBeInTheDocument();
+  });
+
+  // When showFilteredPlays is true, each filtered column renders next to
+  // its all-time counterpart so the two read as a paired comparison.
+  test("showFilteredPlays=true: filtered rarity columns render their scoped values", async () => {
+    await setupWithRouter(
+      <DataTable
+        columns={filteredColumns}
+        data={[
+          makeSong({
+            filteredTimesPlayed: 3,
+            filteredShowsSinceLastPlayed: 9,
+            filteredPercentSinceDebut: 0.42,
+            filteredAverageShowsPerPlay: 2.4,
+          }),
+        ]}
+        hideSearch
+        hidePagination
+      />,
+    );
+
+    // Filtered Current Gap renders the raw integer.
+    expect(screen.getByText("9")).toBeInTheDocument();
+    // Filtered Since Debut renders as a percent (matches existing % formatter).
+    expect(screen.getByText("42%")).toBeInTheDocument();
+    // Filtered Avg Gap renders with one decimal place.
+    expect(screen.getByText("2.4")).toBeInTheDocument();
+  });
+
+  // When showFilteredPlays is true, Last Played and First Played drop the
+  // venue sublabel and shrink — the row is wider with the extra filtered
+  // columns, so we trade venue-on-row for horizontal room.
+  test("showFilteredPlays=true: Last Played and First Played cells omit the venue sublabel", async () => {
+    await setupWithRouter(
+      <DataTable
+        columns={filteredColumns}
+        data={[
+          makeSong({
+            lastPlayedShow: makeShow(),
+            firstPlayedShow: makeShow({ slug: "1995-07-04-some-venue" }),
+          }),
+        ]}
+        hideSearch
+        hidePagination
+      />,
+    );
+
+    // Venue text would appear under the date in the no-filter baseline
+    // (see "Last Played venue" test below). Under filtered columns it
+    // must NOT render — neither for Last Played nor for First Played.
+    expect(screen.queryByText(/The Capitol Theatre/)).not.toBeInTheDocument();
   });
 
   // When showFilteredPlays is true, the factory inserts a "Filtered Plays"
@@ -156,7 +233,7 @@ describe("getSongsColumns", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: /Filtered Plays/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Filtered\s*Plays/i })).toBeInTheDocument();
     // Both the all-time count (42) and the scoped count (7) are present.
     expect(screen.getByText("42")).toBeInTheDocument();
     expect(screen.getByText("7")).toBeInTheDocument();
@@ -352,7 +429,7 @@ describe("getSongsColumns", () => {
       <DataTable columns={filteredColumns} data={songs} hideSearch hidePagination />,
     );
 
-    const sortHeader = screen.getByRole("button", { name: /Filtered Plays/i });
+    const sortHeader = screen.getByRole("button", { name: /Filtered\s*Plays/i });
     await user.click(sortHeader); // asc
 
     // asc: [filtered=2, timesPlayed=30 (Plan B)], [filtered=2, timesPlayed=80 (Crickets)], [filtered=5 (Home Again)]
@@ -399,7 +476,7 @@ describe("getSongsColumns", () => {
     );
 
     // First click: asc. Second click: desc.
-    const sortHeader = screen.getByRole("button", { name: /Filtered Plays/i });
+    const sortHeader = screen.getByRole("button", { name: /Filtered\s*Plays/i });
     await user.click(sortHeader);
 
     const titlesAsc = screen

--- a/apps/web/app/components/song/songs-columns.tsx
+++ b/apps/web/app/components/song/songs-columns.tsx
@@ -1,19 +1,44 @@
 import type { Show, Song } from "@bip/domain";
 import type { ColumnDef, SortingFn } from "@tanstack/react-table";
-import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, Filter } from "lucide-react";
 import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { ShowDate } from "~/components/show-date";
 import { Button } from "~/components/ui/button";
 
+/**
+ * Inline funnel icon used to mark "this column / control is the filtered
+ * variant". Drop-in replacement for the word "Filtered" so the header
+ * compresses to one short token + the secondary word.
+ */
+function FilterMark() {
+  return (
+    <>
+      <Filter className="h-3 w-3 inline-block shrink-0" aria-hidden="true" />
+      <span className="sr-only">Filtered </span>
+    </>
+  );
+}
+
 interface SongWithShows extends Song {
   firstPlayedShow?: Show | null;
   lastPlayedShow?: Show | null;
+  firstFilteredPlayedShow?: Show | null;
+  lastFilteredPlayedShow?: Show | null;
 }
 
 const percentFormatter = new Intl.NumberFormat("en-US", {
   style: "percent",
   maximumFractionDigits: 1,
+});
+
+// Filtered percent columns are already narrower (4 columns share the row
+// with the all-time pair) so the extra decimal makes them feel cramped.
+// Whole-percent reads cleanly enough — drop the decimal in the filtered
+// variant only.
+const wholePercentFormatter = new Intl.NumberFormat("en-US", {
+  style: "percent",
+  maximumFractionDigits: 0,
 });
 
 function nullsLastNumericSort<K extends keyof SongWithShows>(key: K): SortingFn<SongWithShows> {
@@ -41,6 +66,38 @@ function getSortIcon(sortState: false | "asc" | "desc"): ReactNode {
 const HEADER_BUTTON_CLASS =
   "h-auto p-0 font-semibold text-left justify-start hover:bg-brand-primary/10 hover:text-brand-primary transition-colors whitespace-normal leading-tight flex-col items-start gap-0 sm:flex-row sm:items-start sm:gap-1";
 
+/**
+ * Wraps a header's text content. Reserves a leading row that holds either
+ * the funnel icon (filtered columns) or an invisible spacer of the same
+ * height (non-filtered columns when any filtered column is visible). That
+ * way every label's text starts on the same line — the icon-vs-no-icon
+ * distinction lives one line above the words and doesn't push them down.
+ *
+ * `reserveIconRow` is false when no filtered columns are visible at all;
+ * the spacer would just waste vertical space.
+ */
+function HeaderLabel({
+  filtered,
+  reserveIconRow,
+  children,
+}: {
+  filtered?: boolean;
+  reserveIconRow: boolean;
+  children: ReactNode;
+}) {
+  const iconRow = filtered ? (
+    <FilterMark />
+  ) : reserveIconRow ? (
+    <span className="block h-3" aria-hidden="true" />
+  ) : null;
+  return (
+    <span className="flex flex-col leading-tight items-start">
+      {iconRow}
+      {children}
+    </span>
+  );
+}
+
 interface SortableColumnOptions {
   accessorKey: keyof SongWithShows;
   label: ReactNode;
@@ -50,6 +107,12 @@ interface SortableColumnOptions {
   hideOnMobile?: boolean;
   cell: (row: SongWithShows) => ReactNode;
   sortingFn?: SortingFn<SongWithShows>;
+  /**
+   * True when the header reserves a top icon row (filter-icon or matching
+   * spacer). The sort indicator gets pushed down by that row's height so it
+   * sits on the same line as the text, not the icon.
+   */
+  reservesIconRow?: boolean;
 }
 
 /**
@@ -58,6 +121,10 @@ interface SortableColumnOptions {
  * Centralizes the shared header chrome so adding a column is a few lines.
  */
 function makeSortableColumn(opts: SortableColumnOptions): ColumnDef<SongWithShows> {
+  // Push the sort indicator down to text-row height when the label
+  // reserves an icon row on top; otherwise it would sit on the icon line
+  // and look detached from the words below.
+  const sortIconWrapperClass = opts.reservesIconRow ? "sm:mt-3" : "";
   const def: ColumnDef<SongWithShows> = {
     accessorKey: opts.accessorKey,
     meta: { width: opts.width, hideOnMobile: opts.hideOnMobile },
@@ -69,7 +136,7 @@ function makeSortableColumn(opts: SortableColumnOptions): ColumnDef<SongWithShow
         className={HEADER_BUTTON_CLASS}
       >
         {opts.label}
-        {getSortIcon(column.getIsSorted())}
+        <span className={sortIconWrapperClass}>{getSortIcon(column.getIsSorted())}</span>
       </Button>
     ),
     cell: ({ row }) => opts.cell(row.original),
@@ -83,14 +150,25 @@ function makeSortableColumn(opts: SortableColumnOptions): ColumnDef<SongWithShow
  * the date. Used by both Last Played and First Played columns — the only
  * difference between them is which date/show pair feeds in.
  */
-function DateVenueCell({ date, show }: { date: Date | null; show?: Show | null }): ReactNode {
+function DateVenueCell({
+  date,
+  show,
+  hideVenue,
+  compact,
+}: {
+  date: Date | null;
+  show?: Show | null;
+  hideVenue?: boolean;
+  compact?: boolean;
+}): ReactNode {
   if (!date) return <span className="text-content-text-tertiary text-sm">—</span>;
-  const dateBlock = <ShowDate date={date} />;
-  const venueLine = show?.venue ? (
-    <div className="text-content-text-tertiary text-sm hidden sm:block">
-      {show.venue.name}, {show.venue.city} {show.venue.state}
-    </div>
-  ) : null;
+  const dateBlock = <ShowDate date={date} compact={compact} />;
+  const venueLine =
+    show?.venue && !hideVenue ? (
+      <div className="text-content-text-tertiary text-sm hidden sm:block">
+        {show.venue.name}, {show.venue.city} {show.venue.state}
+      </div>
+    ) : null;
   if (show?.slug) {
     return (
       <Link to={`/shows/${show.slug}`} className="text-brand-primary hover:text-brand-secondary transition-colors">
@@ -123,10 +201,10 @@ interface GetSongsColumnsOptions {
  * counts.
  */
 export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): ColumnDef<SongWithShows>[] {
-  const titleColumn = makeSortableColumn({
+  const titleColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
     accessorKey: "title",
-    label: "Song",
-    width: showFilteredPlays ? "22%" : "26%",
+    label: <HeaderLabel reserveIconRow={showFilteredPlays}>Song</HeaderLabel>,
+    width: showFilteredPlays ? "14%" : "26%",
     cell: (song) => (
       <Link
         to={`/songs/${song.slug}`}
@@ -137,10 +215,10 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     ),
   });
 
-  const playsColumn = makeSortableColumn({
+  const playsColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
     accessorKey: "timesPlayed",
-    label: "Plays",
-    width: "8%",
+    label: <HeaderLabel reserveIconRow={showFilteredPlays}>Plays</HeaderLabel>,
+    width: showFilteredPlays ? "5%" : "8%",
     // When Filtered Plays is also visible there isn't room for both count
     // columns on mobile; the all-time count drops out at narrow widths.
     hideOnMobile: showFilteredPlays,
@@ -152,10 +230,15 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
       ),
   });
 
-  const filteredPlaysColumn = makeSortableColumn({
+  const filteredPlaysColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
     accessorKey: "filteredTimesPlayed",
-    label: "Filtered Plays",
-    width: "10%",
+    label: (
+      <HeaderLabel filtered reserveIconRow>
+        <span>Plays</span>
+      </HeaderLabel>
+    ),
+    title: "Filtered Plays",
+    width: "5%",
     cell: (song) => {
       const plays = song.filteredTimesPlayed ?? 0;
       return plays > 0 ? (
@@ -175,29 +258,58 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     },
   });
 
-  const percentSinceDebutColumn = makeSortableColumn({
+  // With filtered columns active the row is busy; both percent columns drop
+  // their decimal so the all-time and filtered values read as a clean pair
+  // at the same precision.
+  const sinceDebutFormatter = showFilteredPlays ? wholePercentFormatter : percentFormatter;
+
+  const percentSinceDebutColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
     accessorKey: "percentSinceDebut",
     label: (
-      <span className="flex flex-col leading-tight">
+      <HeaderLabel reserveIconRow={showFilteredPlays}>
         <span>Since</span>
         <span>Debut</span>
-      </span>
+      </HeaderLabel>
     ),
     title: "% Since Debut",
-    width: showFilteredPlays ? "8%" : "6%",
+    width: showFilteredPlays ? "7%" : "6%",
     hideOnMobile: true,
     cell: (song) =>
-      dashOrSpan(song.percentSinceDebut !== null ? percentFormatter.format(song.percentSinceDebut) : null),
+      dashOrSpan(
+        song.percentSinceDebut !== null ? (
+          <span className="whitespace-nowrap">{sinceDebutFormatter.format(song.percentSinceDebut)}</span>
+        ) : null,
+      ),
     sortingFn: nullsLastNumericSort("percentSinceDebut"),
   });
 
-  const avgGapColumn = makeSortableColumn({
+  const filteredPercentSinceDebutColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
+    accessorKey: "filteredPercentSinceDebut",
+    label: (
+      <HeaderLabel filtered reserveIconRow>
+        <span>Since</span>
+        <span>First</span>
+      </HeaderLabel>
+    ),
+    title: "Filtered Since First",
+    width: "7%",
+    hideOnMobile: true,
+    cell: (song) =>
+      dashOrSpan(
+        song.filteredPercentSinceDebut != null ? (
+          <span className="whitespace-nowrap">{sinceDebutFormatter.format(song.filteredPercentSinceDebut)}</span>
+        ) : null,
+      ),
+    sortingFn: nullsLastNumericSort("filteredPercentSinceDebut"),
+  });
+
+  const avgGapColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
     accessorKey: "averageShowsPerPlay",
     label: (
-      <span className="flex flex-col leading-tight">
+      <HeaderLabel reserveIconRow={showFilteredPlays}>
         <span>Avg</span>
         <span>Gap</span>
-      </span>
+      </HeaderLabel>
     ),
     width: "7%",
     hideOnMobile: true,
@@ -205,9 +317,25 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     sortingFn: nullsLastNumericSort("averageShowsPerPlay"),
   });
 
-  const currentGapColumn = makeSortableColumn({
+  const filteredAvgGapColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
+    accessorKey: "filteredAverageShowsPerPlay",
+    label: (
+      <HeaderLabel filtered reserveIconRow>
+        <span>Avg</span>
+        <span>Gap</span>
+      </HeaderLabel>
+    ),
+    title: "Filtered Avg Gap",
+    width: "7%",
+    hideOnMobile: true,
+    cell: (song) =>
+      dashOrSpan(song.filteredAverageShowsPerPlay != null ? song.filteredAverageShowsPerPlay.toFixed(1) : null),
+    sortingFn: nullsLastNumericSort("filteredAverageShowsPerPlay"),
+  });
+
+  const currentGapColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
     accessorKey: "showsSinceLastPlayed",
-    label: "Gap",
+    label: <HeaderLabel reserveIconRow={showFilteredPlays}>Gap</HeaderLabel>,
     title: "Current Gap",
     width: "7%",
     hideOnMobile: true,
@@ -215,22 +343,101 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     sortingFn: nullsLastNumericSort("showsSinceLastPlayed"),
   });
 
-  const lastPlayedColumn = makeSortableColumn({
-    accessorKey: "dateLastPlayed",
-    label: "Last Played",
-    width: "22%",
-    cell: (song) => <DateVenueCell date={song.dateLastPlayed} show={song.lastPlayedShow} />,
+  const filteredCurrentGapColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
+    accessorKey: "filteredShowsSinceLastPlayed",
+    label: (
+      <HeaderLabel filtered reserveIconRow>
+        <span>Gap</span>
+      </HeaderLabel>
+    ),
+    title: "Filtered Current Gap",
+    width: "7%",
+    hideOnMobile: true,
+    cell: (song) => dashOrSpan(song.filteredShowsSinceLastPlayed ?? null),
+    sortingFn: nullsLastNumericSort("filteredShowsSinceLastPlayed"),
   });
 
-  const firstPlayedColumn = makeSortableColumn({
+  // When filtered columns are active the row is wider; drop the venue
+  // sublabel and shrink the date columns to make room.
+  const dateColumnWidth = showFilteredPlays ? "8%" : "22%";
+
+  const lastPlayedColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
+    accessorKey: "dateLastPlayed",
+    label: <HeaderLabel reserveIconRow={showFilteredPlays}>Last Played</HeaderLabel>,
+    width: dateColumnWidth,
+    cell: (song) => (
+      <DateVenueCell
+        date={song.dateLastPlayed}
+        show={song.lastPlayedShow}
+        hideVenue={showFilteredPlays}
+        compact={showFilteredPlays}
+      />
+    ),
+  });
+
+  const filteredLastPlayedColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
+    accessorKey: "dateLastFilteredPlayed",
+    label: (
+      <HeaderLabel filtered reserveIconRow>
+        Last
+      </HeaderLabel>
+    ),
+    title: "Filtered Last Played",
+    width: dateColumnWidth,
+    cell: (song) => (
+      <DateVenueCell
+        date={song.dateLastFilteredPlayed ?? null}
+        show={song.lastFilteredPlayedShow}
+        hideVenue
+        compact
+      />
+    ),
+  });
+
+  const firstPlayedColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
     accessorKey: "dateFirstPlayed",
-    label: "First Played",
-    width: "22%",
-    cell: (song) => <DateVenueCell date={song.dateFirstPlayed} show={song.firstPlayedShow} />,
+    label: <HeaderLabel reserveIconRow={showFilteredPlays}>First Played</HeaderLabel>,
+    width: dateColumnWidth,
+    cell: (song) => (
+      <DateVenueCell
+        date={song.dateFirstPlayed}
+        show={song.firstPlayedShow}
+        hideVenue={showFilteredPlays}
+        compact={showFilteredPlays}
+      />
+    ),
+  });
+
+  const filteredFirstPlayedColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
+    accessorKey: "dateFirstFilteredPlayed",
+    label: (
+      <HeaderLabel filtered reserveIconRow>
+        First
+      </HeaderLabel>
+    ),
+    title: "Filtered First Played",
+    width: dateColumnWidth,
+    cell: (song) => (
+      <DateVenueCell
+        date={song.dateFirstFilteredPlayed ?? null}
+        show={song.firstFilteredPlayedShow}
+        hideVenue
+        compact
+      />
+    ),
   });
 
   const columns: ColumnDef<SongWithShows>[] = [titleColumn, playsColumn];
   if (showFilteredPlays) columns.push(filteredPlaysColumn);
-  columns.push(percentSinceDebutColumn, avgGapColumn, currentGapColumn, lastPlayedColumn, firstPlayedColumn);
+  columns.push(percentSinceDebutColumn);
+  if (showFilteredPlays) columns.push(filteredPercentSinceDebutColumn);
+  columns.push(avgGapColumn);
+  if (showFilteredPlays) columns.push(filteredAvgGapColumn);
+  columns.push(currentGapColumn);
+  if (showFilteredPlays) columns.push(filteredCurrentGapColumn);
+  columns.push(lastPlayedColumn);
+  if (showFilteredPlays) columns.push(filteredLastPlayedColumn);
+  columns.push(firstPlayedColumn);
+  if (showFilteredPlays) columns.push(filteredFirstPlayedColumn);
   return columns;
 }

--- a/apps/web/app/lib/song-utilities.test.ts
+++ b/apps/web/app/lib/song-utilities.test.ts
@@ -38,6 +38,7 @@ const mockFindManyInDateRange = vi.fn();
 const mockShowsFindMany = vi.fn();
 const mockFindManyByDates = vi.fn().mockResolvedValue([]);
 const mockBuildSongPerformanceCounts = vi.fn();
+const mockBuildFilteredSongRarity = vi.fn().mockResolvedValue(new Map());
 const mockCacheGetOrSet = vi.fn().mockImplementation((_key: string, fn: () => Promise<unknown>) => fn());
 const mockFindByEmail = vi.fn();
 const mockFindByUsername = vi.fn();
@@ -52,6 +53,7 @@ vi.mock("~/server/services", () => ({
     },
     songPageComposer: {
       buildSongPerformanceCounts: (...args: unknown[]) => mockBuildSongPerformanceCounts(...args),
+      buildFilteredSongRarity: (...args: unknown[]) => mockBuildFilteredSongRarity(...args),
     },
     cache: {
       getOrSet: (...args: unknown[]) => mockCacheGetOrSet(...args),
@@ -205,9 +207,9 @@ describe("fetchFilteredSongs", () => {
   // song through computeRarityStats so the columns render real values
   // rather than em-dashes.
   test("rarity: populates showsSinceLastPlayed / percentSinceDebut / averageShowsPerPlay on returned rows", async () => {
-    const tractorbeam = {
-      id: "tb",
-      title: "Tractorbeam",
+    const helicopters = {
+      id: "hel",
+      title: "Helicopters",
       timesPlayed: 200,
       dateFirstPlayed: new Date(Date.UTC(1995, 5, 1)),
       dateLastPlayed: new Date(Date.UTC(2024, 0, 1)),
@@ -219,30 +221,30 @@ describe("fetchFilteredSongs", () => {
       dateFirstPlayed: new Date(Date.UTC(2010, 0, 1)),
       dateLastPlayed: new Date(Date.UTC(2023, 0, 1)),
     } as unknown as Song;
-    mockFindMany.mockResolvedValueOnce([tractorbeam, aboveTheWaves]);
+    mockFindMany.mockResolvedValueOnce([helicopters, aboveTheWaves]);
 
-    // 1995 + 2010 era totals chosen so the math comes out clean: tractorbeam
-    // debuted in 1995 and gets all 1000 shows since debut (200/1000 = 20%,
-    // every 5.0 shows). aboveTheWaves debuted in 2010 with 600 shows since
-    // (50/600 ≈ 8.33%, every 12.0 shows).
+    // 1995 + 2010 era totals: Helicopters debuted in 1995 and gets all 1000
+    // shows since debut → 200/1000 = 20%, mean-gap = (1000-200)/(200-1) ≈
+    // 4.02 shows. Above The Waves debuted in 2010 with 600 shows since →
+    // 50/600 ≈ 8.33%, mean-gap = (600-50)/(50-1) ≈ 11.22 shows.
     mockGetShowsByYear.mockResolvedValueOnce({ 1995: 400, 2010: 600 });
     mockGetShowsSinceLastPlayedBySongIds.mockResolvedValueOnce(
       new Map([
-        ["tb", 12],
+        ["hel", 12],
         ["atw", 47],
       ]),
     );
 
     const result = await fetchFilteredSongs(new URL("http://test/songs"), ctx);
 
-    const tb = result.find((s) => s.id === "tb");
+    const hel = result.find((s) => s.id === "hel");
     const atw = result.find((s) => s.id === "atw");
-    expect(tb?.showsSinceLastPlayed).toBe(12);
-    expect(tb?.percentSinceDebut).toBeCloseTo(0.2, 5);
-    expect(tb?.averageShowsPerPlay).toBeCloseTo(5, 5);
+    expect(hel?.showsSinceLastPlayed).toBe(12);
+    expect(hel?.percentSinceDebut).toBeCloseTo(0.2, 5);
+    expect(hel?.averageShowsPerPlay).toBeCloseTo(800 / 199, 5);
     expect(atw?.showsSinceLastPlayed).toBe(47);
     expect(atw?.percentSinceDebut).toBeCloseTo(50 / 600, 5);
-    expect(atw?.averageShowsPerPlay).toBeCloseTo(12, 5);
+    expect(atw?.averageShowsPerPlay).toBeCloseTo(550 / 49, 5);
   });
 
   // Songs with no debut date keep null rarity fields (computeRarityStats

--- a/apps/web/app/lib/song-utilities.ts
+++ b/apps/web/app/lib/song-utilities.ts
@@ -97,8 +97,14 @@ export async function fetchFilteredSongs(url: URL, context: PublicContext): Prom
           .map((song) => ({ ...song, filteredTimesPlayed: scopeCountsById.get(song.id) }));
       }
 
-      const withVenues = await addVenueInfoToSongs(result);
-      return await populateRarityFields(withVenues);
+      // When a narrowing filter is in effect, also pull per-song filtered
+      // rarity aggregates so the filtered columns on /songs have data.
+      // populateRarityFields runs first because it attaches the
+      // dateFirstFilteredPlayed / dateLastFilteredPlayed Date fields that
+      // addVenueInfoToSongs then resolves to Show records for the link.
+      const filterOptions = scopeCountsById && !showNotPlayed ? await parsePerformanceFilters(url, context) : null;
+      const withRarity = await populateRarityFields(result, filterOptions);
+      return await addVenueInfoToSongs(withRarity);
     },
     { ttl: 86400 },
   );
@@ -111,23 +117,37 @@ export async function fetchFilteredSongs(url: URL, context: PublicContext): Prom
  * Runs inside the cached `fetchFilteredSongs` path so the bulk gap query
  * fires at most once per cache window.
  */
-async function populateRarityFields<T extends Song>(songs: T[]): Promise<T[]> {
+async function populateRarityFields<T extends Song>(
+  songs: T[],
+  filterOptions: Awaited<ReturnType<typeof parsePerformanceFilters>> | null,
+): Promise<T[]> {
   if (songs.length === 0) return songs;
   const songIds = songs.map((s) => s.id);
-  const [showsByYear, gaps] = await Promise.all([
+  const [showsByYear, gaps, filteredRarity] = await Promise.all([
     services.stats.getShowsByYear(),
     services.stats.getShowsSinceLastPlayedBySongIds(songIds),
+    filterOptions ? services.songPageComposer.buildFilteredSongRarity(songIds, filterOptions) : Promise.resolve(null),
   ]);
   return songs.map((song) => {
     const rarity = computeRarityStats(
       { dateFirstPlayed: song.dateFirstPlayed, timesPlayed: song.timesPlayed },
       showsByYear,
     );
+    const filtered = filteredRarity?.get(song.id);
     return {
       ...song,
       showsSinceLastPlayed: gaps.get(song.id) ?? null,
       percentSinceDebut: rarity.percentSinceDebut,
       averageShowsPerPlay: rarity.averageShowsPerPlay,
+      ...(filtered
+        ? {
+            filteredShowsSinceLastPlayed: filtered.filteredShowsSinceLastPlayed,
+            filteredPercentSinceDebut: filtered.filteredPercentSinceDebut,
+            filteredAverageShowsPerPlay: filtered.filteredAverageShowsPerPlay,
+            dateFirstFilteredPlayed: filtered.dateFirstFilteredPlayed,
+            dateLastFilteredPlayed: filtered.dateLastFilteredPlayed,
+          }
+        : {}),
     };
   });
 }
@@ -195,11 +215,22 @@ async function resolveDateRangeForTimeRange(
 }
 
 /**
- * Adds the venue info to a songs firstPlayedShow and lastPlayedShow.
+ * Adds the venue info to a song's firstPlayedShow / lastPlayedShow, and
+ * — when the song carries `dateFirst/LastFilteredPlayed` from the filtered
+ * rarity pass — also to firstFilteredPlayedShow / lastFilteredPlayedShow.
+ * All four show columns on /songs resolve against the same single batch
+ * fetch of show records by date.
  */
-export async function addVenueInfoToSongs(
-  songs: Song[],
-): Promise<Array<Song & { firstPlayedShow: Show | null; lastPlayedShow: Show | null }>> {
+export async function addVenueInfoToSongs(songs: Song[]): Promise<
+  Array<
+    Song & {
+      firstPlayedShow: Show | null;
+      lastPlayedShow: Show | null;
+      firstFilteredPlayedShow?: Show | null;
+      lastFilteredPlayedShow?: Show | null;
+    }
+  >
+> {
   const showDates = new Set<string>();
   songs.forEach((song) => {
     if (song.dateFirstPlayed) {
@@ -207,6 +238,12 @@ export async function addVenueInfoToSongs(
     }
     if (song.dateLastPlayed) {
       showDates.add(dateToISOStringSansTime(song.dateLastPlayed));
+    }
+    if (song.dateFirstFilteredPlayed) {
+      showDates.add(dateToISOStringSansTime(song.dateFirstFilteredPlayed));
+    }
+    if (song.dateLastFilteredPlayed) {
+      showDates.add(dateToISOStringSansTime(song.dateLastFilteredPlayed));
     }
   });
 
@@ -221,5 +258,11 @@ export async function addVenueInfoToSongs(
     lastPlayedShow: song.dateLastPlayed
       ? (showsByDate.get(dateToISOStringSansTime(song.dateLastPlayed)) ?? null)
       : null,
+    firstFilteredPlayedShow: song.dateFirstFilteredPlayed
+      ? (showsByDate.get(dateToISOStringSansTime(song.dateFirstFilteredPlayed)) ?? null)
+      : undefined,
+    lastFilteredPlayedShow: song.dateLastFilteredPlayed
+      ? (showsByDate.get(dateToISOStringSansTime(song.dateLastFilteredPlayed)) ?? null)
+      : undefined,
   }));
 }

--- a/apps/web/app/lib/yearly-chart-data.test.ts
+++ b/apps/web/app/lib/yearly-chart-data.test.ts
@@ -37,7 +37,8 @@ describe("buildYearlyChartData", () => {
 
   // Defensive: if showsByYear is missing a year present in yearlyPlayData
   // (data drift, partial cache), render 0 in percent mode rather than
-  // dividing by zero or NaN. Per Phase 4 plan, we surface 0 not "no point".
+  // dividing by zero or NaN. Missing-denominator years surface as 0 — not
+  // dropped points — so the line stays continuous across the x-axis.
   test("percent mode renders 0 when showsByYear[year] is missing or zero", () => {
     const yearlyPlayData = { 2010: 5, 2011: 3, 2012: 7 };
     const showsByYear = { 2010: 50, 2011: 0 }; // 2011 is zero, 2012 is missing

--- a/apps/web/app/routes/on-this-day.$monthDay.tsx
+++ b/apps/web/app/routes/on-this-day.$monthDay.tsx
@@ -177,6 +177,7 @@ export default function OnThisDay() {
               performances={filteredPerformances}
               isLoading={isLoading}
               showSongColumn
+              showGapColumns={false}
               pageSize={ALL_TIMERS_PAGE_SIZE}
               headerContent={
                 performances.length > ALL_TIMERS_PAGE_SIZE ? (

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -173,6 +173,10 @@ export default function SongPage() {
 
   const hasAllTimers = useMemo(() => allPerformances.some((p) => p.allTimer), [allPerformances]);
   const filteredAllTimers = useMemo(() => filteredPerformances.filter((p) => p.allTimer), [filteredPerformances]);
+  // Server-narrowing filter active = any UI filter that affects the
+  // performance set the server returned. Excludes `searchText` (client-only).
+  // Used to render the Filtered Gap column in the performances table.
+  const hasServerNarrowingFilter = selectedTimeRange !== "all" || activeToggleSet.size > 0;
   const filterContent = (
     <PerformanceFilterControls
       selectedTimeRange={selectedTimeRange}
@@ -458,6 +462,7 @@ export default function SongPage() {
               performances={filteredAllTimers}
               songTitle={song.title}
               isLoading={isLoading}
+              hasNarrowingFilter={hasServerNarrowingFilter}
               headerContent={filterContent}
             />
           </TabsContent>
@@ -469,6 +474,7 @@ export default function SongPage() {
             songTitle={song.title}
             showAllTimerColumn
             isLoading={isLoading}
+            hasNarrowingFilter={hasServerNarrowingFilter}
             headerContent={filterContent}
           />
         </TabsContent>

--- a/apps/web/app/routes/songs/all-timers.tsx
+++ b/apps/web/app/routes/songs/all-timers.tsx
@@ -44,6 +44,7 @@ export default function AllTimersPage() {
         performances={filteredPerformances}
         isLoading={isLoading}
         showSongColumn
+        showGapColumns={false}
         headerContent={
           <PerformanceFilterControls
             selectedTimeRange={selectedTimeRange}

--- a/packages/core/src/page-composers/song-page-composer.test.ts
+++ b/packages/core/src/page-composers/song-page-composer.test.ts
@@ -3,9 +3,11 @@ import { CacheKeys } from "@bip/domain";
 import { Prisma } from "@prisma/client";
 import { describe, expect, test, vi } from "vitest";
 import {
+  assignFilteredGaps,
   buildSetPositionKey,
   computeRarityStats,
   computeTagsForPerformance,
+  isNarrowingFilter,
   type PerformanceDto,
   SongPageComposer,
   transformToSongPagePerformanceView,
@@ -311,10 +313,9 @@ describe("transformToSongPagePerformanceView", () => {
   // current impl). Documented quirk: `|| undefined` means `0` values also
   // become `undefined`, which is fine for rating/ratingsCount but worth
   // pinning so the behavior is explicit.
-  // Phase 1 of the stats expansion denormalized gap onto Track. The
-  // composer must surface gap and previousPerformanceShowId on the view so
-  // the song-detail performances table can render the Gap column without
-  // an extra query per row.
+  // gap is denormalized on Track. The composer must surface gap and
+  // previousPerformanceShowId on the view so the song-detail performances
+  // table can render the Gap column without an extra query per row.
   test("maps gap and previous_performance_show_id through to the view", () => {
     const debutView = transformToSongPagePerformanceView(makeDto({ gap: null, previous_performance_show_id: null }));
     expect(debutView.gap).toBeNull();
@@ -485,6 +486,313 @@ describe("buildSongPerformanceCounts", () => {
 });
 
 // ---------------------------------------------------------------------------
+// isNarrowingFilter — gate for filteredGap computation
+// ---------------------------------------------------------------------------
+
+describe("isNarrowingFilter", () => {
+  // No options at all → nothing to narrow against. Callers skip filteredGap
+  // computation and the column stays hidden.
+  test("returns false when options is undefined", () => {
+    expect(isNarrowingFilter(undefined)).toBe(false);
+  });
+
+  // Empty options object → no active filter. Same outcome as undefined.
+  test("returns false for an empty options object", () => {
+    expect(isNarrowingFilter({})).toBe(false);
+  });
+
+  // Cover/author filters pick which songs appear on /songs but don't narrow
+  // which performances of a given song count — every performance of a cover
+  // song is still a cover. They must NOT trigger filteredGap.
+  test("returns false when only cover or author is set", () => {
+    expect(isNarrowingFilter({ cover: true })).toBe(false);
+    expect(isNarrowingFilter({ authorId: "author-1" })).toBe(false);
+  });
+
+  // Each narrowing axis on its own is sufficient. Parameterized so adding
+  // a new narrowing filter shows up here visibly.
+  test.each([
+    ["startDate", { startDate: new Date("2024-01-01") }],
+    ["endDate", { endDate: new Date("2024-12-31") }],
+    ["attendedUserId", { attendedUserId: "user-1" }],
+    ["encore", { encore: true }],
+    ["setOpener", { setOpener: true }],
+    ["setCloser", { setCloser: true }],
+    ["segueIn", { segueIn: true }],
+    ["segueOut", { segueOut: true }],
+    ["standalone", { standalone: true }],
+    ["inverted", { inverted: true }],
+    ["dyslexic", { dyslexic: true }],
+    ["allTimer", { allTimer: true }],
+    ["monthDay", { monthDay: "07-26" }],
+  ])("returns true when %s is set", (_label, options) => {
+    expect(isNarrowingFilter(options)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assignFilteredGaps — per-performance gap walk against the filtered universe
+// ---------------------------------------------------------------------------
+
+describe("assignFilteredGaps", () => {
+  // Helper: builds a minimal SongPagePerformance with the fields the gap
+  // walk reads (trackId, show.id, show.date, show.dayOrder, position).
+  // Other fields kept thin so the test focuses on gap semantics.
+  function perf(overrides: {
+    trackId: string;
+    showId: string;
+    date: string;
+    position?: number;
+    dayOrder?: number | null;
+  }): SongPagePerformance {
+    return {
+      trackId: overrides.trackId,
+      show: {
+        id: overrides.showId,
+        slug: overrides.date,
+        date: overrides.date,
+        venueId: "venue-1",
+        dayOrder: overrides.dayOrder ?? null,
+        countForStats: true,
+      },
+      position: overrides.position ?? 1,
+      set: "S1",
+      segue: null,
+      allTimer: false,
+      annotations: [],
+    };
+  }
+
+  // The very first filtered performance has no prior, so gap = null (★ debut
+  // of filtered set). Subsequent performances get a number.
+  test("first filtered performance has filteredGap null", () => {
+    const performances = [perf({ trackId: "t-confrontation-2024", showId: "s-2024", date: "2024-06-15" })];
+
+    assignFilteredGaps(performances, ["2024-06-15"]);
+
+    expect(performances[0].filteredGap).toBeNull();
+  });
+
+  // Two filtered performances over a four-show filter-matching universe:
+  // play #1 at index 0, play #2 at index 3 → exactly 2 matching shows
+  // strictly between (indices 1, 2). Mirrors the existing Track.gap math.
+  test("counts filter-matching shows strictly between consecutive performances", () => {
+    const performances = [
+      perf({ trackId: "t-basis-1", showId: "s-1", date: "2024-01-10" }),
+      perf({ trackId: "t-basis-2", showId: "s-4", date: "2024-04-10" }),
+    ];
+
+    // Filter-matching set: 4 shows ordered chronologically. The song was
+    // played at the first and the last; the 2 shows in the middle count.
+    assignFilteredGaps(performances, ["2024-01-10", "2024-02-15", "2024-03-20", "2024-04-10"]);
+
+    expect(performances[0].filteredGap).toBeNull();
+    expect(performances[1].filteredGap).toBe(2);
+  });
+
+  // Within-show repeat: two performances at the same show. The gap walk
+  // shares the same numeric gap across both — the icon (↺) in the cell
+  // distinguishes the repeat, not the gap value. Mirrors Track.gap.
+  test("within-show repeat shares the same filteredGap as the first occurrence", () => {
+    const performances = [
+      perf({ trackId: "t-aceetobee-pre", showId: "s-pre", date: "2024-01-10" }),
+      perf({ trackId: "t-spaga-1", showId: "s-repeat", date: "2024-05-01", position: 2 }),
+      perf({ trackId: "t-spaga-2", showId: "s-repeat", date: "2024-05-01", position: 7 }),
+    ];
+
+    assignFilteredGaps(performances, ["2024-01-10", "2024-03-01", "2024-05-01"]);
+
+    expect(performances[0].filteredGap).toBeNull();
+    // Both tracks at the repeat-show inherit the same gap value (1 show
+    // between 2024-01-10 and 2024-05-01 in the filtered set).
+    expect(performances[1].filteredGap).toBe(1);
+    expect(performances[2].filteredGap).toBe(1);
+  });
+
+  // An empty filter-matching universe (no shows match the filter at all)
+  // means even the song's own performances aren't in the universe. The
+  // first performance is still a "debut" of the filtered set; subsequent
+  // ones gap against the previous filtered performance — but the universe
+  // has no other shows in between, so gap is 0.
+  test("with no shows in matching universe between performances, gap is 0", () => {
+    const performances = [
+      perf({ trackId: "t-helicopters-1", showId: "s-a", date: "2024-01-10" }),
+      perf({ trackId: "t-helicopters-2", showId: "s-b", date: "2024-02-10" }),
+    ];
+
+    // Only the song's own two shows are in the matching universe — nothing
+    // else falls between them in the filtered set.
+    assignFilteredGaps(performances, ["2024-01-10", "2024-02-10"]);
+
+    expect(performances[0].filteredGap).toBeNull();
+    expect(performances[1].filteredGap).toBe(0);
+  });
+
+  // The helper sorts internally before walking — callers can pass
+  // performances in any order (e.g., a query that returned DESC) and the
+  // gap math still uses canonical chronological order.
+  test("walks chronologically even when input order is reversed", () => {
+    const performances = [
+      perf({ trackId: "t-late", showId: "s-late", date: "2024-04-10" }),
+      perf({ trackId: "t-early", showId: "s-early", date: "2024-01-10" }),
+    ];
+
+    assignFilteredGaps(performances, ["2024-01-10", "2024-02-15", "2024-04-10"]);
+
+    // Early track is the debut of the filtered set regardless of input order.
+    const early = performances.find((p) => p.trackId === "t-early");
+    const late = performances.find((p) => p.trackId === "t-late");
+    expect(early?.filteredGap).toBeNull();
+    expect(late?.filteredGap).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFilteredSongRarity — per-song filtered analogs of /songs rarity columns
+// ---------------------------------------------------------------------------
+
+describe("buildFilteredSongRarity", () => {
+  // The helper sequences two queries: first `getFilterMatchingShowDates`
+  // (the matching universe), then a GROUP-BY-song aggregation (per-song
+  // first/last filtered show + count). Mock both responses by chaining
+  // `mockResolvedValueOnce`.
+  function createComposer(
+    matchingDates: Array<{ d: string }>,
+    songRows: Array<{ song_id: string; show_count: string; first_date: string; last_date: string }>,
+  ) {
+    const $queryRaw = vi.fn().mockResolvedValueOnce(matchingDates).mockResolvedValueOnce(songRows);
+    const mockDb = { $queryRaw };
+    return new SongPageComposer(mockDb as never, {} as never);
+  }
+
+  // Empty song id list → short-circuits before any queries fire. Used by the
+  // loader when the filter matched zero songs.
+  test("returns an empty map when songIds is empty", async () => {
+    const composer = createComposer([], []);
+
+    const result = await composer.buildFilteredSongRarity([], { encore: true });
+
+    expect(result.size).toBe(0);
+  });
+
+  // When the matching universe is empty (no shows fit the filter at all),
+  // there can be no per-song aggregates — return empty without firing the
+  // second query.
+  test("returns an empty map when no shows match the filter", async () => {
+    const composer = createComposer(
+      [],
+      [{ song_id: "above-the-waves", show_count: "0", first_date: "2024-01-01", last_date: "2024-01-01" }],
+    );
+
+    const result = await composer.buildFilteredSongRarity(["above-the-waves"], { encore: true });
+
+    expect(result.size).toBe(0);
+  });
+
+  // Core math: a song played at the first and last of 5 matching shows.
+  //  - filteredShowsSinceLastPlayed: shows strictly after last play  → 0
+  //    (the last play IS the latest matching show).
+  //  - showsOnOrAfterDebut: 5 (debut at index 0, inclusive).
+  //  - filteredPercentSinceDebut: 2 / 5 = 0.4.
+  //  - filteredAverageShowsPerPlay: shows-in-gaps / number-of-gaps =
+  //    (5 - 2) / (2 - 1) = 3.0 (3 matching shows fell between the 2 plays).
+  test("computes filteredShowsSinceLastPlayed, percentSinceDebut, averageShowsPerPlay against the matching universe", async () => {
+    const composer = createComposer(
+      [{ d: "2024-01-01" }, { d: "2024-02-01" }, { d: "2024-03-01" }, { d: "2024-04-01" }, { d: "2024-05-01" }],
+      [{ song_id: "above-the-waves", show_count: "2", first_date: "2024-01-01", last_date: "2024-05-01" }],
+    );
+
+    const result = await composer.buildFilteredSongRarity(["above-the-waves"], { encore: true });
+
+    const row = result.get("above-the-waves");
+    expect(row?.filteredShowsSinceLastPlayed).toBe(0);
+    expect(row?.filteredPercentSinceDebut).toBeCloseTo(0.4);
+    expect(row?.filteredAverageShowsPerPlay).toBeCloseTo(3);
+  });
+
+  // When the song's last filtered play is the earliest matching show and
+  // there are more matching shows after it → the gap is the number of
+  // shows after. Sanity check that `countShowsAfter` semantics propagate.
+  // A single play has no gaps to average, so filteredAverageShowsPerPlay
+  // must be null (em-dash in the UI), not a degenerate 1.0.
+  test("filteredShowsSinceLastPlayed counts matching shows strictly after the last filtered play", async () => {
+    const composer = createComposer(
+      [{ d: "2024-01-01" }, { d: "2024-02-01" }, { d: "2024-03-01" }, { d: "2024-04-01" }],
+      [{ song_id: "confrontation", show_count: "1", first_date: "2024-01-01", last_date: "2024-01-01" }],
+    );
+
+    const result = await composer.buildFilteredSongRarity(["confrontation"], { attendedUserId: "user-1" });
+
+    const row = result.get("confrontation");
+    // Three matching shows are strictly after the one filtered play.
+    expect(row?.filteredShowsSinceLastPlayed).toBe(3);
+    // One filtered play → no gaps → null average.
+    expect(row?.filteredAverageShowsPerPlay).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFilterMatchingShowDates — denominator for filtered rarity columns
+// ---------------------------------------------------------------------------
+
+describe("getFilterMatchingShowDates", () => {
+  // The helper returns the set of stats-eligible shows that contain at least
+  // one track matching the active filters. It drives the "shows between" /
+  // "shows since" counts for the Filtered Gap column on song detail and the
+  // filtered rarity columns on /songs.
+  function createComposer(queryRawResult: Array<{ d: string }>) {
+    const mockDb = {
+      $queryRaw: vi.fn().mockResolvedValue(queryRawResult),
+    };
+    return { composer: new SongPageComposer(mockDb as never, {} as never), mockDb };
+  }
+
+  // The raw query returns dates as `YYYY-MM-DD` strings, already ORDER BY'd
+  // ascending. The method should pass them through as-is so callers can
+  // binary-search via `countShowsAfter`.
+  test("returns ISO date strings from raw query result rows", async () => {
+    const { composer } = createComposer([{ d: "2024-06-15" }, { d: "2024-07-26" }, { d: "2024-12-31" }]);
+
+    const result = await composer.getFilterMatchingShowDates({ encore: true });
+
+    expect(result).toEqual(["2024-06-15", "2024-07-26", "2024-12-31"]);
+  });
+
+  // No filter combination matches → empty array, not null. Callers treat
+  // empty as "no matching shows" and short-circuit downstream gap math.
+  test("returns empty array when no rows match", async () => {
+    const { composer } = createComposer([]);
+
+    const result = await composer.getFilterMatchingShowDates({ encore: true, segueIn: true });
+
+    expect(result).toEqual([]);
+  });
+
+  // Confirms the helper actually executes a query when called. SQL
+  // correctness is covered by buildFilterQuery tests; this just verifies
+  // the integration point fires.
+  test("executes a query through the db client", async () => {
+    const { composer, mockDb } = createComposer([{ d: "2024-06-15" }]);
+
+    await composer.getFilterMatchingShowDates({ attendedUserId: "user-1" });
+
+    expect(mockDb.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  // No filters at all → still queries (returns all stats-eligible shows).
+  // Callers may pass `{}` when there's no narrowing; the method must not
+  // throw or short-circuit before issuing the query.
+  test("executes a query even when no filter options are provided", async () => {
+    const { composer, mockDb } = createComposer([{ d: "2024-01-01" }]);
+
+    const result = await composer.getFilterMatchingShowDates({});
+
+    expect(mockDb.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(["2024-01-01"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // CacheKeys — on-this-day all-timers key
 // ---------------------------------------------------------------------------
 
@@ -547,7 +855,8 @@ describe("computeRarityStats", () => {
     expect(result.showsSinceDebut).toBe(260);
     expect(result.percentOfAllShows).toBeCloseTo(0.5, 5);
     expect(result.percentSinceDebut).toBeCloseTo(0.5, 5);
-    expect(result.averageShowsPerPlay).toBeCloseTo(2, 5);
+    // Mean gap between plays: shows-in-gaps / gaps = (260 - 130) / (130 - 1).
+    expect(result.averageShowsPerPlay).toBeCloseTo(130 / 129, 5);
     expect((result.showsBeforeDebut ?? 0) + (result.showsSinceDebut ?? 0)).toBe(result.totalShows);
   });
 
@@ -567,7 +876,9 @@ describe("computeRarityStats", () => {
     expect(result.showsSinceDebut).toBe(60);
     expect(result.percentOfAllShows).toBeCloseTo(6 / 320, 5);
     expect(result.percentSinceDebut).toBeCloseTo(6 / 60, 5);
-    expect(result.averageShowsPerPlay).toBeCloseTo(60 / 6, 5);
+    // Mean gap between plays: (60 - 6) / (6 - 1) = 54 / 5 = 10.8 — average
+    // 10.8 shows happened between consecutive plays of the song.
+    expect(result.averageShowsPerPlay).toBeCloseTo(54 / 5, 5);
     // Sanity: scarcity reads stronger against the song's own era.
     expect(result.percentSinceDebut).toBeGreaterThan(result.percentOfAllShows ?? 0);
   });
@@ -588,5 +899,18 @@ describe("computeRarityStats", () => {
     expect(result.percentSinceDebut).toBeNull();
     expect(result.averageShowsPerPlay).toBeNull();
     expect(result.percentOfAllShows).toBe(0);
+  });
+
+  // Single-play song has no gaps between plays to average — averageShowsPerPlay
+  // must be null, not 1.0 or any degenerate value. percentSinceDebut still
+  // computes (1 play out of the 1 show in the song's era = 100%).
+  test("single-play song nulls averageShowsPerPlay (no gaps to average)", () => {
+    const showsByYear = { 2024: 50 };
+    const dateFirstPlayed = new Date(Date.UTC(2024, 0, 1));
+
+    const result = computeRarityStats({ dateFirstPlayed, timesPlayed: 1 }, showsByYear);
+
+    expect(result.averageShowsPerPlay).toBeNull();
+    expect(result.percentSinceDebut).toBeCloseTo(1 / 50, 5);
   });
 });

--- a/packages/core/src/page-composers/song-page-composer.ts
+++ b/packages/core/src/page-composers/song-page-composer.ts
@@ -2,14 +2,24 @@ import type { AllTimersPageView, Annotation, SongPagePerformance, SongPageView }
 import { Prisma } from "@prisma/client";
 import type { DbClient } from "../_shared/database/models";
 import { showOrderBySql, statsShowsSql } from "../_shared/show-ordering";
+import { computeTrackGaps, sortTracksForGapWalk, type TrackForGapWalk } from "../_shared/track-gap";
 import type { SongService } from "../songs/song-service";
-import type { StatsService } from "../stats/stats-service";
+import { countShowsAfter, countShowsOnOrAfter, type StatsService } from "../stats/stats-service";
 
 /**
  * Filters for querying performances. All fields are optional — only
  * active filters produce SQL conditions. Used by buildAllTimers and
  * buildSongPerformances to construct dynamic WHERE clauses.
  */
+/** Per-song aggregates returned by `buildFilteredSongRarity`. */
+export interface FilteredSongRarity {
+  filteredShowsSinceLastPlayed: number | null;
+  filteredPercentSinceDebut: number | null;
+  filteredAverageShowsPerPlay: number | null;
+  dateFirstFilteredPlayed: Date;
+  dateLastFilteredPlayed: Date;
+}
+
 export interface PerformanceFilterOptions {
   startDate?: Date;
   endDate?: Date;
@@ -227,6 +237,11 @@ export class SongPageComposer {
     }));
     await this.enrichPerformances(performances);
 
+    if (isNarrowingFilter(options)) {
+      const matchingShowDates = await this.getFilterMatchingShowDates(options ?? {});
+      assignFilteredGaps(performances, matchingShowDates);
+    }
+
     return performances;
   }
 
@@ -261,6 +276,108 @@ export class SongPageComposer {
       result[row.song_id] = Number.parseInt(row.count, 10);
     }
     return result;
+  }
+
+  /**
+   * Per-song aggregates restricted to the active filter scope. Returns
+   * filtered-version analogs of the three rarity columns on /songs:
+   *   - filteredShowsSinceLastPlayed: matching-universe shows strictly
+   *     after this song's last filtered play
+   *   - filteredPercentSinceDebut: filteredTimesPlayed divided by the
+   *     count of matching-universe shows on or after this song's first
+   *     filtered play
+   *   - filteredAverageShowsPerPlay: same denominator over the numerator,
+   *     inverted — "matching-universe shows per filtered play"
+   *
+   * Only computed for the survivor set the loader already produced. Songs
+   * absent from the result map are left untouched by the caller; the UI
+   * renders em-dash for missing entries.
+   */
+  async buildFilteredSongRarity(
+    songIds: string[],
+    options: PerformanceFilterOptions,
+  ): Promise<Map<string, FilteredSongRarity>> {
+    if (songIds.length === 0) return new Map();
+
+    const matchingShowDates = await this.getFilterMatchingShowDates(options);
+    if (matchingShowDates.length === 0) return new Map();
+
+    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery([statsShowsSql("shows")], options);
+    conditions.push(Prisma.sql`tracks.song_id = ANY(${songIds}::uuid[])`);
+
+    const whereClause = Prisma.sql`WHERE ${Prisma.join(conditions, " AND ")}`;
+    const extraJoinsSql = extraJoins.length > 0 ? Prisma.sql`${Prisma.join(extraJoins, "\n      ")}` : Prisma.empty;
+
+    const rows = await this.db.$queryRaw<
+      Array<{ song_id: string; show_count: string; first_date: string; last_date: string }>
+    >`
+      SELECT
+        tracks.song_id,
+        COUNT(DISTINCT tracks.show_id)::text AS show_count,
+        to_char(MIN(shows.date::date), 'YYYY-MM-DD') AS first_date,
+        to_char(MAX(shows.date::date), 'YYYY-MM-DD') AS last_date
+      FROM tracks
+      JOIN shows ON tracks.show_id = shows.id
+      JOIN songs ON tracks.song_id = songs.id
+      ${extraJoinsSql}
+      LEFT JOIN tracks prevTracks ON tracks.show_id = prevTracks.show_id
+        AND prevTracks.position = tracks.position - 1
+        AND prevTracks.set = tracks.set
+      ${whereClause}
+      GROUP BY tracks.song_id
+    `;
+
+    const out = new Map<string, FilteredSongRarity>();
+    for (const row of rows) {
+      const filteredTimesPlayed = Number.parseInt(row.show_count, 10);
+      const filteredShowsSinceLastPlayed = countShowsAfter(matchingShowDates, row.last_date);
+      const showsOnOrAfterDebut = countShowsOnOrAfter(matchingShowDates, row.first_date);
+      const filteredPercentSinceDebut = showsOnOrAfterDebut === 0 ? null : filteredTimesPlayed / showsOnOrAfterDebut;
+      // Same mean-gap semantic as computeRarityStats.averageShowsPerPlay:
+      // shows that fell in gaps divided by the number of gaps. Requires
+      // at least 2 plays — a single play has no gaps to average.
+      const filteredAverageShowsPerPlay =
+        filteredTimesPlayed < 2 ? null : (showsOnOrAfterDebut - filteredTimesPlayed) / (filteredTimesPlayed - 1);
+      out.set(row.song_id, {
+        filteredShowsSinceLastPlayed,
+        filteredPercentSinceDebut,
+        filteredAverageShowsPerPlay,
+        dateFirstFilteredPlayed: new Date(row.first_date),
+        dateLastFilteredPlayed: new Date(row.last_date),
+      });
+    }
+    return out;
+  }
+
+  /**
+   * Returns sorted ISO date strings (`YYYY-MM-DD`) for the stats-eligible
+   * shows that contain at least one track matching the active filters.
+   * Drives the "shows between" denominator for the Filtered Gap column on
+   * song detail and the filtered rarity aggregates on /songs.
+   *
+   * The query reuses the same JOINs as `buildSongPerformanceCounts` so the
+   * filter SQL composes consistently — anything that affects which
+   * performances count also affects which shows qualify here.
+   */
+  async getFilterMatchingShowDates(options: PerformanceFilterOptions): Promise<string[]> {
+    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery([statsShowsSql("shows")], options);
+
+    const whereClause = conditions.length > 0 ? Prisma.sql`WHERE ${Prisma.join(conditions, " AND ")}` : Prisma.empty;
+    const extraJoinsSql = extraJoins.length > 0 ? Prisma.sql`${Prisma.join(extraJoins, "\n      ")}` : Prisma.empty;
+
+    const rows = await this.db.$queryRaw<Array<{ d: string }>>`
+      SELECT DISTINCT to_char(shows.date::date, 'YYYY-MM-DD') AS d
+      FROM tracks
+      JOIN shows ON tracks.show_id = shows.id
+      JOIN songs ON tracks.song_id = songs.id
+      ${extraJoinsSql}
+      LEFT JOIN tracks prevTracks ON tracks.show_id = prevTracks.show_id
+        AND prevTracks.position = tracks.position - 1
+        AND prevTracks.set = tracks.set
+      ${whereClause}
+      ORDER BY d
+    `;
+    return rows.map((row) => row.d);
   }
 
   /**
@@ -486,6 +603,74 @@ export function buildSetPositionKey(showId: string, set: string): string {
 }
 
 /**
+ * True when the active filter set actually narrows which performances
+ * count — i.e., would produce a meaningfully different result than the
+ * all-time view. `cover` and `authorId` are intentionally excluded:
+ * they pick which songs surface (on /songs) but every performance of a
+ * surfacing song still counts, so they don't change per-song gap math.
+ *
+ * Used to gate the per-row filteredGap computation in
+ * `buildSongPerformances` — skipping the work entirely when no narrowing
+ * filter is active.
+ */
+export function isNarrowingFilter(options: PerformanceFilterOptions | undefined): boolean {
+  if (!options) return false;
+  return Boolean(
+    options.startDate ||
+      options.endDate ||
+      options.attendedUserId ||
+      options.encore ||
+      options.setOpener ||
+      options.setCloser ||
+      options.segueIn ||
+      options.segueOut ||
+      options.standalone ||
+      options.inverted ||
+      options.dyslexic ||
+      options.allTimer ||
+      options.monthDay,
+  );
+}
+
+/**
+ * Mutates each performance in `performances` to set `filteredGap` against
+ * the supplied `matchingShowDates` (the canonical-ordered ISO dates of
+ * shows in the active filter's universe). Reuses the pure `computeTrackGaps`
+ * walk used for all-time `Track.gap` — same algorithm, different denominator.
+ * Within-show repeats share the gap of their show's first track.
+ *
+ * Called after `enrichPerformances` so the performances already have their
+ * `show` and `position` fields populated.
+ */
+export function assignFilteredGaps(performances: SongPagePerformance[], matchingShowDates: string[]): void {
+  if (performances.length === 0) return;
+
+  const walkInput: TrackForGapWalk[] = performances.map((performance) => ({
+    trackId: performance.trackId,
+    showId: performance.show.id,
+    showDate: performance.show.date,
+    dayOrder: performance.show.dayOrder ?? null,
+    // Every filtered performance participates in the filtered-universe walk.
+    // The filtered set is the universe, so each row advances the "last
+    // performance" cursor — no count_for_stats sub-distinction here.
+    showCountForStats: true,
+    position: performance.position ?? 0,
+  }));
+
+  const sorted = sortTracksForGapWalk(walkInput);
+  const results = computeTrackGaps(sorted, matchingShowDates);
+
+  const gapByTrackId = new Map<string, number | null>();
+  for (const result of results) {
+    gapByTrackId.set(result.trackId, result.gap);
+  }
+
+  for (const performance of performances) {
+    performance.filteredGap = gapByTrackId.get(performance.trackId) ?? null;
+  }
+}
+
+/**
  * Compute the performance tags (encore, opener/closer, segues, standalone,
  * inverted, dyslexic) for a single performance. Pure function — no DB,
  * no side effects.
@@ -631,9 +816,12 @@ export function computeRarityStats(
     .reduce((sum, [, count]) => sum + count, 0);
   const showsBeforeDebut = totalShows - showsSinceDebut;
   const percentSinceDebut = showsSinceDebut === 0 ? null : song.timesPlayed / showsSinceDebut;
-  // Inverse of percentSinceDebut, surfaced separately because "played every
-  // X shows" reads more naturally than a percentage for sparse songs.
-  const averageShowsPerPlay = song.timesPlayed === 0 ? null : showsSinceDebut / song.timesPlayed;
+  // Mean gap between consecutive plays of this song since its debut.
+  // (showsSinceDebut - timesPlayed) is the number of shows that fell in
+  // gaps between plays; dividing by (timesPlayed - 1) gives the mean per
+  // gap. Requires at least 2 plays — a single-play song has no gaps to
+  // average. Null also when the song has never been played.
+  const averageShowsPerPlay = song.timesPlayed < 2 ? null : (showsSinceDebut - song.timesPlayed) / (song.timesPlayed - 1);
 
   return {
     totalShows,

--- a/packages/core/src/setlists/setlist-service.test.ts
+++ b/packages/core/src/setlists/setlist-service.test.ts
@@ -215,10 +215,10 @@ describe("computeMedianSongGap", () => {
 });
 
 describe("SetlistService.findByShowSlug", () => {
-  // The setlist payload powers the gap-chart view (Phase 5). It needs the
-  // prior-show date+slug for the "Last Played" column, so the query must
-  // include the previousPerformanceShow relation with date+slug only (no full
-  // show payload — keeps the response compact).
+  // The setlist payload powers the gap-chart view. It needs the prior-show
+  // date+slug for the "Last Played" column, so the query must include the
+  // previousPerformanceShow relation with date+slug only (no full show
+  // payload — keeps the response compact).
   test("includes previousPerformanceShow date+slug on tracks", async () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never);
@@ -232,8 +232,8 @@ describe("SetlistService.findByShowSlug", () => {
   });
 
   // The setlist domain object exposes averageSongGap so SetlistTable can
-  // render the summary without recomputing client-side. Tracks come back from
-  // Prisma with `gap` already populated (Phase 1 denormalization).
+  // render the summary without recomputing client-side. Tracks come back
+  // from Prisma with the denormalized `gap` field already populated.
   test("returns averageSongGap derived from tracks", async () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never);

--- a/packages/core/src/stats/stats-service.test.ts
+++ b/packages/core/src/stats/stats-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { countShowsAfter, songStatsChanged } from "./stats-service";
+import { countShowsAfter, countShowsOnOrAfter, songStatsChanged } from "./stats-service";
 
 const baseFresh = {
   timesPlayed: 3,
@@ -160,5 +160,36 @@ describe("countShowsAfter", () => {
     const binary = countShowsAfter(dates, target);
     const linear = dates.filter((d) => d > target).length;
     expect(binary).toBe(linear);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countShowsOnOrAfter — inclusive variant for the filtered-debut denominator
+// ---------------------------------------------------------------------------
+
+describe("countShowsOnOrAfter", () => {
+  // Drives Filtered Since Debut / Filtered Avg Gap on /songs: the denominator
+  // is "matching-universe shows from the song's first filtered play onward",
+  // which must include the debut show itself — so this is `>=`, not `>`.
+
+  // Empty catalogue → nothing on or after anything.
+  test("returns 0 for empty input regardless of target", () => {
+    expect(countShowsOnOrAfter([], "2024-01-01")).toBe(0);
+  });
+
+  // Target before every date → every entry counts.
+  test("returns full length when target precedes all dates", () => {
+    expect(countShowsOnOrAfter(["2010-01-01", "2015-06-15", "2020-12-31"], "2000-01-01")).toBe(3);
+  });
+
+  // Target equal to a date → that date counts (this is the on-or-after
+  // variant). Distinguishes this helper from `countShowsAfter`.
+  test("inclusive: target equal to a date includes that date", () => {
+    expect(countShowsOnOrAfter(["2020-01-01", "2021-01-01", "2022-01-01"], "2021-01-01")).toBe(2);
+  });
+
+  // Target later than the latest date → nothing remains.
+  test("returns 0 when target follows every date", () => {
+    expect(countShowsOnOrAfter(["2010-01-01", "2015-06-15"], "2030-01-01")).toBe(0);
   });
 });

--- a/packages/core/src/stats/stats-service.ts
+++ b/packages/core/src/stats/stats-service.ts
@@ -350,6 +350,24 @@ export function countShowsAfter(sortedDates: string[], target: string): number {
   return sortedDates.length - lo;
 }
 
+/**
+ * Counts entries on or after `target` in a sorted-ascending string array.
+ * Used as the denominator for Filtered Since Debut / Filtered Avg Gap on
+ * /songs — "matching-universe shows from this song's first filtered play
+ * onward", which includes the debut show itself.
+ */
+export function countShowsOnOrAfter(sortedDates: string[], target: string): number {
+  if (sortedDates.length === 0) return 0;
+  let lo = 0;
+  let hi = sortedDates.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (sortedDates[mid] < target) lo = mid + 1;
+    else hi = mid;
+  }
+  return sortedDates.length - lo;
+}
+
 function stableYearlyJson(value: unknown): string {
   if (!value || typeof value !== "object") return "[]";
   const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));

--- a/packages/domain/src/models/song.ts
+++ b/packages/domain/src/models/song.ts
@@ -18,6 +18,14 @@ export const songSchema = z.object({
   // Absent when no filter is active; the UI uses its presence to decide whether to render
   // the "Filtered Plays" column alongside the all-time Plays column.
   filteredTimesPlayed: z.number().optional(),
+  // Filtered analogs of the rarity fields below — populated only when a narrowing
+  // filter is active. Drive the Filtered Current Gap / Filtered Since Debut /
+  // Filtered Avg Gap columns on /songs.
+  filteredShowsSinceLastPlayed: z.number().nullable().optional(),
+  filteredPercentSinceDebut: z.number().nullable().optional(),
+  filteredAverageShowsPerPlay: z.number().nullable().optional(),
+  dateFirstFilteredPlayed: z.date().nullable().optional(),
+  dateLastFilteredPlayed: z.date().nullable().optional(),
   dateLastPlayed: z.date().nullable(),
   dateFirstPlayed: z.date().nullable(),
   actualLastPlayedDate: z.date().nullable(),

--- a/packages/domain/src/views/song-page.ts
+++ b/packages/domain/src/views/song-page.ts
@@ -29,6 +29,10 @@ export type SongPagePerformance = {
   cover?: boolean;
   authorId?: string | null;
   gap?: number | null;
+  // Gap measured against the previous performance of this song within the
+  // currently-applied filter scope. Populated server-side only when a
+  // narrowing filter is active.
+  filteredGap?: number | null;
   previousPerformanceShowId?: string | null;
   previousShow?: { slug: string; date: string };
   tags?: {


### PR DESCRIPTION
## Summary

- When a narrowing filter is active, `/songs` surfaces filtered analogs of every rarity column — plays, current gap, % since debut, avg gap, and first/last played — each next to its all-time counterpart and computed against the filter scope.
- `/songs/:slug` gains a Filtered Gap column on the performances table with the same debut/within-show-repeat icon semantics as Gap.
- Avg Gap now reports the mean number of shows between consecutive plays rather than shows-per-play; single-play songs render em-dash.
- A funnel icon replaces the word "Filtered" in column headers and on the mobile filter pill.


https://github.com/user-attachments/assets/2e0e04c1-2dc0-476b-95e7-d34682854256



## Test plan

- [ ] `/songs` with no filter: existing columns unchanged.
- [ ] `/songs?timeRange=2024`: filtered columns appear next to all-time columns; date columns compact to `M/D/YY`.
- [ ] `/songs?attended=attended` (logged in): values reflect the attended subset; Filtered Last/First Played link to the right shows.
- [ ] `/songs?attended=attended&timeRange=2024`: intersection.
- [ ] Toggle Encore/SetOpener/etc.: filtered columns recompute.
- [ ] `/songs/:slug?timeRange=2024`: Filtered Gap column appears in the performances table with the debut star and within-show-repeat icons.
- [ ] All-timer and on-this-day surfaces: Gap and Filtered Gap stay hidden (per-song signals are not meaningful on mixed-song tables).
- [ ] Single-play songs render em-dash in Avg Gap and Filtered Avg Gap.
- [ ] Mobile filter pill shows the funnel icon next to "Filters".

## Implementation notes

- **Filter-matching show universe.** The "shows between" denominator for filtered gap math is the set of shows that contain at least one track matching the active filters (intersection of attended, date range, and track-level filters). Implemented as `SongPageComposer.getFilterMatchingShowDates(options)` returning sorted ISO dates; consumed by both the per-row Filtered Gap walk and the per-song filtered rarity aggregates via `countShowsAfter` / `countShowsOnOrAfter` binary search.
- **Avg Gap formula change.** Previously `showsSinceDebut / timesPlayed` (shows-per-play). Now `(showsSinceDebut - timesPlayed) / (timesPlayed - 1)` (mean shows-between-plays). Same change applied to the filtered analog. Numbers shift for every song; the column name now matches the math.
- **Header alignment.** When filtered columns are visible, every column header reserves a top icon row — filled with the funnel icon on filtered columns and an invisible spacer of the same height elsewhere — so text labels stay top-aligned across the row. The sort indicator is offset down by the icon-row height so it sits next to the text, not the icon.
- **Load order.** `populateRarityFields` runs before `addVenueInfoToSongs` because the filtered first/last-played dates come from the rarity pass; venue resolution then sees all four date fields and can link the filtered date columns to their shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
