### PR TITLE
Render attended shows via SetlistList; paginate heavy profile tabs

### DIFF
--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -247,6 +247,7 @@ function SetlistCardComponent({
                   disabled={attendanceMutation.isPending}
                   className={cn(
                     "flex items-center justify-center gap-1 px-2 h-6 sm:px-3 sm:h-8 rounded-md transition-all",
+                    "shrink-0 whitespace-nowrap",
                     "hover:brightness-110 cursor-pointer",
                     isAttending
                       ? "bg-green-500/10 border border-green-500/50 shadow-[0_0_8px_rgba(34,197,94,0.2)]"

--- a/apps/web/app/components/setlist/setlist-columns.test.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.test.tsx
@@ -22,7 +22,7 @@ function makeTrack(overrides: Partial<TrackLight> & { songId: string; position: 
     gap: overrides.gap ?? null,
     previousPerformanceShowId: overrides.previousPerformanceShowId ?? null,
     previousPerformanceShow: overrides.previousPerformanceShow ?? null,
-    song: overrides.song ?? { id: overrides.songId, title: "Tractorbeam", slug: "tractorbeam" },
+    song: overrides.song ?? { id: overrides.songId, title: "Basis for a Day", slug: "basis-for-a-day" },
   };
 }
 
@@ -93,7 +93,7 @@ describe("createSetlistColumns", () => {
   // Played) interleave sets, so every row keeps its label.
   test("hides repeated set labels when sorted by Set", async () => {
     await renderTable([
-      makeTrack({ songId: "a", position: 1, set: "S1", song: { id: "a", title: "Tractorbeam", slug: "x" } }),
+      makeTrack({ songId: "a", position: 1, set: "S1", song: { id: "a", title: "Basis for a Day", slug: "x" } }),
       makeTrack({ songId: "b", position: 2, set: "S1", song: { id: "b", title: "Above the Waves", slug: "y" } }),
       makeTrack({ songId: "c", position: 3, set: "S2", song: { id: "c", title: "Confrontation", slug: "z" } }),
       makeTrack({ songId: "d", position: 4, set: "S2", song: { id: "d", title: "Crickets", slug: "w" } }),
@@ -112,7 +112,7 @@ describe("createSetlistColumns", () => {
   test("shows the set label on every row when sorted by Gap", async () => {
     const user = userEvent.setup();
     await renderTable([
-      makeTrack({ songId: "a", position: 1, set: "S1", gap: 10, song: { id: "a", title: "Tractorbeam", slug: "x" } }),
+      makeTrack({ songId: "a", position: 1, set: "S1", gap: 10, song: { id: "a", title: "Basis for a Day", slug: "x" } }),
       makeTrack({ songId: "b", position: 2, set: "S1", gap: 5, song: { id: "b", title: "Above the Waves", slug: "y" } }),
       makeTrack({ songId: "c", position: 3, set: "S2", gap: 20, song: { id: "c", title: "Confrontation", slug: "z" } }),
     ]);
@@ -141,7 +141,7 @@ describe("createSetlistColumns", () => {
         position: 2,
         set: "S1",
         previousPerformanceShow: { date: "2024-01-15", slug: "older" },
-        song: { id: "a", title: "Tractorbeam", slug: "x" },
+        song: { id: "a", title: "Basis for a Day", slug: "x" },
       }),
       makeTrack({
         songId: "b",
@@ -154,7 +154,7 @@ describe("createSetlistColumns", () => {
     await user.click(screen.getByRole("button", { name: /Last Played/i }));
     const songCells = screen.getAllByRole("cell").filter((_, i) => i % 5 === 2);
     expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
-      "Tractorbeam",
+      "Basis for a Day",
       "Above the Waves",
       "Crickets",
     ]);
@@ -172,7 +172,7 @@ describe("createSetlistColumns", () => {
         position: 2,
         set: "S1",
         gap: 5,
-        song: { id: "a", title: "Tractorbeam", slug: "x" },
+        song: { id: "a", title: "Basis for a Day", slug: "x" },
       }),
       makeTrack({
         songId: "b",
@@ -185,7 +185,7 @@ describe("createSetlistColumns", () => {
     await user.click(screen.getByRole("button", { name: /Gap/i }));
     const songCells = screen.getAllByRole("cell").filter((_, i) => i % 5 === 2);
     expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
-      "Tractorbeam",
+      "Basis for a Day",
       "Above the Waves",
       "Crickets",
     ]);
@@ -195,7 +195,7 @@ describe("createSetlistColumns", () => {
   // independent of the cumulative position in the show.
   test("renders Track # 1-indexed within each set/encore", async () => {
     await renderTable([
-      makeTrack({ songId: "a", position: 1, set: "S1", song: { id: "a", title: "Tractorbeam", slug: "x" } }),
+      makeTrack({ songId: "a", position: 1, set: "S1", song: { id: "a", title: "Basis for a Day", slug: "x" } }),
       makeTrack({ songId: "b", position: 2, set: "S1", song: { id: "b", title: "Above the Waves", slug: "y" } }),
       makeTrack({ songId: "c", position: 3, set: "S2", song: { id: "c", title: "Confrontation", slug: "z" } }),
       makeTrack({ songId: "d", position: 4, set: "E1", song: { id: "d", title: "Crickets", slug: "w" } }),
@@ -228,7 +228,7 @@ describe("createSetlistColumns", () => {
   // the user which encore came first.
   test("renders a single encore as 'E' but keeps E1/E2 when multiple encores exist", async () => {
     await renderTable([
-      makeTrack({ songId: "a", position: 1, set: "S1", song: { id: "a", title: "Tractorbeam", slug: "t" } }),
+      makeTrack({ songId: "a", position: 1, set: "S1", song: { id: "a", title: "Basis for a Day", slug: "t" } }),
       makeTrack({ songId: "b", position: 2, set: "E1", song: { id: "b", title: "Crickets", slug: "c" } }),
     ]);
     const singleCells = screen.getAllByRole("cell");
@@ -310,7 +310,7 @@ describe("createSetlistColumns", () => {
 
   // Segue indicator carries over from the flow view: a track whose `segue`
   // is truthy gets a trailing ">" so the table preserves the same flow
-  // information ("Tractorbeam > Above the Waves") readers already know.
+  // information ("Basis for a Day > Above the Waves") readers already know.
   // Non-segue rows render the song title alone (no trailing punctuation —
   // the table row separator already does that job).
   test("renders > after segueing tracks and nothing after non-segueing tracks", async () => {
@@ -320,7 +320,7 @@ describe("createSetlistColumns", () => {
         position: 1,
         gap: 5,
         segue: ">",
-        song: { id: "song-segue", title: "Tractorbeam", slug: "tractorbeam" },
+        song: { id: "song-segue", title: "Basis for a Day", slug: "basis-for-a-day" },
       }),
       makeTrack({
         songId: "song-end",
@@ -330,8 +330,8 @@ describe("createSetlistColumns", () => {
         song: { id: "song-end", title: "Crickets", slug: "crickets" },
       }),
     ]);
-    const segueCell = screen.getByRole("link", { name: "Tractorbeam" }).parentElement;
-    expect(segueCell?.textContent).toMatch(/Tractorbeam\s*>/);
+    const segueCell = screen.getByRole("link", { name: "Basis for a Day" }).parentElement;
+    expect(segueCell?.textContent).toMatch(/Basis for a Day\s*>/);
     const endCell = screen.getByRole("link", { name: "Crickets" }).parentElement;
     expect(endCell?.textContent).toBe("Crickets");
   });

--- a/apps/web/app/components/setlist/setlist-table.test.tsx
+++ b/apps/web/app/components/setlist/setlist-table.test.tsx
@@ -20,7 +20,7 @@ function makeTrack(overrides: Partial<TrackLight> & { songId: string; position: 
     gap: overrides.gap ?? null,
     previousPerformanceShowId: overrides.previousPerformanceShowId ?? null,
     previousPerformanceShow: overrides.previousPerformanceShow ?? null,
-    song: overrides.song ?? { id: overrides.songId, title: "Tractorbeam", slug: "tractorbeam" },
+    song: overrides.song ?? { id: overrides.songId, title: "Basis for a Day", slug: "basis-for-a-day" },
   };
 }
 
@@ -50,7 +50,7 @@ describe("SetlistTable", () => {
             songId: "a",
             position: 1,
             set: "S1",
-            song: { id: "a", title: "Tractorbeam", slug: "x" },
+            song: { id: "a", title: "Basis for a Day", slug: "x" },
           }),
           makeTrack({
             songId: "a2",
@@ -63,7 +63,7 @@ describe("SetlistTable", () => {
     );
     const cells = screen.getAllByRole("cell").filter((_, i) => i % 5 === 2);
     expect(cells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
-      "Tractorbeam",
+      "Basis for a Day",
       "Above the Waves",
       "Tempest",
       "Crickets",

--- a/apps/web/app/components/song/songs-columns.test.tsx
+++ b/apps/web/app/components/song/songs-columns.test.tsx
@@ -692,7 +692,7 @@ describe("getSongsColumns", () => {
   // them at the top, masking the smallest real gaps.
   test("Current Gap sort puts nulls last on asc and first on desc", async () => {
     const songs = [
-      makeSong({ id: "a", title: "Tractorbeam", slug: "tractorbeam", showsSinceLastPlayed: 5 }),
+      makeSong({ id: "a", title: "Basis for a Day", slug: "basis-for-a-day", showsSinceLastPlayed: 5 }),
       makeSong({ id: "b", title: "Above The Waves", slug: "above-the-waves", showsSinceLastPlayed: null }),
       makeSong({ id: "c", title: "Tempest", slug: "tempest", showsSinceLastPlayed: 30 }),
     ];
@@ -707,14 +707,14 @@ describe("getSongsColumns", () => {
 
     const titlesAsc = screen
       .getAllByRole("link")
-      .filter((el) => ["Tractorbeam", "Above The Waves", "Tempest"].includes(el.textContent ?? ""));
-    expect(titlesAsc.map((el) => el.textContent)).toEqual(["Tractorbeam", "Tempest", "Above The Waves"]);
+      .filter((el) => ["Basis for a Day", "Above The Waves", "Tempest"].includes(el.textContent ?? ""));
+    expect(titlesAsc.map((el) => el.textContent)).toEqual(["Basis for a Day", "Tempest", "Above The Waves"]);
 
     await user.click(sortHeader); // desc
     const titlesDesc = screen
       .getAllByRole("link")
-      .filter((el) => ["Tractorbeam", "Above The Waves", "Tempest"].includes(el.textContent ?? ""));
-    expect(titlesDesc.map((el) => el.textContent)).toEqual(["Above The Waves", "Tempest", "Tractorbeam"]);
+      .filter((el) => ["Basis for a Day", "Above The Waves", "Tempest"].includes(el.textContent ?? ""));
+    expect(titlesDesc.map((el) => el.textContent)).toEqual(["Above The Waves", "Tempest", "Basis for a Day"]);
   });
 
   // The /songs page shows songs sorted by times played (most played first)

--- a/apps/web/app/components/ui/data-table.tsx
+++ b/apps/web/app/components/ui/data-table.tsx
@@ -21,10 +21,10 @@ declare module "@tanstack/react-table" {
   }
 }
 
-import { type KeyboardEvent, type ReactNode, useState } from "react";
+import { type ReactNode, useState } from "react";
 
-import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
+import { PaginationControls } from "~/components/ui/pagination-controls";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/ui/table";
 import { cn } from "~/lib/utils";
 
@@ -94,73 +94,15 @@ export function DataTable<TData, TValue>({
   const currentPage = table.getState().pagination.pageIndex + 1;
   const totalPages = table.getPageCount();
 
-  function handlePageInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {
-    if (event.key !== "Enter") return;
-    const value = Number(event.currentTarget.value);
-    if (Number.isNaN(value)) return;
-    const clamped = Math.max(1, Math.min(totalPages, value));
-    table.setPageIndex(clamped - 1);
-    event.currentTarget.value = String(clamped);
-  }
-
   const paginationBlock = !hasResults ? null : (
-    <div className="flex items-center justify-between px-2">
-      {!hidePaginationText ? (
-        (() => {
-          const total = table.getFilteredRowModel().rows.length;
-          if (total === 0) {
-            return <div className="text-sm text-content-text-secondary font-medium">0 results</div>;
-          }
-          const pageSize = table.getState().pagination.pageSize;
-          const pageIndex = table.getState().pagination.pageIndex;
-          const from = pageIndex * pageSize + 1;
-          const to = Math.min((pageIndex + 1) * pageSize, total);
-          return (
-            <div className="text-sm text-content-text-secondary font-medium">
-              <span className="hidden sm:inline">{`Showing ${from} to ${to} of ${total} results`}</span>
-              <span className="sm:hidden">{`${from}–${to} of ${total}`}</span>
-            </div>
-          );
-        })()
-      ) : (
-        <div />
-      )}
-      {totalPages > 1 && (
-        <div className="flex items-center space-x-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => table.previousPage()}
-            disabled={!table.getCanPreviousPage()}
-            className="hover:bg-brand-primary/20 hover:border-brand-primary/40"
-          >
-            Previous
-          </Button>
-          <span className="flex items-center gap-1.5 text-sm text-content-text-secondary">
-            Page
-            <input
-              type="number"
-              min={1}
-              max={totalPages}
-              defaultValue={currentPage}
-              key={currentPage}
-              onKeyDown={handlePageInputKeyDown}
-              className="w-12 rounded border border-glass-border bg-glass-bg px-2 py-1 text-center text-sm text-white focus:outline-none focus:ring-1 focus:ring-ring/20 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-            />
-            of {totalPages}
-          </span>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => table.nextPage()}
-            disabled={!table.getCanNextPage()}
-            className="hover:bg-brand-primary/20 hover:border-brand-primary/40"
-          >
-            Next
-          </Button>
-        </div>
-      )}
-    </div>
+    <PaginationControls
+      page={currentPage}
+      totalPages={totalPages}
+      pageSize={table.getState().pagination.pageSize}
+      total={table.getFilteredRowModel().rows.length}
+      onPageChange={(nextPage) => table.setPageIndex(nextPage - 1)}
+      hidePaginationText={hidePaginationText}
+    />
   );
 
   return (

--- a/apps/web/app/components/ui/pagination-controls.test.tsx
+++ b/apps/web/app/components/ui/pagination-controls.test.tsx
@@ -1,0 +1,95 @@
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { PaginationControls } from "./pagination-controls";
+
+describe("PaginationControls", () => {
+  // Desktop row-count copy shows the explicit "Showing X to Y of N results"
+  // phrasing. Mobile uses a compact range; both render so CSS picks one.
+  test("renders both desktop and mobile row-range copy", async () => {
+    await setup(<PaginationControls page={2} totalPages={5} pageSize={10} total={47} onPageChange={vi.fn()} />);
+    expect(screen.getByText("Showing 11 to 20 of 47 results")).toBeInTheDocument();
+    expect(screen.getByText("11–20 of 47")).toBeInTheDocument();
+  });
+
+  // Zero results: the entire "Showing..." copy collapses to "0 results" so
+  // callers don't have to special-case empty lists themselves.
+  test("renders '0 results' when total is 0", async () => {
+    await setup(<PaginationControls page={1} totalPages={1} pageSize={10} total={0} onPageChange={vi.fn()} />);
+    expect(screen.getByText("0 results")).toBeInTheDocument();
+  });
+
+  // Single page: row-range copy still renders so users see context, but the
+  // Previous/Next chrome is suppressed because clicking it would be a no-op.
+  test("hides Previous/Next/page-input when totalPages is 1", async () => {
+    await setup(<PaginationControls page={1} totalPages={1} pageSize={10} total={5} onPageChange={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: /previous/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /next/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
+  });
+
+  // On page 1 Previous is disabled but Next is active. The Next click resolves
+  // to page 2 via onPageChange — that's the only way the parent learns about
+  // navigation, so a regression here breaks every paginated surface.
+  test("disables Previous on page 1, Next fires onPageChange(2)", async () => {
+    const onPageChange = vi.fn();
+    const { user } = await setup(
+      <PaginationControls page={1} totalPages={5} pageSize={10} total={47} onPageChange={onPageChange} />,
+    );
+
+    expect(screen.getByRole("button", { name: /previous/i })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    expect(onPageChange).toHaveBeenCalledWith(2);
+  });
+
+  // On the last page Next is disabled and Previous fires onPageChange(prev).
+  test("disables Next on the last page, Previous fires onPageChange(page-1)", async () => {
+    const onPageChange = vi.fn();
+    const { user } = await setup(
+      <PaginationControls page={5} totalPages={5} pageSize={10} total={47} onPageChange={onPageChange} />,
+    );
+
+    expect(screen.getByRole("button", { name: /next/i })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: /previous/i }));
+    expect(onPageChange).toHaveBeenCalledWith(4);
+  });
+
+  // The page-input field accepts a direct page number and applies it on Enter.
+  // Out-of-range values clamp into [1, totalPages] so users can't navigate to
+  // a non-existent page.
+  test("Enter on page input applies the typed page, clamping to [1, totalPages]", async () => {
+    const onPageChange = vi.fn();
+    const { user } = await setup(
+      <PaginationControls page={1} totalPages={5} pageSize={10} total={47} onPageChange={onPageChange} />,
+    );
+
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    await user.clear(input);
+    await user.type(input, "3{enter}");
+    expect(onPageChange).toHaveBeenLastCalledWith(3);
+
+    onPageChange.mockClear();
+    await user.clear(input);
+    await user.type(input, "99{enter}");
+    expect(onPageChange).toHaveBeenLastCalledWith(5); // clamped to totalPages
+
+    onPageChange.mockClear();
+    await user.clear(input);
+    await user.type(input, "0{enter}");
+    expect(onPageChange).toHaveBeenLastCalledWith(1); // clamped to 1
+  });
+
+  // hidePaginationText hides the left-side row-range copy but keeps the
+  // Previous/Next/input controls. Used by callers that surface the count
+  // elsewhere on the page.
+  test("hidePaginationText drops the row-range copy but keeps the controls", async () => {
+    await setup(
+      <PaginationControls page={2} totalPages={5} pageSize={10} total={47} onPageChange={vi.fn()} hidePaginationText />,
+    );
+
+    expect(screen.queryByText(/Showing/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/of 47/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /previous/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /next/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/ui/pagination-controls.tsx
+++ b/apps/web/app/components/ui/pagination-controls.tsx
@@ -1,0 +1,93 @@
+import type { KeyboardEvent } from "react";
+import { Button } from "~/components/ui/button";
+
+interface PaginationControlsProps {
+  /** 1-indexed current page. */
+  page: number;
+  totalPages: number;
+  /** Page size + total row count drive the "Showing X to Y of N" copy. */
+  pageSize: number;
+  total: number;
+  onPageChange: (nextPage: number) => void;
+  /** Hides the "Showing N to M of T" copy on the left while keeping the controls. */
+  hidePaginationText?: boolean;
+}
+
+/**
+ * Shared Previous / Page-input / Next pagination strip. Used by DataTable for
+ * its client-side TanStack pagination and by any route-level paginator that
+ * wants the same visual treatment — caller wires onPageChange to either a
+ * table method or a URL navigation.
+ */
+export function PaginationControls({
+  page,
+  totalPages,
+  pageSize,
+  total,
+  onPageChange,
+  hidePaginationText = false,
+}: PaginationControlsProps) {
+  function handlePageInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key !== "Enter") return;
+    const value = Number(event.currentTarget.value);
+    if (Number.isNaN(value)) return;
+    const clamped = Math.max(1, Math.min(totalPages, value));
+    onPageChange(clamped);
+    event.currentTarget.value = String(clamped);
+  }
+
+  const from = (page - 1) * pageSize + 1;
+  const to = Math.min(page * pageSize, total);
+
+  return (
+    <div className="flex items-center justify-between px-2">
+      {!hidePaginationText ? (
+        total === 0 ? (
+          <div className="text-sm text-content-text-secondary font-medium">0 results</div>
+        ) : (
+          <div className="text-sm text-content-text-secondary font-medium">
+            <span className="hidden sm:inline">{`Showing ${from} to ${to} of ${total} results`}</span>
+            <span className="sm:hidden">{`${from}–${to} of ${total}`}</span>
+          </div>
+        )
+      ) : (
+        <div />
+      )}
+      {totalPages > 1 && (
+        <div className="flex items-center space-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onPageChange(Math.max(1, page - 1))}
+            disabled={page <= 1}
+            className="hover:bg-brand-primary/20 hover:border-brand-primary/40"
+          >
+            Previous
+          </Button>
+          <span className="flex items-center gap-1.5 text-sm text-content-text-secondary">
+            Page
+            <input
+              type="number"
+              min={1}
+              max={totalPages}
+              defaultValue={page}
+              key={page}
+              onKeyDown={handlePageInputKeyDown}
+              className="w-12 rounded border border-glass-border bg-glass-bg px-2 py-1 text-center text-sm text-white focus:outline-none focus:ring-1 focus:ring-ring/20 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            />
+            of {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onPageChange(Math.min(totalPages, page + 1))}
+            disabled={page >= totalPages}
+            className="hover:bg-brand-primary/20 hover:border-brand-primary/40"
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/lib/yearly-chart-data.test.ts
+++ b/apps/web/app/lib/yearly-chart-data.test.ts
@@ -4,7 +4,7 @@ import { buildYearlyChartData, expandPlayedYears, expandYearlyDataToRange } from
 describe("buildYearlyChartData", () => {
   // Count mode is the default rendering: each year's raw play count maps
   // straight to `value`. Years are sorted ascending so the line chart reads
-  // left-to-right chronologically. Disco Biscuits' "Tractorbeam" — a
+  // left-to-right chronologically. Disco Biscuits' "Basis for a Day" — a
   // long-running staple — exercises the multi-year case.
   test("count mode returns sorted {year, value} pairs of raw play counts", () => {
     const yearlyPlayData = { 2010: 12, 2008: 5, 2012: 8 };

--- a/apps/web/app/routes/songs/$slug.test.tsx
+++ b/apps/web/app/routes/songs/$slug.test.tsx
@@ -282,8 +282,8 @@ describe("SongPage", () => {
   test("Average Gap StatBox renders label 'Average Gap' and the bare numeric value", () => {
     vi.mocked(useSerializedLoaderData).mockReturnValueOnce({
       song: {
-        title: "Tractorbeam",
-        slug: "tractorbeam",
+        title: "Basis for a Day",
+        slug: "basis-for-a-day",
         timesPlayed: 200,
         dateFirstPlayed: "1995-06-01",
         dateLastPlayed: "2024-01-01",

--- a/apps/web/app/routes/users/$username.test.tsx
+++ b/apps/web/app/routes/users/$username.test.tsx
@@ -1,0 +1,332 @@
+import { mockShallowComponent } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// Server-side modules — stubbed so the component can import the route file
+// without pulling Prisma/Supabase into the test bundle.
+vi.mock("~/server/services", () => ({ services: {} }));
+vi.mock("~/server/show-external-sources", () => ({ computeShowExternalSources: vi.fn() }));
+vi.mock("~/server/show-user-data", () => ({ computeShowUserData: vi.fn() }));
+vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
+
+// Default loader payload — most attendance has a Disco Biscuits setlist
+// (per project test convention).
+const baseLoaderData = {
+  user: {
+    id: "u1",
+    email: "evan@foo.net",
+    username: "evan",
+    avatarUrl: null,
+    createdAt: new Date("2020-01-01T00:00:00Z"),
+  },
+  reviews: [],
+  blogPosts: [],
+  attendedSetlists: [
+    {
+      show: {
+        id: "show-1",
+        date: "2024-08-12",
+        slug: "2024-08-12-port-chester-ny",
+        averageRating: 4.5,
+        venue: { name: "The Capitol Theatre", city: "Port Chester", state: "NY" },
+      },
+      sets: [{ label: "S1", tracks: [{ id: "t1", song: { title: "Basis for a Day" } }] }],
+    },
+  ],
+  attendedExternalSources: {},
+  attendedInitialUserData: { attendances: [], userRatings: [], averageRatings: [] },
+  attendedPagination: { page: 1, pageSize: 100, totalPages: 1, total: 1 },
+  ratingsPagination: { page: 1, pageSize: 100, totalPages: 1, total: 0 },
+  activeTab: "shows" as const,
+  showRatings: [],
+  trackRatings: [],
+  attendanceCount: 1,
+  reviewCount: 0,
+  showRatingsCount: 0,
+  trackRatingsCount: 0,
+  totalRatings: 0,
+  userStat: { communityScore: 0, badges: [], blogPostCount: 0 },
+  firstShow: { id: "show-1", date: "2024-08-12" },
+  lastShow: { id: "show-1", date: "2024-08-12" },
+  isOwnProfile: true,
+};
+
+vi.mock("~/hooks/use-serialized-loader-data", () => ({
+  useSerializedLoaderData: vi.fn(() => baseLoaderData),
+}));
+
+// Stub the heavy SetlistList child. We still want to verify the `empty`
+// slot, so we render it inline when no setlists were passed — mirroring
+// SetlistList's own behavior. When setlists is non-empty we surface the
+// count and first show id as data-attrs so tests can assert wiring without
+// depending on JSON-stringified prop serialization (mockShallowComponent's
+// replacer drops nested keys).
+vi.mock("~/components/setlist/setlist-list", () => ({
+  SetlistList: (props: {
+    setlists: Array<{ show: { id: string } }>;
+    empty?: React.ReactNode;
+    externalSources?: Record<string, unknown>;
+    initialUserData?: unknown;
+  }) => {
+    if (!props.setlists || props.setlists.length === 0) {
+      return <div data-testid="SetlistList">{props.empty}</div>;
+    }
+    return (
+      <div
+        data-testid="SetlistList"
+        data-setlists-count={props.setlists.length}
+        data-first-show-id={props.setlists[0]?.show?.id ?? ""}
+        data-has-initial-user-data={props.initialUserData ? "yes" : "no"}
+      >
+        {mockShallowComponent("SetlistListShallow", { setlistsCount: props.setlists.length })}
+      </div>
+    );
+  },
+}));
+
+import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
+import UserProfile from "./$username";
+
+function renderProfile(initialEntry = "/users/evan") {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <UserProfile />
+    </MemoryRouter>,
+  );
+}
+
+describe("UserProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useSerializedLoaderData).mockReturnValue(baseLoaderData);
+  });
+
+  // The Shows Attended tab is the user's primary activity record and should
+  // be the first thing seen on the profile page.
+  test("Shows Attended is the leftmost tab", () => {
+    renderProfile();
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[0]).toHaveTextContent(/shows attended/i);
+  });
+
+  // Tab order matters — keep Reviews/Ratings/Blog after Shows so the most
+  // common landing surface is at the start.
+  test("tabs render in order: Shows Attended, Reviews, Show Ratings, Song Version Ratings", () => {
+    renderProfile();
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[0]).toHaveTextContent(/shows attended/i);
+    expect(tabs[1]).toHaveTextContent(/reviews/i);
+    expect(tabs[2]).toHaveTextContent(/show ratings/i);
+    expect(tabs[3]).toHaveTextContent(/song version ratings/i);
+  });
+
+  // Default selection is "shows" — landing on a profile shows the attended
+  // setlist list, not the (often empty) reviews tab.
+  test("Shows Attended tab is selected by default", () => {
+    renderProfile();
+
+    const showsTab = screen.getByRole("tab", { name: /shows attended/i });
+    expect(showsTab.getAttribute("data-state")).toBe("active");
+  });
+
+  // Active tab is driven by the loader-provided `activeTab` (parsed from
+  // `?tab=` on the server). Loading the page with ?tab=track-ratings should
+  // surface that tab as active so a refresh / shared link lands on the same
+  // surface. `mockReturnValue` (not Once) covers React's potential double-
+  // render in concurrent mode.
+  test("active tab follows the loader's activeTab value", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValue({
+      ...baseLoaderData,
+      activeTab: "track-ratings",
+    });
+
+    renderProfile("/users/evan?tab=track-ratings");
+
+    const trackTab = screen.getByRole("tab", { name: /song version ratings/i });
+    expect(trackTab.getAttribute("data-state")).toBe("active");
+    const showsTab = screen.getByRole("tab", { name: /shows attended/i });
+    expect(showsTab.getAttribute("data-state")).toBe("inactive");
+  });
+
+  // Each tab is rendered as a <Link> (via Radix asChild) so clicking
+  // triggers a full navigation — the loader re-runs and fetches only that
+  // tab's data. Radix overrides the anchor's role to "tab", so we query by
+  // tab role and verify the underlying href.
+  test("each tab links to ?tab=<value> for server-side navigation", () => {
+    renderProfile();
+
+    const expectedTargets: Array<[RegExp, string]> = [
+      [/shows attended/i, "?tab=shows"],
+      [/^reviews/i, "?tab=reviews"],
+      [/^show ratings/i, "?tab=show-ratings"],
+      [/song version ratings/i, "?tab=track-ratings"],
+    ];
+    for (const [label, expectedHref] of expectedTargets) {
+      const tab = screen.getByRole("tab", { name: label });
+      expect(tab.getAttribute("href")).toContain(expectedHref);
+    }
+  });
+
+  // Profile tabs render as a <select> on mobile (sm:hidden) and the
+  // horizontal tab strip at sm+. Mirrors the song-detail page pattern so
+  // the long "Song Version Ratings" label doesn't clip on phones.
+  test("tabs render as a select on mobile and a tab strip at sm+", () => {
+    renderProfile();
+
+    const tabList = screen.getByRole("tablist");
+    expect(tabList.className).toContain("hidden");
+    expect(tabList.className).toContain("sm:flex");
+
+    const select = screen.getByLabelText(/profile view/i);
+    const wrapper = select.closest("div");
+    expect(wrapper?.className).toContain("sm:hidden");
+  });
+
+  // The route delegates rendering to SetlistList, passing through the
+  // loader-built setlists, external sources, and initial user-data payload.
+  // Load-bearing wiring test: if the loader keys are renamed without
+  // updating the JSX, this catches it via the stub's surfaced data-attrs.
+  test("renders SetlistList with the loader's attended-shows payload", () => {
+    renderProfile();
+
+    const setlistList = screen.getByTestId("SetlistList");
+    expect(setlistList).toBeInTheDocument();
+    expect(setlistList.getAttribute("data-setlists-count")).toBe("1");
+    expect(setlistList.getAttribute("data-first-show-id")).toBe("show-1");
+    expect(setlistList.getAttribute("data-has-initial-user-data")).toBe("yes");
+  });
+
+  // Empty attended-shows list: SetlistList renders the `empty` slot when
+  // no setlists are passed; the route's empty copy must be wired through.
+  test("renders the own-profile empty copy when no attended shows", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValueOnce({
+      ...baseLoaderData,
+      attendedSetlists: [],
+      attendedExternalSources: {},
+      attendanceCount: 0,
+    });
+
+    renderProfile();
+
+    expect(screen.getByText("No Shows Attended")).toBeInTheDocument();
+    expect(screen.getByText(/you haven't marked any shows/i)).toBeInTheDocument();
+  });
+
+  // Pagination chrome is hidden when there's only one page — most users
+  // have <100 attended shows so we shouldn't show empty Prev/Next controls.
+  test("does not render pagination when totalPages is 1", () => {
+    renderProfile();
+    expect(screen.queryByRole("button", { name: /next/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
+  });
+
+  // Heaviest user case: 459 shows across 5 pages of 100. Pagination chrome
+  // renders both above and below the list, so we expect two of each button.
+  // PaginationControls also surfaces a "Page [input] of N" widget — both
+  // page-input fields should reflect the current page.
+  test("renders Prev/Next buttons and row range when totalPages > 1", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValueOnce({
+      ...baseLoaderData,
+      attendedPagination: { page: 3, pageSize: 100, totalPages: 5, total: 459 },
+    });
+
+    renderProfile();
+    // "Showing 201 to 300 of 459 results" (desktop) — two pagination strips.
+    expect(screen.getAllByText(/Showing 201 to 300 of 459 results/)).toHaveLength(2);
+    expect(screen.getAllByText(/of 5/)).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: /previous/i })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: /next/i })).toHaveLength(2);
+    // The page input is a spinbutton with the current page as defaultValue.
+    const pageInputs = screen.getAllByRole("spinbutton");
+    expect(pageInputs).toHaveLength(2);
+    for (const input of pageInputs) {
+      expect(input).toHaveAttribute("max", "5");
+      expect((input as HTMLInputElement).defaultValue).toBe("3");
+    }
+  });
+
+  // Show-Ratings and Track-Ratings tabs paginate at 100/page to keep the
+  // rendered DOM small on heavy users (~7,800 track ratings at the top end). The
+  // loader provides `ratingsPagination` whenever the active tab is one of
+  // the rating tabs; component renders PaginationControls below the list.
+  test("renders rating-tab pagination when activeTab is show-ratings and totalPages > 1", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValue({
+      ...baseLoaderData,
+      activeTab: "show-ratings",
+      showRatings: [],
+      ratingsPagination: { page: 1, pageSize: 100, totalPages: 18, total: 1739 },
+    });
+
+    renderProfile("/users/evan?tab=show-ratings");
+    // Pagination chrome renders both above and below the list.
+    expect(screen.getAllByText(/Showing 1 to 100 of 1739 results/)).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: /next/i })).toHaveLength(2);
+  });
+
+  // Same for track-ratings — pagination chrome is shared infrastructure.
+  test("renders rating-tab pagination when activeTab is track-ratings and totalPages > 1", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValue({
+      ...baseLoaderData,
+      activeTab: "track-ratings",
+      trackRatings: [],
+      ratingsPagination: { page: 2, pageSize: 100, totalPages: 78, total: 7784 },
+    });
+
+    renderProfile("/users/evan?tab=track-ratings");
+    expect(screen.getAllByText(/Showing 101 to 200 of 7784 results/)).toHaveLength(2);
+  });
+
+  // Pagination chrome stays hidden on the rating tabs when the user has
+  // fewer ratings than a single page — avoids noisy "Page 1 of 1" UI for
+  // the typical user who has <100 ratings.
+  test("hides rating-tab pagination when totalPages is 1", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValue({
+      ...baseLoaderData,
+      activeTab: "show-ratings",
+      showRatings: [],
+      ratingsPagination: { page: 1, pageSize: 100, totalPages: 1, total: 5 },
+    });
+
+    renderProfile("/users/evan?tab=show-ratings");
+    expect(screen.queryByRole("button", { name: /next/i })).not.toBeInTheDocument();
+  });
+
+  // Last page: Next button is rendered but disabled. Previous remains enabled.
+  test("disables Next on the last page", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValueOnce({
+      ...baseLoaderData,
+      attendedPagination: { page: 5, pageSize: 100, totalPages: 5, total: 459 },
+    });
+
+    renderProfile();
+    const nextButtons = screen.getAllByRole("button", { name: /next/i });
+    const prevButtons = screen.getAllByRole("button", { name: /previous/i });
+    expect(nextButtons).toHaveLength(2);
+    expect(prevButtons).toHaveLength(2);
+    for (const btn of nextButtons) {
+      expect(btn).toBeDisabled();
+    }
+    for (const btn of prevButtons) {
+      expect(btn).not.toBeDisabled();
+    }
+  });
+
+  // Other-user view: the empty-state copy switches from second-person to
+  // third-person and includes the viewed user's username.
+  test("empty-state copy references the username when viewing another user's profile", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValueOnce({
+      ...baseLoaderData,
+      attendedSetlists: [],
+      attendanceCount: 0,
+      isOwnProfile: false,
+      user: { ...baseLoaderData.user, username: "barberj" },
+    });
+
+    renderProfile();
+
+    expect(screen.getByText(/barberj hasn't marked any shows/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/routes/users/$username.tsx
+++ b/apps/web/app/routes/users/$username.tsx
@@ -1,47 +1,43 @@
-import { compareByShowDate } from "@bip/domain";
+import { CacheKeys, compareByShowDate } from "@bip/domain";
 import { CalendarDays, Edit, MessageSquare, Star, Users } from "lucide-react";
 import type { LoaderFunctionArgs, MetaFunction } from "react-router-dom";
-import { Link, useLoaderData } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
+import { SetlistList } from "~/components/setlist/setlist-list";
+import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { PaginationControls } from "~/components/ui/pagination-controls";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
+import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
+import { type PublicContext, publicLoader } from "~/lib/base-loaders";
 import { formatDateLong } from "~/lib/utils";
 import { services } from "~/server/services";
-import { getServerClient } from "~/server/supabase";
+import { computeShowExternalSources } from "~/server/show-external-sources";
+import { computeShowUserData } from "~/server/show-user-data";
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
-  if (!data?.user) {
-    return [
-      { title: "User Not Found | Biscuits Internet Project" },
-      { name: "description", content: "The requested user profile could not be found." },
-    ];
-  }
+const ATTENDED_SHOWS_PAGE_SIZE = 50;
+const RATINGS_PAGE_SIZE = 100;
 
-  return [
-    { title: `${data.user.username} | Biscuits Internet Project` },
-    { name: "description", content: `View ${data.user.username}'s profile, reviews, and show attendance.` },
-  ];
-};
+const TAB_VALUES = ["shows", "reviews", "show-ratings", "track-ratings", "blog"] as const;
+type TabValue = (typeof TAB_VALUES)[number];
 
-export async function loader({ params, request }: LoaderFunctionArgs) {
+function parseTab(raw: string | null): TabValue {
+  return (TAB_VALUES as readonly string[]).includes(raw ?? "") ? (raw as TabValue) : "shows";
+}
+
+async function loadUserProfile({ params, request, context }: LoaderFunctionArgs & { context: PublicContext }) {
   const { username } = params;
   if (!username) {
     throw new Response("Username not provided", { status: 400 });
   }
 
-  // Get current session user (use getUser() to verify JWT, not getSession())
-  const { supabase } = getServerClient(request);
-  const {
-    data: { user: authUser },
-  } = await supabase.auth.getUser();
-  const sessionUser = authUser
-    ? {
-        id: authUser.id,
-        email: authUser.email,
-        role: authUser.user_metadata?.role,
-      }
-    : null;
+  const url = new URL(request.url);
+  const rawPage = Number.parseInt(url.searchParams.get("page") ?? "1", 10);
+  const pageParam = Number.isFinite(rawPage) && rawPage > 0 ? rawPage : 1;
+  const activeTab = parseTab(url.searchParams.get("tab"));
+
+  const sessionUser = context.currentUser ?? null;
 
   // Find the user by username
   const user = await services.users.findByUsername(username);
@@ -49,51 +45,117 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     throw new Response("User not found", { status: 404 });
   }
 
-  // Get user's reviews with show data
-  const reviews = await services.reviews.findByUserIdWithShow(user.id, {
-    sort: [{ field: "createdAt", direction: "desc" }],
-  });
+  // Always fetch: counts (drive tab labels) + user stats (header badges) +
+  // attendance summary (count + first/last show for header). Only fetch the
+  // active tab's row data — heavy users have 7000+ track ratings and
+  // shipping all tabs' data on every load costs megabytes.
+  const [tabCounts, userStats, profileHeader] = await Promise.all([
+    services.users.getUserTabCounts(user.id),
+    services.users.getUserStats(user.id),
+    services.users.getUserProfileHeader(user.id),
+  ]);
+  const userStat = userStats[0]; // getUserStats returns an array
+  const { attendanceCount, firstShow, lastShow } = profileHeader;
 
   // Get user's blog posts (simplified - we'll enhance this later)
-  const blogPosts: Array<Record<string, unknown>> = []; // TODO: Implement blog post retrieval
+  // TODO: Implement blog post retrieval
+  const blogPosts: Array<{ id: string; slug: string; title: string; content?: string; createdAt?: string | Date }> = [];
 
-  // Get user's attendances with show data
-  const userAttendances = await services.attendances.findByUserIdWithShow(user.id, {
-    sort: [{ field: "createdAt", direction: "desc" }],
-  });
+  const reviews =
+    activeTab === "reviews"
+      ? await services.reviews.findByUserIdWithShow(user.id, { sort: [{ field: "createdAt", direction: "desc" }] })
+      : [];
 
-  // Get user's ratings with show and track data
-  const [showRatings, trackRatings] = await Promise.all([
-    services.ratings.findShowRatingsByUserId(user.id),
-    services.ratings.findTrackRatingsByUserId(user.id),
-  ]);
+  // Pagination state for the rating tabs — shares the `?page=` param with
+  // Shows Attended (different totalPages per tab; navigating to a tab via
+  // <Link to="?tab=X"> drops the param so page resets to 1).
+  const ratingsTotal =
+    activeTab === "show-ratings"
+      ? tabCounts.showRatingsCount
+      : activeTab === "track-ratings"
+        ? tabCounts.trackRatingsCount
+        : 0;
+  const ratingsTotalPages = Math.max(1, Math.ceil(ratingsTotal / RATINGS_PAGE_SIZE));
+  const clampedRatingsPage = Math.min(Math.max(1, pageParam), ratingsTotalPages);
+  const ratingsSkip = (clampedRatingsPage - 1) * RATINGS_PAGE_SIZE;
 
-  // Get user stats (includes badges and community score)
-  const userStats = await services.users.getUserStats(user.id);
-  const userStat = userStats[0]; // getUserStats returns an array
+  const showRatings =
+    activeTab === "show-ratings"
+      ? await services.ratings.findShowRatingsByUserId(user.id, { skip: ratingsSkip, take: RATINGS_PAGE_SIZE })
+      : [];
+  const trackRatings =
+    activeTab === "track-ratings"
+      ? await services.ratings.findTrackRatingsByUserId(user.id, { skip: ratingsSkip, take: RATINGS_PAGE_SIZE })
+      : [];
 
-  const attendanceCount = userAttendances.length;
-  const reviewCount = reviews.length;
-  const showRatingsCount = showRatings.length;
-  const trackRatingsCount = trackRatings.length;
-  const totalRatings = showRatingsCount + trackRatingsCount;
+  const totalRatings = tabCounts.showRatingsCount + tabCounts.trackRatingsCount;
 
-  // Calculate first and last show dates
-  const sortedAttendances = userAttendances.sort(compareByShowDate);
-  const firstShow = sortedAttendances[0]?.show || null;
-  const lastShow = sortedAttendances[sortedAttendances.length - 1]?.show || null;
+  // Total attended pages comes straight from the count — no full-list fetch
+  // needed to derive the page count.
+  const totalAttendedPages = Math.max(1, Math.ceil(attendanceCount / ATTENDED_SHOWS_PAGE_SIZE));
+  const clampedAttendedPage = Math.min(Math.max(1, pageParam), totalAttendedPages);
+
+  // Only fetch the full attendance list when we actually need to paginate
+  // it — i.e. the Shows Attended tab is active. Other tabs (reviews,
+  // ratings) don't render any attendances directly, only the header count
+  // we already have. Saves ~30-50ms on non-shows tab loads for heavy users.
+  const pageShowIds: string[] =
+    activeTab === "shows"
+      ? await (async () => {
+          const userAttendances = await services.attendances.findByUserIdWithShow(user.id, {
+            sort: [{ field: "createdAt", direction: "desc" }],
+          });
+          // Re-sort by show date desc so pages are stable across attendance
+          // toggles (mirrors every other SetlistList surface in the app).
+          const byShowDateDesc = [...userAttendances].sort((a, b) => -compareByShowDate(a, b));
+          const start = (clampedAttendedPage - 1) * ATTENDED_SHOWS_PAGE_SIZE;
+          return byShowDateDesc.slice(start, start + ATTENDED_SHOWS_PAGE_SIZE).map((a) => a.show.id);
+        })()
+      : [];
+
+  const { attendedSetlists, attendedExternalSources } = pageShowIds.length
+    ? await services.cache.getOrSet(CacheKeys.users.attendedSetlists(user.id, clampedAttendedPage), async () => {
+        const setlists = await services.setlists.findManyByShowIds(pageShowIds);
+        const externalSources: Record<string, ShowExternalSources> = await computeShowExternalSources(
+          setlists.map((s) => s.show),
+        );
+        return { attendedSetlists: setlists, attendedExternalSources: externalSources };
+      })
+    : { attendedSetlists: [], attendedExternalSources: {} as Record<string, ShowExternalSources> };
+
+  // Per-viewer overlay (attendance / rating badges) — not cached; depends on
+  // the logged-in user, not the profile being viewed.
+  const attendedInitialUserData = await computeShowUserData(
+    context,
+    attendedSetlists.map((s) => s.show.id),
+  );
 
   return {
     user,
     reviews,
     blogPosts,
-    userAttendances,
+    attendedSetlists,
+    attendedExternalSources,
+    attendedInitialUserData,
+    attendedPagination: {
+      page: clampedAttendedPage,
+      pageSize: ATTENDED_SHOWS_PAGE_SIZE,
+      totalPages: totalAttendedPages,
+      total: attendanceCount,
+    },
     showRatings,
     trackRatings,
+    ratingsPagination: {
+      page: clampedRatingsPage,
+      pageSize: RATINGS_PAGE_SIZE,
+      totalPages: ratingsTotalPages,
+      total: ratingsTotal,
+    },
+    activeTab,
     attendanceCount,
-    reviewCount,
-    showRatingsCount,
-    trackRatingsCount,
+    reviewCount: tabCounts.reviewCount,
+    showRatingsCount: tabCounts.showRatingsCount,
+    trackRatingsCount: tabCounts.trackRatingsCount,
     totalRatings,
     userStat,
     firstShow,
@@ -102,14 +164,38 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   };
 }
 
+export type LoaderData = Awaited<ReturnType<typeof loadUserProfile>>;
+
+export const loader = publicLoader<LoaderData>(loadUserProfile);
+
+export const meta: MetaFunction = ({ data }) => {
+  const typed = data as LoaderData | undefined;
+  if (!typed?.user) {
+    return [
+      { title: "User Not Found | Biscuits Internet Project" },
+      { name: "description", content: "The requested user profile could not be found." },
+    ];
+  }
+
+  return [
+    { title: `${typed.user.username} | Biscuits Internet Project` },
+    { name: "description", content: `View ${typed.user.username}'s profile, reviews, and show attendance.` },
+  ];
+};
+
 export default function UserProfile() {
   const {
     user,
     reviews,
     blogPosts,
-    userAttendances,
+    attendedSetlists,
+    attendedExternalSources,
+    attendedInitialUserData,
+    attendedPagination,
     showRatings,
     trackRatings,
+    ratingsPagination,
+    activeTab,
     attendanceCount,
     reviewCount,
     showRatingsCount,
@@ -119,42 +205,60 @@ export default function UserProfile() {
     firstShow,
     lastShow,
     isOwnProfile,
-  } = useLoaderData<typeof loader>();
+  } = useSerializedLoaderData<LoaderData>();
+
+  const navigate = useNavigate();
+
+  // Same handler for every paginated tab — page param is shared across
+  // tabs, but we always preserve the active tab so refreshes land back
+  // on the right surface. `preventScrollReset` keeps the viewport where
+  // the user clicked Next/Prev — otherwise React Router yanks them back
+  // to the top of the page on every pagination click.
+  const handlePageChange = (nextPage: number) => {
+    navigate(`?tab=${activeTab}&page=${nextPage}`, { preventScrollReset: true });
+  };
 
   return (
     <div className="w-full space-y-6">
       {/* Profile Header */}
       <Card className="card-premium">
         <CardContent className="pt-6">
-          {/* Top row: Avatar, Name/Score, Badges, Edit Button */}
-          <div className="flex items-start justify-between mb-6">
-            <div className="flex items-center gap-6">
-              {/* Avatar */}
-              <div className="w-20 h-20 rounded-full overflow-hidden bg-glass-bg border-2 border-glass-border flex items-center justify-center flex-shrink-0">
+          {/* Top row: Avatar, Name/Score, Badges, Edit Button.
+              Mobile stacks (avatar+info on top, badges+edit below); sm+ goes
+              side-by-side. */}
+          <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 sm:gap-0 mb-6">
+            <div className="flex items-center gap-4 sm:gap-6">
+              {/* Avatar — smaller on mobile so the username fits beside it. */}
+              <div className="w-16 h-16 sm:w-20 sm:h-20 rounded-full overflow-hidden bg-glass-bg border-2 border-glass-border flex items-center justify-center flex-shrink-0">
                 {user.avatarUrl ? (
                   <img src={user.avatarUrl} alt={`${user.username}'s avatar`} className="w-full h-full object-cover" />
                 ) : (
-                  <Users className="w-8 h-8 text-content-text-tertiary" />
+                  <Users className="w-7 h-7 sm:w-8 sm:h-8 text-content-text-tertiary" />
                 )}
               </div>
 
               {/* User Info */}
-              <div>
-                <div className="flex items-center gap-4 mb-2">
-                  <h1 className="text-3xl font-bold text-content-text-primary">{user.username}</h1>
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2 sm:gap-4 mb-1 sm:mb-2">
+                  <h1 className="text-2xl sm:text-3xl font-bold text-content-text-primary break-words">
+                    {user.username}
+                  </h1>
                   {userStat && (
-                    <Badge variant="default" className="bg-brand-primary text-white font-bold text-lg px-4 py-2">
+                    <Badge
+                      variant="default"
+                      className="bg-brand-primary text-white font-bold text-base sm:text-lg px-3 sm:px-4 py-1 sm:py-2"
+                    >
                       {userStat.communityScore || 0}
                     </Badge>
                   )}
                 </div>
-                <p className="text-content-text-secondary">
+                <p className="text-sm sm:text-base text-content-text-secondary">
                   Member since {formatDateLong(user.createdAt.toISOString())}
                 </p>
 
-                {/* First and Last Show - compact */}
+                {/* First and Last Show - wrap on narrow screens. */}
                 {(firstShow || lastShow) && (
-                  <div className="flex items-center gap-4 text-sm mt-2">
+                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm mt-2">
                     {firstShow && (
                       <span className="text-content-text-secondary">
                         First show:{" "}
@@ -172,11 +276,12 @@ export default function UserProfile() {
               </div>
             </div>
 
-            {/* Right side: Badges and Edit Button */}
-            <div className="flex flex-col items-end gap-3">
-              {/* Badges - top right */}
+            {/* Right side: Badges and Edit Button. Aligned left on mobile so
+                it reads as a continuation of the user block; right-aligned at sm+. */}
+            <div className="flex flex-col items-start sm:items-end gap-3">
+              {/* Badges */}
               {userStat?.badges && userStat.badges.length > 0 && (
-                <div className="flex flex-wrap gap-2 justify-end">
+                <div className="flex flex-wrap gap-2 sm:justify-end">
                   {userStat.badges.slice(0, 4).map((badge) => (
                     <div
                       key={badge.id}
@@ -201,52 +306,81 @@ export default function UserProfile() {
             </div>
           </div>
 
-          {/* Stats Grid - now spans full width */}
-          <div className="grid grid-cols-4 gap-6 p-4 bg-content-bg/30 rounded-lg border border-content-border/30 mb-4">
+          {/* Stats Grid — 2-up on mobile so each cell stays readable, 4-up at sm+. */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-6 p-3 sm:p-4 bg-content-bg/30 rounded-lg border border-content-border/30 mb-4">
             <div className="text-center">
-              <div className="text-2xl font-bold text-brand-primary">{attendanceCount}</div>
-              <div className="text-sm text-content-text-secondary">Shows Attended</div>
+              <div className="text-xl sm:text-2xl font-bold text-brand-primary">{attendanceCount}</div>
+              <div className="text-xs sm:text-sm text-content-text-secondary">Shows Attended</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-brand-secondary">{reviewCount}</div>
-              <div className="text-sm text-content-text-secondary">Reviews Written</div>
+              <div className="text-xl sm:text-2xl font-bold text-brand-secondary">{reviewCount}</div>
+              <div className="text-xs sm:text-sm text-content-text-secondary">Reviews Written</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-brand-tertiary">{totalRatings}</div>
-              <div className="text-sm text-content-text-secondary">Total Ratings</div>
+              <div className="text-xl sm:text-2xl font-bold text-brand-tertiary">{totalRatings}</div>
+              <div className="text-xs sm:text-sm text-content-text-secondary">Total Ratings</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-green-500">{userStat?.blogPostCount || 0}</div>
-              <div className="text-sm text-content-text-secondary">Blog Posts</div>
+              <div className="text-xl sm:text-2xl font-bold text-green-500">{userStat?.blogPostCount || 0}</div>
+              <div className="text-xs sm:text-sm text-content-text-secondary">Blog Posts</div>
             </div>
           </div>
         </CardContent>
       </Card>
 
-      {/* Content Tabs */}
-      <Tabs defaultValue="reviews" className="w-full">
-        <TabsList className="glass mb-6">
-          <TabsTrigger value="reviews" className="data-[state=active]:bg-brand-primary data-[state=active]:text-white">
-            Reviews ({reviewCount})
-          </TabsTrigger>
-          <TabsTrigger
-            value="show-ratings"
-            className="data-[state=active]:bg-brand-primary data-[state=active]:text-white"
+      {/* Content Tabs — mobile shows a <select> dropdown (sm:hidden), sm+
+          renders the horizontal tab strip. Mirrors the song-detail page so
+          the long "Song Version Ratings" label doesn't clip on phones. */}
+      <Tabs value={activeTab} onValueChange={(value) => navigate(`?tab=${value}`)} className="w-full">
+        <div className="sm:hidden mb-4">
+          <label htmlFor="user-profile-tab-select" className="sr-only">
+            Profile view
+          </label>
+          <select
+            id="user-profile-tab-select"
+            value={activeTab}
+            onChange={(event) => navigate(`?tab=${event.target.value}`)}
+            className="w-full h-11 px-3 rounded-md bg-glass-bg border border-glass-border text-content-text-primary focus:outline-none focus:ring-1 focus:ring-ring/20"
           >
-            Show Ratings ({showRatingsCount})
+            <option value="shows">Shows Attended ({attendanceCount})</option>
+            <option value="reviews">Reviews ({reviewCount})</option>
+            <option value="show-ratings">Show Ratings ({showRatingsCount})</option>
+            <option value="track-ratings">Song Version Ratings ({trackRatingsCount})</option>
+            {blogPosts.length > 0 && <option value="blog">Blog Posts ({blogPosts.length})</option>}
+          </select>
+        </div>
+        <TabsList className="glass mb-6 hidden sm:flex">
+          <TabsTrigger value="shows" asChild>
+            <Link to="?tab=shows" className="data-[state=active]:bg-brand-primary data-[state=active]:text-white">
+              Shows Attended ({attendanceCount})
+            </Link>
           </TabsTrigger>
-          <TabsTrigger
-            value="track-ratings"
-            className="data-[state=active]:bg-brand-primary data-[state=active]:text-white"
-          >
-            Song Version Ratings ({trackRatingsCount})
+          <TabsTrigger value="reviews" asChild>
+            <Link to="?tab=reviews" className="data-[state=active]:bg-brand-primary data-[state=active]:text-white">
+              Reviews ({reviewCount})
+            </Link>
           </TabsTrigger>
-          <TabsTrigger value="shows" className="data-[state=active]:bg-brand-primary data-[state=active]:text-white">
-            Shows Attended ({attendanceCount})
+          <TabsTrigger value="show-ratings" asChild>
+            <Link
+              to="?tab=show-ratings"
+              className="data-[state=active]:bg-brand-primary data-[state=active]:text-white"
+            >
+              Show Ratings ({showRatingsCount})
+            </Link>
+          </TabsTrigger>
+          <TabsTrigger value="track-ratings" asChild>
+            <Link
+              to="?tab=track-ratings"
+              className="data-[state=active]:bg-brand-primary data-[state=active]:text-white"
+            >
+              Song Version Ratings ({trackRatingsCount})
+            </Link>
           </TabsTrigger>
           {blogPosts.length > 0 && (
-            <TabsTrigger value="blog" className="data-[state=active]:bg-brand-primary data-[state=active]:text-white">
-              Blog Posts ({blogPosts.length})
+            <TabsTrigger value="blog" asChild>
+              <Link to="?tab=blog" className="data-[state=active]:bg-brand-primary data-[state=active]:text-white">
+                Blog Posts ({blogPosts.length})
+              </Link>
             </TabsTrigger>
           )}
         </TabsList>
@@ -312,6 +446,15 @@ export default function UserProfile() {
 
         {/* Show Ratings Tab */}
         <TabsContent value="show-ratings" className="space-y-4">
+          {activeTab === "show-ratings" && ratingsPagination.totalPages > 1 && (
+            <PaginationControls
+              page={ratingsPagination.page}
+              totalPages={ratingsPagination.totalPages}
+              total={ratingsPagination.total}
+              pageSize={ratingsPagination.pageSize}
+              onPageChange={handlePageChange}
+            />
+          )}
           {showRatings.length > 0 ? (
             <div className="space-y-4">
               {showRatings.map((rating) => (
@@ -366,10 +509,28 @@ export default function UserProfile() {
               </CardContent>
             </Card>
           )}
+          {activeTab === "show-ratings" && ratingsPagination.totalPages > 1 && (
+            <PaginationControls
+              page={ratingsPagination.page}
+              totalPages={ratingsPagination.totalPages}
+              total={ratingsPagination.total}
+              pageSize={ratingsPagination.pageSize}
+              onPageChange={handlePageChange}
+            />
+          )}
         </TabsContent>
 
         {/* Song Version Ratings Tab */}
         <TabsContent value="track-ratings" className="space-y-4">
+          {activeTab === "track-ratings" && ratingsPagination.totalPages > 1 && (
+            <PaginationControls
+              page={ratingsPagination.page}
+              totalPages={ratingsPagination.totalPages}
+              total={ratingsPagination.total}
+              pageSize={ratingsPagination.pageSize}
+              onPageChange={handlePageChange}
+            />
+          )}
           {trackRatings.length > 0 ? (
             <div className="space-y-4">
               {trackRatings.map((rating) => (
@@ -434,6 +595,15 @@ export default function UserProfile() {
               </CardContent>
             </Card>
           )}
+          {activeTab === "track-ratings" && ratingsPagination.totalPages > 1 && (
+            <PaginationControls
+              page={ratingsPagination.page}
+              totalPages={ratingsPagination.totalPages}
+              total={ratingsPagination.total}
+              pageSize={ratingsPagination.pageSize}
+              onPageChange={handlePageChange}
+            />
+          )}
         </TabsContent>
 
         {/* Blog Posts Tab */}
@@ -490,53 +660,42 @@ export default function UserProfile() {
 
         {/* Shows Attended Tab */}
         <TabsContent value="shows" className="space-y-4">
-          {userAttendances.length > 0 ? (
-            <div className="space-y-4">
-              {userAttendances.map((attendance) => (
-                <Card key={attendance.id} className="card-premium">
-                  <CardHeader>
-                    <div className="flex items-center justify-between">
-                      <CardTitle className="text-lg">
-                        {attendance.show.slug ? (
-                          <Link
-                            to={`/shows/${attendance.show.slug}`}
-                            className="text-brand-primary hover:text-brand-secondary transition-colors hover:underline"
-                          >
-                            {attendance.show.venue?.name || "Unknown Venue"}
-                          </Link>
-                        ) : (
-                          <span className="text-brand-primary">{attendance.show.venue?.name || "Unknown Venue"}</span>
-                        )}
-                      </CardTitle>
-                      <span className="text-sm text-content-text-tertiary">
-                        Marked {formatDateLong(attendance.createdAt.toISOString())}
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-2 text-sm text-content-text-secondary mt-1">
-                      <CalendarDays className="w-4 h-4" />
-                      <span>{formatDateLong(attendance.show.date)}</span>
-                      {attendance.show.venue?.city && attendance.show.venue?.state && (
-                        <span>
-                          • {attendance.show.venue.city}, {attendance.show.venue.state}
-                        </span>
-                      )}
-                    </div>
-                  </CardHeader>
-                </Card>
-              ))}
-            </div>
-          ) : (
-            <Card className="card-premium">
-              <CardContent className="py-12 text-center">
-                <CalendarDays className="w-12 h-12 text-content-text-tertiary mx-auto mb-4" />
-                <h3 className="text-lg font-medium text-content-text-primary mb-2">No Shows Attended</h3>
-                <p className="text-content-text-secondary">
-                  {isOwnProfile
-                    ? "You haven't marked any shows as attended yet. Browse shows and mark the ones you've been to!"
-                    : `${user.username} hasn't marked any shows as attended yet.`}
-                </p>
-              </CardContent>
-            </Card>
+          {attendedPagination.totalPages > 1 && (
+            <PaginationControls
+              page={attendedPagination.page}
+              totalPages={attendedPagination.totalPages}
+              total={attendedPagination.total}
+              pageSize={attendedPagination.pageSize}
+              onPageChange={handlePageChange}
+            />
+          )}
+          <SetlistList
+            setlists={attendedSetlists}
+            externalSources={attendedExternalSources}
+            initialUserData={attendedInitialUserData}
+            collapsible
+            empty={
+              <Card className="card-premium">
+                <CardContent className="py-12 text-center">
+                  <CalendarDays className="w-12 h-12 text-content-text-tertiary mx-auto mb-4" />
+                  <h3 className="text-lg font-medium text-content-text-primary mb-2">No Shows Attended</h3>
+                  <p className="text-content-text-secondary">
+                    {isOwnProfile
+                      ? "You haven't marked any shows as attended yet. Browse shows and mark the ones you've been to!"
+                      : `${user.username} hasn't marked any shows as attended yet.`}
+                  </p>
+                </CardContent>
+              </Card>
+            }
+          />
+          {attendedPagination.totalPages > 1 && (
+            <PaginationControls
+              page={attendedPagination.page}
+              totalPages={attendedPagination.totalPages}
+              total={attendedPagination.total}
+              pageSize={attendedPagination.pageSize}
+              onPageChange={handlePageChange}
+            />
           )}
         </TabsContent>
       </Tabs>

--- a/packages/core/scripts/sync-missing-shows.test.ts
+++ b/packages/core/scripts/sync-missing-shows.test.ts
@@ -553,8 +553,8 @@ describe("buildSongCreateInput", () => {
     const now = new Date("2026-04-23T12:00:00Z");
     const input = buildSongCreateInput(
       {
-        slug: "tractorbeam",
-        title: "Tractorbeam",
+        slug: "basis-for-a-day",
+        title: "Basis for a Day",
         author: "Disco Biscuits",
         lyrics: null,
         timesPlayed: 412,
@@ -564,8 +564,8 @@ describe("buildSongCreateInput", () => {
       now,
     );
     expect(input).toEqual({
-      slug: "tractorbeam",
-      title: "Tractorbeam",
+      slug: "basis-for-a-day",
+      title: "Basis for a Day",
       lyrics: null,
       timesPlayed: 412,
       dateFirstPlayed: new Date("1998-07-04"),

--- a/packages/core/src/_shared/cache/cache-invalidation-service.test.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.test.ts
@@ -1,0 +1,61 @@
+import { CacheKeys } from "@bip/domain";
+import { describe, expect, test, vi } from "vitest";
+import { CacheInvalidationService } from "./cache-invalidation-service";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+
+function makeCache() {
+  return {
+    del: vi.fn().mockResolvedValue(undefined),
+    delPattern: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("CacheInvalidationService.invalidateAttendanceCaches", () => {
+  // Toggling attendance changes which shows appear in /songs filtered-by-user
+  // results AND which setlists appear on the user-profile Shows Attended tab.
+  // Both per-user caches must be wiped together — otherwise the profile shows
+  // stale setlists or the /songs filter shows stale attendance hits.
+  test("wipes both per-user filtered-songs and attended-setlists patterns", async () => {
+    const cache = makeCache();
+    const service = new CacheInvalidationService(cache as never, logger);
+
+    await service.invalidateAttendanceCaches("u-rynow");
+
+    expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.songs.allFilteredForUser("u-rynow"));
+    expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.users.allAttendedSetlistsForUser("u-rynow"));
+    // Both patterns scope by user — never wipe global caches from a single
+    // user's attendance change.
+    expect(cache.delPattern).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("CacheInvalidationService.invalidateShowListings", () => {
+  // Admin edits to show metadata (date, venue, etc.) bubble through here.
+  // Per-user attended-setlists caches embed that metadata, so they must be
+  // wiped along with the global show-listing caches. Pattern-wide wipe avoids
+  // tracking which users attended which show.
+  test("wipes per-user attended-setlists across all users on show-listing changes", async () => {
+    const cache = makeCache();
+    const service = new CacheInvalidationService(cache as never, logger);
+
+    await service.invalidateShowListings();
+
+    expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.users.allAttendedSetlists());
+  });
+
+  // Regression guard for the existing global show-listing invalidations —
+  // adding the new attended-setlists pattern shouldn't have dropped any of
+  // the original wipes.
+  test("still wipes the original show-listing + stats caches", async () => {
+    const cache = makeCache();
+    const service = new CacheInvalidationService(cache as never, logger);
+
+    await service.invalidateShowListings();
+
+    expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.shows.allLists());
+    expect(cache.delPattern).toHaveBeenCalledWith("home:*");
+    expect(cache.del).toHaveBeenCalledWith(CacheKeys.stats.showsByYear());
+    expect(cache.del).toHaveBeenCalledWith(CacheKeys.stats.showDates());
+  });
+});

--- a/packages/core/src/_shared/cache/cache-invalidation-service.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.ts
@@ -52,6 +52,9 @@ export class CacheInvalidationService {
       this.cache.delPattern("home:*"), // Invalidate all home page caches
       this.cache.del(CacheKeys.stats.showsByYear()), // shows-per-year aggregate is tied to the show catalog
       this.cache.del(CacheKeys.stats.showDates()), // sorted stats-show-dates array backs Current Gap on /songs
+      // Per-user attended-setlists caches include each show's setlist + venue;
+      // wipe them all when any show metadata moves.
+      this.cache.delPattern(CacheKeys.users.allAttendedSetlists()),
       this.cloudflareCache?.purgeYearListings(),
     ]);
   }
@@ -100,7 +103,11 @@ export class CacheInvalidationService {
    */
   async invalidateAttendanceCaches(userId: string): Promise<void> {
     this.logger.info(`Invalidating attendance caches for user: ${userId}`);
-    await this.cache.delPattern(CacheKeys.songs.allFilteredForUser(userId));
+    await Promise.all([
+      this.cache.delPattern(CacheKeys.songs.allFilteredForUser(userId)),
+      // User profile's Shows Attended tab uses a per-user paginated setlists payload.
+      this.cache.delPattern(CacheKeys.users.allAttendedSetlistsForUser(userId)),
+    ]);
   }
 
   /**

--- a/packages/core/src/ratings/rating-service.test.ts
+++ b/packages/core/src/ratings/rating-service.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, test, vi } from "vitest";
+import { RatingService } from "./rating-service";
+
+// Minimal stub — service only invalidates caches at write paths; the read
+// methods under test don't touch it.
+const cacheInvalidation = {
+  invalidateAttendanceCaches: vi.fn(),
+  invalidateShowComprehensive: vi.fn(),
+} as never;
+
+type MockRating = {
+  id: string;
+  userId: string;
+  rateableId: string;
+  rateableType: string;
+  value: number;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function rating(overrides: Partial<MockRating>): MockRating {
+  return {
+    id: "r1",
+    userId: "u1",
+    rateableId: "x1",
+    rateableType: "Show",
+    value: 5,
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    updatedAt: new Date("2024-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("RatingService.findShowRatingsByUserId", () => {
+  // The user-profile show-ratings list only displays id/value/createdAt +
+  // nested slug/date/venue trio. Returning a Rating-extending shape with
+  // userId/rateableId/etc. forces ~1.7 MB of unused JSON onto heavy users
+  // (the heaviest user has ~1,700 show ratings). The slim shape strips those.
+  test("returns slim shape without userId, rateableId, rateableType, or updatedAt", async () => {
+    const db = {
+      rating: {
+        findMany: vi.fn().mockResolvedValue([rating({ id: "r1", rateableId: "show-1" })]),
+      },
+      show: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "show-1",
+            slug: "2024-08-12-cap-theatre",
+            date: "2024-08-12",
+            venue: { name: "The Capitol Theatre", city: "Port Chester", state: "NY" },
+          },
+        ]),
+      },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    const result = await service.findShowRatingsByUserId("u1");
+
+    expect(result).toHaveLength(1);
+    const row = result[0];
+    expect(row).toEqual({
+      id: "r1",
+      value: 5,
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+      show: {
+        slug: "2024-08-12-cap-theatre",
+        date: "2024-08-12",
+        venue: { name: "The Capitol Theatre", city: "Port Chester", state: "NY" },
+      },
+    });
+    // Explicit negative assertions — these fields drove the bloat.
+    expect(row).not.toHaveProperty("userId");
+    expect(row).not.toHaveProperty("rateableId");
+    expect(row).not.toHaveProperty("rateableType");
+    expect(row).not.toHaveProperty("updatedAt");
+  });
+
+  // If the underlying show was deleted while the rating remained (data
+  // drift), we drop the orphan rather than crash. Mirrors the original
+  // .filter() behavior; protects the user profile from white-screening on
+  // dangling ratings.
+  test("skips ratings whose related show is missing", async () => {
+    const db = {
+      rating: {
+        findMany: vi
+          .fn()
+          .mockResolvedValue([rating({ id: "r1", rateableId: "missing" }), rating({ id: "r2", rateableId: "show-1" })]),
+      },
+      show: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "show-1",
+            slug: "show-slug",
+            date: "2024-08-12",
+            venue: null,
+          },
+        ]),
+      },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    const result = await service.findShowRatingsByUserId("u1");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("r2");
+    expect(result[0].show.venue).toBeNull();
+  });
+
+  // Heavy users (~1,700 show ratings) need server-side pagination —
+  // shipping all rows on every load costs hundreds of KB. The service
+  // accepts skip/take and the caller is expected to combine with
+  // getUserTabCounts() for the total. Verifies the slice is applied at the
+  // DB level, not in JS.
+  test("supports skip/take pagination at the DB layer", async () => {
+    const ratingFindMany = vi.fn().mockResolvedValue([rating({ id: "r-page-3", rateableId: "show-page-3" })]);
+    const db = {
+      rating: { findMany: ratingFindMany },
+      show: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "show-page-3",
+            slug: "s",
+            date: "2024-01-01",
+            venue: null,
+          },
+        ]),
+      },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    const result = await service.findShowRatingsByUserId("u1", { skip: 200, take: 100 });
+
+    expect(ratingFindMany.mock.calls[0][0]).toMatchObject({ skip: 200, take: 100 });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("r-page-3");
+  });
+
+  // Narrowed Prisma projection: only select the columns the slim shape
+  // surfaces. Regression guard — accidentally going back to `include` re-bloats
+  // every load.
+  test("queries the DB with a narrow `select` (no full row projection)", async () => {
+    const showFindMany = vi.fn().mockResolvedValue([]);
+    const db = {
+      rating: { findMany: vi.fn().mockResolvedValue([rating({ rateableId: "show-1" })]) },
+      show: { findMany: showFindMany },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    await service.findShowRatingsByUserId("u1");
+
+    const args = showFindMany.mock.calls[0][0];
+    expect(args).toHaveProperty("select");
+    expect(args).not.toHaveProperty("include");
+    expect(args.select).toMatchObject({
+      id: true,
+      slug: true,
+      date: true,
+      venue: { select: { name: true, city: true, state: true } },
+    });
+  });
+});
+
+describe("RatingService.findTrackRatingsByUserId", () => {
+  // The user-profile track-ratings list is the worst offender — 7,784 rows
+  // for the heaviest user. The slim shape drops every unused field, including venue
+  // city/state (which the track-rating row doesn't display, unlike the
+  // show-rating row above).
+  test("returns slim shape with no venue.city/state and no UUIDs", async () => {
+    const db = {
+      rating: {
+        findMany: vi.fn().mockResolvedValue([rating({ id: "r1", rateableId: "track-1", rateableType: "Track" })]),
+      },
+      track: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "track-1",
+            slug: "basis-for-a-day-2024-08-12",
+            position: 3,
+            set: "S1",
+            show: {
+              slug: "2024-08-12-cap-theatre",
+              date: "2024-08-12",
+              venue: { name: "The Capitol Theatre" },
+            },
+            song: { slug: "basis-for-a-day", title: "Basis for a Day" },
+          },
+        ]),
+      },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    const result = await service.findTrackRatingsByUserId("u1");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: "r1",
+      value: 5,
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+      track: {
+        slug: "basis-for-a-day-2024-08-12",
+        position: 3,
+        set: "S1",
+        show: {
+          slug: "2024-08-12-cap-theatre",
+          date: "2024-08-12",
+          venue: { name: "The Capitol Theatre" },
+        },
+        song: { slug: "basis-for-a-day", title: "Basis for a Day" },
+      },
+    });
+    expect(result[0]).not.toHaveProperty("userId");
+    expect(result[0]).not.toHaveProperty("rateableType");
+    expect(result[0].track).not.toHaveProperty("id");
+    expect(result[0].track.show).not.toHaveProperty("id");
+    expect(result[0].track.show.venue).not.toHaveProperty("city");
+    expect(result[0].track.show.venue).not.toHaveProperty("state");
+    expect(result[0].track.song).not.toHaveProperty("id");
+  });
+
+  // Same orphan-protection as show ratings — if the joined track is gone we
+  // drop the row instead of crashing the user profile.
+  test("skips ratings whose related track is missing", async () => {
+    const db = {
+      rating: {
+        findMany: vi
+          .fn()
+          .mockResolvedValue([
+            rating({ id: "r1", rateableId: "missing-track", rateableType: "Track" }),
+            rating({ id: "r2", rateableId: "track-1", rateableType: "Track" }),
+          ]),
+      },
+      track: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "track-1",
+            slug: "above-the-waves",
+            position: 1,
+            set: "S2",
+            show: { slug: "show-slug", date: "2024-01-01", venue: { name: "Some Venue" } },
+            song: { slug: "above-the-waves", title: "Above The Waves" },
+          },
+        ]),
+      },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    const result = await service.findTrackRatingsByUserId("u1");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("r2");
+  });
+
+  // Same pagination requirement as show ratings — the heaviest user has ~7,800 track
+  // ratings and a single full payload is ~4 MB. skip/take must reach the
+  // DB so we never marshal rows we don't render.
+  test("supports skip/take pagination at the DB layer", async () => {
+    const ratingFindMany = vi
+      .fn()
+      .mockResolvedValue([rating({ id: "r-tracks-page-2", rateableId: "track-page-2", rateableType: "Track" })]);
+    const db = {
+      rating: { findMany: ratingFindMany },
+      track: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "track-page-2",
+            slug: "basis-for-a-day",
+            position: 1,
+            set: "S1",
+            show: { slug: "s", date: "2024-01-01", venue: { name: "v" } },
+            song: { slug: "basis-for-a-day", title: "Basis for a Day" },
+          },
+        ]),
+      },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    const result = await service.findTrackRatingsByUserId("u1", { skip: 100, take: 100 });
+
+    expect(ratingFindMany.mock.calls[0][0]).toMatchObject({ skip: 100, take: 100 });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("r-tracks-page-2");
+  });
+
+  // Same Prisma narrowing regression guard as show ratings — the track
+  // method must use `select` (not `include`) and limit nested venue/song.
+  test("queries the DB with a narrow `select`", async () => {
+    const trackFindMany = vi.fn().mockResolvedValue([]);
+    const db = {
+      rating: { findMany: vi.fn().mockResolvedValue([rating({ rateableType: "Track", rateableId: "track-1" })]) },
+      track: { findMany: trackFindMany },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    await service.findTrackRatingsByUserId("u1");
+
+    const args = trackFindMany.mock.calls[0][0];
+    expect(args).toHaveProperty("select");
+    expect(args).not.toHaveProperty("include");
+    // Venue should expose only `name` — city/state would re-introduce bloat.
+    expect(args.select.show.select.venue.select).toEqual({ name: true });
+    // Song should expose only slug/title — no UUID.
+    expect(args.select.song.select).toEqual({ slug: true, title: true });
+  });
+});

--- a/packages/core/src/ratings/rating-service.ts
+++ b/packages/core/src/ratings/rating-service.ts
@@ -2,9 +2,17 @@ import type { Rating } from "@bip/domain";
 import type { CacheInvalidationService } from "../_shared/cache";
 import type { DbClient, DbRating } from "../_shared/database/models";
 
-export interface RatingWithShow extends Rating {
+/**
+ * Slim show-rating row for list views — only fields the user-profile page
+ * actually renders. UUIDs, rateable_id/type, userId, and updatedAt are
+ * omitted because heavy users have 1000+ ratings and the unused fields
+ * dominate the JSON payload.
+ */
+export interface RatingWithShow {
+  id: string;
+  value: number;
+  createdAt: Date;
   show: {
-    id: string;
     slug: string | null;
     date: string;
     venue: {
@@ -15,24 +23,25 @@ export interface RatingWithShow extends Rating {
   };
 }
 
-export interface RatingWithTrack extends Rating {
+/**
+ * Slim track-rating row for list views. Same motivation as RatingWithShow —
+ * we additionally drop venue.city/state on the nested show because the
+ * track-rating row doesn't display them (the show-rating row does).
+ */
+export interface RatingWithTrack {
+  id: string;
+  value: number;
+  createdAt: Date;
   track: {
-    id: string;
     slug: string | null;
     position: number;
     set: string;
     show: {
-      id: string;
       slug: string | null;
       date: string;
-      venue: {
-        name: string | null;
-        city: string | null;
-        state: string | null;
-      } | null;
+      venue: { name: string | null } | null;
     };
     song: {
-      id: string;
       slug: string;
       title: string;
     };
@@ -189,7 +198,7 @@ export class RatingService {
     return result ? mapRatingToDomainEntity(result) : null;
   }
 
-  async findShowRatingsByUserId(userId: string): Promise<RatingWithShow[]> {
+  async findShowRatingsByUserId(userId: string, options?: { skip?: number; take?: number }): Promise<RatingWithShow[]> {
     const results = await this.db.rating.findMany({
       where: {
         userId,
@@ -197,26 +206,35 @@ export class RatingService {
         value: { gte: 1, lte: 5 }, // Only valid ratings
       },
       orderBy: { createdAt: "desc" },
+      skip: options?.skip,
+      take: options?.take,
     });
 
-    // Get show data for all ratings
+    // Get show data for all ratings — narrow projection (slug/date/venue
+    // trio) since the user-profile list cards don't use any other field.
     const showIds = results.map((r) => r.rateableId);
     const shows = await this.db.show.findMany({
       where: { id: { in: showIds } },
-      include: { venue: true },
+      select: {
+        id: true,
+        slug: true,
+        date: true,
+        venue: { select: { name: true, city: true, state: true } },
+      },
     });
 
     const showMap = new Map(shows.map((show) => [show.id, show]));
 
     return results
-      .map((rating) => {
+      .map((rating): RatingWithShow | null => {
         const show = showMap.get(rating.rateableId);
         if (!show) return null;
 
         return {
-          ...mapRatingToDomainEntity(rating),
+          id: rating.id,
+          value: rating.value,
+          createdAt: rating.createdAt,
           show: {
-            id: show.id,
             slug: show.slug,
             date: show.date,
             venue: show.venue
@@ -232,7 +250,10 @@ export class RatingService {
       .filter((rating): rating is RatingWithShow => rating !== null);
   }
 
-  async findTrackRatingsByUserId(userId: string): Promise<RatingWithTrack[]> {
+  async findTrackRatingsByUserId(
+    userId: string,
+    options?: { skip?: number; take?: number },
+  ): Promise<RatingWithTrack[]> {
     const results = await this.db.rating.findMany({
       where: {
         userId,
@@ -240,46 +261,53 @@ export class RatingService {
         value: { gte: 1, lte: 5 }, // Only valid ratings
       },
       orderBy: { createdAt: "desc" },
+      skip: options?.skip,
+      take: options?.take,
     });
 
-    // Get track data with show and song info
+    // Get track data with show and song info — narrow projection: the
+    // user-profile track-rating cards only display set/position + nested
+    // slug/date/venue.name + song.slug/title.
     const trackIds = results.map((r) => r.rateableId);
     const tracks = await this.db.track.findMany({
       where: { id: { in: trackIds } },
-      include: {
-        show: { include: { venue: true } },
-        song: true,
+      select: {
+        id: true,
+        slug: true,
+        position: true,
+        set: true,
+        show: {
+          select: {
+            slug: true,
+            date: true,
+            venue: { select: { name: true } },
+          },
+        },
+        song: { select: { slug: true, title: true } },
       },
     });
 
     const trackMap = new Map(tracks.map((track) => [track.id, track]));
 
     return results
-      .map((rating) => {
+      .map((rating): RatingWithTrack | null => {
         const track = trackMap.get(rating.rateableId);
         if (!track) return null;
 
         return {
-          ...mapRatingToDomainEntity(rating),
+          id: rating.id,
+          value: rating.value,
+          createdAt: rating.createdAt,
           track: {
-            id: track.id,
             slug: track.slug,
             position: track.position,
             set: track.set,
             show: {
-              id: track.show.id,
               slug: track.show.slug,
               date: track.show.date,
-              venue: track.show.venue
-                ? {
-                    name: track.show.venue.name,
-                    city: track.show.venue.city,
-                    state: track.show.venue.state,
-                  }
-                : null,
+              venue: track.show.venue ? { name: track.show.venue.name } : null,
             },
             song: {
-              id: track.song.id,
               slug: track.song.slug,
               title: track.song.title,
             },

--- a/packages/core/src/setlists/setlist-service.test.ts
+++ b/packages/core/src/setlists/setlist-service.test.ts
@@ -131,7 +131,7 @@ describe("computeAverageSongGap", () => {
   // average down to "we never played this".
   test("averages real gaps and ignores debuts", () => {
     const tracks = [
-      { songId: "a", position: 1, gap: null }, // Tractorbeam debut
+      { songId: "a", position: 1, gap: null }, // Basis for a Day debut
       { songId: "b", position: 2, gap: 5 }, // Above the Waves
       { songId: "c", position: 3, gap: 10 }, // Confrontation
     ];
@@ -169,7 +169,7 @@ describe("computeMedianSongGap", () => {
   // an outlier dragging it like the average can.
   test("returns the middle value for an odd-count eligible list", () => {
     const tracks = [
-      { songId: "a", position: 1, gap: 30 }, // Tractorbeam
+      { songId: "a", position: 1, gap: 30 }, // Basis for a Day
       { songId: "b", position: 2, gap: 5 }, // Above the Waves
       { songId: "c", position: 3, gap: 10 }, // Confrontation
     ];
@@ -207,7 +207,7 @@ describe("computeMedianSongGap", () => {
   // hide the summary line entirely.
   test("returns null when no eligible tracks remain", () => {
     const tracks = [
-      { songId: "a", position: 1, gap: null }, // Tractorbeam debut
+      { songId: "a", position: 1, gap: null }, // Basis for a Day debut
       { songId: "b", position: 2, gap: null }, // Above the Waves debut
     ];
     expect(computeMedianSongGap(tracks)).toBeNull();
@@ -246,7 +246,7 @@ describe("SetlistService.findByShowSlug", () => {
       venueId: "v-1",
       bandId: "b-1",
       tracks: [
-        // Tractorbeam debut — gap=null
+        // Basis for a Day debut — gap=null
         {
           id: "t-1",
           showId: "show-1",

--- a/packages/core/src/users/user-service.test.ts
+++ b/packages/core/src/users/user-service.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test, vi } from "vitest";
+import { UserService } from "./user-service";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+
+describe("UserService.getUserTabCounts", () => {
+  // The user-profile page renders tab labels like "Reviews (12)" /
+  // "Track Ratings (783)". Pulling the full data just to derive the count
+  // for the tab label was costing megabytes on heavy users — this method
+  // returns just the four counts via cheap aggregations so the loader can
+  // populate labels without fetching the underlying rows.
+  test("returns review/show-rating/track-rating/blog-post counts via cheap COUNT queries", async () => {
+    const ratingCount = vi
+      .fn()
+      .mockImplementationOnce(async () => 17) // first call: show ratings
+      .mockImplementationOnce(async () => 42); // second call: track ratings
+
+    const db = {
+      review: { count: vi.fn().mockResolvedValue(6) },
+      rating: { count: ratingCount },
+      blogPost: { count: vi.fn().mockResolvedValue(3) },
+    } as never;
+
+    const service = new UserService(db, logger);
+    const counts = await service.getUserTabCounts("u-rynow");
+
+    expect(counts).toEqual({
+      reviewCount: 6,
+      showRatingsCount: 17,
+      trackRatingsCount: 42,
+      blogPostCount: 3,
+    });
+  });
+
+  // The two rating counts are filtered by rateableType so we never conflate
+  // show ratings with track ratings — the user profile shows them in
+  // separate tabs and their counts must not overlap.
+  test("filters rating counts by rateableType (Show vs Track)", async () => {
+    const ratingCount = vi.fn().mockResolvedValue(0);
+    const db = {
+      review: { count: vi.fn().mockResolvedValue(0) },
+      rating: { count: ratingCount },
+      blogPost: { count: vi.fn().mockResolvedValue(0) },
+    } as never;
+
+    const service = new UserService(db, logger);
+    await service.getUserTabCounts("u-1");
+
+    // First rating.count call → show ratings
+    expect(ratingCount.mock.calls[0][0].where).toMatchObject({
+      userId: "u-1",
+      rateableType: "Show",
+    });
+    // Second rating.count call → track ratings
+    expect(ratingCount.mock.calls[1][0].where).toMatchObject({
+      userId: "u-1",
+      rateableType: "Track",
+    });
+  });
+
+  // Blog post count must mirror getUserStats's filter: only published posts.
+  // Otherwise the tab label disagrees with what actually renders in the tab.
+  test("blog post count only includes published posts", async () => {
+    const blogCount = vi.fn().mockResolvedValue(0);
+    const db = {
+      review: { count: vi.fn().mockResolvedValue(0) },
+      rating: { count: vi.fn().mockResolvedValue(0) },
+      blogPost: { count: blogCount },
+    } as never;
+
+    const service = new UserService(db, logger);
+    await service.getUserTabCounts("u-1");
+
+    expect(blogCount.mock.calls[0][0].where).toMatchObject({
+      userId: "u-1",
+      state: "published",
+    });
+  });
+});
+
+describe("UserService.getUserProfileHeader", () => {
+  // The user-profile header always renders attendance count + first/last
+  // show dates. Pulling the full attendance list just to derive three
+  // values was costing ~30-50ms on heavy users; this method does it via
+  // a COUNT + two cheap findFirst queries.
+  test("returns attendanceCount + first and last attended shows", async () => {
+    const attendanceCount = vi.fn().mockResolvedValue(459);
+    const findFirst = vi
+      .fn()
+      // Ascending: oldest show (first attended)
+      .mockResolvedValueOnce({ show: { id: "show-first", date: "1998-04-25" } })
+      // Descending: newest show (most recent)
+      .mockResolvedValueOnce({ show: { id: "show-last", date: "2026-04-25" } });
+
+    const db = {
+      attendance: {
+        count: attendanceCount,
+        findFirst,
+      },
+    } as never;
+
+    const service = new UserService(db, logger);
+    const header = await service.getUserProfileHeader("u-1");
+
+    expect(header).toEqual({
+      attendanceCount: 459,
+      firstShow: { id: "show-first", date: "1998-04-25" },
+      lastShow: { id: "show-last", date: "2026-04-25" },
+    });
+  });
+
+  // When the user has no attendances, firstShow/lastShow are null and the
+  // header still renders cleanly (no attendances row + zero count).
+  test("returns nulls for first/last show when user has no attendances", async () => {
+    const db = {
+      attendance: {
+        count: vi.fn().mockResolvedValue(0),
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+    } as never;
+
+    const service = new UserService(db, logger);
+    const header = await service.getUserProfileHeader("u-1");
+
+    expect(header).toEqual({
+      attendanceCount: 0,
+      firstShow: null,
+      lastShow: null,
+    });
+  });
+
+  // Ordering matters: first show is the oldest by date, last show is the
+  // newest. The findFirst calls must specify these directions explicitly.
+  test("orders first by show.date asc and last by show.date desc", async () => {
+    const findFirst = vi.fn().mockResolvedValue(null);
+    const db = {
+      attendance: {
+        count: vi.fn().mockResolvedValue(0),
+        findFirst,
+      },
+    } as never;
+
+    const service = new UserService(db, logger);
+    await service.getUserProfileHeader("u-1");
+
+    expect(findFirst.mock.calls[0][0].orderBy).toMatchObject({ show: { date: "asc" } });
+    expect(findFirst.mock.calls[1][0].orderBy).toMatchObject({ show: { date: "desc" } });
+  });
+});

--- a/packages/core/src/users/user-service.ts
+++ b/packages/core/src/users/user-service.ts
@@ -276,6 +276,58 @@ export class UserService {
     }
   }
 
+  /**
+   * Tab labels on the user profile page ("Reviews (N)", "Track Ratings (N)",
+   * etc.) need counts even when we don't fetch the underlying rows. Heavy
+   * users have 7,000+ track ratings; pulling that array just to call
+   * `.length` costs megabytes of payload. These COUNT queries replace that.
+   */
+  async getUserTabCounts(userId: string): Promise<{
+    reviewCount: number;
+    showRatingsCount: number;
+    trackRatingsCount: number;
+    blogPostCount: number;
+  }> {
+    const [reviewCount, showRatingsCount, trackRatingsCount, blogPostCount] = await Promise.all([
+      this.db.review.count({ where: { userId } }),
+      this.db.rating.count({ where: { userId, rateableType: "Show", value: { gte: 1, lte: 5 } } }),
+      this.db.rating.count({ where: { userId, rateableType: "Track", value: { gte: 1, lte: 5 } } }),
+      this.db.blogPost.count({ where: { userId, state: "published" } }),
+    ]);
+    return { reviewCount, showRatingsCount, trackRatingsCount, blogPostCount };
+  }
+
+  /**
+   * Header summary for the user-profile page: total attendance count plus
+   * the oldest and newest shows the user has marked attended. Avoids
+   * fetching the full attendance list (~30-50ms on heavy users) just to
+   * derive these three values for the page header.
+   */
+  async getUserProfileHeader(userId: string): Promise<{
+    attendanceCount: number;
+    firstShow: { id: string; date: string } | null;
+    lastShow: { id: string; date: string } | null;
+  }> {
+    const [attendanceCount, firstAttendance, lastAttendance] = await Promise.all([
+      this.db.attendance.count({ where: { userId } }),
+      this.db.attendance.findFirst({
+        where: { userId },
+        orderBy: { show: { date: "asc" } },
+        select: { show: { select: { id: true, date: true } } },
+      }),
+      this.db.attendance.findFirst({
+        where: { userId },
+        orderBy: { show: { date: "desc" } },
+        select: { show: { select: { id: true, date: true } } },
+      }),
+    ]);
+    return {
+      attendanceCount,
+      firstShow: firstAttendance?.show ?? null,
+      lastShow: lastAttendance?.show ?? null,
+    };
+  }
+
   async getUserStats(userId?: string): Promise<UserStats[]> {
     this.logger.info("getUserStats called", { userId });
     const whereClause = userId ? { id: userId } : {};

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -87,6 +87,23 @@ export const CacheKeys = {
   },
 
   /**
+   * Per-user cache keys
+   */
+  users: {
+    /**
+     * Pre-built SetlistList payload (setlists + external sources) for one
+     * page of a user's attended shows. Paginated because the heaviest users
+     * have 400+ attended shows and the un-paginated payload is large enough
+     * to be slow to deserialize/transport even from Redis.
+     */
+    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}`,
+    /** All pages of a single user's attended-setlists caches (for per-user invalidation). */
+    allAttendedSetlistsForUser: (userId: string) => `user:${userId}:attended-setlists:*`,
+    /** All per-user attended-setlists caches (for pattern deletion on broad show mutations). */
+    allAttendedSetlists: () => "user:*:attended-setlists:*",
+  },
+
+  /**
    * Home page cache keys
    */
   home: {


### PR DESCRIPTION
## Summary

- **Shows Attended tab** on user profiles now renders via the shared SetlistList + SetlistCard components — inheriting the gap-chart toggle, ratings, attendance badges, media badges, and anniversary chrome that every other show-list surface gets. Promoted to leftmost / default tab.
- **Tabs are URL-driven** (?tab=...) so the loader only fetches the active tab's row data. Heavy users (~10k records) were shipping all tabs' data on every load; this trims the default payload by ~50% and the worst-case tab by ~85%.
- **Pagination** added to Shows Attended (50/page), Show Ratings (100/page), and Track Ratings (100/page). New shared PaginationControls widget replaces the inline implementation in DataTable and is used in both places.
- **Per-user Redis cache** for the attended-setlists payload, keyed by user:{id}:attended-setlists:p{N}, invalidated by attendance toggles and any show-listing mutation.
- **Slim rating service shapes**: findShowRatingsByUserId / findTrackRatingsByUserId return only the fields the UI consumes (no userId/rateableId/unused UUIDs) and accept skip/take for DB-level pagination.
- **Cheap header query**: new UserService.getUserProfileHeader returns attendance count + first/last show via COUNT + two findFirst queries so non-shows tabs don't pay for the full 459-row attendance list.
- **Mobile-friendly**: tabs collapse to a select on phones (mirrors the song-detail page), header stacks vertically, stats grid is 2-up on mobile.
- **Bug fix**: "Saw it?" button no longer wraps on narrow viewports.


https://github.com/user-attachments/assets/e8ed97c7-edcf-4ad6-80ae-d32b6075a2a9



## Performance (heaviest user, ~10k records)

| Surface | Before | After |
|---|---|---|
| Default (Shows Attended) | 3.0 s / 7.5 MB | **0.5 s / 3.1 MB** |
| ?tab=track-ratings | 2.4 s / 17.8 MB | **0.4 s / 2.7 MB** |
| ?tab=reviews | (bundled) | **0.1 s** |

Median user (~21 records) loads in ~80 ms / ~700 KB.

## Test plan
- [ ] Visit /users/<your-username> — Shows Attended is leftmost and selected; cards render as full SetlistCards (collapsible, gap toggle, ratings).
- [ ] Mark/unmark a show on the profile — the page-1 cache invalidates and shows update on reload.
- [ ] Click each tab — URL updates to ?tab=...; data loads for that tab only. Refresh; same tab stays active.
- [ ] On a user with 100+ attended shows or 100+ ratings, paginate via Prev/Next or the page-number input. Refresh on ?page=2 lands back on page 2.
- [ ] Mobile width (375px): tabs render as a select; header avatar/name/badges stack; stats grid is 2-up; "Saw it?" button doesn't wrap.
- [ ] An admin show edit invalidates all per-user attended-setlists caches.

## Stacked on

This branch is based on eb-filtered-rarity-columns (PR #120). Merge that first; this PR will then target main automatically.

## Technical notes

- Rating services intentionally return caller-specific slim shapes rather than a shared "list-item" union — different callers need different fields, and the union would re-bloat the leanest one.
- ?tab=X navigation drops ?page=, which is the intended behavior — switching tabs resets pagination since each tab has a different totalPages.
- The full attendance list is only fetched when the active tab is shows, since that's the only surface that paginates it. Other tabs' header stats come from the cheap getUserProfileHeader query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
