### PR TITLE
Train: attended-shows SetlistList + filtered rarity columns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,12 @@ Any code that orders or filters shows/tracks chronologically MUST use the helper
 
 Use `SHOW_ORDER_ASC` / `SHOW_ORDER_DESC` for Prisma `orderBy`, `showOrderBySql` for raw SQL, `TRACK_BY_SHOW_ORDER_ASC` for ordering tracks by their show, `statsShowsSql` / `STATS_SHOWS_WHERE` for the count_for_stats=true predicate, and `compareByShowDate` for in-memory sorts.
 
+## Commit and PR Messages
+
+Describe the final before→after change as the user will see it, not the development process or intermediate iterations. Be pithy. Lead with the user-visible change.
+
+If a change involves a particularly tricky technical detail or a non-obvious design decision the reviewer should know about, put it in a separate section at the end of the PR description (not in the lead). Skip that section entirely when the change is straightforward.
+
 ## CRITICAL: Don't Guess
 
 **NEVER guess field names, function signatures, or code structure.** Always look at the actual files first. This applies to database fields, function parameters, API endpoints, file paths, configuration keys — anything with a definitive answer in the codebase.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,12 @@ This is a **monorepo** using **pnpm workspaces** with **Bun** as the runtime:
 - Never commit secrets or API keys
 - Use `doppler run --` prefix for commands that need environment variables
 
+## Show Ordering
+
+Any code that orders or filters shows/tracks chronologically MUST use the helpers in `packages/core/src/_shared/show-ordering.ts` (or `compareByShowDate` from `packages/domain/src/show-ordering.ts` for in-memory work). Never write `orderBy: { date: 'asc' }` directly — same-day shows have a `dayOrder` column (NULLS LAST) plus track-position tiebreakers, and the helpers centralize that logic so it stays consistent across SQL, Prisma, and JS.
+
+Use `SHOW_ORDER_ASC` / `SHOW_ORDER_DESC` for Prisma `orderBy`, `showOrderBySql` for raw SQL, `TRACK_BY_SHOW_ORDER_ASC` for ordering tracks by their show, `statsShowsSql` / `STATS_SHOWS_WHERE` for the count_for_stats=true predicate, and `compareByShowDate` for in-memory sorts.
+
 ## CRITICAL: Don't Guess
 
 **NEVER guess field names, function signatures, or code structure.** Always look at the actual files first. This applies to database fields, function parameters, API endpoints, file paths, configuration keys — anything with a definitive answer in the codebase.

--- a/apps/web/app/components/performance/performance-columns.test.tsx
+++ b/apps/web/app/components/performance/performance-columns.test.tsx
@@ -120,6 +120,82 @@ describe("createPerformanceColumns", () => {
     expect(ids).not.toContain("lastPlayed");
   });
 
+  // Filtered Gap appears only when a server-narrowing filter is active —
+  // the column has no meaning otherwise (it would just duplicate Gap).
+  test("Filtered Gap column is absent by default", () => {
+    const columns = createPerformanceColumns(defaultOptions);
+    const ids = columns.map((c) => ("id" in c ? c.id : undefined));
+    expect(ids).not.toContain("filteredGap");
+  });
+
+  // When narrowing is active, Filtered Gap renders immediately after the
+  // all-time Gap column so the two read as a paired comparison.
+  test("Filtered Gap column is present when hasNarrowingFilter is true", () => {
+    const columns = createPerformanceColumns({ ...defaultOptions, hasNarrowingFilter: true });
+    const ids = columns.map((c) => ("id" in c ? c.id : undefined));
+    const gapIdx = ids.indexOf("gap");
+    const filteredGapIdx = ids.indexOf("filteredGap");
+    expect(filteredGapIdx).toBeGreaterThan(-1);
+    expect(filteredGapIdx).toBe(gapIdx + 1);
+  });
+
+  // Filtered Gap rides on the same `showGapColumns` gate as Gap. On
+  // mixed-song surfaces (all-timers, on-this-day) the entire gap family
+  // hides regardless of whether the filter is narrowing.
+  test("Filtered Gap column is hidden when showGapColumns is false even with hasNarrowingFilter", () => {
+    const columns = createPerformanceColumns({
+      ...defaultOptions,
+      showGapColumns: false,
+      hasNarrowingFilter: true,
+    });
+    const ids = columns.map((c) => ("id" in c ? c.id : undefined));
+    expect(ids).not.toContain("filteredGap");
+  });
+
+  // Cell rendering mirrors the all-time Gap column: ★ for debut of the
+  // filtered set (filteredGap == null), ↺ for the second occurrence within
+  // the same show, integer otherwise.
+  test("Filtered Gap cell renders Star icon for filteredGap=null debut", async () => {
+    const performances = [makePerformance({ trackId: "t-debut", filteredGap: null, position: 1 })];
+    const columns = createPerformanceColumns({ ...defaultOptions, hasNarrowingFilter: true });
+    const { container } = await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    // Two stars expected: the all-time Gap column treats this row the same
+    // way (its gap field defaulted to 5 from makePerformance, so the Gap
+    // cell renders a number, not a star). Filtered Gap renders the star.
+    expect(container.querySelectorAll(".lucide-star").length).toBe(1);
+  });
+
+  test("Filtered Gap cell renders rotate icon for within-show repeat", async () => {
+    const performances = [
+      makePerformance({
+        trackId: "t-first",
+        filteredGap: 3,
+        position: 2,
+        show: { id: "s-1", slug: "2024-06-15", date: "2024-06-15", venueId: "v", countForStats: true },
+      }),
+      makePerformance({
+        trackId: "t-repeat",
+        filteredGap: 3,
+        position: 7,
+        show: { id: "s-1", slug: "2024-06-15", date: "2024-06-15", venueId: "v", countForStats: true },
+      }),
+    ];
+    const columns = createPerformanceColumns({ ...defaultOptions, hasNarrowingFilter: true });
+    const { container } = await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    // Within-show repeats render ↺ in both Gap AND Filtered Gap columns on
+    // the second row — two `.lucide-rotate-ccw` icons total.
+    expect(container.querySelectorAll(".lucide-rotate-ccw").length).toBe(2);
+  });
+
+  test("Filtered Gap cell renders the numeric value when not a debut or repeat", async () => {
+    const performances = [makePerformance({ trackId: "t-1", filteredGap: 7, position: 1 })];
+    const columns = createPerformanceColumns({ ...defaultOptions, hasNarrowingFilter: true });
+    await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    // The Gap column renders 5 (from makePerformance default); Filtered Gap
+    // renders 7. Looking for "7" is unambiguous since the all-time Gap is 5.
+    expect(screen.getByText("7")).toBeInTheDocument();
+  });
+
   // The Song column only appears on /songs/all-timers where performances
   // span multiple songs. On /songs/$slug (single song), it's omitted.
   test("Song column present when showSongColumn is true, absent otherwise", async () => {
@@ -270,8 +346,8 @@ describe("createPerformanceColumns", () => {
     expect(container.querySelectorAll(".lucide-star").length).toBe(1);
   });
 
-  // When a song is played twice in the same show, Phase 1 stores the SAME
-  // gap on both tracks (the gap to the previous *show* the song was played).
+  // When a song is played twice in the same show, both tracks carry the
+  // SAME gap value (the gap to the previous *show* the song was played).
   // The repeat is identified at render time by checking for an earlier-
   // position track in the same show, and gets a RotateCcw icon instead of
   // a number to flag the within-show repeat.
@@ -297,8 +373,8 @@ describe("createPerformanceColumns", () => {
   });
 
   // The Last Played column shows the date of the song's prior performance
-  // (sourced from Phase 1's Track.previousPerformanceShowId join) and links
-  // to that show. When sorted by Gap (or any non-date order), this column
+  // (sourced from the Track.previousPerformanceShowId join) and links to
+  // that show. When sorted by Gap (or any non-date order), this column
   // gives users back the chronological context the Date column otherwise
   // provides at a glance.
   test("Last Played column renders linked date for non-debut rows", async () => {

--- a/apps/web/app/components/performance/performance-columns.test.tsx
+++ b/apps/web/app/components/performance/performance-columns.test.tsx
@@ -101,6 +101,25 @@ describe("createPerformanceColumns", () => {
     expect(sequenceColumn?.meta?.hideOnMobile).toBeFalsy();
   });
 
+  // Gap and Last Played are per-song signals — they only make sense when
+  // every row of the table refers to the same song. On surfaces that mix
+  // songs (`/songs/all-timers`, `/on-this-day/:monthDay`), the columns
+  // become noise and the caller passes `showGapColumns={false}` to hide
+  // both at once.
+  test("Gap and Last Played columns are present by default", () => {
+    const columns = createPerformanceColumns(defaultOptions);
+    const ids = columns.map((c) => ("id" in c ? c.id : undefined));
+    expect(ids).toContain("gap");
+    expect(ids).toContain("lastPlayed");
+  });
+
+  test("Gap and Last Played columns are absent when showGapColumns is false", () => {
+    const columns = createPerformanceColumns({ ...defaultOptions, showGapColumns: false });
+    const ids = columns.map((c) => ("id" in c ? c.id : undefined));
+    expect(ids).not.toContain("gap");
+    expect(ids).not.toContain("lastPlayed");
+  });
+
   // The Song column only appears on /songs/all-timers where performances
   // span multiple songs. On /songs/$slug (single song), it's omitted.
   test("Song column present when showSongColumn is true, absent otherwise", async () => {

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -1,6 +1,6 @@
 import { compareByShowDate, type SongPagePerformance } from "@bip/domain";
 import { type Column, type ColumnDef, createColumnHelper, type Row } from "@tanstack/react-table";
-import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon, Flame, RotateCcw, Star } from "lucide-react";
+import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon, Filter, Flame, RotateCcw, Star } from "lucide-react";
 import { GapIcon } from "~/components/gap-icon";
 import { formatSetLabel } from "~/components/setlist/set-label";
 import { ShowDate } from "~/components/show-date";
@@ -9,22 +9,57 @@ import { DateVenueCell } from "./date-venue-cell";
 import { TrackRatingCell } from "./track-rating-cell";
 
 /**
- * Sort comparator for the Gap column. Debuts (gap=null) sort first because a
- * debut is the rarest possible event; remaining rows sort by gap ascending.
- * Ties break by show date so all rows from the same show — including
- * within-show repeats, which share both gap and date — cluster together;
- * track position is the final tiebreak so within-show repeats stay in
- * setlist order relative to each other.
+ * Sort comparator for any gap-flavored column. Debuts (gap=null) sort first
+ * because a debut is the rarest possible event; remaining rows sort by gap
+ * ascending. Ties break by show date so all rows from the same show —
+ * including within-show repeats, which share both gap and date — cluster
+ * together; track position is the final tiebreak so within-show repeats
+ * stay in setlist order relative to each other.
+ *
+ * Parameterized by `key` so the same comparator drives both Gap (`gap`)
+ * and Filtered Gap (`filteredGap`).
  */
-export function gapSortingFn(a: Row<SongPagePerformance>, b: Row<SongPagePerformance>): number {
-  const aGap = a.original.gap;
-  const bGap = b.original.gap;
-  const aKey = aGap == null ? Number.NEGATIVE_INFINITY : aGap;
-  const bKey = bGap == null ? Number.NEGATIVE_INFINITY : bGap;
-  if (aKey !== bKey) return aKey - bKey;
-  const dateCmp = compareByShowDate(a.original, b.original);
-  if (dateCmp !== 0) return dateCmp;
-  return (a.original.position ?? 0) - (b.original.position ?? 0);
+function makeGapSortingFn(key: "gap" | "filteredGap") {
+  return (a: Row<SongPagePerformance>, b: Row<SongPagePerformance>): number => {
+    const aGap = a.original[key];
+    const bGap = b.original[key];
+    const aKey = aGap == null ? Number.NEGATIVE_INFINITY : aGap;
+    const bKey = bGap == null ? Number.NEGATIVE_INFINITY : bGap;
+    if (aKey !== bKey) return aKey - bKey;
+    const dateCmp = compareByShowDate(a.original, b.original);
+    if (dateCmp !== 0) return dateCmp;
+    return (a.original.position ?? 0) - (b.original.position ?? 0);
+  };
+}
+
+export const gapSortingFn = makeGapSortingFn("gap");
+export const filteredGapSortingFn = makeGapSortingFn("filteredGap");
+
+/**
+ * Shared cell renderer for Gap and Filtered Gap. Same icon semantics: ★
+ * for a debut (null), ↺ for the second occurrence within the same show,
+ * tabular number otherwise.
+ */
+function renderGapCell({ value, isRepeat }: { value: number | null | undefined; isRepeat: boolean }) {
+  if (isRepeat) {
+    return <GapIcon icon={<RotateCcw className="h-4 w-4 text-content-text-secondary" />} label="Same Show" />;
+  }
+  if (value == null) {
+    return <GapIcon icon={<Star className="h-4 w-4 text-content-text-secondary" />} label="Debut" />;
+  }
+  return <span className="text-content-text-secondary tabular-nums">{value}</span>;
+}
+
+/**
+ * Detects whether `row` is the second-or-later occurrence of its song
+ * within the same show. The gap and filtered-gap values themselves are
+ * shared across within-show repeats, so the icon — not the number —
+ * distinguishes the repeat from its first occurrence.
+ */
+function isWithinShowRepeat(row: SongPagePerformance, allRows: Array<{ original: SongPagePerformance }>): boolean {
+  return allRows.some(
+    (other) => other.original.show.id === row.show.id && (other.original.position ?? 0) < (row.position ?? 0),
+  );
 }
 
 interface PerformanceColumnOptions {
@@ -35,22 +70,34 @@ interface PerformanceColumnOptions {
    * (all-timers, on-this-day), pass `false` to hide both. Defaults true.
    */
   showGapColumns?: boolean;
+  /**
+   * When true, render the Filtered Gap column alongside the all-time Gap.
+   * The route sets this from `hasNarrowingFilter` so the column only
+   * appears when the filtered set differs from all-time.
+   */
+  hasNarrowingFilter?: boolean;
   songTitle?: string;
   userRatingMap: Map<string, number>;
   isAuthenticated: boolean;
 }
 
-function SortableHeader({ column, label }: { column: Column<SongPagePerformance, unknown>; label: string }) {
+function SortableHeader({
+  column,
+  label,
+}: {
+  column: Column<SongPagePerformance, unknown>;
+  label: string | React.ReactNode;
+}) {
   if (!column.getCanSort()) return <span>{label}</span>;
 
   return (
     <button
       type="button"
-      className="cursor-pointer select-none hover:text-content-text-primary w-full text-left"
+      className="cursor-pointer select-none hover:text-content-text-primary w-full text-left flex items-start gap-1"
       onClick={() => column.toggleSorting()}
     >
       <span className={column.getIsSorted() ? "text-content-text-primary font-semibold" : ""}>{label}</span>
-      <span className={column.getIsSorted() ? "text-brand-primary ml-1" : "ml-1"}>
+      <span className={column.getIsSorted() ? "text-brand-primary" : ""}>
         {column.getIsSorted() === "asc" ? (
           <ArrowUpIcon className="h-4 w-4 inline" />
         ) : column.getIsSorted() === "desc" ? (
@@ -64,7 +111,15 @@ function SortableHeader({ column, label }: { column: Column<SongPagePerformance,
 }
 
 export function createPerformanceColumns(options: PerformanceColumnOptions): ColumnDef<SongPagePerformance, unknown>[] {
-  const { showSongColumn, showAllTimerColumn, showGapColumns, songTitle, userRatingMap, isAuthenticated } = options;
+  const {
+    showSongColumn,
+    showAllTimerColumn,
+    showGapColumns,
+    hasNarrowingFilter,
+    songTitle,
+    userRatingMap,
+    isAuthenticated,
+  } = options;
   const includeGapColumns = showGapColumns !== false;
   const columnHelper = createColumnHelper<SongPagePerformance>();
   const columns: ColumnDef<SongPagePerformance, unknown>[] = [];
@@ -144,26 +199,43 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
         sortingFn: gapSortingFn,
         cell: (info) => {
           const row = info.row.original;
-          const allRows = info.table.getCoreRowModel().rows;
-          // Within-show repeat: another row exists in the same show with an
-          // earlier track position. Phase 1 stores the same gap on both tracks
-          // of a within-show repeat, so the icon — not the gap value — is what
-          // distinguishes the repeat from its first occurrence.
-          const isRepeat = allRows.some(
-            (other) => other.original.show.id === row.show.id && (other.original.position ?? 0) < (row.position ?? 0),
-          );
-
-          if (isRepeat) {
-            return <GapIcon icon={<RotateCcw className="h-4 w-4 text-content-text-secondary" />} label="Same Show" />;
-          }
-
-          if (row.gap == null) {
-            return <GapIcon icon={<Star className="h-4 w-4 text-content-text-secondary" />} label="Debut" />;
-          }
-
-          return <span className="text-content-text-secondary tabular-nums">{row.gap}</span>;
+          return renderGapCell({
+            value: row.gap,
+            isRepeat: isWithinShowRepeat(row, info.table.getCoreRowModel().rows),
+          });
         },
       }) as ColumnDef<SongPagePerformance, unknown>,
+    );
+    if (hasNarrowingFilter) {
+      columns.push(
+        columnHelper.accessor((row) => row.filteredGap ?? Number.NEGATIVE_INFINITY, {
+          id: "filteredGap",
+          meta: { width: "72px" },
+          header: ({ column }) => (
+            <SortableHeader
+              column={column}
+              label={
+                <span className="inline-flex items-center gap-1">
+                  <Filter className="h-3 w-3" aria-hidden="true" />
+                  <span className="sr-only">Filtered</span>
+                  Gap
+                </span>
+              }
+            />
+          ),
+          enableSorting: true,
+          sortingFn: filteredGapSortingFn,
+          cell: (info) => {
+            const row = info.row.original;
+            return renderGapCell({
+              value: row.filteredGap,
+              isRepeat: isWithinShowRepeat(row, info.table.getCoreRowModel().rows),
+            });
+          },
+        }) as ColumnDef<SongPagePerformance, unknown>,
+      );
+    }
+    columns.push(
       columnHelper.accessor((row) => row.previousShow?.date ?? "", {
         id: "lastPlayed",
         meta: { width: "110px", hideOnMobile: true },

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -30,6 +30,11 @@ export function gapSortingFn(a: Row<SongPagePerformance>, b: Row<SongPagePerform
 interface PerformanceColumnOptions {
   showSongColumn?: boolean;
   showAllTimerColumn?: boolean;
+  /**
+   * Gap + Last Played are per-song signals. On surfaces that mix songs
+   * (all-timers, on-this-day), pass `false` to hide both. Defaults true.
+   */
+  showGapColumns?: boolean;
   songTitle?: string;
   userRatingMap: Map<string, number>;
   isAuthenticated: boolean;
@@ -59,7 +64,8 @@ function SortableHeader({ column, label }: { column: Column<SongPagePerformance,
 }
 
 export function createPerformanceColumns(options: PerformanceColumnOptions): ColumnDef<SongPagePerformance, unknown>[] {
-  const { showSongColumn, showAllTimerColumn, songTitle, userRatingMap, isAuthenticated } = options;
+  const { showSongColumn, showAllTimerColumn, showGapColumns, songTitle, userRatingMap, isAuthenticated } = options;
+  const includeGapColumns = showGapColumns !== false;
   const columnHelper = createColumnHelper<SongPagePerformance>();
   const columns: ColumnDef<SongPagePerformance, unknown>[] = [];
 
@@ -126,52 +132,60 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
         );
       },
     }) as ColumnDef<SongPagePerformance, unknown>,
-    columnHelper.accessor((row) => row.gap ?? Number.NEGATIVE_INFINITY, {
-      id: "gap",
-      meta: { width: "64px" },
-      header: ({ column }) => <SortableHeader column={column} label="Gap" />,
-      enableSorting: true,
-      sortingFn: gapSortingFn,
-      cell: (info) => {
-        const row = info.row.original;
-        const allRows = info.table.getCoreRowModel().rows;
-        // Within-show repeat: another row exists in the same show with an
-        // earlier track position. Phase 1 stores the same gap on both tracks
-        // of a within-show repeat, so the icon — not the gap value — is what
-        // distinguishes the repeat from its first occurrence.
-        const isRepeat = allRows.some(
-          (other) => other.original.show.id === row.show.id && (other.original.position ?? 0) < (row.position ?? 0),
-        );
+  );
 
-        if (isRepeat) {
-          return <GapIcon icon={<RotateCcw className="h-4 w-4 text-content-text-secondary" />} label="Same Show" />;
-        }
+  if (includeGapColumns) {
+    columns.push(
+      columnHelper.accessor((row) => row.gap ?? Number.NEGATIVE_INFINITY, {
+        id: "gap",
+        meta: { width: "64px" },
+        header: ({ column }) => <SortableHeader column={column} label="Gap" />,
+        enableSorting: true,
+        sortingFn: gapSortingFn,
+        cell: (info) => {
+          const row = info.row.original;
+          const allRows = info.table.getCoreRowModel().rows;
+          // Within-show repeat: another row exists in the same show with an
+          // earlier track position. Phase 1 stores the same gap on both tracks
+          // of a within-show repeat, so the icon — not the gap value — is what
+          // distinguishes the repeat from its first occurrence.
+          const isRepeat = allRows.some(
+            (other) => other.original.show.id === row.show.id && (other.original.position ?? 0) < (row.position ?? 0),
+          );
 
-        if (row.gap == null) {
-          return <GapIcon icon={<Star className="h-4 w-4 text-content-text-secondary" />} label="Debut" />;
-        }
+          if (isRepeat) {
+            return <GapIcon icon={<RotateCcw className="h-4 w-4 text-content-text-secondary" />} label="Same Show" />;
+          }
 
-        return <span className="text-content-text-secondary tabular-nums">{row.gap}</span>;
-      },
-    }) as ColumnDef<SongPagePerformance, unknown>,
-    columnHelper.accessor((row) => row.previousShow?.date ?? "", {
-      id: "lastPlayed",
-      meta: { width: "110px", hideOnMobile: true },
-      header: ({ column }) => <SortableHeader column={column} label="Last Played" />,
-      enableSorting: true,
-      sortingFn: "alphanumeric",
-      cell: (info) => {
-        const previousShow = info.row.original.previousShow;
-        if (!previousShow) {
-          return <span className="text-content-text-tertiary">—</span>;
-        }
-        return (
-          <a href={`/shows/${previousShow.slug}`} className="text-base text-brand-primary hover:text-brand-secondary">
-            <ShowDate date={previousShow.date} />
-          </a>
-        );
-      },
-    }) as ColumnDef<SongPagePerformance, unknown>,
+          if (row.gap == null) {
+            return <GapIcon icon={<Star className="h-4 w-4 text-content-text-secondary" />} label="Debut" />;
+          }
+
+          return <span className="text-content-text-secondary tabular-nums">{row.gap}</span>;
+        },
+      }) as ColumnDef<SongPagePerformance, unknown>,
+      columnHelper.accessor((row) => row.previousShow?.date ?? "", {
+        id: "lastPlayed",
+        meta: { width: "110px", hideOnMobile: true },
+        header: ({ column }) => <SortableHeader column={column} label="Last Played" />,
+        enableSorting: true,
+        sortingFn: "alphanumeric",
+        cell: (info) => {
+          const previousShow = info.row.original.previousShow;
+          if (!previousShow) {
+            return <span className="text-content-text-tertiary">—</span>;
+          }
+          return (
+            <a href={`/shows/${previousShow.slug}`} className="text-base text-brand-primary hover:text-brand-secondary">
+              <ShowDate date={previousShow.date} />
+            </a>
+          );
+        },
+      }) as ColumnDef<SongPagePerformance, unknown>,
+    );
+  }
+
+  columns.push(
     columnHelper.accessor("set", {
       header: "Set",
       meta: { width: "48px" },

--- a/apps/web/app/components/performance/performance-filter-controls.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Filter } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import { AuthorSearch } from "~/components/author/author-search";
 import { SelectFilter } from "~/components/ui/filters";
@@ -80,6 +80,7 @@ export function PerformanceFilterControls({
         aria-expanded={mobileOpen}
       >
         <span className="flex items-center gap-2">
+          <Filter className="h-4 w-4" aria-hidden="true" />
           Filters
           {activeFilterCount > 0 && (
             <span className="px-2 py-0.5 rounded-full bg-brand-primary/20 text-brand-primary text-xs">

--- a/apps/web/app/components/performance/performance-table.tsx
+++ b/apps/web/app/components/performance/performance-table.tsx
@@ -15,6 +15,12 @@ interface PerformanceTableProps {
   showSongColumn?: boolean;
   showAllTimerColumn?: boolean;
   showGapColumns?: boolean;
+  /**
+   * When true, render the Filtered Gap column. Route is responsible for
+   * deriving this from its server-narrowing filter state (timeRange,
+   * attended, toggles) — `searchText` does not count.
+   */
+  hasNarrowingFilter?: boolean;
   headerContent?: ReactNode;
   isLoading?: boolean;
   pageSize?: number;
@@ -31,6 +37,7 @@ export function PerformanceTable({
   showSongColumn,
   showAllTimerColumn,
   showGapColumns,
+  hasNarrowingFilter,
   headerContent,
   isLoading,
   pageSize,
@@ -63,11 +70,12 @@ export function PerformanceTable({
         showSongColumn,
         showAllTimerColumn,
         showGapColumns,
+        hasNarrowingFilter,
         songTitle,
         userRatingMap,
         isAuthenticated,
       }),
-    [showSongColumn, showAllTimerColumn, showGapColumns, songTitle, userRatingMap, isAuthenticated],
+    [showSongColumn, showAllTimerColumn, showGapColumns, hasNarrowingFilter, songTitle, userRatingMap, isAuthenticated],
   );
 
   return (

--- a/apps/web/app/components/performance/performance-table.tsx
+++ b/apps/web/app/components/performance/performance-table.tsx
@@ -14,6 +14,7 @@ interface PerformanceTableProps {
   songTitle?: string;
   showSongColumn?: boolean;
   showAllTimerColumn?: boolean;
+  showGapColumns?: boolean;
   headerContent?: ReactNode;
   isLoading?: boolean;
   pageSize?: number;
@@ -29,6 +30,7 @@ export function PerformanceTable({
   songTitle,
   showSongColumn,
   showAllTimerColumn,
+  showGapColumns,
   headerContent,
   isLoading,
   pageSize,
@@ -56,8 +58,16 @@ export function PerformanceTable({
   const { userRatingMap } = useTrackUserRatings(trackIds);
 
   const columns = useMemo(
-    () => createPerformanceColumns({ showSongColumn, showAllTimerColumn, songTitle, userRatingMap, isAuthenticated }),
-    [showSongColumn, showAllTimerColumn, songTitle, userRatingMap, isAuthenticated],
+    () =>
+      createPerformanceColumns({
+        showSongColumn,
+        showAllTimerColumn,
+        showGapColumns,
+        songTitle,
+        userRatingMap,
+        isAuthenticated,
+      }),
+    [showSongColumn, showAllTimerColumn, showGapColumns, songTitle, userRatingMap, isAuthenticated],
   );
 
   return (

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -247,6 +247,7 @@ function SetlistCardComponent({
                   disabled={attendanceMutation.isPending}
                   className={cn(
                     "flex items-center justify-center gap-1 px-2 h-6 sm:px-3 sm:h-8 rounded-md transition-all",
+                    "shrink-0 whitespace-nowrap",
                     "hover:brightness-110 cursor-pointer",
                     isAttending
                       ? "bg-green-500/10 border border-green-500/50 shadow-[0_0_8px_rgba(34,197,94,0.2)]"

--- a/apps/web/app/components/setlist/setlist-columns.test.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.test.tsx
@@ -22,7 +22,7 @@ function makeTrack(overrides: Partial<TrackLight> & { songId: string; position: 
     gap: overrides.gap ?? null,
     previousPerformanceShowId: overrides.previousPerformanceShowId ?? null,
     previousPerformanceShow: overrides.previousPerformanceShow ?? null,
-    song: overrides.song ?? { id: overrides.songId, title: "Tractorbeam", slug: "tractorbeam" },
+    song: overrides.song ?? { id: overrides.songId, title: "Basis for a Day", slug: "basis-for-a-day" },
   };
 }
 
@@ -93,7 +93,7 @@ describe("createSetlistColumns", () => {
   // Played) interleave sets, so every row keeps its label.
   test("hides repeated set labels when sorted by Set", async () => {
     await renderTable([
-      makeTrack({ songId: "a", position: 1, set: "S1", song: { id: "a", title: "Tractorbeam", slug: "x" } }),
+      makeTrack({ songId: "a", position: 1, set: "S1", song: { id: "a", title: "Basis for a Day", slug: "x" } }),
       makeTrack({ songId: "b", position: 2, set: "S1", song: { id: "b", title: "Above the Waves", slug: "y" } }),
       makeTrack({ songId: "c", position: 3, set: "S2", song: { id: "c", title: "Confrontation", slug: "z" } }),
       makeTrack({ songId: "d", position: 4, set: "S2", song: { id: "d", title: "Crickets", slug: "w" } }),
@@ -112,7 +112,7 @@ describe("createSetlistColumns", () => {
   test("shows the set label on every row when sorted by Gap", async () => {
     const user = userEvent.setup();
     await renderTable([
-      makeTrack({ songId: "a", position: 1, set: "S1", gap: 10, song: { id: "a", title: "Tractorbeam", slug: "x" } }),
+      makeTrack({ songId: "a", position: 1, set: "S1", gap: 10, song: { id: "a", title: "Basis for a Day", slug: "x" } }),
       makeTrack({ songId: "b", position: 2, set: "S1", gap: 5, song: { id: "b", title: "Above the Waves", slug: "y" } }),
       makeTrack({ songId: "c", position: 3, set: "S2", gap: 20, song: { id: "c", title: "Confrontation", slug: "z" } }),
     ]);
@@ -141,7 +141,7 @@ describe("createSetlistColumns", () => {
         position: 2,
         set: "S1",
         previousPerformanceShow: { date: "2024-01-15", slug: "older" },
-        song: { id: "a", title: "Tractorbeam", slug: "x" },
+        song: { id: "a", title: "Basis for a Day", slug: "x" },
       }),
       makeTrack({
         songId: "b",
@@ -154,7 +154,7 @@ describe("createSetlistColumns", () => {
     await user.click(screen.getByRole("button", { name: /Last Played/i }));
     const songCells = screen.getAllByRole("cell").filter((_, i) => i % 5 === 2);
     expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
-      "Tractorbeam",
+      "Basis for a Day",
       "Above the Waves",
       "Crickets",
     ]);
@@ -172,7 +172,7 @@ describe("createSetlistColumns", () => {
         position: 2,
         set: "S1",
         gap: 5,
-        song: { id: "a", title: "Tractorbeam", slug: "x" },
+        song: { id: "a", title: "Basis for a Day", slug: "x" },
       }),
       makeTrack({
         songId: "b",
@@ -185,7 +185,7 @@ describe("createSetlistColumns", () => {
     await user.click(screen.getByRole("button", { name: /Gap/i }));
     const songCells = screen.getAllByRole("cell").filter((_, i) => i % 5 === 2);
     expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
-      "Tractorbeam",
+      "Basis for a Day",
       "Above the Waves",
       "Crickets",
     ]);
@@ -195,7 +195,7 @@ describe("createSetlistColumns", () => {
   // independent of the cumulative position in the show.
   test("renders Track # 1-indexed within each set/encore", async () => {
     await renderTable([
-      makeTrack({ songId: "a", position: 1, set: "S1", song: { id: "a", title: "Tractorbeam", slug: "x" } }),
+      makeTrack({ songId: "a", position: 1, set: "S1", song: { id: "a", title: "Basis for a Day", slug: "x" } }),
       makeTrack({ songId: "b", position: 2, set: "S1", song: { id: "b", title: "Above the Waves", slug: "y" } }),
       makeTrack({ songId: "c", position: 3, set: "S2", song: { id: "c", title: "Confrontation", slug: "z" } }),
       makeTrack({ songId: "d", position: 4, set: "E1", song: { id: "d", title: "Crickets", slug: "w" } }),
@@ -228,7 +228,7 @@ describe("createSetlistColumns", () => {
   // the user which encore came first.
   test("renders a single encore as 'E' but keeps E1/E2 when multiple encores exist", async () => {
     await renderTable([
-      makeTrack({ songId: "a", position: 1, set: "S1", song: { id: "a", title: "Tractorbeam", slug: "t" } }),
+      makeTrack({ songId: "a", position: 1, set: "S1", song: { id: "a", title: "Basis for a Day", slug: "t" } }),
       makeTrack({ songId: "b", position: 2, set: "E1", song: { id: "b", title: "Crickets", slug: "c" } }),
     ]);
     const singleCells = screen.getAllByRole("cell");
@@ -310,7 +310,7 @@ describe("createSetlistColumns", () => {
 
   // Segue indicator carries over from the flow view: a track whose `segue`
   // is truthy gets a trailing ">" so the table preserves the same flow
-  // information ("Tractorbeam > Above the Waves") readers already know.
+  // information ("Basis for a Day > Above the Waves") readers already know.
   // Non-segue rows render the song title alone (no trailing punctuation —
   // the table row separator already does that job).
   test("renders > after segueing tracks and nothing after non-segueing tracks", async () => {
@@ -320,7 +320,7 @@ describe("createSetlistColumns", () => {
         position: 1,
         gap: 5,
         segue: ">",
-        song: { id: "song-segue", title: "Tractorbeam", slug: "tractorbeam" },
+        song: { id: "song-segue", title: "Basis for a Day", slug: "basis-for-a-day" },
       }),
       makeTrack({
         songId: "song-end",
@@ -330,8 +330,8 @@ describe("createSetlistColumns", () => {
         song: { id: "song-end", title: "Crickets", slug: "crickets" },
       }),
     ]);
-    const segueCell = screen.getByRole("link", { name: "Tractorbeam" }).parentElement;
-    expect(segueCell?.textContent).toMatch(/Tractorbeam\s*>/);
+    const segueCell = screen.getByRole("link", { name: "Basis for a Day" }).parentElement;
+    expect(segueCell?.textContent).toMatch(/Basis for a Day\s*>/);
     const endCell = screen.getByRole("link", { name: "Crickets" }).parentElement;
     expect(endCell?.textContent).toBe("Crickets");
   });

--- a/apps/web/app/components/setlist/setlist-columns.test.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.test.tsx
@@ -283,9 +283,9 @@ describe("createSetlistColumns", () => {
   });
 
   // Within-show repeat: same songId appears at an earlier position in the
-  // table. Phase 1 stores the same gap on both tracks of a within-show
-  // repeat, so the icon — not the value — is what distinguishes the repeat
-  // from its first occurrence.
+  // table. Both occurrences share the same gap value, so the icon — not
+  // the number — is what distinguishes the repeat from its first
+  // occurrence.
   test("renders ↺ This Show for a within-show repeat", async () => {
     await renderTable([
       makeTrack({

--- a/apps/web/app/components/setlist/setlist-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.tsx
@@ -6,10 +6,9 @@ import { ShowDate } from "~/components/show-date";
 import { countDistinctEncores, formatSetLabel } from "./set-label";
 
 /**
- * Row shape consumed by the gap-chart table. A SetlistTableRow is a TrackLight
- * (with the Phase 5 gap+previousPerformanceShow fields) and is intentionally
- * narrowed from the full Setlist tree so the column factory doesn't depend on
- * Set/Show/Venue context.
+ * Row shape consumed by the gap-chart table. Narrowed from the full Setlist
+ * tree so the column factory doesn't depend on Set/Show/Venue context —
+ * just a TrackLight with the denormalized gap + previous-performance fields.
  */
 export type SetlistTableRow = TrackLight;
 
@@ -152,8 +151,8 @@ export function createSetlistColumns(): ColumnDef<SetlistTableRow, unknown>[] {
       enableSorting: true,
       // Numeric ascending; debuts (gap=null) become +∞ so they cluster at
       // the end on asc and at the start on desc. Within-show repeats share
-      // their first occurrence's gap by Phase 1 design — sort treats them
-      // as equal and the icon (not the value) tells the story per row.
+      // their first occurrence's gap value — sort treats them as equal and
+      // the icon (not the value) tells the story per row.
       sortingFn: "basic",
       // First click sorts ascending. TanStack auto-flips to desc-first for
       // numeric accessors; force asc so "smallest gap first" matches the

--- a/apps/web/app/components/setlist/setlist-table.test.tsx
+++ b/apps/web/app/components/setlist/setlist-table.test.tsx
@@ -20,7 +20,7 @@ function makeTrack(overrides: Partial<TrackLight> & { songId: string; position: 
     gap: overrides.gap ?? null,
     previousPerformanceShowId: overrides.previousPerformanceShowId ?? null,
     previousPerformanceShow: overrides.previousPerformanceShow ?? null,
-    song: overrides.song ?? { id: overrides.songId, title: "Tractorbeam", slug: "tractorbeam" },
+    song: overrides.song ?? { id: overrides.songId, title: "Basis for a Day", slug: "basis-for-a-day" },
   };
 }
 
@@ -50,7 +50,7 @@ describe("SetlistTable", () => {
             songId: "a",
             position: 1,
             set: "S1",
-            song: { id: "a", title: "Tractorbeam", slug: "x" },
+            song: { id: "a", title: "Basis for a Day", slug: "x" },
           }),
           makeTrack({
             songId: "a2",
@@ -63,7 +63,7 @@ describe("SetlistTable", () => {
     );
     const cells = screen.getAllByRole("cell").filter((_, i) => i % 5 === 2);
     expect(cells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
-      "Tractorbeam",
+      "Basis for a Day",
       "Above the Waves",
       "Tempest",
       "Crickets",

--- a/apps/web/app/components/show-date.tsx
+++ b/apps/web/app/components/show-date.tsx
@@ -2,6 +2,12 @@ import { formatDateShort, formatDateShortMobile } from "~/lib/utils";
 
 interface ShowDateProps {
   date: string | Date;
+  /**
+   * Render the compact `M/D/YY` form at all viewport sizes instead of
+   * only on mobile. For dense surfaces where the four-digit year would
+   * wrap the cell.
+   */
+  compact?: boolean;
 }
 
 /**
@@ -11,7 +17,8 @@ interface ShowDateProps {
  * date formatting consistent everywhere a show date is displayed — change
  * the format once and every callsite follows.
  */
-export function ShowDate({ date }: ShowDateProps) {
+export function ShowDate({ date, compact }: ShowDateProps) {
+  if (compact) return <span>{formatDateShortMobile(date)}</span>;
   return (
     <>
       <span className="hidden sm:inline">{formatDateShort(date)}</span>

--- a/apps/web/app/components/song/songs-columns.test.tsx
+++ b/apps/web/app/components/song/songs-columns.test.tsx
@@ -141,7 +141,84 @@ describe("getSongsColumns", () => {
       />,
     );
 
-    expect(screen.queryByRole("button", { name: /Filtered Plays/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Filtered\s*Plays/i })).not.toBeInTheDocument();
+  });
+
+  // The three filtered rarity columns ride on the same `showFilteredPlays`
+  // gate as Filtered Plays. They mirror Current Gap / Since Debut / Avg Gap,
+  // computed against the active filter scope. Hidden by default so they
+  // don't duplicate the all-time columns when no filter narrows the data.
+  test("showFilteredPlays=false: filtered rarity columns are not rendered", async () => {
+    await setupWithRouter(
+      <DataTable
+        columns={baseColumns}
+        data={[
+          makeSong({
+            filteredTimesPlayed: 3,
+            filteredShowsSinceLastPlayed: 9,
+            filteredPercentSinceDebut: 0.42,
+            filteredAverageShowsPerPlay: 2.4,
+          }),
+        ]}
+        hideSearch
+        hidePagination
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /Filtered Current Gap/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Filtered Since Debut/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Filtered Avg Gap/i })).not.toBeInTheDocument();
+  });
+
+  // When showFilteredPlays is true, each filtered column renders next to
+  // its all-time counterpart so the two read as a paired comparison.
+  test("showFilteredPlays=true: filtered rarity columns render their scoped values", async () => {
+    await setupWithRouter(
+      <DataTable
+        columns={filteredColumns}
+        data={[
+          makeSong({
+            filteredTimesPlayed: 3,
+            filteredShowsSinceLastPlayed: 9,
+            filteredPercentSinceDebut: 0.42,
+            filteredAverageShowsPerPlay: 2.4,
+          }),
+        ]}
+        hideSearch
+        hidePagination
+      />,
+    );
+
+    // Filtered Current Gap renders the raw integer.
+    expect(screen.getByText("9")).toBeInTheDocument();
+    // Filtered Since Debut renders as a percent (matches existing % formatter).
+    expect(screen.getByText("42%")).toBeInTheDocument();
+    // Filtered Avg Gap renders with one decimal place.
+    expect(screen.getByText("2.4")).toBeInTheDocument();
+  });
+
+  // When showFilteredPlays is true, Last Played and First Played drop the
+  // venue sublabel and shrink — the row is wider with the extra filtered
+  // columns, so we trade venue-on-row for horizontal room.
+  test("showFilteredPlays=true: Last Played and First Played cells omit the venue sublabel", async () => {
+    await setupWithRouter(
+      <DataTable
+        columns={filteredColumns}
+        data={[
+          makeSong({
+            lastPlayedShow: makeShow(),
+            firstPlayedShow: makeShow({ slug: "1995-07-04-some-venue" }),
+          }),
+        ]}
+        hideSearch
+        hidePagination
+      />,
+    );
+
+    // Venue text would appear under the date in the no-filter baseline
+    // (see "Last Played venue" test below). Under filtered columns it
+    // must NOT render — neither for Last Played nor for First Played.
+    expect(screen.queryByText(/The Capitol Theatre/)).not.toBeInTheDocument();
   });
 
   // When showFilteredPlays is true, the factory inserts a "Filtered Plays"
@@ -156,7 +233,7 @@ describe("getSongsColumns", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: /Filtered Plays/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Filtered\s*Plays/i })).toBeInTheDocument();
     // Both the all-time count (42) and the scoped count (7) are present.
     expect(screen.getByText("42")).toBeInTheDocument();
     expect(screen.getByText("7")).toBeInTheDocument();
@@ -352,7 +429,7 @@ describe("getSongsColumns", () => {
       <DataTable columns={filteredColumns} data={songs} hideSearch hidePagination />,
     );
 
-    const sortHeader = screen.getByRole("button", { name: /Filtered Plays/i });
+    const sortHeader = screen.getByRole("button", { name: /Filtered\s*Plays/i });
     await user.click(sortHeader); // asc
 
     // asc: [filtered=2, timesPlayed=30 (Plan B)], [filtered=2, timesPlayed=80 (Crickets)], [filtered=5 (Home Again)]
@@ -399,7 +476,7 @@ describe("getSongsColumns", () => {
     );
 
     // First click: asc. Second click: desc.
-    const sortHeader = screen.getByRole("button", { name: /Filtered Plays/i });
+    const sortHeader = screen.getByRole("button", { name: /Filtered\s*Plays/i });
     await user.click(sortHeader);
 
     const titlesAsc = screen

--- a/apps/web/app/components/song/songs-columns.test.tsx
+++ b/apps/web/app/components/song/songs-columns.test.tsx
@@ -692,7 +692,7 @@ describe("getSongsColumns", () => {
   // them at the top, masking the smallest real gaps.
   test("Current Gap sort puts nulls last on asc and first on desc", async () => {
     const songs = [
-      makeSong({ id: "a", title: "Tractorbeam", slug: "tractorbeam", showsSinceLastPlayed: 5 }),
+      makeSong({ id: "a", title: "Basis for a Day", slug: "basis-for-a-day", showsSinceLastPlayed: 5 }),
       makeSong({ id: "b", title: "Above The Waves", slug: "above-the-waves", showsSinceLastPlayed: null }),
       makeSong({ id: "c", title: "Tempest", slug: "tempest", showsSinceLastPlayed: 30 }),
     ];
@@ -707,14 +707,14 @@ describe("getSongsColumns", () => {
 
     const titlesAsc = screen
       .getAllByRole("link")
-      .filter((el) => ["Tractorbeam", "Above The Waves", "Tempest"].includes(el.textContent ?? ""));
-    expect(titlesAsc.map((el) => el.textContent)).toEqual(["Tractorbeam", "Tempest", "Above The Waves"]);
+      .filter((el) => ["Basis for a Day", "Above The Waves", "Tempest"].includes(el.textContent ?? ""));
+    expect(titlesAsc.map((el) => el.textContent)).toEqual(["Basis for a Day", "Tempest", "Above The Waves"]);
 
     await user.click(sortHeader); // desc
     const titlesDesc = screen
       .getAllByRole("link")
-      .filter((el) => ["Tractorbeam", "Above The Waves", "Tempest"].includes(el.textContent ?? ""));
-    expect(titlesDesc.map((el) => el.textContent)).toEqual(["Above The Waves", "Tempest", "Tractorbeam"]);
+      .filter((el) => ["Basis for a Day", "Above The Waves", "Tempest"].includes(el.textContent ?? ""));
+    expect(titlesDesc.map((el) => el.textContent)).toEqual(["Above The Waves", "Tempest", "Basis for a Day"]);
   });
 
   // The /songs page shows songs sorted by times played (most played first)

--- a/apps/web/app/components/song/songs-columns.tsx
+++ b/apps/web/app/components/song/songs-columns.tsx
@@ -1,19 +1,44 @@
 import type { Show, Song } from "@bip/domain";
 import type { ColumnDef, SortingFn } from "@tanstack/react-table";
-import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, Filter } from "lucide-react";
 import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { ShowDate } from "~/components/show-date";
 import { Button } from "~/components/ui/button";
 
+/**
+ * Inline funnel icon used to mark "this column / control is the filtered
+ * variant". Drop-in replacement for the word "Filtered" so the header
+ * compresses to one short token + the secondary word.
+ */
+function FilterMark() {
+  return (
+    <>
+      <Filter className="h-3 w-3 inline-block shrink-0" aria-hidden="true" />
+      <span className="sr-only">Filtered </span>
+    </>
+  );
+}
+
 interface SongWithShows extends Song {
   firstPlayedShow?: Show | null;
   lastPlayedShow?: Show | null;
+  firstFilteredPlayedShow?: Show | null;
+  lastFilteredPlayedShow?: Show | null;
 }
 
 const percentFormatter = new Intl.NumberFormat("en-US", {
   style: "percent",
   maximumFractionDigits: 1,
+});
+
+// Filtered percent columns are already narrower (4 columns share the row
+// with the all-time pair) so the extra decimal makes them feel cramped.
+// Whole-percent reads cleanly enough — drop the decimal in the filtered
+// variant only.
+const wholePercentFormatter = new Intl.NumberFormat("en-US", {
+  style: "percent",
+  maximumFractionDigits: 0,
 });
 
 function nullsLastNumericSort<K extends keyof SongWithShows>(key: K): SortingFn<SongWithShows> {
@@ -41,6 +66,38 @@ function getSortIcon(sortState: false | "asc" | "desc"): ReactNode {
 const HEADER_BUTTON_CLASS =
   "h-auto p-0 font-semibold text-left justify-start hover:bg-brand-primary/10 hover:text-brand-primary transition-colors whitespace-normal leading-tight flex-col items-start gap-0 sm:flex-row sm:items-start sm:gap-1";
 
+/**
+ * Wraps a header's text content. Reserves a leading row that holds either
+ * the funnel icon (filtered columns) or an invisible spacer of the same
+ * height (non-filtered columns when any filtered column is visible). That
+ * way every label's text starts on the same line — the icon-vs-no-icon
+ * distinction lives one line above the words and doesn't push them down.
+ *
+ * `reserveIconRow` is false when no filtered columns are visible at all;
+ * the spacer would just waste vertical space.
+ */
+function HeaderLabel({
+  filtered,
+  reserveIconRow,
+  children,
+}: {
+  filtered?: boolean;
+  reserveIconRow: boolean;
+  children: ReactNode;
+}) {
+  const iconRow = filtered ? (
+    <FilterMark />
+  ) : reserveIconRow ? (
+    <span className="block h-3" aria-hidden="true" />
+  ) : null;
+  return (
+    <span className="flex flex-col leading-tight items-start">
+      {iconRow}
+      {children}
+    </span>
+  );
+}
+
 interface SortableColumnOptions {
   accessorKey: keyof SongWithShows;
   label: ReactNode;
@@ -50,6 +107,12 @@ interface SortableColumnOptions {
   hideOnMobile?: boolean;
   cell: (row: SongWithShows) => ReactNode;
   sortingFn?: SortingFn<SongWithShows>;
+  /**
+   * True when the header reserves a top icon row (filter-icon or matching
+   * spacer). The sort indicator gets pushed down by that row's height so it
+   * sits on the same line as the text, not the icon.
+   */
+  reservesIconRow?: boolean;
 }
 
 /**
@@ -58,6 +121,10 @@ interface SortableColumnOptions {
  * Centralizes the shared header chrome so adding a column is a few lines.
  */
 function makeSortableColumn(opts: SortableColumnOptions): ColumnDef<SongWithShows> {
+  // Push the sort indicator down to text-row height when the label
+  // reserves an icon row on top; otherwise it would sit on the icon line
+  // and look detached from the words below.
+  const sortIconWrapperClass = opts.reservesIconRow ? "sm:mt-3" : "";
   const def: ColumnDef<SongWithShows> = {
     accessorKey: opts.accessorKey,
     meta: { width: opts.width, hideOnMobile: opts.hideOnMobile },
@@ -69,7 +136,7 @@ function makeSortableColumn(opts: SortableColumnOptions): ColumnDef<SongWithShow
         className={HEADER_BUTTON_CLASS}
       >
         {opts.label}
-        {getSortIcon(column.getIsSorted())}
+        <span className={sortIconWrapperClass}>{getSortIcon(column.getIsSorted())}</span>
       </Button>
     ),
     cell: ({ row }) => opts.cell(row.original),
@@ -83,14 +150,25 @@ function makeSortableColumn(opts: SortableColumnOptions): ColumnDef<SongWithShow
  * the date. Used by both Last Played and First Played columns — the only
  * difference between them is which date/show pair feeds in.
  */
-function DateVenueCell({ date, show }: { date: Date | null; show?: Show | null }): ReactNode {
+function DateVenueCell({
+  date,
+  show,
+  hideVenue,
+  compact,
+}: {
+  date: Date | null;
+  show?: Show | null;
+  hideVenue?: boolean;
+  compact?: boolean;
+}): ReactNode {
   if (!date) return <span className="text-content-text-tertiary text-sm">—</span>;
-  const dateBlock = <ShowDate date={date} />;
-  const venueLine = show?.venue ? (
-    <div className="text-content-text-tertiary text-sm hidden sm:block">
-      {show.venue.name}, {show.venue.city} {show.venue.state}
-    </div>
-  ) : null;
+  const dateBlock = <ShowDate date={date} compact={compact} />;
+  const venueLine =
+    show?.venue && !hideVenue ? (
+      <div className="text-content-text-tertiary text-sm hidden sm:block">
+        {show.venue.name}, {show.venue.city} {show.venue.state}
+      </div>
+    ) : null;
   if (show?.slug) {
     return (
       <Link to={`/shows/${show.slug}`} className="text-brand-primary hover:text-brand-secondary transition-colors">
@@ -123,10 +201,10 @@ interface GetSongsColumnsOptions {
  * counts.
  */
 export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): ColumnDef<SongWithShows>[] {
-  const titleColumn = makeSortableColumn({
+  const titleColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
     accessorKey: "title",
-    label: "Song",
-    width: showFilteredPlays ? "22%" : "26%",
+    label: <HeaderLabel reserveIconRow={showFilteredPlays}>Song</HeaderLabel>,
+    width: showFilteredPlays ? "14%" : "26%",
     cell: (song) => (
       <Link
         to={`/songs/${song.slug}`}
@@ -137,10 +215,10 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     ),
   });
 
-  const playsColumn = makeSortableColumn({
+  const playsColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
     accessorKey: "timesPlayed",
-    label: "Plays",
-    width: "8%",
+    label: <HeaderLabel reserveIconRow={showFilteredPlays}>Plays</HeaderLabel>,
+    width: showFilteredPlays ? "5%" : "8%",
     // When Filtered Plays is also visible there isn't room for both count
     // columns on mobile; the all-time count drops out at narrow widths.
     hideOnMobile: showFilteredPlays,
@@ -152,10 +230,15 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
       ),
   });
 
-  const filteredPlaysColumn = makeSortableColumn({
+  const filteredPlaysColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
     accessorKey: "filteredTimesPlayed",
-    label: "Filtered Plays",
-    width: "10%",
+    label: (
+      <HeaderLabel filtered reserveIconRow>
+        <span>Plays</span>
+      </HeaderLabel>
+    ),
+    title: "Filtered Plays",
+    width: "5%",
     cell: (song) => {
       const plays = song.filteredTimesPlayed ?? 0;
       return plays > 0 ? (
@@ -175,29 +258,58 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     },
   });
 
-  const percentSinceDebutColumn = makeSortableColumn({
+  // With filtered columns active the row is busy; both percent columns drop
+  // their decimal so the all-time and filtered values read as a clean pair
+  // at the same precision.
+  const sinceDebutFormatter = showFilteredPlays ? wholePercentFormatter : percentFormatter;
+
+  const percentSinceDebutColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
     accessorKey: "percentSinceDebut",
     label: (
-      <span className="flex flex-col leading-tight">
+      <HeaderLabel reserveIconRow={showFilteredPlays}>
         <span>Since</span>
         <span>Debut</span>
-      </span>
+      </HeaderLabel>
     ),
     title: "% Since Debut",
-    width: showFilteredPlays ? "8%" : "6%",
+    width: showFilteredPlays ? "7%" : "6%",
     hideOnMobile: true,
     cell: (song) =>
-      dashOrSpan(song.percentSinceDebut !== null ? percentFormatter.format(song.percentSinceDebut) : null),
+      dashOrSpan(
+        song.percentSinceDebut !== null ? (
+          <span className="whitespace-nowrap">{sinceDebutFormatter.format(song.percentSinceDebut)}</span>
+        ) : null,
+      ),
     sortingFn: nullsLastNumericSort("percentSinceDebut"),
   });
 
-  const avgGapColumn = makeSortableColumn({
+  const filteredPercentSinceDebutColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
+    accessorKey: "filteredPercentSinceDebut",
+    label: (
+      <HeaderLabel filtered reserveIconRow>
+        <span>Since</span>
+        <span>First</span>
+      </HeaderLabel>
+    ),
+    title: "Filtered Since First",
+    width: "7%",
+    hideOnMobile: true,
+    cell: (song) =>
+      dashOrSpan(
+        song.filteredPercentSinceDebut != null ? (
+          <span className="whitespace-nowrap">{sinceDebutFormatter.format(song.filteredPercentSinceDebut)}</span>
+        ) : null,
+      ),
+    sortingFn: nullsLastNumericSort("filteredPercentSinceDebut"),
+  });
+
+  const avgGapColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
     accessorKey: "averageShowsPerPlay",
     label: (
-      <span className="flex flex-col leading-tight">
+      <HeaderLabel reserveIconRow={showFilteredPlays}>
         <span>Avg</span>
         <span>Gap</span>
-      </span>
+      </HeaderLabel>
     ),
     width: "7%",
     hideOnMobile: true,
@@ -205,9 +317,25 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     sortingFn: nullsLastNumericSort("averageShowsPerPlay"),
   });
 
-  const currentGapColumn = makeSortableColumn({
+  const filteredAvgGapColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
+    accessorKey: "filteredAverageShowsPerPlay",
+    label: (
+      <HeaderLabel filtered reserveIconRow>
+        <span>Avg</span>
+        <span>Gap</span>
+      </HeaderLabel>
+    ),
+    title: "Filtered Avg Gap",
+    width: "7%",
+    hideOnMobile: true,
+    cell: (song) =>
+      dashOrSpan(song.filteredAverageShowsPerPlay != null ? song.filteredAverageShowsPerPlay.toFixed(1) : null),
+    sortingFn: nullsLastNumericSort("filteredAverageShowsPerPlay"),
+  });
+
+  const currentGapColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
     accessorKey: "showsSinceLastPlayed",
-    label: "Gap",
+    label: <HeaderLabel reserveIconRow={showFilteredPlays}>Gap</HeaderLabel>,
     title: "Current Gap",
     width: "7%",
     hideOnMobile: true,
@@ -215,22 +343,101 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     sortingFn: nullsLastNumericSort("showsSinceLastPlayed"),
   });
 
-  const lastPlayedColumn = makeSortableColumn({
-    accessorKey: "dateLastPlayed",
-    label: "Last Played",
-    width: "22%",
-    cell: (song) => <DateVenueCell date={song.dateLastPlayed} show={song.lastPlayedShow} />,
+  const filteredCurrentGapColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
+    accessorKey: "filteredShowsSinceLastPlayed",
+    label: (
+      <HeaderLabel filtered reserveIconRow>
+        <span>Gap</span>
+      </HeaderLabel>
+    ),
+    title: "Filtered Current Gap",
+    width: "7%",
+    hideOnMobile: true,
+    cell: (song) => dashOrSpan(song.filteredShowsSinceLastPlayed ?? null),
+    sortingFn: nullsLastNumericSort("filteredShowsSinceLastPlayed"),
   });
 
-  const firstPlayedColumn = makeSortableColumn({
+  // When filtered columns are active the row is wider; drop the venue
+  // sublabel and shrink the date columns to make room.
+  const dateColumnWidth = showFilteredPlays ? "8%" : "22%";
+
+  const lastPlayedColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
+    accessorKey: "dateLastPlayed",
+    label: <HeaderLabel reserveIconRow={showFilteredPlays}>Last Played</HeaderLabel>,
+    width: dateColumnWidth,
+    cell: (song) => (
+      <DateVenueCell
+        date={song.dateLastPlayed}
+        show={song.lastPlayedShow}
+        hideVenue={showFilteredPlays}
+        compact={showFilteredPlays}
+      />
+    ),
+  });
+
+  const filteredLastPlayedColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
+    accessorKey: "dateLastFilteredPlayed",
+    label: (
+      <HeaderLabel filtered reserveIconRow>
+        Last
+      </HeaderLabel>
+    ),
+    title: "Filtered Last Played",
+    width: dateColumnWidth,
+    cell: (song) => (
+      <DateVenueCell
+        date={song.dateLastFilteredPlayed ?? null}
+        show={song.lastFilteredPlayedShow}
+        hideVenue
+        compact
+      />
+    ),
+  });
+
+  const firstPlayedColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
     accessorKey: "dateFirstPlayed",
-    label: "First Played",
-    width: "22%",
-    cell: (song) => <DateVenueCell date={song.dateFirstPlayed} show={song.firstPlayedShow} />,
+    label: <HeaderLabel reserveIconRow={showFilteredPlays}>First Played</HeaderLabel>,
+    width: dateColumnWidth,
+    cell: (song) => (
+      <DateVenueCell
+        date={song.dateFirstPlayed}
+        show={song.firstPlayedShow}
+        hideVenue={showFilteredPlays}
+        compact={showFilteredPlays}
+      />
+    ),
+  });
+
+  const filteredFirstPlayedColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
+    accessorKey: "dateFirstFilteredPlayed",
+    label: (
+      <HeaderLabel filtered reserveIconRow>
+        First
+      </HeaderLabel>
+    ),
+    title: "Filtered First Played",
+    width: dateColumnWidth,
+    cell: (song) => (
+      <DateVenueCell
+        date={song.dateFirstFilteredPlayed ?? null}
+        show={song.firstFilteredPlayedShow}
+        hideVenue
+        compact
+      />
+    ),
   });
 
   const columns: ColumnDef<SongWithShows>[] = [titleColumn, playsColumn];
   if (showFilteredPlays) columns.push(filteredPlaysColumn);
-  columns.push(percentSinceDebutColumn, avgGapColumn, currentGapColumn, lastPlayedColumn, firstPlayedColumn);
+  columns.push(percentSinceDebutColumn);
+  if (showFilteredPlays) columns.push(filteredPercentSinceDebutColumn);
+  columns.push(avgGapColumn);
+  if (showFilteredPlays) columns.push(filteredAvgGapColumn);
+  columns.push(currentGapColumn);
+  if (showFilteredPlays) columns.push(filteredCurrentGapColumn);
+  columns.push(lastPlayedColumn);
+  if (showFilteredPlays) columns.push(filteredLastPlayedColumn);
+  columns.push(firstPlayedColumn);
+  if (showFilteredPlays) columns.push(filteredFirstPlayedColumn);
   return columns;
 }

--- a/apps/web/app/components/ui/data-table.tsx
+++ b/apps/web/app/components/ui/data-table.tsx
@@ -21,10 +21,10 @@ declare module "@tanstack/react-table" {
   }
 }
 
-import { type KeyboardEvent, type ReactNode, useState } from "react";
+import { type ReactNode, useState } from "react";
 
-import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
+import { PaginationControls } from "~/components/ui/pagination-controls";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/ui/table";
 import { cn } from "~/lib/utils";
 
@@ -94,73 +94,15 @@ export function DataTable<TData, TValue>({
   const currentPage = table.getState().pagination.pageIndex + 1;
   const totalPages = table.getPageCount();
 
-  function handlePageInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {
-    if (event.key !== "Enter") return;
-    const value = Number(event.currentTarget.value);
-    if (Number.isNaN(value)) return;
-    const clamped = Math.max(1, Math.min(totalPages, value));
-    table.setPageIndex(clamped - 1);
-    event.currentTarget.value = String(clamped);
-  }
-
   const paginationBlock = !hasResults ? null : (
-    <div className="flex items-center justify-between px-2">
-      {!hidePaginationText ? (
-        (() => {
-          const total = table.getFilteredRowModel().rows.length;
-          if (total === 0) {
-            return <div className="text-sm text-content-text-secondary font-medium">0 results</div>;
-          }
-          const pageSize = table.getState().pagination.pageSize;
-          const pageIndex = table.getState().pagination.pageIndex;
-          const from = pageIndex * pageSize + 1;
-          const to = Math.min((pageIndex + 1) * pageSize, total);
-          return (
-            <div className="text-sm text-content-text-secondary font-medium">
-              <span className="hidden sm:inline">{`Showing ${from} to ${to} of ${total} results`}</span>
-              <span className="sm:hidden">{`${from}–${to} of ${total}`}</span>
-            </div>
-          );
-        })()
-      ) : (
-        <div />
-      )}
-      {totalPages > 1 && (
-        <div className="flex items-center space-x-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => table.previousPage()}
-            disabled={!table.getCanPreviousPage()}
-            className="hover:bg-brand-primary/20 hover:border-brand-primary/40"
-          >
-            Previous
-          </Button>
-          <span className="flex items-center gap-1.5 text-sm text-content-text-secondary">
-            Page
-            <input
-              type="number"
-              min={1}
-              max={totalPages}
-              defaultValue={currentPage}
-              key={currentPage}
-              onKeyDown={handlePageInputKeyDown}
-              className="w-12 rounded border border-glass-border bg-glass-bg px-2 py-1 text-center text-sm text-white focus:outline-none focus:ring-1 focus:ring-ring/20 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-            />
-            of {totalPages}
-          </span>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => table.nextPage()}
-            disabled={!table.getCanNextPage()}
-            className="hover:bg-brand-primary/20 hover:border-brand-primary/40"
-          >
-            Next
-          </Button>
-        </div>
-      )}
-    </div>
+    <PaginationControls
+      page={currentPage}
+      totalPages={totalPages}
+      pageSize={table.getState().pagination.pageSize}
+      total={table.getFilteredRowModel().rows.length}
+      onPageChange={(nextPage) => table.setPageIndex(nextPage - 1)}
+      hidePaginationText={hidePaginationText}
+    />
   );
 
   return (

--- a/apps/web/app/components/ui/pagination-controls.test.tsx
+++ b/apps/web/app/components/ui/pagination-controls.test.tsx
@@ -1,0 +1,95 @@
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { PaginationControls } from "./pagination-controls";
+
+describe("PaginationControls", () => {
+  // Desktop row-count copy shows the explicit "Showing X to Y of N results"
+  // phrasing. Mobile uses a compact range; both render so CSS picks one.
+  test("renders both desktop and mobile row-range copy", async () => {
+    await setup(<PaginationControls page={2} totalPages={5} pageSize={10} total={47} onPageChange={vi.fn()} />);
+    expect(screen.getByText("Showing 11 to 20 of 47 results")).toBeInTheDocument();
+    expect(screen.getByText("11–20 of 47")).toBeInTheDocument();
+  });
+
+  // Zero results: the entire "Showing..." copy collapses to "0 results" so
+  // callers don't have to special-case empty lists themselves.
+  test("renders '0 results' when total is 0", async () => {
+    await setup(<PaginationControls page={1} totalPages={1} pageSize={10} total={0} onPageChange={vi.fn()} />);
+    expect(screen.getByText("0 results")).toBeInTheDocument();
+  });
+
+  // Single page: row-range copy still renders so users see context, but the
+  // Previous/Next chrome is suppressed because clicking it would be a no-op.
+  test("hides Previous/Next/page-input when totalPages is 1", async () => {
+    await setup(<PaginationControls page={1} totalPages={1} pageSize={10} total={5} onPageChange={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: /previous/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /next/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
+  });
+
+  // On page 1 Previous is disabled but Next is active. The Next click resolves
+  // to page 2 via onPageChange — that's the only way the parent learns about
+  // navigation, so a regression here breaks every paginated surface.
+  test("disables Previous on page 1, Next fires onPageChange(2)", async () => {
+    const onPageChange = vi.fn();
+    const { user } = await setup(
+      <PaginationControls page={1} totalPages={5} pageSize={10} total={47} onPageChange={onPageChange} />,
+    );
+
+    expect(screen.getByRole("button", { name: /previous/i })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    expect(onPageChange).toHaveBeenCalledWith(2);
+  });
+
+  // On the last page Next is disabled and Previous fires onPageChange(prev).
+  test("disables Next on the last page, Previous fires onPageChange(page-1)", async () => {
+    const onPageChange = vi.fn();
+    const { user } = await setup(
+      <PaginationControls page={5} totalPages={5} pageSize={10} total={47} onPageChange={onPageChange} />,
+    );
+
+    expect(screen.getByRole("button", { name: /next/i })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: /previous/i }));
+    expect(onPageChange).toHaveBeenCalledWith(4);
+  });
+
+  // The page-input field accepts a direct page number and applies it on Enter.
+  // Out-of-range values clamp into [1, totalPages] so users can't navigate to
+  // a non-existent page.
+  test("Enter on page input applies the typed page, clamping to [1, totalPages]", async () => {
+    const onPageChange = vi.fn();
+    const { user } = await setup(
+      <PaginationControls page={1} totalPages={5} pageSize={10} total={47} onPageChange={onPageChange} />,
+    );
+
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    await user.clear(input);
+    await user.type(input, "3{enter}");
+    expect(onPageChange).toHaveBeenLastCalledWith(3);
+
+    onPageChange.mockClear();
+    await user.clear(input);
+    await user.type(input, "99{enter}");
+    expect(onPageChange).toHaveBeenLastCalledWith(5); // clamped to totalPages
+
+    onPageChange.mockClear();
+    await user.clear(input);
+    await user.type(input, "0{enter}");
+    expect(onPageChange).toHaveBeenLastCalledWith(1); // clamped to 1
+  });
+
+  // hidePaginationText hides the left-side row-range copy but keeps the
+  // Previous/Next/input controls. Used by callers that surface the count
+  // elsewhere on the page.
+  test("hidePaginationText drops the row-range copy but keeps the controls", async () => {
+    await setup(
+      <PaginationControls page={2} totalPages={5} pageSize={10} total={47} onPageChange={vi.fn()} hidePaginationText />,
+    );
+
+    expect(screen.queryByText(/Showing/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/of 47/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /previous/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /next/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/ui/pagination-controls.tsx
+++ b/apps/web/app/components/ui/pagination-controls.tsx
@@ -1,0 +1,93 @@
+import type { KeyboardEvent } from "react";
+import { Button } from "~/components/ui/button";
+
+interface PaginationControlsProps {
+  /** 1-indexed current page. */
+  page: number;
+  totalPages: number;
+  /** Page size + total row count drive the "Showing X to Y of N" copy. */
+  pageSize: number;
+  total: number;
+  onPageChange: (nextPage: number) => void;
+  /** Hides the "Showing N to M of T" copy on the left while keeping the controls. */
+  hidePaginationText?: boolean;
+}
+
+/**
+ * Shared Previous / Page-input / Next pagination strip. Used by DataTable for
+ * its client-side TanStack pagination and by any route-level paginator that
+ * wants the same visual treatment — caller wires onPageChange to either a
+ * table method or a URL navigation.
+ */
+export function PaginationControls({
+  page,
+  totalPages,
+  pageSize,
+  total,
+  onPageChange,
+  hidePaginationText = false,
+}: PaginationControlsProps) {
+  function handlePageInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key !== "Enter") return;
+    const value = Number(event.currentTarget.value);
+    if (Number.isNaN(value)) return;
+    const clamped = Math.max(1, Math.min(totalPages, value));
+    onPageChange(clamped);
+    event.currentTarget.value = String(clamped);
+  }
+
+  const from = (page - 1) * pageSize + 1;
+  const to = Math.min(page * pageSize, total);
+
+  return (
+    <div className="flex items-center justify-between px-2">
+      {!hidePaginationText ? (
+        total === 0 ? (
+          <div className="text-sm text-content-text-secondary font-medium">0 results</div>
+        ) : (
+          <div className="text-sm text-content-text-secondary font-medium">
+            <span className="hidden sm:inline">{`Showing ${from} to ${to} of ${total} results`}</span>
+            <span className="sm:hidden">{`${from}–${to} of ${total}`}</span>
+          </div>
+        )
+      ) : (
+        <div />
+      )}
+      {totalPages > 1 && (
+        <div className="flex items-center space-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onPageChange(Math.max(1, page - 1))}
+            disabled={page <= 1}
+            className="hover:bg-brand-primary/20 hover:border-brand-primary/40"
+          >
+            Previous
+          </Button>
+          <span className="flex items-center gap-1.5 text-sm text-content-text-secondary">
+            Page
+            <input
+              type="number"
+              min={1}
+              max={totalPages}
+              defaultValue={page}
+              key={page}
+              onKeyDown={handlePageInputKeyDown}
+              className="w-12 rounded border border-glass-border bg-glass-bg px-2 py-1 text-center text-sm text-white focus:outline-none focus:ring-1 focus:ring-ring/20 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            />
+            of {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onPageChange(Math.min(totalPages, page + 1))}
+            disabled={page >= totalPages}
+            className="hover:bg-brand-primary/20 hover:border-brand-primary/40"
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/lib/song-utilities.test.ts
+++ b/apps/web/app/lib/song-utilities.test.ts
@@ -38,6 +38,7 @@ const mockFindManyInDateRange = vi.fn();
 const mockShowsFindMany = vi.fn();
 const mockFindManyByDates = vi.fn().mockResolvedValue([]);
 const mockBuildSongPerformanceCounts = vi.fn();
+const mockBuildFilteredSongRarity = vi.fn().mockResolvedValue(new Map());
 const mockCacheGetOrSet = vi.fn().mockImplementation((_key: string, fn: () => Promise<unknown>) => fn());
 const mockFindByEmail = vi.fn();
 const mockFindByUsername = vi.fn();
@@ -52,6 +53,7 @@ vi.mock("~/server/services", () => ({
     },
     songPageComposer: {
       buildSongPerformanceCounts: (...args: unknown[]) => mockBuildSongPerformanceCounts(...args),
+      buildFilteredSongRarity: (...args: unknown[]) => mockBuildFilteredSongRarity(...args),
     },
     cache: {
       getOrSet: (...args: unknown[]) => mockCacheGetOrSet(...args),
@@ -205,9 +207,9 @@ describe("fetchFilteredSongs", () => {
   // song through computeRarityStats so the columns render real values
   // rather than em-dashes.
   test("rarity: populates showsSinceLastPlayed / percentSinceDebut / averageShowsPerPlay on returned rows", async () => {
-    const tractorbeam = {
-      id: "tb",
-      title: "Tractorbeam",
+    const helicopters = {
+      id: "hel",
+      title: "Helicopters",
       timesPlayed: 200,
       dateFirstPlayed: new Date(Date.UTC(1995, 5, 1)),
       dateLastPlayed: new Date(Date.UTC(2024, 0, 1)),
@@ -219,30 +221,30 @@ describe("fetchFilteredSongs", () => {
       dateFirstPlayed: new Date(Date.UTC(2010, 0, 1)),
       dateLastPlayed: new Date(Date.UTC(2023, 0, 1)),
     } as unknown as Song;
-    mockFindMany.mockResolvedValueOnce([tractorbeam, aboveTheWaves]);
+    mockFindMany.mockResolvedValueOnce([helicopters, aboveTheWaves]);
 
-    // 1995 + 2010 era totals chosen so the math comes out clean: tractorbeam
-    // debuted in 1995 and gets all 1000 shows since debut (200/1000 = 20%,
-    // every 5.0 shows). aboveTheWaves debuted in 2010 with 600 shows since
-    // (50/600 ≈ 8.33%, every 12.0 shows).
+    // 1995 + 2010 era totals: Helicopters debuted in 1995 and gets all 1000
+    // shows since debut → 200/1000 = 20%, mean-gap = (1000-200)/(200-1) ≈
+    // 4.02 shows. Above The Waves debuted in 2010 with 600 shows since →
+    // 50/600 ≈ 8.33%, mean-gap = (600-50)/(50-1) ≈ 11.22 shows.
     mockGetShowsByYear.mockResolvedValueOnce({ 1995: 400, 2010: 600 });
     mockGetShowsSinceLastPlayedBySongIds.mockResolvedValueOnce(
       new Map([
-        ["tb", 12],
+        ["hel", 12],
         ["atw", 47],
       ]),
     );
 
     const result = await fetchFilteredSongs(new URL("http://test/songs"), ctx);
 
-    const tb = result.find((s) => s.id === "tb");
+    const hel = result.find((s) => s.id === "hel");
     const atw = result.find((s) => s.id === "atw");
-    expect(tb?.showsSinceLastPlayed).toBe(12);
-    expect(tb?.percentSinceDebut).toBeCloseTo(0.2, 5);
-    expect(tb?.averageShowsPerPlay).toBeCloseTo(5, 5);
+    expect(hel?.showsSinceLastPlayed).toBe(12);
+    expect(hel?.percentSinceDebut).toBeCloseTo(0.2, 5);
+    expect(hel?.averageShowsPerPlay).toBeCloseTo(800 / 199, 5);
     expect(atw?.showsSinceLastPlayed).toBe(47);
     expect(atw?.percentSinceDebut).toBeCloseTo(50 / 600, 5);
-    expect(atw?.averageShowsPerPlay).toBeCloseTo(12, 5);
+    expect(atw?.averageShowsPerPlay).toBeCloseTo(550 / 49, 5);
   });
 
   // Songs with no debut date keep null rarity fields (computeRarityStats

--- a/apps/web/app/lib/song-utilities.ts
+++ b/apps/web/app/lib/song-utilities.ts
@@ -97,8 +97,14 @@ export async function fetchFilteredSongs(url: URL, context: PublicContext): Prom
           .map((song) => ({ ...song, filteredTimesPlayed: scopeCountsById.get(song.id) }));
       }
 
-      const withVenues = await addVenueInfoToSongs(result);
-      return await populateRarityFields(withVenues);
+      // When a narrowing filter is in effect, also pull per-song filtered
+      // rarity aggregates so the filtered columns on /songs have data.
+      // populateRarityFields runs first because it attaches the
+      // dateFirstFilteredPlayed / dateLastFilteredPlayed Date fields that
+      // addVenueInfoToSongs then resolves to Show records for the link.
+      const filterOptions = scopeCountsById && !showNotPlayed ? await parsePerformanceFilters(url, context) : null;
+      const withRarity = await populateRarityFields(result, filterOptions);
+      return await addVenueInfoToSongs(withRarity);
     },
     { ttl: 86400 },
   );
@@ -111,23 +117,37 @@ export async function fetchFilteredSongs(url: URL, context: PublicContext): Prom
  * Runs inside the cached `fetchFilteredSongs` path so the bulk gap query
  * fires at most once per cache window.
  */
-async function populateRarityFields<T extends Song>(songs: T[]): Promise<T[]> {
+async function populateRarityFields<T extends Song>(
+  songs: T[],
+  filterOptions: Awaited<ReturnType<typeof parsePerformanceFilters>> | null,
+): Promise<T[]> {
   if (songs.length === 0) return songs;
   const songIds = songs.map((s) => s.id);
-  const [showsByYear, gaps] = await Promise.all([
+  const [showsByYear, gaps, filteredRarity] = await Promise.all([
     services.stats.getShowsByYear(),
     services.stats.getShowsSinceLastPlayedBySongIds(songIds),
+    filterOptions ? services.songPageComposer.buildFilteredSongRarity(songIds, filterOptions) : Promise.resolve(null),
   ]);
   return songs.map((song) => {
     const rarity = computeRarityStats(
       { dateFirstPlayed: song.dateFirstPlayed, timesPlayed: song.timesPlayed },
       showsByYear,
     );
+    const filtered = filteredRarity?.get(song.id);
     return {
       ...song,
       showsSinceLastPlayed: gaps.get(song.id) ?? null,
       percentSinceDebut: rarity.percentSinceDebut,
       averageShowsPerPlay: rarity.averageShowsPerPlay,
+      ...(filtered
+        ? {
+            filteredShowsSinceLastPlayed: filtered.filteredShowsSinceLastPlayed,
+            filteredPercentSinceDebut: filtered.filteredPercentSinceDebut,
+            filteredAverageShowsPerPlay: filtered.filteredAverageShowsPerPlay,
+            dateFirstFilteredPlayed: filtered.dateFirstFilteredPlayed,
+            dateLastFilteredPlayed: filtered.dateLastFilteredPlayed,
+          }
+        : {}),
     };
   });
 }
@@ -195,11 +215,22 @@ async function resolveDateRangeForTimeRange(
 }
 
 /**
- * Adds the venue info to a songs firstPlayedShow and lastPlayedShow.
+ * Adds the venue info to a song's firstPlayedShow / lastPlayedShow, and
+ * — when the song carries `dateFirst/LastFilteredPlayed` from the filtered
+ * rarity pass — also to firstFilteredPlayedShow / lastFilteredPlayedShow.
+ * All four show columns on /songs resolve against the same single batch
+ * fetch of show records by date.
  */
-export async function addVenueInfoToSongs(
-  songs: Song[],
-): Promise<Array<Song & { firstPlayedShow: Show | null; lastPlayedShow: Show | null }>> {
+export async function addVenueInfoToSongs(songs: Song[]): Promise<
+  Array<
+    Song & {
+      firstPlayedShow: Show | null;
+      lastPlayedShow: Show | null;
+      firstFilteredPlayedShow?: Show | null;
+      lastFilteredPlayedShow?: Show | null;
+    }
+  >
+> {
   const showDates = new Set<string>();
   songs.forEach((song) => {
     if (song.dateFirstPlayed) {
@@ -207,6 +238,12 @@ export async function addVenueInfoToSongs(
     }
     if (song.dateLastPlayed) {
       showDates.add(dateToISOStringSansTime(song.dateLastPlayed));
+    }
+    if (song.dateFirstFilteredPlayed) {
+      showDates.add(dateToISOStringSansTime(song.dateFirstFilteredPlayed));
+    }
+    if (song.dateLastFilteredPlayed) {
+      showDates.add(dateToISOStringSansTime(song.dateLastFilteredPlayed));
     }
   });
 
@@ -221,5 +258,11 @@ export async function addVenueInfoToSongs(
     lastPlayedShow: song.dateLastPlayed
       ? (showsByDate.get(dateToISOStringSansTime(song.dateLastPlayed)) ?? null)
       : null,
+    firstFilteredPlayedShow: song.dateFirstFilteredPlayed
+      ? (showsByDate.get(dateToISOStringSansTime(song.dateFirstFilteredPlayed)) ?? null)
+      : undefined,
+    lastFilteredPlayedShow: song.dateLastFilteredPlayed
+      ? (showsByDate.get(dateToISOStringSansTime(song.dateLastFilteredPlayed)) ?? null)
+      : undefined,
   }));
 }

--- a/apps/web/app/lib/yearly-chart-data.test.ts
+++ b/apps/web/app/lib/yearly-chart-data.test.ts
@@ -37,7 +37,8 @@ describe("buildYearlyChartData", () => {
 
   // Defensive: if showsByYear is missing a year present in yearlyPlayData
   // (data drift, partial cache), render 0 in percent mode rather than
-  // dividing by zero or NaN. Per Phase 4 plan, we surface 0 not "no point".
+  // dividing by zero or NaN. Missing-denominator years surface as 0 — not
+  // dropped points — so the line stays continuous across the x-axis.
   test("percent mode renders 0 when showsByYear[year] is missing or zero", () => {
     const yearlyPlayData = { 2010: 5, 2011: 3, 2012: 7 };
     const showsByYear = { 2010: 50, 2011: 0 }; // 2011 is zero, 2012 is missing

--- a/apps/web/app/lib/yearly-chart-data.test.ts
+++ b/apps/web/app/lib/yearly-chart-data.test.ts
@@ -4,7 +4,7 @@ import { buildYearlyChartData, expandPlayedYears, expandYearlyDataToRange } from
 describe("buildYearlyChartData", () => {
   // Count mode is the default rendering: each year's raw play count maps
   // straight to `value`. Years are sorted ascending so the line chart reads
-  // left-to-right chronologically. Disco Biscuits' "Tractorbeam" — a
+  // left-to-right chronologically. Disco Biscuits' "Basis for a Day" — a
   // long-running staple — exercises the multi-year case.
   test("count mode returns sorted {year, value} pairs of raw play counts", () => {
     const yearlyPlayData = { 2010: 12, 2008: 5, 2012: 8 };

--- a/apps/web/app/routes/on-this-day.$monthDay.tsx
+++ b/apps/web/app/routes/on-this-day.$monthDay.tsx
@@ -177,6 +177,7 @@ export default function OnThisDay() {
               performances={filteredPerformances}
               isLoading={isLoading}
               showSongColumn
+              showGapColumns={false}
               pageSize={ALL_TIMERS_PAGE_SIZE}
               headerContent={
                 performances.length > ALL_TIMERS_PAGE_SIZE ? (

--- a/apps/web/app/routes/songs/$slug.test.tsx
+++ b/apps/web/app/routes/songs/$slug.test.tsx
@@ -282,8 +282,8 @@ describe("SongPage", () => {
   test("Average Gap StatBox renders label 'Average Gap' and the bare numeric value", () => {
     vi.mocked(useSerializedLoaderData).mockReturnValueOnce({
       song: {
-        title: "Tractorbeam",
-        slug: "tractorbeam",
+        title: "Basis for a Day",
+        slug: "basis-for-a-day",
         timesPlayed: 200,
         dateFirstPlayed: "1995-06-01",
         dateLastPlayed: "2024-01-01",

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -173,6 +173,10 @@ export default function SongPage() {
 
   const hasAllTimers = useMemo(() => allPerformances.some((p) => p.allTimer), [allPerformances]);
   const filteredAllTimers = useMemo(() => filteredPerformances.filter((p) => p.allTimer), [filteredPerformances]);
+  // Server-narrowing filter active = any UI filter that affects the
+  // performance set the server returned. Excludes `searchText` (client-only).
+  // Used to render the Filtered Gap column in the performances table.
+  const hasServerNarrowingFilter = selectedTimeRange !== "all" || activeToggleSet.size > 0;
   const filterContent = (
     <PerformanceFilterControls
       selectedTimeRange={selectedTimeRange}
@@ -458,6 +462,7 @@ export default function SongPage() {
               performances={filteredAllTimers}
               songTitle={song.title}
               isLoading={isLoading}
+              hasNarrowingFilter={hasServerNarrowingFilter}
               headerContent={filterContent}
             />
           </TabsContent>
@@ -469,6 +474,7 @@ export default function SongPage() {
             songTitle={song.title}
             showAllTimerColumn
             isLoading={isLoading}
+            hasNarrowingFilter={hasServerNarrowingFilter}
             headerContent={filterContent}
           />
         </TabsContent>

--- a/apps/web/app/routes/songs/all-timers.tsx
+++ b/apps/web/app/routes/songs/all-timers.tsx
@@ -44,6 +44,7 @@ export default function AllTimersPage() {
         performances={filteredPerformances}
         isLoading={isLoading}
         showSongColumn
+        showGapColumns={false}
         headerContent={
           <PerformanceFilterControls
             selectedTimeRange={selectedTimeRange}

--- a/apps/web/app/routes/users/$username.test.tsx
+++ b/apps/web/app/routes/users/$username.test.tsx
@@ -1,0 +1,332 @@
+import { mockShallowComponent } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// Server-side modules — stubbed so the component can import the route file
+// without pulling Prisma/Supabase into the test bundle.
+vi.mock("~/server/services", () => ({ services: {} }));
+vi.mock("~/server/show-external-sources", () => ({ computeShowExternalSources: vi.fn() }));
+vi.mock("~/server/show-user-data", () => ({ computeShowUserData: vi.fn() }));
+vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
+
+// Default loader payload — most attendance has a Disco Biscuits setlist
+// (per project test convention).
+const baseLoaderData = {
+  user: {
+    id: "u1",
+    email: "evan@foo.net",
+    username: "evan",
+    avatarUrl: null,
+    createdAt: new Date("2020-01-01T00:00:00Z"),
+  },
+  reviews: [],
+  blogPosts: [],
+  attendedSetlists: [
+    {
+      show: {
+        id: "show-1",
+        date: "2024-08-12",
+        slug: "2024-08-12-port-chester-ny",
+        averageRating: 4.5,
+        venue: { name: "The Capitol Theatre", city: "Port Chester", state: "NY" },
+      },
+      sets: [{ label: "S1", tracks: [{ id: "t1", song: { title: "Basis for a Day" } }] }],
+    },
+  ],
+  attendedExternalSources: {},
+  attendedInitialUserData: { attendances: [], userRatings: [], averageRatings: [] },
+  attendedPagination: { page: 1, pageSize: 100, totalPages: 1, total: 1 },
+  ratingsPagination: { page: 1, pageSize: 100, totalPages: 1, total: 0 },
+  activeTab: "shows" as const,
+  showRatings: [],
+  trackRatings: [],
+  attendanceCount: 1,
+  reviewCount: 0,
+  showRatingsCount: 0,
+  trackRatingsCount: 0,
+  totalRatings: 0,
+  userStat: { communityScore: 0, badges: [], blogPostCount: 0 },
+  firstShow: { id: "show-1", date: "2024-08-12" },
+  lastShow: { id: "show-1", date: "2024-08-12" },
+  isOwnProfile: true,
+};
+
+vi.mock("~/hooks/use-serialized-loader-data", () => ({
+  useSerializedLoaderData: vi.fn(() => baseLoaderData),
+}));
+
+// Stub the heavy SetlistList child. We still want to verify the `empty`
+// slot, so we render it inline when no setlists were passed — mirroring
+// SetlistList's own behavior. When setlists is non-empty we surface the
+// count and first show id as data-attrs so tests can assert wiring without
+// depending on JSON-stringified prop serialization (mockShallowComponent's
+// replacer drops nested keys).
+vi.mock("~/components/setlist/setlist-list", () => ({
+  SetlistList: (props: {
+    setlists: Array<{ show: { id: string } }>;
+    empty?: React.ReactNode;
+    externalSources?: Record<string, unknown>;
+    initialUserData?: unknown;
+  }) => {
+    if (!props.setlists || props.setlists.length === 0) {
+      return <div data-testid="SetlistList">{props.empty}</div>;
+    }
+    return (
+      <div
+        data-testid="SetlistList"
+        data-setlists-count={props.setlists.length}
+        data-first-show-id={props.setlists[0]?.show?.id ?? ""}
+        data-has-initial-user-data={props.initialUserData ? "yes" : "no"}
+      >
+        {mockShallowComponent("SetlistListShallow", { setlistsCount: props.setlists.length })}
+      </div>
+    );
+  },
+}));
+
+import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
+import UserProfile from "./$username";
+
+function renderProfile(initialEntry = "/users/evan") {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <UserProfile />
+    </MemoryRouter>,
+  );
+}
+
+describe("UserProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useSerializedLoaderData).mockReturnValue(baseLoaderData);
+  });
+
+  // The Shows Attended tab is the user's primary activity record and should
+  // be the first thing seen on the profile page.
+  test("Shows Attended is the leftmost tab", () => {
+    renderProfile();
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[0]).toHaveTextContent(/shows attended/i);
+  });
+
+  // Tab order matters — keep Reviews/Ratings/Blog after Shows so the most
+  // common landing surface is at the start.
+  test("tabs render in order: Shows Attended, Reviews, Show Ratings, Song Version Ratings", () => {
+    renderProfile();
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[0]).toHaveTextContent(/shows attended/i);
+    expect(tabs[1]).toHaveTextContent(/reviews/i);
+    expect(tabs[2]).toHaveTextContent(/show ratings/i);
+    expect(tabs[3]).toHaveTextContent(/song version ratings/i);
+  });
+
+  // Default selection is "shows" — landing on a profile shows the attended
+  // setlist list, not the (often empty) reviews tab.
+  test("Shows Attended tab is selected by default", () => {
+    renderProfile();
+
+    const showsTab = screen.getByRole("tab", { name: /shows attended/i });
+    expect(showsTab.getAttribute("data-state")).toBe("active");
+  });
+
+  // Active tab is driven by the loader-provided `activeTab` (parsed from
+  // `?tab=` on the server). Loading the page with ?tab=track-ratings should
+  // surface that tab as active so a refresh / shared link lands on the same
+  // surface. `mockReturnValue` (not Once) covers React's potential double-
+  // render in concurrent mode.
+  test("active tab follows the loader's activeTab value", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValue({
+      ...baseLoaderData,
+      activeTab: "track-ratings",
+    });
+
+    renderProfile("/users/evan?tab=track-ratings");
+
+    const trackTab = screen.getByRole("tab", { name: /song version ratings/i });
+    expect(trackTab.getAttribute("data-state")).toBe("active");
+    const showsTab = screen.getByRole("tab", { name: /shows attended/i });
+    expect(showsTab.getAttribute("data-state")).toBe("inactive");
+  });
+
+  // Each tab is rendered as a <Link> (via Radix asChild) so clicking
+  // triggers a full navigation — the loader re-runs and fetches only that
+  // tab's data. Radix overrides the anchor's role to "tab", so we query by
+  // tab role and verify the underlying href.
+  test("each tab links to ?tab=<value> for server-side navigation", () => {
+    renderProfile();
+
+    const expectedTargets: Array<[RegExp, string]> = [
+      [/shows attended/i, "?tab=shows"],
+      [/^reviews/i, "?tab=reviews"],
+      [/^show ratings/i, "?tab=show-ratings"],
+      [/song version ratings/i, "?tab=track-ratings"],
+    ];
+    for (const [label, expectedHref] of expectedTargets) {
+      const tab = screen.getByRole("tab", { name: label });
+      expect(tab.getAttribute("href")).toContain(expectedHref);
+    }
+  });
+
+  // Profile tabs render as a <select> on mobile (sm:hidden) and the
+  // horizontal tab strip at sm+. Mirrors the song-detail page pattern so
+  // the long "Song Version Ratings" label doesn't clip on phones.
+  test("tabs render as a select on mobile and a tab strip at sm+", () => {
+    renderProfile();
+
+    const tabList = screen.getByRole("tablist");
+    expect(tabList.className).toContain("hidden");
+    expect(tabList.className).toContain("sm:flex");
+
+    const select = screen.getByLabelText(/profile view/i);
+    const wrapper = select.closest("div");
+    expect(wrapper?.className).toContain("sm:hidden");
+  });
+
+  // The route delegates rendering to SetlistList, passing through the
+  // loader-built setlists, external sources, and initial user-data payload.
+  // Load-bearing wiring test: if the loader keys are renamed without
+  // updating the JSX, this catches it via the stub's surfaced data-attrs.
+  test("renders SetlistList with the loader's attended-shows payload", () => {
+    renderProfile();
+
+    const setlistList = screen.getByTestId("SetlistList");
+    expect(setlistList).toBeInTheDocument();
+    expect(setlistList.getAttribute("data-setlists-count")).toBe("1");
+    expect(setlistList.getAttribute("data-first-show-id")).toBe("show-1");
+    expect(setlistList.getAttribute("data-has-initial-user-data")).toBe("yes");
+  });
+
+  // Empty attended-shows list: SetlistList renders the `empty` slot when
+  // no setlists are passed; the route's empty copy must be wired through.
+  test("renders the own-profile empty copy when no attended shows", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValueOnce({
+      ...baseLoaderData,
+      attendedSetlists: [],
+      attendedExternalSources: {},
+      attendanceCount: 0,
+    });
+
+    renderProfile();
+
+    expect(screen.getByText("No Shows Attended")).toBeInTheDocument();
+    expect(screen.getByText(/you haven't marked any shows/i)).toBeInTheDocument();
+  });
+
+  // Pagination chrome is hidden when there's only one page — most users
+  // have <100 attended shows so we shouldn't show empty Prev/Next controls.
+  test("does not render pagination when totalPages is 1", () => {
+    renderProfile();
+    expect(screen.queryByRole("button", { name: /next/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
+  });
+
+  // Heaviest user case: 459 shows across 5 pages of 100. Pagination chrome
+  // renders both above and below the list, so we expect two of each button.
+  // PaginationControls also surfaces a "Page [input] of N" widget — both
+  // page-input fields should reflect the current page.
+  test("renders Prev/Next buttons and row range when totalPages > 1", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValueOnce({
+      ...baseLoaderData,
+      attendedPagination: { page: 3, pageSize: 100, totalPages: 5, total: 459 },
+    });
+
+    renderProfile();
+    // "Showing 201 to 300 of 459 results" (desktop) — two pagination strips.
+    expect(screen.getAllByText(/Showing 201 to 300 of 459 results/)).toHaveLength(2);
+    expect(screen.getAllByText(/of 5/)).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: /previous/i })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: /next/i })).toHaveLength(2);
+    // The page input is a spinbutton with the current page as defaultValue.
+    const pageInputs = screen.getAllByRole("spinbutton");
+    expect(pageInputs).toHaveLength(2);
+    for (const input of pageInputs) {
+      expect(input).toHaveAttribute("max", "5");
+      expect((input as HTMLInputElement).defaultValue).toBe("3");
+    }
+  });
+
+  // Show-Ratings and Track-Ratings tabs paginate at 100/page to keep the
+  // rendered DOM small on heavy users (~7,800 track ratings at the top end). The
+  // loader provides `ratingsPagination` whenever the active tab is one of
+  // the rating tabs; component renders PaginationControls below the list.
+  test("renders rating-tab pagination when activeTab is show-ratings and totalPages > 1", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValue({
+      ...baseLoaderData,
+      activeTab: "show-ratings",
+      showRatings: [],
+      ratingsPagination: { page: 1, pageSize: 100, totalPages: 18, total: 1739 },
+    });
+
+    renderProfile("/users/evan?tab=show-ratings");
+    // Pagination chrome renders both above and below the list.
+    expect(screen.getAllByText(/Showing 1 to 100 of 1739 results/)).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: /next/i })).toHaveLength(2);
+  });
+
+  // Same for track-ratings — pagination chrome is shared infrastructure.
+  test("renders rating-tab pagination when activeTab is track-ratings and totalPages > 1", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValue({
+      ...baseLoaderData,
+      activeTab: "track-ratings",
+      trackRatings: [],
+      ratingsPagination: { page: 2, pageSize: 100, totalPages: 78, total: 7784 },
+    });
+
+    renderProfile("/users/evan?tab=track-ratings");
+    expect(screen.getAllByText(/Showing 101 to 200 of 7784 results/)).toHaveLength(2);
+  });
+
+  // Pagination chrome stays hidden on the rating tabs when the user has
+  // fewer ratings than a single page — avoids noisy "Page 1 of 1" UI for
+  // the typical user who has <100 ratings.
+  test("hides rating-tab pagination when totalPages is 1", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValue({
+      ...baseLoaderData,
+      activeTab: "show-ratings",
+      showRatings: [],
+      ratingsPagination: { page: 1, pageSize: 100, totalPages: 1, total: 5 },
+    });
+
+    renderProfile("/users/evan?tab=show-ratings");
+    expect(screen.queryByRole("button", { name: /next/i })).not.toBeInTheDocument();
+  });
+
+  // Last page: Next button is rendered but disabled. Previous remains enabled.
+  test("disables Next on the last page", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValueOnce({
+      ...baseLoaderData,
+      attendedPagination: { page: 5, pageSize: 100, totalPages: 5, total: 459 },
+    });
+
+    renderProfile();
+    const nextButtons = screen.getAllByRole("button", { name: /next/i });
+    const prevButtons = screen.getAllByRole("button", { name: /previous/i });
+    expect(nextButtons).toHaveLength(2);
+    expect(prevButtons).toHaveLength(2);
+    for (const btn of nextButtons) {
+      expect(btn).toBeDisabled();
+    }
+    for (const btn of prevButtons) {
+      expect(btn).not.toBeDisabled();
+    }
+  });
+
+  // Other-user view: the empty-state copy switches from second-person to
+  // third-person and includes the viewed user's username.
+  test("empty-state copy references the username when viewing another user's profile", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValueOnce({
+      ...baseLoaderData,
+      attendedSetlists: [],
+      attendanceCount: 0,
+      isOwnProfile: false,
+      user: { ...baseLoaderData.user, username: "barberj" },
+    });
+
+    renderProfile();
+
+    expect(screen.getByText(/barberj hasn't marked any shows/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/routes/users/$username.tsx
+++ b/apps/web/app/routes/users/$username.tsx
@@ -1,47 +1,43 @@
-import { compareByShowDate } from "@bip/domain";
+import { CacheKeys, compareByShowDate } from "@bip/domain";
 import { CalendarDays, Edit, MessageSquare, Star, Users } from "lucide-react";
 import type { LoaderFunctionArgs, MetaFunction } from "react-router-dom";
-import { Link, useLoaderData } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
+import { SetlistList } from "~/components/setlist/setlist-list";
+import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { PaginationControls } from "~/components/ui/pagination-controls";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
+import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
+import { type PublicContext, publicLoader } from "~/lib/base-loaders";
 import { formatDateLong } from "~/lib/utils";
 import { services } from "~/server/services";
-import { getServerClient } from "~/server/supabase";
+import { computeShowExternalSources } from "~/server/show-external-sources";
+import { computeShowUserData } from "~/server/show-user-data";
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
-  if (!data?.user) {
-    return [
-      { title: "User Not Found | Biscuits Internet Project" },
-      { name: "description", content: "The requested user profile could not be found." },
-    ];
-  }
+const ATTENDED_SHOWS_PAGE_SIZE = 50;
+const RATINGS_PAGE_SIZE = 100;
 
-  return [
-    { title: `${data.user.username} | Biscuits Internet Project` },
-    { name: "description", content: `View ${data.user.username}'s profile, reviews, and show attendance.` },
-  ];
-};
+const TAB_VALUES = ["shows", "reviews", "show-ratings", "track-ratings", "blog"] as const;
+type TabValue = (typeof TAB_VALUES)[number];
 
-export async function loader({ params, request }: LoaderFunctionArgs) {
+function parseTab(raw: string | null): TabValue {
+  return (TAB_VALUES as readonly string[]).includes(raw ?? "") ? (raw as TabValue) : "shows";
+}
+
+async function loadUserProfile({ params, request, context }: LoaderFunctionArgs & { context: PublicContext }) {
   const { username } = params;
   if (!username) {
     throw new Response("Username not provided", { status: 400 });
   }
 
-  // Get current session user (use getUser() to verify JWT, not getSession())
-  const { supabase } = getServerClient(request);
-  const {
-    data: { user: authUser },
-  } = await supabase.auth.getUser();
-  const sessionUser = authUser
-    ? {
-        id: authUser.id,
-        email: authUser.email,
-        role: authUser.user_metadata?.role,
-      }
-    : null;
+  const url = new URL(request.url);
+  const rawPage = Number.parseInt(url.searchParams.get("page") ?? "1", 10);
+  const pageParam = Number.isFinite(rawPage) && rawPage > 0 ? rawPage : 1;
+  const activeTab = parseTab(url.searchParams.get("tab"));
+
+  const sessionUser = context.currentUser ?? null;
 
   // Find the user by username
   const user = await services.users.findByUsername(username);
@@ -49,51 +45,117 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     throw new Response("User not found", { status: 404 });
   }
 
-  // Get user's reviews with show data
-  const reviews = await services.reviews.findByUserIdWithShow(user.id, {
-    sort: [{ field: "createdAt", direction: "desc" }],
-  });
+  // Always fetch: counts (drive tab labels) + user stats (header badges) +
+  // attendance summary (count + first/last show for header). Only fetch the
+  // active tab's row data — heavy users have 7000+ track ratings and
+  // shipping all tabs' data on every load costs megabytes.
+  const [tabCounts, userStats, profileHeader] = await Promise.all([
+    services.users.getUserTabCounts(user.id),
+    services.users.getUserStats(user.id),
+    services.users.getUserProfileHeader(user.id),
+  ]);
+  const userStat = userStats[0]; // getUserStats returns an array
+  const { attendanceCount, firstShow, lastShow } = profileHeader;
 
   // Get user's blog posts (simplified - we'll enhance this later)
-  const blogPosts: Array<Record<string, unknown>> = []; // TODO: Implement blog post retrieval
+  // TODO: Implement blog post retrieval
+  const blogPosts: Array<{ id: string; slug: string; title: string; content?: string; createdAt?: string | Date }> = [];
 
-  // Get user's attendances with show data
-  const userAttendances = await services.attendances.findByUserIdWithShow(user.id, {
-    sort: [{ field: "createdAt", direction: "desc" }],
-  });
+  const reviews =
+    activeTab === "reviews"
+      ? await services.reviews.findByUserIdWithShow(user.id, { sort: [{ field: "createdAt", direction: "desc" }] })
+      : [];
 
-  // Get user's ratings with show and track data
-  const [showRatings, trackRatings] = await Promise.all([
-    services.ratings.findShowRatingsByUserId(user.id),
-    services.ratings.findTrackRatingsByUserId(user.id),
-  ]);
+  // Pagination state for the rating tabs — shares the `?page=` param with
+  // Shows Attended (different totalPages per tab; navigating to a tab via
+  // <Link to="?tab=X"> drops the param so page resets to 1).
+  const ratingsTotal =
+    activeTab === "show-ratings"
+      ? tabCounts.showRatingsCount
+      : activeTab === "track-ratings"
+        ? tabCounts.trackRatingsCount
+        : 0;
+  const ratingsTotalPages = Math.max(1, Math.ceil(ratingsTotal / RATINGS_PAGE_SIZE));
+  const clampedRatingsPage = Math.min(Math.max(1, pageParam), ratingsTotalPages);
+  const ratingsSkip = (clampedRatingsPage - 1) * RATINGS_PAGE_SIZE;
 
-  // Get user stats (includes badges and community score)
-  const userStats = await services.users.getUserStats(user.id);
-  const userStat = userStats[0]; // getUserStats returns an array
+  const showRatings =
+    activeTab === "show-ratings"
+      ? await services.ratings.findShowRatingsByUserId(user.id, { skip: ratingsSkip, take: RATINGS_PAGE_SIZE })
+      : [];
+  const trackRatings =
+    activeTab === "track-ratings"
+      ? await services.ratings.findTrackRatingsByUserId(user.id, { skip: ratingsSkip, take: RATINGS_PAGE_SIZE })
+      : [];
 
-  const attendanceCount = userAttendances.length;
-  const reviewCount = reviews.length;
-  const showRatingsCount = showRatings.length;
-  const trackRatingsCount = trackRatings.length;
-  const totalRatings = showRatingsCount + trackRatingsCount;
+  const totalRatings = tabCounts.showRatingsCount + tabCounts.trackRatingsCount;
 
-  // Calculate first and last show dates
-  const sortedAttendances = userAttendances.sort(compareByShowDate);
-  const firstShow = sortedAttendances[0]?.show || null;
-  const lastShow = sortedAttendances[sortedAttendances.length - 1]?.show || null;
+  // Total attended pages comes straight from the count — no full-list fetch
+  // needed to derive the page count.
+  const totalAttendedPages = Math.max(1, Math.ceil(attendanceCount / ATTENDED_SHOWS_PAGE_SIZE));
+  const clampedAttendedPage = Math.min(Math.max(1, pageParam), totalAttendedPages);
+
+  // Only fetch the full attendance list when we actually need to paginate
+  // it — i.e. the Shows Attended tab is active. Other tabs (reviews,
+  // ratings) don't render any attendances directly, only the header count
+  // we already have. Saves ~30-50ms on non-shows tab loads for heavy users.
+  const pageShowIds: string[] =
+    activeTab === "shows"
+      ? await (async () => {
+          const userAttendances = await services.attendances.findByUserIdWithShow(user.id, {
+            sort: [{ field: "createdAt", direction: "desc" }],
+          });
+          // Re-sort by show date desc so pages are stable across attendance
+          // toggles (mirrors every other SetlistList surface in the app).
+          const byShowDateDesc = [...userAttendances].sort((a, b) => -compareByShowDate(a, b));
+          const start = (clampedAttendedPage - 1) * ATTENDED_SHOWS_PAGE_SIZE;
+          return byShowDateDesc.slice(start, start + ATTENDED_SHOWS_PAGE_SIZE).map((a) => a.show.id);
+        })()
+      : [];
+
+  const { attendedSetlists, attendedExternalSources } = pageShowIds.length
+    ? await services.cache.getOrSet(CacheKeys.users.attendedSetlists(user.id, clampedAttendedPage), async () => {
+        const setlists = await services.setlists.findManyByShowIds(pageShowIds);
+        const externalSources: Record<string, ShowExternalSources> = await computeShowExternalSources(
+          setlists.map((s) => s.show),
+        );
+        return { attendedSetlists: setlists, attendedExternalSources: externalSources };
+      })
+    : { attendedSetlists: [], attendedExternalSources: {} as Record<string, ShowExternalSources> };
+
+  // Per-viewer overlay (attendance / rating badges) — not cached; depends on
+  // the logged-in user, not the profile being viewed.
+  const attendedInitialUserData = await computeShowUserData(
+    context,
+    attendedSetlists.map((s) => s.show.id),
+  );
 
   return {
     user,
     reviews,
     blogPosts,
-    userAttendances,
+    attendedSetlists,
+    attendedExternalSources,
+    attendedInitialUserData,
+    attendedPagination: {
+      page: clampedAttendedPage,
+      pageSize: ATTENDED_SHOWS_PAGE_SIZE,
+      totalPages: totalAttendedPages,
+      total: attendanceCount,
+    },
     showRatings,
     trackRatings,
+    ratingsPagination: {
+      page: clampedRatingsPage,
+      pageSize: RATINGS_PAGE_SIZE,
+      totalPages: ratingsTotalPages,
+      total: ratingsTotal,
+    },
+    activeTab,
     attendanceCount,
-    reviewCount,
-    showRatingsCount,
-    trackRatingsCount,
+    reviewCount: tabCounts.reviewCount,
+    showRatingsCount: tabCounts.showRatingsCount,
+    trackRatingsCount: tabCounts.trackRatingsCount,
     totalRatings,
     userStat,
     firstShow,
@@ -102,14 +164,38 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   };
 }
 
+export type LoaderData = Awaited<ReturnType<typeof loadUserProfile>>;
+
+export const loader = publicLoader<LoaderData>(loadUserProfile);
+
+export const meta: MetaFunction = ({ data }) => {
+  const typed = data as LoaderData | undefined;
+  if (!typed?.user) {
+    return [
+      { title: "User Not Found | Biscuits Internet Project" },
+      { name: "description", content: "The requested user profile could not be found." },
+    ];
+  }
+
+  return [
+    { title: `${typed.user.username} | Biscuits Internet Project` },
+    { name: "description", content: `View ${typed.user.username}'s profile, reviews, and show attendance.` },
+  ];
+};
+
 export default function UserProfile() {
   const {
     user,
     reviews,
     blogPosts,
-    userAttendances,
+    attendedSetlists,
+    attendedExternalSources,
+    attendedInitialUserData,
+    attendedPagination,
     showRatings,
     trackRatings,
+    ratingsPagination,
+    activeTab,
     attendanceCount,
     reviewCount,
     showRatingsCount,
@@ -119,42 +205,60 @@ export default function UserProfile() {
     firstShow,
     lastShow,
     isOwnProfile,
-  } = useLoaderData<typeof loader>();
+  } = useSerializedLoaderData<LoaderData>();
+
+  const navigate = useNavigate();
+
+  // Same handler for every paginated tab — page param is shared across
+  // tabs, but we always preserve the active tab so refreshes land back
+  // on the right surface. `preventScrollReset` keeps the viewport where
+  // the user clicked Next/Prev — otherwise React Router yanks them back
+  // to the top of the page on every pagination click.
+  const handlePageChange = (nextPage: number) => {
+    navigate(`?tab=${activeTab}&page=${nextPage}`, { preventScrollReset: true });
+  };
 
   return (
     <div className="w-full space-y-6">
       {/* Profile Header */}
       <Card className="card-premium">
         <CardContent className="pt-6">
-          {/* Top row: Avatar, Name/Score, Badges, Edit Button */}
-          <div className="flex items-start justify-between mb-6">
-            <div className="flex items-center gap-6">
-              {/* Avatar */}
-              <div className="w-20 h-20 rounded-full overflow-hidden bg-glass-bg border-2 border-glass-border flex items-center justify-center flex-shrink-0">
+          {/* Top row: Avatar, Name/Score, Badges, Edit Button.
+              Mobile stacks (avatar+info on top, badges+edit below); sm+ goes
+              side-by-side. */}
+          <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 sm:gap-0 mb-6">
+            <div className="flex items-center gap-4 sm:gap-6">
+              {/* Avatar — smaller on mobile so the username fits beside it. */}
+              <div className="w-16 h-16 sm:w-20 sm:h-20 rounded-full overflow-hidden bg-glass-bg border-2 border-glass-border flex items-center justify-center flex-shrink-0">
                 {user.avatarUrl ? (
                   <img src={user.avatarUrl} alt={`${user.username}'s avatar`} className="w-full h-full object-cover" />
                 ) : (
-                  <Users className="w-8 h-8 text-content-text-tertiary" />
+                  <Users className="w-7 h-7 sm:w-8 sm:h-8 text-content-text-tertiary" />
                 )}
               </div>
 
               {/* User Info */}
-              <div>
-                <div className="flex items-center gap-4 mb-2">
-                  <h1 className="text-3xl font-bold text-content-text-primary">{user.username}</h1>
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2 sm:gap-4 mb-1 sm:mb-2">
+                  <h1 className="text-2xl sm:text-3xl font-bold text-content-text-primary break-words">
+                    {user.username}
+                  </h1>
                   {userStat && (
-                    <Badge variant="default" className="bg-brand-primary text-white font-bold text-lg px-4 py-2">
+                    <Badge
+                      variant="default"
+                      className="bg-brand-primary text-white font-bold text-base sm:text-lg px-3 sm:px-4 py-1 sm:py-2"
+                    >
                       {userStat.communityScore || 0}
                     </Badge>
                   )}
                 </div>
-                <p className="text-content-text-secondary">
+                <p className="text-sm sm:text-base text-content-text-secondary">
                   Member since {formatDateLong(user.createdAt.toISOString())}
                 </p>
 
-                {/* First and Last Show - compact */}
+                {/* First and Last Show - wrap on narrow screens. */}
                 {(firstShow || lastShow) && (
-                  <div className="flex items-center gap-4 text-sm mt-2">
+                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm mt-2">
                     {firstShow && (
                       <span className="text-content-text-secondary">
                         First show:{" "}
@@ -172,11 +276,12 @@ export default function UserProfile() {
               </div>
             </div>
 
-            {/* Right side: Badges and Edit Button */}
-            <div className="flex flex-col items-end gap-3">
-              {/* Badges - top right */}
+            {/* Right side: Badges and Edit Button. Aligned left on mobile so
+                it reads as a continuation of the user block; right-aligned at sm+. */}
+            <div className="flex flex-col items-start sm:items-end gap-3">
+              {/* Badges */}
               {userStat?.badges && userStat.badges.length > 0 && (
-                <div className="flex flex-wrap gap-2 justify-end">
+                <div className="flex flex-wrap gap-2 sm:justify-end">
                   {userStat.badges.slice(0, 4).map((badge) => (
                     <div
                       key={badge.id}
@@ -201,52 +306,81 @@ export default function UserProfile() {
             </div>
           </div>
 
-          {/* Stats Grid - now spans full width */}
-          <div className="grid grid-cols-4 gap-6 p-4 bg-content-bg/30 rounded-lg border border-content-border/30 mb-4">
+          {/* Stats Grid — 2-up on mobile so each cell stays readable, 4-up at sm+. */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-6 p-3 sm:p-4 bg-content-bg/30 rounded-lg border border-content-border/30 mb-4">
             <div className="text-center">
-              <div className="text-2xl font-bold text-brand-primary">{attendanceCount}</div>
-              <div className="text-sm text-content-text-secondary">Shows Attended</div>
+              <div className="text-xl sm:text-2xl font-bold text-brand-primary">{attendanceCount}</div>
+              <div className="text-xs sm:text-sm text-content-text-secondary">Shows Attended</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-brand-secondary">{reviewCount}</div>
-              <div className="text-sm text-content-text-secondary">Reviews Written</div>
+              <div className="text-xl sm:text-2xl font-bold text-brand-secondary">{reviewCount}</div>
+              <div className="text-xs sm:text-sm text-content-text-secondary">Reviews Written</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-brand-tertiary">{totalRatings}</div>
-              <div className="text-sm text-content-text-secondary">Total Ratings</div>
+              <div className="text-xl sm:text-2xl font-bold text-brand-tertiary">{totalRatings}</div>
+              <div className="text-xs sm:text-sm text-content-text-secondary">Total Ratings</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-green-500">{userStat?.blogPostCount || 0}</div>
-              <div className="text-sm text-content-text-secondary">Blog Posts</div>
+              <div className="text-xl sm:text-2xl font-bold text-green-500">{userStat?.blogPostCount || 0}</div>
+              <div className="text-xs sm:text-sm text-content-text-secondary">Blog Posts</div>
             </div>
           </div>
         </CardContent>
       </Card>
 
-      {/* Content Tabs */}
-      <Tabs defaultValue="reviews" className="w-full">
-        <TabsList className="glass mb-6">
-          <TabsTrigger value="reviews" className="data-[state=active]:bg-brand-primary data-[state=active]:text-white">
-            Reviews ({reviewCount})
-          </TabsTrigger>
-          <TabsTrigger
-            value="show-ratings"
-            className="data-[state=active]:bg-brand-primary data-[state=active]:text-white"
+      {/* Content Tabs — mobile shows a <select> dropdown (sm:hidden), sm+
+          renders the horizontal tab strip. Mirrors the song-detail page so
+          the long "Song Version Ratings" label doesn't clip on phones. */}
+      <Tabs value={activeTab} onValueChange={(value) => navigate(`?tab=${value}`)} className="w-full">
+        <div className="sm:hidden mb-4">
+          <label htmlFor="user-profile-tab-select" className="sr-only">
+            Profile view
+          </label>
+          <select
+            id="user-profile-tab-select"
+            value={activeTab}
+            onChange={(event) => navigate(`?tab=${event.target.value}`)}
+            className="w-full h-11 px-3 rounded-md bg-glass-bg border border-glass-border text-content-text-primary focus:outline-none focus:ring-1 focus:ring-ring/20"
           >
-            Show Ratings ({showRatingsCount})
+            <option value="shows">Shows Attended ({attendanceCount})</option>
+            <option value="reviews">Reviews ({reviewCount})</option>
+            <option value="show-ratings">Show Ratings ({showRatingsCount})</option>
+            <option value="track-ratings">Song Version Ratings ({trackRatingsCount})</option>
+            {blogPosts.length > 0 && <option value="blog">Blog Posts ({blogPosts.length})</option>}
+          </select>
+        </div>
+        <TabsList className="glass mb-6 hidden sm:flex">
+          <TabsTrigger value="shows" asChild>
+            <Link to="?tab=shows" className="data-[state=active]:bg-brand-primary data-[state=active]:text-white">
+              Shows Attended ({attendanceCount})
+            </Link>
           </TabsTrigger>
-          <TabsTrigger
-            value="track-ratings"
-            className="data-[state=active]:bg-brand-primary data-[state=active]:text-white"
-          >
-            Song Version Ratings ({trackRatingsCount})
+          <TabsTrigger value="reviews" asChild>
+            <Link to="?tab=reviews" className="data-[state=active]:bg-brand-primary data-[state=active]:text-white">
+              Reviews ({reviewCount})
+            </Link>
           </TabsTrigger>
-          <TabsTrigger value="shows" className="data-[state=active]:bg-brand-primary data-[state=active]:text-white">
-            Shows Attended ({attendanceCount})
+          <TabsTrigger value="show-ratings" asChild>
+            <Link
+              to="?tab=show-ratings"
+              className="data-[state=active]:bg-brand-primary data-[state=active]:text-white"
+            >
+              Show Ratings ({showRatingsCount})
+            </Link>
+          </TabsTrigger>
+          <TabsTrigger value="track-ratings" asChild>
+            <Link
+              to="?tab=track-ratings"
+              className="data-[state=active]:bg-brand-primary data-[state=active]:text-white"
+            >
+              Song Version Ratings ({trackRatingsCount})
+            </Link>
           </TabsTrigger>
           {blogPosts.length > 0 && (
-            <TabsTrigger value="blog" className="data-[state=active]:bg-brand-primary data-[state=active]:text-white">
-              Blog Posts ({blogPosts.length})
+            <TabsTrigger value="blog" asChild>
+              <Link to="?tab=blog" className="data-[state=active]:bg-brand-primary data-[state=active]:text-white">
+                Blog Posts ({blogPosts.length})
+              </Link>
             </TabsTrigger>
           )}
         </TabsList>
@@ -312,6 +446,15 @@ export default function UserProfile() {
 
         {/* Show Ratings Tab */}
         <TabsContent value="show-ratings" className="space-y-4">
+          {activeTab === "show-ratings" && ratingsPagination.totalPages > 1 && (
+            <PaginationControls
+              page={ratingsPagination.page}
+              totalPages={ratingsPagination.totalPages}
+              total={ratingsPagination.total}
+              pageSize={ratingsPagination.pageSize}
+              onPageChange={handlePageChange}
+            />
+          )}
           {showRatings.length > 0 ? (
             <div className="space-y-4">
               {showRatings.map((rating) => (
@@ -366,10 +509,28 @@ export default function UserProfile() {
               </CardContent>
             </Card>
           )}
+          {activeTab === "show-ratings" && ratingsPagination.totalPages > 1 && (
+            <PaginationControls
+              page={ratingsPagination.page}
+              totalPages={ratingsPagination.totalPages}
+              total={ratingsPagination.total}
+              pageSize={ratingsPagination.pageSize}
+              onPageChange={handlePageChange}
+            />
+          )}
         </TabsContent>
 
         {/* Song Version Ratings Tab */}
         <TabsContent value="track-ratings" className="space-y-4">
+          {activeTab === "track-ratings" && ratingsPagination.totalPages > 1 && (
+            <PaginationControls
+              page={ratingsPagination.page}
+              totalPages={ratingsPagination.totalPages}
+              total={ratingsPagination.total}
+              pageSize={ratingsPagination.pageSize}
+              onPageChange={handlePageChange}
+            />
+          )}
           {trackRatings.length > 0 ? (
             <div className="space-y-4">
               {trackRatings.map((rating) => (
@@ -434,6 +595,15 @@ export default function UserProfile() {
               </CardContent>
             </Card>
           )}
+          {activeTab === "track-ratings" && ratingsPagination.totalPages > 1 && (
+            <PaginationControls
+              page={ratingsPagination.page}
+              totalPages={ratingsPagination.totalPages}
+              total={ratingsPagination.total}
+              pageSize={ratingsPagination.pageSize}
+              onPageChange={handlePageChange}
+            />
+          )}
         </TabsContent>
 
         {/* Blog Posts Tab */}
@@ -490,53 +660,42 @@ export default function UserProfile() {
 
         {/* Shows Attended Tab */}
         <TabsContent value="shows" className="space-y-4">
-          {userAttendances.length > 0 ? (
-            <div className="space-y-4">
-              {userAttendances.map((attendance) => (
-                <Card key={attendance.id} className="card-premium">
-                  <CardHeader>
-                    <div className="flex items-center justify-between">
-                      <CardTitle className="text-lg">
-                        {attendance.show.slug ? (
-                          <Link
-                            to={`/shows/${attendance.show.slug}`}
-                            className="text-brand-primary hover:text-brand-secondary transition-colors hover:underline"
-                          >
-                            {attendance.show.venue?.name || "Unknown Venue"}
-                          </Link>
-                        ) : (
-                          <span className="text-brand-primary">{attendance.show.venue?.name || "Unknown Venue"}</span>
-                        )}
-                      </CardTitle>
-                      <span className="text-sm text-content-text-tertiary">
-                        Marked {formatDateLong(attendance.createdAt.toISOString())}
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-2 text-sm text-content-text-secondary mt-1">
-                      <CalendarDays className="w-4 h-4" />
-                      <span>{formatDateLong(attendance.show.date)}</span>
-                      {attendance.show.venue?.city && attendance.show.venue?.state && (
-                        <span>
-                          • {attendance.show.venue.city}, {attendance.show.venue.state}
-                        </span>
-                      )}
-                    </div>
-                  </CardHeader>
-                </Card>
-              ))}
-            </div>
-          ) : (
-            <Card className="card-premium">
-              <CardContent className="py-12 text-center">
-                <CalendarDays className="w-12 h-12 text-content-text-tertiary mx-auto mb-4" />
-                <h3 className="text-lg font-medium text-content-text-primary mb-2">No Shows Attended</h3>
-                <p className="text-content-text-secondary">
-                  {isOwnProfile
-                    ? "You haven't marked any shows as attended yet. Browse shows and mark the ones you've been to!"
-                    : `${user.username} hasn't marked any shows as attended yet.`}
-                </p>
-              </CardContent>
-            </Card>
+          {attendedPagination.totalPages > 1 && (
+            <PaginationControls
+              page={attendedPagination.page}
+              totalPages={attendedPagination.totalPages}
+              total={attendedPagination.total}
+              pageSize={attendedPagination.pageSize}
+              onPageChange={handlePageChange}
+            />
+          )}
+          <SetlistList
+            setlists={attendedSetlists}
+            externalSources={attendedExternalSources}
+            initialUserData={attendedInitialUserData}
+            collapsible
+            empty={
+              <Card className="card-premium">
+                <CardContent className="py-12 text-center">
+                  <CalendarDays className="w-12 h-12 text-content-text-tertiary mx-auto mb-4" />
+                  <h3 className="text-lg font-medium text-content-text-primary mb-2">No Shows Attended</h3>
+                  <p className="text-content-text-secondary">
+                    {isOwnProfile
+                      ? "You haven't marked any shows as attended yet. Browse shows and mark the ones you've been to!"
+                      : `${user.username} hasn't marked any shows as attended yet.`}
+                  </p>
+                </CardContent>
+              </Card>
+            }
+          />
+          {attendedPagination.totalPages > 1 && (
+            <PaginationControls
+              page={attendedPagination.page}
+              totalPages={attendedPagination.totalPages}
+              total={attendedPagination.total}
+              pageSize={attendedPagination.pageSize}
+              onPageChange={handlePageChange}
+            />
           )}
         </TabsContent>
       </Tabs>

--- a/packages/core/scripts/sync-missing-shows.test.ts
+++ b/packages/core/scripts/sync-missing-shows.test.ts
@@ -553,8 +553,8 @@ describe("buildSongCreateInput", () => {
     const now = new Date("2026-04-23T12:00:00Z");
     const input = buildSongCreateInput(
       {
-        slug: "tractorbeam",
-        title: "Tractorbeam",
+        slug: "basis-for-a-day",
+        title: "Basis for a Day",
         author: "Disco Biscuits",
         lyrics: null,
         timesPlayed: 412,
@@ -564,8 +564,8 @@ describe("buildSongCreateInput", () => {
       now,
     );
     expect(input).toEqual({
-      slug: "tractorbeam",
-      title: "Tractorbeam",
+      slug: "basis-for-a-day",
+      title: "Basis for a Day",
       lyrics: null,
       timesPlayed: 412,
       dateFirstPlayed: new Date("1998-07-04"),

--- a/packages/core/src/_shared/cache/cache-invalidation-service.test.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.test.ts
@@ -1,0 +1,61 @@
+import { CacheKeys } from "@bip/domain";
+import { describe, expect, test, vi } from "vitest";
+import { CacheInvalidationService } from "./cache-invalidation-service";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+
+function makeCache() {
+  return {
+    del: vi.fn().mockResolvedValue(undefined),
+    delPattern: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("CacheInvalidationService.invalidateAttendanceCaches", () => {
+  // Toggling attendance changes which shows appear in /songs filtered-by-user
+  // results AND which setlists appear on the user-profile Shows Attended tab.
+  // Both per-user caches must be wiped together — otherwise the profile shows
+  // stale setlists or the /songs filter shows stale attendance hits.
+  test("wipes both per-user filtered-songs and attended-setlists patterns", async () => {
+    const cache = makeCache();
+    const service = new CacheInvalidationService(cache as never, logger);
+
+    await service.invalidateAttendanceCaches("u-rynow");
+
+    expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.songs.allFilteredForUser("u-rynow"));
+    expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.users.allAttendedSetlistsForUser("u-rynow"));
+    // Both patterns scope by user — never wipe global caches from a single
+    // user's attendance change.
+    expect(cache.delPattern).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("CacheInvalidationService.invalidateShowListings", () => {
+  // Admin edits to show metadata (date, venue, etc.) bubble through here.
+  // Per-user attended-setlists caches embed that metadata, so they must be
+  // wiped along with the global show-listing caches. Pattern-wide wipe avoids
+  // tracking which users attended which show.
+  test("wipes per-user attended-setlists across all users on show-listing changes", async () => {
+    const cache = makeCache();
+    const service = new CacheInvalidationService(cache as never, logger);
+
+    await service.invalidateShowListings();
+
+    expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.users.allAttendedSetlists());
+  });
+
+  // Regression guard for the existing global show-listing invalidations —
+  // adding the new attended-setlists pattern shouldn't have dropped any of
+  // the original wipes.
+  test("still wipes the original show-listing + stats caches", async () => {
+    const cache = makeCache();
+    const service = new CacheInvalidationService(cache as never, logger);
+
+    await service.invalidateShowListings();
+
+    expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.shows.allLists());
+    expect(cache.delPattern).toHaveBeenCalledWith("home:*");
+    expect(cache.del).toHaveBeenCalledWith(CacheKeys.stats.showsByYear());
+    expect(cache.del).toHaveBeenCalledWith(CacheKeys.stats.showDates());
+  });
+});

--- a/packages/core/src/_shared/cache/cache-invalidation-service.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.ts
@@ -52,6 +52,9 @@ export class CacheInvalidationService {
       this.cache.delPattern("home:*"), // Invalidate all home page caches
       this.cache.del(CacheKeys.stats.showsByYear()), // shows-per-year aggregate is tied to the show catalog
       this.cache.del(CacheKeys.stats.showDates()), // sorted stats-show-dates array backs Current Gap on /songs
+      // Per-user attended-setlists caches include each show's setlist + venue;
+      // wipe them all when any show metadata moves.
+      this.cache.delPattern(CacheKeys.users.allAttendedSetlists()),
       this.cloudflareCache?.purgeYearListings(),
     ]);
   }
@@ -100,7 +103,11 @@ export class CacheInvalidationService {
    */
   async invalidateAttendanceCaches(userId: string): Promise<void> {
     this.logger.info(`Invalidating attendance caches for user: ${userId}`);
-    await this.cache.delPattern(CacheKeys.songs.allFilteredForUser(userId));
+    await Promise.all([
+      this.cache.delPattern(CacheKeys.songs.allFilteredForUser(userId)),
+      // User profile's Shows Attended tab uses a per-user paginated setlists payload.
+      this.cache.delPattern(CacheKeys.users.allAttendedSetlistsForUser(userId)),
+    ]);
   }
 
   /**

--- a/packages/core/src/page-composers/song-page-composer.test.ts
+++ b/packages/core/src/page-composers/song-page-composer.test.ts
@@ -3,9 +3,11 @@ import { CacheKeys } from "@bip/domain";
 import { Prisma } from "@prisma/client";
 import { describe, expect, test, vi } from "vitest";
 import {
+  assignFilteredGaps,
   buildSetPositionKey,
   computeRarityStats,
   computeTagsForPerformance,
+  isNarrowingFilter,
   type PerformanceDto,
   SongPageComposer,
   transformToSongPagePerformanceView,
@@ -311,10 +313,9 @@ describe("transformToSongPagePerformanceView", () => {
   // current impl). Documented quirk: `|| undefined` means `0` values also
   // become `undefined`, which is fine for rating/ratingsCount but worth
   // pinning so the behavior is explicit.
-  // Phase 1 of the stats expansion denormalized gap onto Track. The
-  // composer must surface gap and previousPerformanceShowId on the view so
-  // the song-detail performances table can render the Gap column without
-  // an extra query per row.
+  // gap is denormalized on Track. The composer must surface gap and
+  // previousPerformanceShowId on the view so the song-detail performances
+  // table can render the Gap column without an extra query per row.
   test("maps gap and previous_performance_show_id through to the view", () => {
     const debutView = transformToSongPagePerformanceView(makeDto({ gap: null, previous_performance_show_id: null }));
     expect(debutView.gap).toBeNull();
@@ -485,6 +486,313 @@ describe("buildSongPerformanceCounts", () => {
 });
 
 // ---------------------------------------------------------------------------
+// isNarrowingFilter — gate for filteredGap computation
+// ---------------------------------------------------------------------------
+
+describe("isNarrowingFilter", () => {
+  // No options at all → nothing to narrow against. Callers skip filteredGap
+  // computation and the column stays hidden.
+  test("returns false when options is undefined", () => {
+    expect(isNarrowingFilter(undefined)).toBe(false);
+  });
+
+  // Empty options object → no active filter. Same outcome as undefined.
+  test("returns false for an empty options object", () => {
+    expect(isNarrowingFilter({})).toBe(false);
+  });
+
+  // Cover/author filters pick which songs appear on /songs but don't narrow
+  // which performances of a given song count — every performance of a cover
+  // song is still a cover. They must NOT trigger filteredGap.
+  test("returns false when only cover or author is set", () => {
+    expect(isNarrowingFilter({ cover: true })).toBe(false);
+    expect(isNarrowingFilter({ authorId: "author-1" })).toBe(false);
+  });
+
+  // Each narrowing axis on its own is sufficient. Parameterized so adding
+  // a new narrowing filter shows up here visibly.
+  test.each([
+    ["startDate", { startDate: new Date("2024-01-01") }],
+    ["endDate", { endDate: new Date("2024-12-31") }],
+    ["attendedUserId", { attendedUserId: "user-1" }],
+    ["encore", { encore: true }],
+    ["setOpener", { setOpener: true }],
+    ["setCloser", { setCloser: true }],
+    ["segueIn", { segueIn: true }],
+    ["segueOut", { segueOut: true }],
+    ["standalone", { standalone: true }],
+    ["inverted", { inverted: true }],
+    ["dyslexic", { dyslexic: true }],
+    ["allTimer", { allTimer: true }],
+    ["monthDay", { monthDay: "07-26" }],
+  ])("returns true when %s is set", (_label, options) => {
+    expect(isNarrowingFilter(options)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assignFilteredGaps — per-performance gap walk against the filtered universe
+// ---------------------------------------------------------------------------
+
+describe("assignFilteredGaps", () => {
+  // Helper: builds a minimal SongPagePerformance with the fields the gap
+  // walk reads (trackId, show.id, show.date, show.dayOrder, position).
+  // Other fields kept thin so the test focuses on gap semantics.
+  function perf(overrides: {
+    trackId: string;
+    showId: string;
+    date: string;
+    position?: number;
+    dayOrder?: number | null;
+  }): SongPagePerformance {
+    return {
+      trackId: overrides.trackId,
+      show: {
+        id: overrides.showId,
+        slug: overrides.date,
+        date: overrides.date,
+        venueId: "venue-1",
+        dayOrder: overrides.dayOrder ?? null,
+        countForStats: true,
+      },
+      position: overrides.position ?? 1,
+      set: "S1",
+      segue: null,
+      allTimer: false,
+      annotations: [],
+    };
+  }
+
+  // The very first filtered performance has no prior, so gap = null (★ debut
+  // of filtered set). Subsequent performances get a number.
+  test("first filtered performance has filteredGap null", () => {
+    const performances = [perf({ trackId: "t-confrontation-2024", showId: "s-2024", date: "2024-06-15" })];
+
+    assignFilteredGaps(performances, ["2024-06-15"]);
+
+    expect(performances[0].filteredGap).toBeNull();
+  });
+
+  // Two filtered performances over a four-show filter-matching universe:
+  // play #1 at index 0, play #2 at index 3 → exactly 2 matching shows
+  // strictly between (indices 1, 2). Mirrors the existing Track.gap math.
+  test("counts filter-matching shows strictly between consecutive performances", () => {
+    const performances = [
+      perf({ trackId: "t-basis-1", showId: "s-1", date: "2024-01-10" }),
+      perf({ trackId: "t-basis-2", showId: "s-4", date: "2024-04-10" }),
+    ];
+
+    // Filter-matching set: 4 shows ordered chronologically. The song was
+    // played at the first and the last; the 2 shows in the middle count.
+    assignFilteredGaps(performances, ["2024-01-10", "2024-02-15", "2024-03-20", "2024-04-10"]);
+
+    expect(performances[0].filteredGap).toBeNull();
+    expect(performances[1].filteredGap).toBe(2);
+  });
+
+  // Within-show repeat: two performances at the same show. The gap walk
+  // shares the same numeric gap across both — the icon (↺) in the cell
+  // distinguishes the repeat, not the gap value. Mirrors Track.gap.
+  test("within-show repeat shares the same filteredGap as the first occurrence", () => {
+    const performances = [
+      perf({ trackId: "t-aceetobee-pre", showId: "s-pre", date: "2024-01-10" }),
+      perf({ trackId: "t-spaga-1", showId: "s-repeat", date: "2024-05-01", position: 2 }),
+      perf({ trackId: "t-spaga-2", showId: "s-repeat", date: "2024-05-01", position: 7 }),
+    ];
+
+    assignFilteredGaps(performances, ["2024-01-10", "2024-03-01", "2024-05-01"]);
+
+    expect(performances[0].filteredGap).toBeNull();
+    // Both tracks at the repeat-show inherit the same gap value (1 show
+    // between 2024-01-10 and 2024-05-01 in the filtered set).
+    expect(performances[1].filteredGap).toBe(1);
+    expect(performances[2].filteredGap).toBe(1);
+  });
+
+  // An empty filter-matching universe (no shows match the filter at all)
+  // means even the song's own performances aren't in the universe. The
+  // first performance is still a "debut" of the filtered set; subsequent
+  // ones gap against the previous filtered performance — but the universe
+  // has no other shows in between, so gap is 0.
+  test("with no shows in matching universe between performances, gap is 0", () => {
+    const performances = [
+      perf({ trackId: "t-helicopters-1", showId: "s-a", date: "2024-01-10" }),
+      perf({ trackId: "t-helicopters-2", showId: "s-b", date: "2024-02-10" }),
+    ];
+
+    // Only the song's own two shows are in the matching universe — nothing
+    // else falls between them in the filtered set.
+    assignFilteredGaps(performances, ["2024-01-10", "2024-02-10"]);
+
+    expect(performances[0].filteredGap).toBeNull();
+    expect(performances[1].filteredGap).toBe(0);
+  });
+
+  // The helper sorts internally before walking — callers can pass
+  // performances in any order (e.g., a query that returned DESC) and the
+  // gap math still uses canonical chronological order.
+  test("walks chronologically even when input order is reversed", () => {
+    const performances = [
+      perf({ trackId: "t-late", showId: "s-late", date: "2024-04-10" }),
+      perf({ trackId: "t-early", showId: "s-early", date: "2024-01-10" }),
+    ];
+
+    assignFilteredGaps(performances, ["2024-01-10", "2024-02-15", "2024-04-10"]);
+
+    // Early track is the debut of the filtered set regardless of input order.
+    const early = performances.find((p) => p.trackId === "t-early");
+    const late = performances.find((p) => p.trackId === "t-late");
+    expect(early?.filteredGap).toBeNull();
+    expect(late?.filteredGap).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFilteredSongRarity — per-song filtered analogs of /songs rarity columns
+// ---------------------------------------------------------------------------
+
+describe("buildFilteredSongRarity", () => {
+  // The helper sequences two queries: first `getFilterMatchingShowDates`
+  // (the matching universe), then a GROUP-BY-song aggregation (per-song
+  // first/last filtered show + count). Mock both responses by chaining
+  // `mockResolvedValueOnce`.
+  function createComposer(
+    matchingDates: Array<{ d: string }>,
+    songRows: Array<{ song_id: string; show_count: string; first_date: string; last_date: string }>,
+  ) {
+    const $queryRaw = vi.fn().mockResolvedValueOnce(matchingDates).mockResolvedValueOnce(songRows);
+    const mockDb = { $queryRaw };
+    return new SongPageComposer(mockDb as never, {} as never);
+  }
+
+  // Empty song id list → short-circuits before any queries fire. Used by the
+  // loader when the filter matched zero songs.
+  test("returns an empty map when songIds is empty", async () => {
+    const composer = createComposer([], []);
+
+    const result = await composer.buildFilteredSongRarity([], { encore: true });
+
+    expect(result.size).toBe(0);
+  });
+
+  // When the matching universe is empty (no shows fit the filter at all),
+  // there can be no per-song aggregates — return empty without firing the
+  // second query.
+  test("returns an empty map when no shows match the filter", async () => {
+    const composer = createComposer(
+      [],
+      [{ song_id: "above-the-waves", show_count: "0", first_date: "2024-01-01", last_date: "2024-01-01" }],
+    );
+
+    const result = await composer.buildFilteredSongRarity(["above-the-waves"], { encore: true });
+
+    expect(result.size).toBe(0);
+  });
+
+  // Core math: a song played at the first and last of 5 matching shows.
+  //  - filteredShowsSinceLastPlayed: shows strictly after last play  → 0
+  //    (the last play IS the latest matching show).
+  //  - showsOnOrAfterDebut: 5 (debut at index 0, inclusive).
+  //  - filteredPercentSinceDebut: 2 / 5 = 0.4.
+  //  - filteredAverageShowsPerPlay: shows-in-gaps / number-of-gaps =
+  //    (5 - 2) / (2 - 1) = 3.0 (3 matching shows fell between the 2 plays).
+  test("computes filteredShowsSinceLastPlayed, percentSinceDebut, averageShowsPerPlay against the matching universe", async () => {
+    const composer = createComposer(
+      [{ d: "2024-01-01" }, { d: "2024-02-01" }, { d: "2024-03-01" }, { d: "2024-04-01" }, { d: "2024-05-01" }],
+      [{ song_id: "above-the-waves", show_count: "2", first_date: "2024-01-01", last_date: "2024-05-01" }],
+    );
+
+    const result = await composer.buildFilteredSongRarity(["above-the-waves"], { encore: true });
+
+    const row = result.get("above-the-waves");
+    expect(row?.filteredShowsSinceLastPlayed).toBe(0);
+    expect(row?.filteredPercentSinceDebut).toBeCloseTo(0.4);
+    expect(row?.filteredAverageShowsPerPlay).toBeCloseTo(3);
+  });
+
+  // When the song's last filtered play is the earliest matching show and
+  // there are more matching shows after it → the gap is the number of
+  // shows after. Sanity check that `countShowsAfter` semantics propagate.
+  // A single play has no gaps to average, so filteredAverageShowsPerPlay
+  // must be null (em-dash in the UI), not a degenerate 1.0.
+  test("filteredShowsSinceLastPlayed counts matching shows strictly after the last filtered play", async () => {
+    const composer = createComposer(
+      [{ d: "2024-01-01" }, { d: "2024-02-01" }, { d: "2024-03-01" }, { d: "2024-04-01" }],
+      [{ song_id: "confrontation", show_count: "1", first_date: "2024-01-01", last_date: "2024-01-01" }],
+    );
+
+    const result = await composer.buildFilteredSongRarity(["confrontation"], { attendedUserId: "user-1" });
+
+    const row = result.get("confrontation");
+    // Three matching shows are strictly after the one filtered play.
+    expect(row?.filteredShowsSinceLastPlayed).toBe(3);
+    // One filtered play → no gaps → null average.
+    expect(row?.filteredAverageShowsPerPlay).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFilterMatchingShowDates — denominator for filtered rarity columns
+// ---------------------------------------------------------------------------
+
+describe("getFilterMatchingShowDates", () => {
+  // The helper returns the set of stats-eligible shows that contain at least
+  // one track matching the active filters. It drives the "shows between" /
+  // "shows since" counts for the Filtered Gap column on song detail and the
+  // filtered rarity columns on /songs.
+  function createComposer(queryRawResult: Array<{ d: string }>) {
+    const mockDb = {
+      $queryRaw: vi.fn().mockResolvedValue(queryRawResult),
+    };
+    return { composer: new SongPageComposer(mockDb as never, {} as never), mockDb };
+  }
+
+  // The raw query returns dates as `YYYY-MM-DD` strings, already ORDER BY'd
+  // ascending. The method should pass them through as-is so callers can
+  // binary-search via `countShowsAfter`.
+  test("returns ISO date strings from raw query result rows", async () => {
+    const { composer } = createComposer([{ d: "2024-06-15" }, { d: "2024-07-26" }, { d: "2024-12-31" }]);
+
+    const result = await composer.getFilterMatchingShowDates({ encore: true });
+
+    expect(result).toEqual(["2024-06-15", "2024-07-26", "2024-12-31"]);
+  });
+
+  // No filter combination matches → empty array, not null. Callers treat
+  // empty as "no matching shows" and short-circuit downstream gap math.
+  test("returns empty array when no rows match", async () => {
+    const { composer } = createComposer([]);
+
+    const result = await composer.getFilterMatchingShowDates({ encore: true, segueIn: true });
+
+    expect(result).toEqual([]);
+  });
+
+  // Confirms the helper actually executes a query when called. SQL
+  // correctness is covered by buildFilterQuery tests; this just verifies
+  // the integration point fires.
+  test("executes a query through the db client", async () => {
+    const { composer, mockDb } = createComposer([{ d: "2024-06-15" }]);
+
+    await composer.getFilterMatchingShowDates({ attendedUserId: "user-1" });
+
+    expect(mockDb.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  // No filters at all → still queries (returns all stats-eligible shows).
+  // Callers may pass `{}` when there's no narrowing; the method must not
+  // throw or short-circuit before issuing the query.
+  test("executes a query even when no filter options are provided", async () => {
+    const { composer, mockDb } = createComposer([{ d: "2024-01-01" }]);
+
+    const result = await composer.getFilterMatchingShowDates({});
+
+    expect(mockDb.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(["2024-01-01"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // CacheKeys — on-this-day all-timers key
 // ---------------------------------------------------------------------------
 
@@ -547,7 +855,8 @@ describe("computeRarityStats", () => {
     expect(result.showsSinceDebut).toBe(260);
     expect(result.percentOfAllShows).toBeCloseTo(0.5, 5);
     expect(result.percentSinceDebut).toBeCloseTo(0.5, 5);
-    expect(result.averageShowsPerPlay).toBeCloseTo(2, 5);
+    // Mean gap between plays: shows-in-gaps / gaps = (260 - 130) / (130 - 1).
+    expect(result.averageShowsPerPlay).toBeCloseTo(130 / 129, 5);
     expect((result.showsBeforeDebut ?? 0) + (result.showsSinceDebut ?? 0)).toBe(result.totalShows);
   });
 
@@ -567,7 +876,9 @@ describe("computeRarityStats", () => {
     expect(result.showsSinceDebut).toBe(60);
     expect(result.percentOfAllShows).toBeCloseTo(6 / 320, 5);
     expect(result.percentSinceDebut).toBeCloseTo(6 / 60, 5);
-    expect(result.averageShowsPerPlay).toBeCloseTo(60 / 6, 5);
+    // Mean gap between plays: (60 - 6) / (6 - 1) = 54 / 5 = 10.8 — average
+    // 10.8 shows happened between consecutive plays of the song.
+    expect(result.averageShowsPerPlay).toBeCloseTo(54 / 5, 5);
     // Sanity: scarcity reads stronger against the song's own era.
     expect(result.percentSinceDebut).toBeGreaterThan(result.percentOfAllShows ?? 0);
   });
@@ -588,5 +899,18 @@ describe("computeRarityStats", () => {
     expect(result.percentSinceDebut).toBeNull();
     expect(result.averageShowsPerPlay).toBeNull();
     expect(result.percentOfAllShows).toBe(0);
+  });
+
+  // Single-play song has no gaps between plays to average — averageShowsPerPlay
+  // must be null, not 1.0 or any degenerate value. percentSinceDebut still
+  // computes (1 play out of the 1 show in the song's era = 100%).
+  test("single-play song nulls averageShowsPerPlay (no gaps to average)", () => {
+    const showsByYear = { 2024: 50 };
+    const dateFirstPlayed = new Date(Date.UTC(2024, 0, 1));
+
+    const result = computeRarityStats({ dateFirstPlayed, timesPlayed: 1 }, showsByYear);
+
+    expect(result.averageShowsPerPlay).toBeNull();
+    expect(result.percentSinceDebut).toBeCloseTo(1 / 50, 5);
   });
 });

--- a/packages/core/src/page-composers/song-page-composer.ts
+++ b/packages/core/src/page-composers/song-page-composer.ts
@@ -2,14 +2,24 @@ import type { AllTimersPageView, Annotation, SongPagePerformance, SongPageView }
 import { Prisma } from "@prisma/client";
 import type { DbClient } from "../_shared/database/models";
 import { showOrderBySql, statsShowsSql } from "../_shared/show-ordering";
+import { computeTrackGaps, sortTracksForGapWalk, type TrackForGapWalk } from "../_shared/track-gap";
 import type { SongService } from "../songs/song-service";
-import type { StatsService } from "../stats/stats-service";
+import { countShowsAfter, countShowsOnOrAfter, type StatsService } from "../stats/stats-service";
 
 /**
  * Filters for querying performances. All fields are optional — only
  * active filters produce SQL conditions. Used by buildAllTimers and
  * buildSongPerformances to construct dynamic WHERE clauses.
  */
+/** Per-song aggregates returned by `buildFilteredSongRarity`. */
+export interface FilteredSongRarity {
+  filteredShowsSinceLastPlayed: number | null;
+  filteredPercentSinceDebut: number | null;
+  filteredAverageShowsPerPlay: number | null;
+  dateFirstFilteredPlayed: Date;
+  dateLastFilteredPlayed: Date;
+}
+
 export interface PerformanceFilterOptions {
   startDate?: Date;
   endDate?: Date;
@@ -227,6 +237,11 @@ export class SongPageComposer {
     }));
     await this.enrichPerformances(performances);
 
+    if (isNarrowingFilter(options)) {
+      const matchingShowDates = await this.getFilterMatchingShowDates(options ?? {});
+      assignFilteredGaps(performances, matchingShowDates);
+    }
+
     return performances;
   }
 
@@ -261,6 +276,108 @@ export class SongPageComposer {
       result[row.song_id] = Number.parseInt(row.count, 10);
     }
     return result;
+  }
+
+  /**
+   * Per-song aggregates restricted to the active filter scope. Returns
+   * filtered-version analogs of the three rarity columns on /songs:
+   *   - filteredShowsSinceLastPlayed: matching-universe shows strictly
+   *     after this song's last filtered play
+   *   - filteredPercentSinceDebut: filteredTimesPlayed divided by the
+   *     count of matching-universe shows on or after this song's first
+   *     filtered play
+   *   - filteredAverageShowsPerPlay: same denominator over the numerator,
+   *     inverted — "matching-universe shows per filtered play"
+   *
+   * Only computed for the survivor set the loader already produced. Songs
+   * absent from the result map are left untouched by the caller; the UI
+   * renders em-dash for missing entries.
+   */
+  async buildFilteredSongRarity(
+    songIds: string[],
+    options: PerformanceFilterOptions,
+  ): Promise<Map<string, FilteredSongRarity>> {
+    if (songIds.length === 0) return new Map();
+
+    const matchingShowDates = await this.getFilterMatchingShowDates(options);
+    if (matchingShowDates.length === 0) return new Map();
+
+    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery([statsShowsSql("shows")], options);
+    conditions.push(Prisma.sql`tracks.song_id = ANY(${songIds}::uuid[])`);
+
+    const whereClause = Prisma.sql`WHERE ${Prisma.join(conditions, " AND ")}`;
+    const extraJoinsSql = extraJoins.length > 0 ? Prisma.sql`${Prisma.join(extraJoins, "\n      ")}` : Prisma.empty;
+
+    const rows = await this.db.$queryRaw<
+      Array<{ song_id: string; show_count: string; first_date: string; last_date: string }>
+    >`
+      SELECT
+        tracks.song_id,
+        COUNT(DISTINCT tracks.show_id)::text AS show_count,
+        to_char(MIN(shows.date::date), 'YYYY-MM-DD') AS first_date,
+        to_char(MAX(shows.date::date), 'YYYY-MM-DD') AS last_date
+      FROM tracks
+      JOIN shows ON tracks.show_id = shows.id
+      JOIN songs ON tracks.song_id = songs.id
+      ${extraJoinsSql}
+      LEFT JOIN tracks prevTracks ON tracks.show_id = prevTracks.show_id
+        AND prevTracks.position = tracks.position - 1
+        AND prevTracks.set = tracks.set
+      ${whereClause}
+      GROUP BY tracks.song_id
+    `;
+
+    const out = new Map<string, FilteredSongRarity>();
+    for (const row of rows) {
+      const filteredTimesPlayed = Number.parseInt(row.show_count, 10);
+      const filteredShowsSinceLastPlayed = countShowsAfter(matchingShowDates, row.last_date);
+      const showsOnOrAfterDebut = countShowsOnOrAfter(matchingShowDates, row.first_date);
+      const filteredPercentSinceDebut = showsOnOrAfterDebut === 0 ? null : filteredTimesPlayed / showsOnOrAfterDebut;
+      // Same mean-gap semantic as computeRarityStats.averageShowsPerPlay:
+      // shows that fell in gaps divided by the number of gaps. Requires
+      // at least 2 plays — a single play has no gaps to average.
+      const filteredAverageShowsPerPlay =
+        filteredTimesPlayed < 2 ? null : (showsOnOrAfterDebut - filteredTimesPlayed) / (filteredTimesPlayed - 1);
+      out.set(row.song_id, {
+        filteredShowsSinceLastPlayed,
+        filteredPercentSinceDebut,
+        filteredAverageShowsPerPlay,
+        dateFirstFilteredPlayed: new Date(row.first_date),
+        dateLastFilteredPlayed: new Date(row.last_date),
+      });
+    }
+    return out;
+  }
+
+  /**
+   * Returns sorted ISO date strings (`YYYY-MM-DD`) for the stats-eligible
+   * shows that contain at least one track matching the active filters.
+   * Drives the "shows between" denominator for the Filtered Gap column on
+   * song detail and the filtered rarity aggregates on /songs.
+   *
+   * The query reuses the same JOINs as `buildSongPerformanceCounts` so the
+   * filter SQL composes consistently — anything that affects which
+   * performances count also affects which shows qualify here.
+   */
+  async getFilterMatchingShowDates(options: PerformanceFilterOptions): Promise<string[]> {
+    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery([statsShowsSql("shows")], options);
+
+    const whereClause = conditions.length > 0 ? Prisma.sql`WHERE ${Prisma.join(conditions, " AND ")}` : Prisma.empty;
+    const extraJoinsSql = extraJoins.length > 0 ? Prisma.sql`${Prisma.join(extraJoins, "\n      ")}` : Prisma.empty;
+
+    const rows = await this.db.$queryRaw<Array<{ d: string }>>`
+      SELECT DISTINCT to_char(shows.date::date, 'YYYY-MM-DD') AS d
+      FROM tracks
+      JOIN shows ON tracks.show_id = shows.id
+      JOIN songs ON tracks.song_id = songs.id
+      ${extraJoinsSql}
+      LEFT JOIN tracks prevTracks ON tracks.show_id = prevTracks.show_id
+        AND prevTracks.position = tracks.position - 1
+        AND prevTracks.set = tracks.set
+      ${whereClause}
+      ORDER BY d
+    `;
+    return rows.map((row) => row.d);
   }
 
   /**
@@ -486,6 +603,74 @@ export function buildSetPositionKey(showId: string, set: string): string {
 }
 
 /**
+ * True when the active filter set actually narrows which performances
+ * count — i.e., would produce a meaningfully different result than the
+ * all-time view. `cover` and `authorId` are intentionally excluded:
+ * they pick which songs surface (on /songs) but every performance of a
+ * surfacing song still counts, so they don't change per-song gap math.
+ *
+ * Used to gate the per-row filteredGap computation in
+ * `buildSongPerformances` — skipping the work entirely when no narrowing
+ * filter is active.
+ */
+export function isNarrowingFilter(options: PerformanceFilterOptions | undefined): boolean {
+  if (!options) return false;
+  return Boolean(
+    options.startDate ||
+      options.endDate ||
+      options.attendedUserId ||
+      options.encore ||
+      options.setOpener ||
+      options.setCloser ||
+      options.segueIn ||
+      options.segueOut ||
+      options.standalone ||
+      options.inverted ||
+      options.dyslexic ||
+      options.allTimer ||
+      options.monthDay,
+  );
+}
+
+/**
+ * Mutates each performance in `performances` to set `filteredGap` against
+ * the supplied `matchingShowDates` (the canonical-ordered ISO dates of
+ * shows in the active filter's universe). Reuses the pure `computeTrackGaps`
+ * walk used for all-time `Track.gap` — same algorithm, different denominator.
+ * Within-show repeats share the gap of their show's first track.
+ *
+ * Called after `enrichPerformances` so the performances already have their
+ * `show` and `position` fields populated.
+ */
+export function assignFilteredGaps(performances: SongPagePerformance[], matchingShowDates: string[]): void {
+  if (performances.length === 0) return;
+
+  const walkInput: TrackForGapWalk[] = performances.map((performance) => ({
+    trackId: performance.trackId,
+    showId: performance.show.id,
+    showDate: performance.show.date,
+    dayOrder: performance.show.dayOrder ?? null,
+    // Every filtered performance participates in the filtered-universe walk.
+    // The filtered set is the universe, so each row advances the "last
+    // performance" cursor — no count_for_stats sub-distinction here.
+    showCountForStats: true,
+    position: performance.position ?? 0,
+  }));
+
+  const sorted = sortTracksForGapWalk(walkInput);
+  const results = computeTrackGaps(sorted, matchingShowDates);
+
+  const gapByTrackId = new Map<string, number | null>();
+  for (const result of results) {
+    gapByTrackId.set(result.trackId, result.gap);
+  }
+
+  for (const performance of performances) {
+    performance.filteredGap = gapByTrackId.get(performance.trackId) ?? null;
+  }
+}
+
+/**
  * Compute the performance tags (encore, opener/closer, segues, standalone,
  * inverted, dyslexic) for a single performance. Pure function — no DB,
  * no side effects.
@@ -631,9 +816,12 @@ export function computeRarityStats(
     .reduce((sum, [, count]) => sum + count, 0);
   const showsBeforeDebut = totalShows - showsSinceDebut;
   const percentSinceDebut = showsSinceDebut === 0 ? null : song.timesPlayed / showsSinceDebut;
-  // Inverse of percentSinceDebut, surfaced separately because "played every
-  // X shows" reads more naturally than a percentage for sparse songs.
-  const averageShowsPerPlay = song.timesPlayed === 0 ? null : showsSinceDebut / song.timesPlayed;
+  // Mean gap between consecutive plays of this song since its debut.
+  // (showsSinceDebut - timesPlayed) is the number of shows that fell in
+  // gaps between plays; dividing by (timesPlayed - 1) gives the mean per
+  // gap. Requires at least 2 plays — a single-play song has no gaps to
+  // average. Null also when the song has never been played.
+  const averageShowsPerPlay = song.timesPlayed < 2 ? null : (showsSinceDebut - song.timesPlayed) / (song.timesPlayed - 1);
 
   return {
     totalShows,

--- a/packages/core/src/ratings/rating-service.test.ts
+++ b/packages/core/src/ratings/rating-service.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, test, vi } from "vitest";
+import { RatingService } from "./rating-service";
+
+// Minimal stub — service only invalidates caches at write paths; the read
+// methods under test don't touch it.
+const cacheInvalidation = {
+  invalidateAttendanceCaches: vi.fn(),
+  invalidateShowComprehensive: vi.fn(),
+} as never;
+
+type MockRating = {
+  id: string;
+  userId: string;
+  rateableId: string;
+  rateableType: string;
+  value: number;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function rating(overrides: Partial<MockRating>): MockRating {
+  return {
+    id: "r1",
+    userId: "u1",
+    rateableId: "x1",
+    rateableType: "Show",
+    value: 5,
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    updatedAt: new Date("2024-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("RatingService.findShowRatingsByUserId", () => {
+  // The user-profile show-ratings list only displays id/value/createdAt +
+  // nested slug/date/venue trio. Returning a Rating-extending shape with
+  // userId/rateableId/etc. forces ~1.7 MB of unused JSON onto heavy users
+  // (the heaviest user has ~1,700 show ratings). The slim shape strips those.
+  test("returns slim shape without userId, rateableId, rateableType, or updatedAt", async () => {
+    const db = {
+      rating: {
+        findMany: vi.fn().mockResolvedValue([rating({ id: "r1", rateableId: "show-1" })]),
+      },
+      show: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "show-1",
+            slug: "2024-08-12-cap-theatre",
+            date: "2024-08-12",
+            venue: { name: "The Capitol Theatre", city: "Port Chester", state: "NY" },
+          },
+        ]),
+      },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    const result = await service.findShowRatingsByUserId("u1");
+
+    expect(result).toHaveLength(1);
+    const row = result[0];
+    expect(row).toEqual({
+      id: "r1",
+      value: 5,
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+      show: {
+        slug: "2024-08-12-cap-theatre",
+        date: "2024-08-12",
+        venue: { name: "The Capitol Theatre", city: "Port Chester", state: "NY" },
+      },
+    });
+    // Explicit negative assertions — these fields drove the bloat.
+    expect(row).not.toHaveProperty("userId");
+    expect(row).not.toHaveProperty("rateableId");
+    expect(row).not.toHaveProperty("rateableType");
+    expect(row).not.toHaveProperty("updatedAt");
+  });
+
+  // If the underlying show was deleted while the rating remained (data
+  // drift), we drop the orphan rather than crash. Mirrors the original
+  // .filter() behavior; protects the user profile from white-screening on
+  // dangling ratings.
+  test("skips ratings whose related show is missing", async () => {
+    const db = {
+      rating: {
+        findMany: vi
+          .fn()
+          .mockResolvedValue([rating({ id: "r1", rateableId: "missing" }), rating({ id: "r2", rateableId: "show-1" })]),
+      },
+      show: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "show-1",
+            slug: "show-slug",
+            date: "2024-08-12",
+            venue: null,
+          },
+        ]),
+      },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    const result = await service.findShowRatingsByUserId("u1");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("r2");
+    expect(result[0].show.venue).toBeNull();
+  });
+
+  // Heavy users (~1,700 show ratings) need server-side pagination —
+  // shipping all rows on every load costs hundreds of KB. The service
+  // accepts skip/take and the caller is expected to combine with
+  // getUserTabCounts() for the total. Verifies the slice is applied at the
+  // DB level, not in JS.
+  test("supports skip/take pagination at the DB layer", async () => {
+    const ratingFindMany = vi.fn().mockResolvedValue([rating({ id: "r-page-3", rateableId: "show-page-3" })]);
+    const db = {
+      rating: { findMany: ratingFindMany },
+      show: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "show-page-3",
+            slug: "s",
+            date: "2024-01-01",
+            venue: null,
+          },
+        ]),
+      },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    const result = await service.findShowRatingsByUserId("u1", { skip: 200, take: 100 });
+
+    expect(ratingFindMany.mock.calls[0][0]).toMatchObject({ skip: 200, take: 100 });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("r-page-3");
+  });
+
+  // Narrowed Prisma projection: only select the columns the slim shape
+  // surfaces. Regression guard — accidentally going back to `include` re-bloats
+  // every load.
+  test("queries the DB with a narrow `select` (no full row projection)", async () => {
+    const showFindMany = vi.fn().mockResolvedValue([]);
+    const db = {
+      rating: { findMany: vi.fn().mockResolvedValue([rating({ rateableId: "show-1" })]) },
+      show: { findMany: showFindMany },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    await service.findShowRatingsByUserId("u1");
+
+    const args = showFindMany.mock.calls[0][0];
+    expect(args).toHaveProperty("select");
+    expect(args).not.toHaveProperty("include");
+    expect(args.select).toMatchObject({
+      id: true,
+      slug: true,
+      date: true,
+      venue: { select: { name: true, city: true, state: true } },
+    });
+  });
+});
+
+describe("RatingService.findTrackRatingsByUserId", () => {
+  // The user-profile track-ratings list is the worst offender — 7,784 rows
+  // for the heaviest user. The slim shape drops every unused field, including venue
+  // city/state (which the track-rating row doesn't display, unlike the
+  // show-rating row above).
+  test("returns slim shape with no venue.city/state and no UUIDs", async () => {
+    const db = {
+      rating: {
+        findMany: vi.fn().mockResolvedValue([rating({ id: "r1", rateableId: "track-1", rateableType: "Track" })]),
+      },
+      track: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "track-1",
+            slug: "basis-for-a-day-2024-08-12",
+            position: 3,
+            set: "S1",
+            show: {
+              slug: "2024-08-12-cap-theatre",
+              date: "2024-08-12",
+              venue: { name: "The Capitol Theatre" },
+            },
+            song: { slug: "basis-for-a-day", title: "Basis for a Day" },
+          },
+        ]),
+      },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    const result = await service.findTrackRatingsByUserId("u1");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: "r1",
+      value: 5,
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+      track: {
+        slug: "basis-for-a-day-2024-08-12",
+        position: 3,
+        set: "S1",
+        show: {
+          slug: "2024-08-12-cap-theatre",
+          date: "2024-08-12",
+          venue: { name: "The Capitol Theatre" },
+        },
+        song: { slug: "basis-for-a-day", title: "Basis for a Day" },
+      },
+    });
+    expect(result[0]).not.toHaveProperty("userId");
+    expect(result[0]).not.toHaveProperty("rateableType");
+    expect(result[0].track).not.toHaveProperty("id");
+    expect(result[0].track.show).not.toHaveProperty("id");
+    expect(result[0].track.show.venue).not.toHaveProperty("city");
+    expect(result[0].track.show.venue).not.toHaveProperty("state");
+    expect(result[0].track.song).not.toHaveProperty("id");
+  });
+
+  // Same orphan-protection as show ratings — if the joined track is gone we
+  // drop the row instead of crashing the user profile.
+  test("skips ratings whose related track is missing", async () => {
+    const db = {
+      rating: {
+        findMany: vi
+          .fn()
+          .mockResolvedValue([
+            rating({ id: "r1", rateableId: "missing-track", rateableType: "Track" }),
+            rating({ id: "r2", rateableId: "track-1", rateableType: "Track" }),
+          ]),
+      },
+      track: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "track-1",
+            slug: "above-the-waves",
+            position: 1,
+            set: "S2",
+            show: { slug: "show-slug", date: "2024-01-01", venue: { name: "Some Venue" } },
+            song: { slug: "above-the-waves", title: "Above The Waves" },
+          },
+        ]),
+      },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    const result = await service.findTrackRatingsByUserId("u1");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("r2");
+  });
+
+  // Same pagination requirement as show ratings — the heaviest user has ~7,800 track
+  // ratings and a single full payload is ~4 MB. skip/take must reach the
+  // DB so we never marshal rows we don't render.
+  test("supports skip/take pagination at the DB layer", async () => {
+    const ratingFindMany = vi
+      .fn()
+      .mockResolvedValue([rating({ id: "r-tracks-page-2", rateableId: "track-page-2", rateableType: "Track" })]);
+    const db = {
+      rating: { findMany: ratingFindMany },
+      track: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "track-page-2",
+            slug: "basis-for-a-day",
+            position: 1,
+            set: "S1",
+            show: { slug: "s", date: "2024-01-01", venue: { name: "v" } },
+            song: { slug: "basis-for-a-day", title: "Basis for a Day" },
+          },
+        ]),
+      },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    const result = await service.findTrackRatingsByUserId("u1", { skip: 100, take: 100 });
+
+    expect(ratingFindMany.mock.calls[0][0]).toMatchObject({ skip: 100, take: 100 });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("r-tracks-page-2");
+  });
+
+  // Same Prisma narrowing regression guard as show ratings — the track
+  // method must use `select` (not `include`) and limit nested venue/song.
+  test("queries the DB with a narrow `select`", async () => {
+    const trackFindMany = vi.fn().mockResolvedValue([]);
+    const db = {
+      rating: { findMany: vi.fn().mockResolvedValue([rating({ rateableType: "Track", rateableId: "track-1" })]) },
+      track: { findMany: trackFindMany },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    await service.findTrackRatingsByUserId("u1");
+
+    const args = trackFindMany.mock.calls[0][0];
+    expect(args).toHaveProperty("select");
+    expect(args).not.toHaveProperty("include");
+    // Venue should expose only `name` — city/state would re-introduce bloat.
+    expect(args.select.show.select.venue.select).toEqual({ name: true });
+    // Song should expose only slug/title — no UUID.
+    expect(args.select.song.select).toEqual({ slug: true, title: true });
+  });
+});

--- a/packages/core/src/ratings/rating-service.ts
+++ b/packages/core/src/ratings/rating-service.ts
@@ -2,9 +2,17 @@ import type { Rating } from "@bip/domain";
 import type { CacheInvalidationService } from "../_shared/cache";
 import type { DbClient, DbRating } from "../_shared/database/models";
 
-export interface RatingWithShow extends Rating {
+/**
+ * Slim show-rating row for list views — only fields the user-profile page
+ * actually renders. UUIDs, rateable_id/type, userId, and updatedAt are
+ * omitted because heavy users have 1000+ ratings and the unused fields
+ * dominate the JSON payload.
+ */
+export interface RatingWithShow {
+  id: string;
+  value: number;
+  createdAt: Date;
   show: {
-    id: string;
     slug: string | null;
     date: string;
     venue: {
@@ -15,24 +23,25 @@ export interface RatingWithShow extends Rating {
   };
 }
 
-export interface RatingWithTrack extends Rating {
+/**
+ * Slim track-rating row for list views. Same motivation as RatingWithShow —
+ * we additionally drop venue.city/state on the nested show because the
+ * track-rating row doesn't display them (the show-rating row does).
+ */
+export interface RatingWithTrack {
+  id: string;
+  value: number;
+  createdAt: Date;
   track: {
-    id: string;
     slug: string | null;
     position: number;
     set: string;
     show: {
-      id: string;
       slug: string | null;
       date: string;
-      venue: {
-        name: string | null;
-        city: string | null;
-        state: string | null;
-      } | null;
+      venue: { name: string | null } | null;
     };
     song: {
-      id: string;
       slug: string;
       title: string;
     };
@@ -189,7 +198,7 @@ export class RatingService {
     return result ? mapRatingToDomainEntity(result) : null;
   }
 
-  async findShowRatingsByUserId(userId: string): Promise<RatingWithShow[]> {
+  async findShowRatingsByUserId(userId: string, options?: { skip?: number; take?: number }): Promise<RatingWithShow[]> {
     const results = await this.db.rating.findMany({
       where: {
         userId,
@@ -197,26 +206,35 @@ export class RatingService {
         value: { gte: 1, lte: 5 }, // Only valid ratings
       },
       orderBy: { createdAt: "desc" },
+      skip: options?.skip,
+      take: options?.take,
     });
 
-    // Get show data for all ratings
+    // Get show data for all ratings — narrow projection (slug/date/venue
+    // trio) since the user-profile list cards don't use any other field.
     const showIds = results.map((r) => r.rateableId);
     const shows = await this.db.show.findMany({
       where: { id: { in: showIds } },
-      include: { venue: true },
+      select: {
+        id: true,
+        slug: true,
+        date: true,
+        venue: { select: { name: true, city: true, state: true } },
+      },
     });
 
     const showMap = new Map(shows.map((show) => [show.id, show]));
 
     return results
-      .map((rating) => {
+      .map((rating): RatingWithShow | null => {
         const show = showMap.get(rating.rateableId);
         if (!show) return null;
 
         return {
-          ...mapRatingToDomainEntity(rating),
+          id: rating.id,
+          value: rating.value,
+          createdAt: rating.createdAt,
           show: {
-            id: show.id,
             slug: show.slug,
             date: show.date,
             venue: show.venue
@@ -232,7 +250,10 @@ export class RatingService {
       .filter((rating): rating is RatingWithShow => rating !== null);
   }
 
-  async findTrackRatingsByUserId(userId: string): Promise<RatingWithTrack[]> {
+  async findTrackRatingsByUserId(
+    userId: string,
+    options?: { skip?: number; take?: number },
+  ): Promise<RatingWithTrack[]> {
     const results = await this.db.rating.findMany({
       where: {
         userId,
@@ -240,46 +261,53 @@ export class RatingService {
         value: { gte: 1, lte: 5 }, // Only valid ratings
       },
       orderBy: { createdAt: "desc" },
+      skip: options?.skip,
+      take: options?.take,
     });
 
-    // Get track data with show and song info
+    // Get track data with show and song info — narrow projection: the
+    // user-profile track-rating cards only display set/position + nested
+    // slug/date/venue.name + song.slug/title.
     const trackIds = results.map((r) => r.rateableId);
     const tracks = await this.db.track.findMany({
       where: { id: { in: trackIds } },
-      include: {
-        show: { include: { venue: true } },
-        song: true,
+      select: {
+        id: true,
+        slug: true,
+        position: true,
+        set: true,
+        show: {
+          select: {
+            slug: true,
+            date: true,
+            venue: { select: { name: true } },
+          },
+        },
+        song: { select: { slug: true, title: true } },
       },
     });
 
     const trackMap = new Map(tracks.map((track) => [track.id, track]));
 
     return results
-      .map((rating) => {
+      .map((rating): RatingWithTrack | null => {
         const track = trackMap.get(rating.rateableId);
         if (!track) return null;
 
         return {
-          ...mapRatingToDomainEntity(rating),
+          id: rating.id,
+          value: rating.value,
+          createdAt: rating.createdAt,
           track: {
-            id: track.id,
             slug: track.slug,
             position: track.position,
             set: track.set,
             show: {
-              id: track.show.id,
               slug: track.show.slug,
               date: track.show.date,
-              venue: track.show.venue
-                ? {
-                    name: track.show.venue.name,
-                    city: track.show.venue.city,
-                    state: track.show.venue.state,
-                  }
-                : null,
+              venue: track.show.venue ? { name: track.show.venue.name } : null,
             },
             song: {
-              id: track.song.id,
               slug: track.song.slug,
               title: track.song.title,
             },

--- a/packages/core/src/setlists/setlist-service.test.ts
+++ b/packages/core/src/setlists/setlist-service.test.ts
@@ -131,7 +131,7 @@ describe("computeAverageSongGap", () => {
   // average down to "we never played this".
   test("averages real gaps and ignores debuts", () => {
     const tracks = [
-      { songId: "a", position: 1, gap: null }, // Tractorbeam debut
+      { songId: "a", position: 1, gap: null }, // Basis for a Day debut
       { songId: "b", position: 2, gap: 5 }, // Above the Waves
       { songId: "c", position: 3, gap: 10 }, // Confrontation
     ];
@@ -169,7 +169,7 @@ describe("computeMedianSongGap", () => {
   // an outlier dragging it like the average can.
   test("returns the middle value for an odd-count eligible list", () => {
     const tracks = [
-      { songId: "a", position: 1, gap: 30 }, // Tractorbeam
+      { songId: "a", position: 1, gap: 30 }, // Basis for a Day
       { songId: "b", position: 2, gap: 5 }, // Above the Waves
       { songId: "c", position: 3, gap: 10 }, // Confrontation
     ];
@@ -207,7 +207,7 @@ describe("computeMedianSongGap", () => {
   // hide the summary line entirely.
   test("returns null when no eligible tracks remain", () => {
     const tracks = [
-      { songId: "a", position: 1, gap: null }, // Tractorbeam debut
+      { songId: "a", position: 1, gap: null }, // Basis for a Day debut
       { songId: "b", position: 2, gap: null }, // Above the Waves debut
     ];
     expect(computeMedianSongGap(tracks)).toBeNull();
@@ -246,7 +246,7 @@ describe("SetlistService.findByShowSlug", () => {
       venueId: "v-1",
       bandId: "b-1",
       tracks: [
-        // Tractorbeam debut — gap=null
+        // Basis for a Day debut — gap=null
         {
           id: "t-1",
           showId: "show-1",

--- a/packages/core/src/setlists/setlist-service.test.ts
+++ b/packages/core/src/setlists/setlist-service.test.ts
@@ -215,10 +215,10 @@ describe("computeMedianSongGap", () => {
 });
 
 describe("SetlistService.findByShowSlug", () => {
-  // The setlist payload powers the gap-chart view (Phase 5). It needs the
-  // prior-show date+slug for the "Last Played" column, so the query must
-  // include the previousPerformanceShow relation with date+slug only (no full
-  // show payload — keeps the response compact).
+  // The setlist payload powers the gap-chart view. It needs the prior-show
+  // date+slug for the "Last Played" column, so the query must include the
+  // previousPerformanceShow relation with date+slug only (no full show
+  // payload — keeps the response compact).
   test("includes previousPerformanceShow date+slug on tracks", async () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never);
@@ -232,8 +232,8 @@ describe("SetlistService.findByShowSlug", () => {
   });
 
   // The setlist domain object exposes averageSongGap so SetlistTable can
-  // render the summary without recomputing client-side. Tracks come back from
-  // Prisma with `gap` already populated (Phase 1 denormalization).
+  // render the summary without recomputing client-side. Tracks come back
+  // from Prisma with the denormalized `gap` field already populated.
   test("returns averageSongGap derived from tracks", async () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never);

--- a/packages/core/src/stats/stats-service.test.ts
+++ b/packages/core/src/stats/stats-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { countShowsAfter, songStatsChanged } from "./stats-service";
+import { countShowsAfter, countShowsOnOrAfter, songStatsChanged } from "./stats-service";
 
 const baseFresh = {
   timesPlayed: 3,
@@ -160,5 +160,36 @@ describe("countShowsAfter", () => {
     const binary = countShowsAfter(dates, target);
     const linear = dates.filter((d) => d > target).length;
     expect(binary).toBe(linear);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countShowsOnOrAfter — inclusive variant for the filtered-debut denominator
+// ---------------------------------------------------------------------------
+
+describe("countShowsOnOrAfter", () => {
+  // Drives Filtered Since Debut / Filtered Avg Gap on /songs: the denominator
+  // is "matching-universe shows from the song's first filtered play onward",
+  // which must include the debut show itself — so this is `>=`, not `>`.
+
+  // Empty catalogue → nothing on or after anything.
+  test("returns 0 for empty input regardless of target", () => {
+    expect(countShowsOnOrAfter([], "2024-01-01")).toBe(0);
+  });
+
+  // Target before every date → every entry counts.
+  test("returns full length when target precedes all dates", () => {
+    expect(countShowsOnOrAfter(["2010-01-01", "2015-06-15", "2020-12-31"], "2000-01-01")).toBe(3);
+  });
+
+  // Target equal to a date → that date counts (this is the on-or-after
+  // variant). Distinguishes this helper from `countShowsAfter`.
+  test("inclusive: target equal to a date includes that date", () => {
+    expect(countShowsOnOrAfter(["2020-01-01", "2021-01-01", "2022-01-01"], "2021-01-01")).toBe(2);
+  });
+
+  // Target later than the latest date → nothing remains.
+  test("returns 0 when target follows every date", () => {
+    expect(countShowsOnOrAfter(["2010-01-01", "2015-06-15"], "2030-01-01")).toBe(0);
   });
 });

--- a/packages/core/src/stats/stats-service.ts
+++ b/packages/core/src/stats/stats-service.ts
@@ -350,6 +350,24 @@ export function countShowsAfter(sortedDates: string[], target: string): number {
   return sortedDates.length - lo;
 }
 
+/**
+ * Counts entries on or after `target` in a sorted-ascending string array.
+ * Used as the denominator for Filtered Since Debut / Filtered Avg Gap on
+ * /songs — "matching-universe shows from this song's first filtered play
+ * onward", which includes the debut show itself.
+ */
+export function countShowsOnOrAfter(sortedDates: string[], target: string): number {
+  if (sortedDates.length === 0) return 0;
+  let lo = 0;
+  let hi = sortedDates.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (sortedDates[mid] < target) lo = mid + 1;
+    else hi = mid;
+  }
+  return sortedDates.length - lo;
+}
+
 function stableYearlyJson(value: unknown): string {
   if (!value || typeof value !== "object") return "[]";
   const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));

--- a/packages/core/src/users/user-service.test.ts
+++ b/packages/core/src/users/user-service.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test, vi } from "vitest";
+import { UserService } from "./user-service";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+
+describe("UserService.getUserTabCounts", () => {
+  // The user-profile page renders tab labels like "Reviews (12)" /
+  // "Track Ratings (783)". Pulling the full data just to derive the count
+  // for the tab label was costing megabytes on heavy users — this method
+  // returns just the four counts via cheap aggregations so the loader can
+  // populate labels without fetching the underlying rows.
+  test("returns review/show-rating/track-rating/blog-post counts via cheap COUNT queries", async () => {
+    const ratingCount = vi
+      .fn()
+      .mockImplementationOnce(async () => 17) // first call: show ratings
+      .mockImplementationOnce(async () => 42); // second call: track ratings
+
+    const db = {
+      review: { count: vi.fn().mockResolvedValue(6) },
+      rating: { count: ratingCount },
+      blogPost: { count: vi.fn().mockResolvedValue(3) },
+    } as never;
+
+    const service = new UserService(db, logger);
+    const counts = await service.getUserTabCounts("u-rynow");
+
+    expect(counts).toEqual({
+      reviewCount: 6,
+      showRatingsCount: 17,
+      trackRatingsCount: 42,
+      blogPostCount: 3,
+    });
+  });
+
+  // The two rating counts are filtered by rateableType so we never conflate
+  // show ratings with track ratings — the user profile shows them in
+  // separate tabs and their counts must not overlap.
+  test("filters rating counts by rateableType (Show vs Track)", async () => {
+    const ratingCount = vi.fn().mockResolvedValue(0);
+    const db = {
+      review: { count: vi.fn().mockResolvedValue(0) },
+      rating: { count: ratingCount },
+      blogPost: { count: vi.fn().mockResolvedValue(0) },
+    } as never;
+
+    const service = new UserService(db, logger);
+    await service.getUserTabCounts("u-1");
+
+    // First rating.count call → show ratings
+    expect(ratingCount.mock.calls[0][0].where).toMatchObject({
+      userId: "u-1",
+      rateableType: "Show",
+    });
+    // Second rating.count call → track ratings
+    expect(ratingCount.mock.calls[1][0].where).toMatchObject({
+      userId: "u-1",
+      rateableType: "Track",
+    });
+  });
+
+  // Blog post count must mirror getUserStats's filter: only published posts.
+  // Otherwise the tab label disagrees with what actually renders in the tab.
+  test("blog post count only includes published posts", async () => {
+    const blogCount = vi.fn().mockResolvedValue(0);
+    const db = {
+      review: { count: vi.fn().mockResolvedValue(0) },
+      rating: { count: vi.fn().mockResolvedValue(0) },
+      blogPost: { count: blogCount },
+    } as never;
+
+    const service = new UserService(db, logger);
+    await service.getUserTabCounts("u-1");
+
+    expect(blogCount.mock.calls[0][0].where).toMatchObject({
+      userId: "u-1",
+      state: "published",
+    });
+  });
+});
+
+describe("UserService.getUserProfileHeader", () => {
+  // The user-profile header always renders attendance count + first/last
+  // show dates. Pulling the full attendance list just to derive three
+  // values was costing ~30-50ms on heavy users; this method does it via
+  // a COUNT + two cheap findFirst queries.
+  test("returns attendanceCount + first and last attended shows", async () => {
+    const attendanceCount = vi.fn().mockResolvedValue(459);
+    const findFirst = vi
+      .fn()
+      // Ascending: oldest show (first attended)
+      .mockResolvedValueOnce({ show: { id: "show-first", date: "1998-04-25" } })
+      // Descending: newest show (most recent)
+      .mockResolvedValueOnce({ show: { id: "show-last", date: "2026-04-25" } });
+
+    const db = {
+      attendance: {
+        count: attendanceCount,
+        findFirst,
+      },
+    } as never;
+
+    const service = new UserService(db, logger);
+    const header = await service.getUserProfileHeader("u-1");
+
+    expect(header).toEqual({
+      attendanceCount: 459,
+      firstShow: { id: "show-first", date: "1998-04-25" },
+      lastShow: { id: "show-last", date: "2026-04-25" },
+    });
+  });
+
+  // When the user has no attendances, firstShow/lastShow are null and the
+  // header still renders cleanly (no attendances row + zero count).
+  test("returns nulls for first/last show when user has no attendances", async () => {
+    const db = {
+      attendance: {
+        count: vi.fn().mockResolvedValue(0),
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+    } as never;
+
+    const service = new UserService(db, logger);
+    const header = await service.getUserProfileHeader("u-1");
+
+    expect(header).toEqual({
+      attendanceCount: 0,
+      firstShow: null,
+      lastShow: null,
+    });
+  });
+
+  // Ordering matters: first show is the oldest by date, last show is the
+  // newest. The findFirst calls must specify these directions explicitly.
+  test("orders first by show.date asc and last by show.date desc", async () => {
+    const findFirst = vi.fn().mockResolvedValue(null);
+    const db = {
+      attendance: {
+        count: vi.fn().mockResolvedValue(0),
+        findFirst,
+      },
+    } as never;
+
+    const service = new UserService(db, logger);
+    await service.getUserProfileHeader("u-1");
+
+    expect(findFirst.mock.calls[0][0].orderBy).toMatchObject({ show: { date: "asc" } });
+    expect(findFirst.mock.calls[1][0].orderBy).toMatchObject({ show: { date: "desc" } });
+  });
+});

--- a/packages/core/src/users/user-service.ts
+++ b/packages/core/src/users/user-service.ts
@@ -276,6 +276,58 @@ export class UserService {
     }
   }
 
+  /**
+   * Tab labels on the user profile page ("Reviews (N)", "Track Ratings (N)",
+   * etc.) need counts even when we don't fetch the underlying rows. Heavy
+   * users have 7,000+ track ratings; pulling that array just to call
+   * `.length` costs megabytes of payload. These COUNT queries replace that.
+   */
+  async getUserTabCounts(userId: string): Promise<{
+    reviewCount: number;
+    showRatingsCount: number;
+    trackRatingsCount: number;
+    blogPostCount: number;
+  }> {
+    const [reviewCount, showRatingsCount, trackRatingsCount, blogPostCount] = await Promise.all([
+      this.db.review.count({ where: { userId } }),
+      this.db.rating.count({ where: { userId, rateableType: "Show", value: { gte: 1, lte: 5 } } }),
+      this.db.rating.count({ where: { userId, rateableType: "Track", value: { gte: 1, lte: 5 } } }),
+      this.db.blogPost.count({ where: { userId, state: "published" } }),
+    ]);
+    return { reviewCount, showRatingsCount, trackRatingsCount, blogPostCount };
+  }
+
+  /**
+   * Header summary for the user-profile page: total attendance count plus
+   * the oldest and newest shows the user has marked attended. Avoids
+   * fetching the full attendance list (~30-50ms on heavy users) just to
+   * derive these three values for the page header.
+   */
+  async getUserProfileHeader(userId: string): Promise<{
+    attendanceCount: number;
+    firstShow: { id: string; date: string } | null;
+    lastShow: { id: string; date: string } | null;
+  }> {
+    const [attendanceCount, firstAttendance, lastAttendance] = await Promise.all([
+      this.db.attendance.count({ where: { userId } }),
+      this.db.attendance.findFirst({
+        where: { userId },
+        orderBy: { show: { date: "asc" } },
+        select: { show: { select: { id: true, date: true } } },
+      }),
+      this.db.attendance.findFirst({
+        where: { userId },
+        orderBy: { show: { date: "desc" } },
+        select: { show: { select: { id: true, date: true } } },
+      }),
+    ]);
+    return {
+      attendanceCount,
+      firstShow: firstAttendance?.show ?? null,
+      lastShow: lastAttendance?.show ?? null,
+    };
+  }
+
   async getUserStats(userId?: string): Promise<UserStats[]> {
     this.logger.info("getUserStats called", { userId });
     const whereClause = userId ? { id: userId } : {};

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -87,6 +87,23 @@ export const CacheKeys = {
   },
 
   /**
+   * Per-user cache keys
+   */
+  users: {
+    /**
+     * Pre-built SetlistList payload (setlists + external sources) for one
+     * page of a user's attended shows. Paginated because the heaviest users
+     * have 400+ attended shows and the un-paginated payload is large enough
+     * to be slow to deserialize/transport even from Redis.
+     */
+    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}`,
+    /** All pages of a single user's attended-setlists caches (for per-user invalidation). */
+    allAttendedSetlistsForUser: (userId: string) => `user:${userId}:attended-setlists:*`,
+    /** All per-user attended-setlists caches (for pattern deletion on broad show mutations). */
+    allAttendedSetlists: () => "user:*:attended-setlists:*",
+  },
+
+  /**
    * Home page cache keys
    */
   home: {

--- a/packages/domain/src/models/song.ts
+++ b/packages/domain/src/models/song.ts
@@ -18,6 +18,14 @@ export const songSchema = z.object({
   // Absent when no filter is active; the UI uses its presence to decide whether to render
   // the "Filtered Plays" column alongside the all-time Plays column.
   filteredTimesPlayed: z.number().optional(),
+  // Filtered analogs of the rarity fields below — populated only when a narrowing
+  // filter is active. Drive the Filtered Current Gap / Filtered Since Debut /
+  // Filtered Avg Gap columns on /songs.
+  filteredShowsSinceLastPlayed: z.number().nullable().optional(),
+  filteredPercentSinceDebut: z.number().nullable().optional(),
+  filteredAverageShowsPerPlay: z.number().nullable().optional(),
+  dateFirstFilteredPlayed: z.date().nullable().optional(),
+  dateLastFilteredPlayed: z.date().nullable().optional(),
   dateLastPlayed: z.date().nullable(),
   dateFirstPlayed: z.date().nullable(),
   actualLastPlayedDate: z.date().nullable(),

--- a/packages/domain/src/views/song-page.ts
+++ b/packages/domain/src/views/song-page.ts
@@ -29,6 +29,10 @@ export type SongPagePerformance = {
   cover?: boolean;
   authorId?: string | null;
   gap?: number | null;
+  // Gap measured against the previous performance of this song within the
+  // currently-applied filter scope. Populated server-side only when a
+  // narrowing filter is active.
+  filteredGap?: number | null;
   previousPerformanceShowId?: string | null;
   previousShow?: { slug: string; date: string };
   tags?: {


### PR DESCRIPTION
## Why this train exists

Bundles a set of sub-PRs that depend on each other so they can be reviewed individually and then merged together as a single commit to `main`. Avoids the cascade of fake GitHub merge conflicts that show up when stacked PRs land one at a time. Same pattern as #113 / #101 / #102 / #105.

## What's bundled

- **#120** — Filtered rarity columns on `/songs` + Filtered Gap column on song-detail.
- **#121** — User-profile Shows Attended tab renders via shared `SetlistList`; URL-driven tabs (`?tab=`); pagination on Shows/Show Ratings/Track Ratings; per-user Redis cache for attended setlists; mobile-friendly tabs + header.

## Review notes

Review each sub-PR on its own branch. This PR exists to merge the combined set as one commit once those approvals are in. `make tc`, `make test`, and `make lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
