### PR TITLE
Add personal gap chart view to SetlistCard

### DIFF
--- a/apps/web/app/components/performance/performance-columns.test.tsx
+++ b/apps/web/app/components/performance/performance-columns.test.tsx
@@ -1,5 +1,5 @@
 import type { SongPagePerformance } from "@bip/domain";
-import { mockShallowComponent, setup } from "@test/test-utils";
+import { mockShallowComponent, setupWithRouter } from "@test/test-utils";
 import { screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import { DataTable } from "~/components/ui/data-table";
@@ -53,7 +53,7 @@ describe("createPerformanceColumns", () => {
   // viewports stack venue beneath the date in the same column.
   test("default columns include Date, Set, Sequence, Notes, Rating headers (Venue is not a separate column)", async () => {
     const columns = createPerformanceColumns(defaultOptions);
-    await setup(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
 
     expect(screen.getByText("Date")).toBeInTheDocument();
     expect(screen.getByText("Set")).toBeInTheDocument();
@@ -69,7 +69,7 @@ describe("createPerformanceColumns", () => {
   // is responsive (hidden sm:block) but still in the DOM for desktop users.
   test("Date cell renders venue name beneath the date", async () => {
     const columns = createPerformanceColumns(defaultOptions);
-    await setup(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
 
     expect(screen.getByText(/The Capitol Theatre, Port Chester, NY/)).toBeInTheDocument();
   });
@@ -158,7 +158,7 @@ describe("createPerformanceColumns", () => {
   test("Filtered Gap cell renders Star icon for filteredGap=null debut", async () => {
     const performances = [makePerformance({ trackId: "t-debut", filteredGap: null, position: 1 })];
     const columns = createPerformanceColumns({ ...defaultOptions, hasNarrowingFilter: true });
-    const { container } = await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    const { container } = await setupWithRouter(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
     // Two stars expected: the all-time Gap column treats this row the same
     // way (its gap field defaulted to 5 from makePerformance, so the Gap
     // cell renders a number, not a star). Filtered Gap renders the star.
@@ -181,7 +181,7 @@ describe("createPerformanceColumns", () => {
       }),
     ];
     const columns = createPerformanceColumns({ ...defaultOptions, hasNarrowingFilter: true });
-    const { container } = await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    const { container } = await setupWithRouter(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
     // Within-show repeats render ↺ in both Gap AND Filtered Gap columns on
     // the second row — two `.lucide-rotate-ccw` icons total.
     expect(container.querySelectorAll(".lucide-rotate-ccw").length).toBe(2);
@@ -190,7 +190,7 @@ describe("createPerformanceColumns", () => {
   test("Filtered Gap cell renders the numeric value when not a debut or repeat", async () => {
     const performances = [makePerformance({ trackId: "t-1", filteredGap: 7, position: 1 })];
     const columns = createPerformanceColumns({ ...defaultOptions, hasNarrowingFilter: true });
-    await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
     // The Gap column renders 5 (from makePerformance default); Filtered Gap
     // renders 7. Looking for "7" is unambiguous since the all-time Gap is 5.
     expect(screen.getByText("7")).toBeInTheDocument();
@@ -202,12 +202,12 @@ describe("createPerformanceColumns", () => {
     const performances = [makePerformance({ songTitle: "Cassidy", songSlug: "cassidy" })];
 
     const withSong = createPerformanceColumns({ ...defaultOptions, showSongColumn: true });
-    const { unmount } = await setup(<DataTable columns={withSong} data={performances} hideSearch hidePagination />);
+    const { unmount } = await setupWithRouter(<DataTable columns={withSong} data={performances} hideSearch hidePagination />);
     expect(screen.getByText("Song")).toBeInTheDocument();
     unmount();
 
     const withoutSong = createPerformanceColumns(defaultOptions);
-    await setup(<DataTable columns={withoutSong} data={performances} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={withoutSong} data={performances} hideSearch hidePagination />);
     expect(screen.queryByText("Song")).not.toBeInTheDocument();
   });
 
@@ -217,7 +217,7 @@ describe("createPerformanceColumns", () => {
   test("AllTimer flame column present when showAllTimerColumn is true", async () => {
     const performances = [makePerformance({ allTimer: true })];
     const columns = createPerformanceColumns({ ...defaultOptions, showAllTimerColumn: true });
-    const { container } = await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    const { container } = await setupWithRouter(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
 
     expect(container.querySelectorAll(".lucide-flame").length).toBe(1);
   });
@@ -229,7 +229,7 @@ describe("createPerformanceColumns", () => {
   test("passes initialRating from performance.rating even when userRatingMap is empty", async () => {
     const performances = [makePerformance({ trackId: "t1", rating: 3.5, ratingsCount: 2 })];
     const columns = createPerformanceColumns({ ...defaultOptions, userRatingMap: new Map() });
-    await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
 
     const cell = screen.getByTestId("TrackRatingCell");
     // initialRating should be 3.5, not null
@@ -243,7 +243,7 @@ describe("createPerformanceColumns", () => {
   test("passes initialRating as null when performance.rating is undefined", async () => {
     const performances = [makePerformance({ trackId: "t1", rating: undefined, ratingsCount: undefined })];
     const columns = createPerformanceColumns(defaultOptions);
-    await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
 
     const cell = screen.getByTestId("TrackRatingCell");
     expect(cell.textContent).toContain('"initialRating":null');
@@ -259,7 +259,7 @@ describe("createPerformanceColumns", () => {
       }),
     ];
     const columns = createPerformanceColumns(defaultOptions);
-    await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
 
     // Date is formatted M/D/YYYY (formatDateShort) for visual consistency
     // with /shows listings and song-detail stat cards.
@@ -273,7 +273,7 @@ describe("createPerformanceColumns", () => {
   // render plain text headers with no icon.
   test("sortable columns show sort indicator, non-sortable columns do not", async () => {
     const columns = createPerformanceColumns(defaultOptions);
-    await setup(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
 
     // Sortable columns render a <button> with an SVG icon inside
     const dateHeader = screen.getByText("Date").closest("button");
@@ -300,7 +300,7 @@ describe("createPerformanceColumns", () => {
   // additions don't accidentally reshuffle this flow.
   test("column order is Date, Gap, Last Played, Set, Sequence", async () => {
     const columns = createPerformanceColumns(defaultOptions);
-    await setup(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
 
     const headers = Array.from(document.querySelectorAll("th"))
       .map((th) => th.textContent?.trim() ?? "")
@@ -322,7 +322,7 @@ describe("createPerformanceColumns", () => {
   test("Gap column renders integer for normal rows", async () => {
     const columns = createPerformanceColumns(defaultOptions);
     const performances = [makePerformance({ trackId: "t-cassidy", gap: 12, previousPerformanceShowId: "prev-1" })];
-    await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
 
     expect(screen.getByText("12")).toBeInTheDocument();
   });
@@ -341,7 +341,7 @@ describe("createPerformanceColumns", () => {
         previousPerformanceShowId: null,
       }),
     ];
-    const { container } = await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    const { container } = await setupWithRouter(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
 
     expect(container.querySelectorAll(".lucide-star").length).toBe(1);
   });
@@ -364,7 +364,7 @@ describe("createPerformanceColumns", () => {
       makePerformance({ trackId: "t-first", show: sharedShow, position: 3, gap: 5, previousPerformanceShowId: "p" }),
       makePerformance({ trackId: "t-repeat", show: sharedShow, position: 8, gap: 5, previousPerformanceShowId: "p" }),
     ];
-    const { container } = await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    const { container } = await setupWithRouter(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
 
     // Exactly one rotate-ccw icon — the second occurrence; the first
     // occurrence still renders the integer 5.
@@ -387,7 +387,7 @@ describe("createPerformanceColumns", () => {
         previousShow: { slug: "2018-02-14-bowery", date: "2018-02-14" },
       }),
     ];
-    await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
 
     const link = screen.getByRole("link", { name: /2\/14\/2018/ });
     expect(link).toHaveAttribute("href", "/shows/2018-02-14-bowery");
@@ -405,7 +405,7 @@ describe("createPerformanceColumns", () => {
         previousShow: undefined,
       }),
     ];
-    const { container } = await setup(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+    const { container } = await setupWithRouter(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
 
     // The cell sits between Set and Gap in the header order, so we look up
     // the third td in the row (after Date and Set). Rather than rely on
@@ -417,7 +417,7 @@ describe("createPerformanceColumns", () => {
   // indicator icon, just like Date and Rating.
   test("Gap column is sortable", async () => {
     const columns = createPerformanceColumns(defaultOptions);
-    await setup(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
 
     const gapHeader = screen.getByText("Gap").closest("button");
     expect(gapHeader).not.toBeNull();

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -4,6 +4,7 @@ import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon, Filter, Flame, RotateCcw, Star
 import { GapIcon } from "~/components/gap-icon";
 import { formatSetLabel } from "~/components/setlist/set-label";
 import { ShowDate } from "~/components/show-date";
+import { ShowDateLink } from "~/components/show-date-link";
 import { CombinedNotes } from "./combined-notes";
 import { DateVenueCell } from "./date-venue-cell";
 import { TrackRatingCell } from "./track-rating-cell";
@@ -242,17 +243,7 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
         header: ({ column }) => <SortableHeader column={column} label="Last Played" />,
         enableSorting: true,
         sortingFn: "alphanumeric",
-        cell: (info) => {
-          const previousShow = info.row.original.previousShow;
-          if (!previousShow) {
-            return <span className="text-content-text-tertiary">—</span>;
-          }
-          return (
-            <a href={`/shows/${previousShow.slug}`} className="text-base text-brand-primary hover:text-brand-secondary">
-              <ShowDate date={previousShow.date} />
-            </a>
-          );
-        },
+        cell: (info) => <ShowDateLink show={info.row.original.previousShow} />,
       }) as ColumnDef<SongPagePerformance, unknown>,
     );
   }

--- a/apps/web/app/components/performance/performance-table.test.tsx
+++ b/apps/web/app/components/performance/performance-table.test.tsx
@@ -1,5 +1,5 @@
 import type { SongPagePerformance } from "@bip/domain";
-import { mockShallowComponent, setup } from "@test/test-utils";
+import { mockShallowComponent, setupWithRouter } from "@test/test-utils";
 import { screen } from "@testing-library/react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -86,7 +86,7 @@ describe("PerformanceTable", () => {
         show: { ...makePerformance().show, id: "s2", date: "2024-07-20" },
       }),
     ];
-    await setup(<PerformanceTable performances={performances} />);
+    await setupWithRouter(<PerformanceTable performances={performances} />);
 
     expect(screen.getAllByTestId("TrackRatingCell")).toHaveLength(2);
     // Dates render via ShowDate (M/D/YYYY at sm+, M/D/YY on mobile); both
@@ -100,11 +100,11 @@ describe("PerformanceTable", () => {
   test("renders Song column when showSongColumn is true, omits it otherwise", async () => {
     const performances = [makePerformance({ songTitle: "Cassidy", songSlug: "cassidy" })];
 
-    const { unmount } = await setup(<PerformanceTable performances={performances} showSongColumn />);
+    const { unmount } = await setupWithRouter(<PerformanceTable performances={performances} showSongColumn />);
     expect(screen.getByRole("link", { name: "Cassidy" })).toBeInTheDocument();
     unmount();
 
-    await setup(<PerformanceTable performances={performances} />);
+    await setupWithRouter(<PerformanceTable performances={performances} />);
     expect(screen.queryByRole("link", { name: "Cassidy" })).not.toBeInTheDocument();
   });
 
@@ -122,7 +122,7 @@ describe("PerformanceTable", () => {
         show: { ...makePerformance().show, id: "s-not-stats", countForStats: false },
       }),
     ];
-    await setup(<PerformanceTable performances={performances} />);
+    await setupWithRouter(<PerformanceTable performances={performances} />);
 
     const rows = screen.getAllByRole("row");
     const greyedRow = rows.find((row) => row.className.includes("opacity-60"));
@@ -153,7 +153,7 @@ describe("PerformanceTable", () => {
         show: { ...makePerformance().show, id: "s-soundcheck", countForStats: false },
       }),
     ];
-    await setup(<PerformanceTable performances={performances} />);
+    await setupWithRouter(<PerformanceTable performances={performances} />);
 
     const row = screen.getAllByRole("row").find((r) => r.className.includes("opacity-60"));
     expect(row).toBeDefined();
@@ -176,7 +176,7 @@ describe("PerformanceTable", () => {
       makePerformance({ trackId: "t1", show: { ...makePerformance().show, id: "s-attended" } }),
       makePerformance({ trackId: "t2", show: { ...makePerformance().show, id: "s-other" } }),
     ];
-    await setup(<PerformanceTable performances={performances} />);
+    await setupWithRouter(<PerformanceTable performances={performances} />);
 
     const rows = screen.getAllByRole("row");
     // Attended row should have both the green background tint and the left
@@ -204,7 +204,7 @@ describe("PerformanceTable", () => {
       loading: false,
     });
 
-    await setup(<PerformanceTable performances={[makePerformance()]} />);
+    await setupWithRouter(<PerformanceTable performances={[makePerformance()]} />);
 
     const cell = screen.getByTestId("TrackRatingCell");
     expect(cell.textContent).toContain('"isAuthenticated":true');
@@ -214,7 +214,7 @@ describe("PerformanceTable", () => {
   // toggle chips, etc.) above the table. PerformanceTable passes it through
   // to DataTable's filterComponent slot.
   test("renders headerContent when provided", async () => {
-    await setup(
+    await setupWithRouter(
       <PerformanceTable
         performances={[makePerformance()]}
         headerContent={<div data-testid="filter-controls">Filter controls here</div>}
@@ -228,7 +228,7 @@ describe("PerformanceTable", () => {
   // When all performances fit on a single page, pagination nav controls
   // (Previous/Next) are hidden to avoid showing disabled "Page 1 of 1" UI.
   test("hides pagination nav when data fits on one page", async () => {
-    await setup(<PerformanceTable performances={[makePerformance()]} />);
+    await setupWithRouter(<PerformanceTable performances={[makePerformance()]} />);
 
     expect(screen.queryByRole("button", { name: "Previous" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();

--- a/apps/web/app/components/setlist/gap-cell.test.tsx
+++ b/apps/web/app/components/setlist/gap-cell.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { buildGapCellState, GapCell, isWithinShowRepeat } from "./gap-cell";
+
+describe("GapCell", () => {
+  // Debut state: render a ★ with the caller-provided label so the same
+  // component can say "Debut" (catalog) or "Your debut" (personal view).
+  test("renders the debut star with the supplied label", () => {
+    render(<GapCell state={{ kind: "debut" }} debutLabel="Debut" thisShowLabel="This Show" />);
+    expect(screen.getByLabelText("Debut")).toBeInTheDocument();
+  });
+
+  test("uses the supplied personal debut label when passed", () => {
+    render(<GapCell state={{ kind: "debut" }} debutLabel="Your debut" thisShowLabel="Earlier this show" />);
+    expect(screen.getByLabelText("Your debut")).toBeInTheDocument();
+  });
+
+  // This-show state: render ↺ with the caller-provided label.
+  test("renders the within-show repeat icon with the supplied label", () => {
+    render(<GapCell state={{ kind: "this-show" }} debutLabel="Debut" thisShowLabel="This Show" />);
+    expect(screen.getByLabelText("This Show")).toBeInTheDocument();
+  });
+
+  // Numeric state: render the value as tabular-nums text. No icon, no
+  // label — just the number.
+  test("renders the numeric gap value with no icon when kind is count", () => {
+    render(<GapCell state={{ kind: "count", value: 7 }} debutLabel="Debut" thisShowLabel="This Show" />);
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Debut")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("This Show")).not.toBeInTheDocument();
+  });
+
+  // gap=0 still renders — back-to-back shows are a meaningful signal,
+  // not the same as a debut.
+  test("renders gap=0 as a real value (not a debut)", () => {
+    render(<GapCell state={{ kind: "count", value: 0 }} debutLabel="Debut" thisShowLabel="This Show" />);
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Debut")).not.toBeInTheDocument();
+  });
+});
+
+describe("buildGapCellState", () => {
+  // Repeat overrides everything else: even if the underlying gap value is
+  // a real number or null, a within-show repeat collapses to ↺.
+  test("isRepeat=true always produces 'this-show' regardless of gap", () => {
+    expect(buildGapCellState({ isRepeat: true, gap: null })).toEqual({ kind: "this-show" });
+    expect(buildGapCellState({ isRepeat: true, gap: 0 })).toEqual({ kind: "this-show" });
+    expect(buildGapCellState({ isRepeat: true, gap: 42 })).toEqual({ kind: "this-show" });
+  });
+
+  // Null gap with no repeat means "no prior to compare against" → debut.
+  test("gap=null without repeat produces a debut", () => {
+    expect(buildGapCellState({ isRepeat: false, gap: null })).toEqual({ kind: "debut" });
+  });
+
+  // Numeric gap with no repeat produces a count state with that value.
+  // gap=0 is intentionally distinct from a debut.
+  test("numeric gap without repeat produces a count state", () => {
+    expect(buildGapCellState({ isRepeat: false, gap: 0 })).toEqual({ kind: "count", value: 0 });
+    expect(buildGapCellState({ isRepeat: false, gap: 7 })).toEqual({ kind: "count", value: 7 });
+  });
+});
+
+describe("isWithinShowRepeat", () => {
+  // First occurrence: no earlier-position row with the same songId, so
+  // not a repeat.
+  test("returns false when no earlier same-song row exists", () => {
+    const rows = [
+      { id: "t1", songId: "tractorbeam", position: 1 },
+      { id: "t2", songId: "spaga", position: 2 },
+    ];
+    expect(isWithinShowRepeat(rows, rows[0])).toBe(false);
+    expect(isWithinShowRepeat(rows, rows[1])).toBe(false);
+  });
+
+  // Same songId at an earlier position → repeat.
+  test("returns true when the same song appears at an earlier position", () => {
+    const rows = [
+      { id: "t1", songId: "tractorbeam", position: 1 },
+      { id: "t2", songId: "spaga", position: 2 },
+      { id: "t3", songId: "tractorbeam", position: 5 }, // reprise
+    ];
+    expect(isWithinShowRepeat(rows, rows[2])).toBe(true);
+  });
+
+  // Same song LATER in the show: the earlier instance is the first
+  // occurrence (not a repeat); the later one is.
+  test("only the second-and-later occurrences are repeats", () => {
+    const rows = [
+      { id: "t1", songId: "helicopters", position: 2 },
+      { id: "t2", songId: "helicopters", position: 7 },
+    ];
+    expect(isWithinShowRepeat(rows, rows[0])).toBe(false);
+    expect(isWithinShowRepeat(rows, rows[1])).toBe(true);
+  });
+});

--- a/apps/web/app/components/setlist/gap-cell.tsx
+++ b/apps/web/app/components/setlist/gap-cell.tsx
@@ -1,0 +1,61 @@
+import { RotateCcw, Star } from "lucide-react";
+import { GapIcon } from "~/components/gap-icon";
+
+/**
+ * Discriminated union for the three possible states of a Gap or Your-Gap
+ * cell. Numeric `count` is the common case; `debut` and `this-show` carry
+ * no extra data and render as icons. Shared by the gap-chart and
+ * personal-gap-chart columns — keeps the rendering logic in one place.
+ */
+export type GapCellState = { kind: "debut" } | { kind: "this-show" } | { kind: "count"; value: number };
+
+/**
+ * Resolves the GapCell state from the two inputs every caller computes:
+ *   - `isRepeat`: this row's song already appeared earlier in the show.
+ *   - `gap`: a numeric distance, or null when there's no prior to compare.
+ * Centralizes the precedence (repeat beats debut beats numeric) so the
+ * gap-chart and personal-gap-chart cells stay aligned by construction.
+ */
+export function buildGapCellState(args: { isRepeat: boolean; gap: number | null }): GapCellState {
+  if (args.isRepeat) return { kind: "this-show" };
+  if (args.gap == null) return { kind: "debut" };
+  return { kind: "count", value: args.gap };
+}
+
+/**
+ * True when this row's `songId` already appears at an earlier `position`
+ * in the supplied list — i.e., the row is a within-show repeat. Generic
+ * over the row shape; both column factories and the personal pure helpers
+ * use this to drive the ↺ marker.
+ */
+export function isWithinShowRepeat<T extends { id: string; songId: string; position: number }>(
+  rows: ReadonlyArray<T>,
+  current: T,
+): boolean {
+  return rows.some((r) => r.songId === current.songId && r.position < current.position);
+}
+
+/**
+ * Renders a Gap-style cell: ★ for a debut, ↺ for a within-show repeat,
+ * or the numeric gap value otherwise. The two icon labels are passed in
+ * so the gap-chart can say "Debut" / "This Show" while the personal view
+ * says "Your debut" / "Earlier this show" — same visual treatment with
+ * tooltips appropriate to context.
+ */
+export function GapCell({
+  state,
+  debutLabel,
+  thisShowLabel,
+}: {
+  state: GapCellState;
+  debutLabel: string;
+  thisShowLabel: string;
+}) {
+  if (state.kind === "debut") {
+    return <GapIcon icon={<Star className="h-4 w-4 text-content-text-secondary" />} label={debutLabel} />;
+  }
+  if (state.kind === "this-show") {
+    return <GapIcon icon={<RotateCcw className="h-4 w-4 text-content-text-secondary" />} label={thisShowLabel} />;
+  }
+  return <span className="text-content-text-secondary tabular-nums">{state.value}</span>;
+}

--- a/apps/web/app/components/setlist/set-label.test.ts
+++ b/apps/web/app/components/setlist/set-label.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { countDistinctEncores, formatSetLabel } from "./set-label";
+import { compareBySetThenPosition, countDistinctEncores, formatSetLabel, setSortKey } from "./set-label";
 
 describe("formatSetLabel", () => {
   // S-prefixed regular sets drop the "S" because the column header (or
@@ -82,5 +82,74 @@ describe("countDistinctEncores", () => {
   // don't have to pre-normalize input.
   test("normalizes lowercase encore labels for de-duplication", () => {
     expect(countDistinctEncores([{ set: "e1" }, { set: "E1" }])).toBe(1);
+  });
+});
+
+describe("setSortKey", () => {
+  // Soundcheck is the earliest possible "set" — sorts before everything
+  // else so reading top-to-bottom matches the chronological narrative.
+  test("soundcheck sorts before all regular sets", () => {
+    expect(setSortKey("soundcheck")).toBeLessThan(setSortKey("S1"));
+    expect(setSortKey("Soundcheck")).toBeLessThan(setSortKey("S1"));
+  });
+
+  // Set numbering ascends 10/20/30/40 with gaps so future inserts have
+  // room. The relative order is all that matters for callers.
+  test("regular sets S1 → S4 are strictly ascending", () => {
+    expect(setSortKey("S1")).toBeLessThan(setSortKey("S2"));
+    expect(setSortKey("S2")).toBeLessThan(setSortKey("S3"));
+    expect(setSortKey("S3")).toBeLessThan(setSortKey("S4"));
+  });
+
+  // Encores come after every regular set so they cluster at the end of
+  // the table even when sorted by Set.
+  test("every encore sorts after every regular set", () => {
+    expect(setSortKey("S4")).toBeLessThan(setSortKey("E1"));
+    expect(setSortKey("E1")).toBeLessThan(setSortKey("E2"));
+    expect(setSortKey("E2")).toBeLessThan(setSortKey("E3"));
+  });
+
+  // Unknown labels (typos, new schemas we haven't accounted for) sort at
+  // the end so they're visually flagged but don't crash the table.
+  test("unknown labels sort last", () => {
+    expect(setSortKey("???")).toBeGreaterThan(setSortKey("E3"));
+    expect(setSortKey("")).toBeGreaterThan(setSortKey("E3"));
+  });
+});
+
+describe("compareBySetThenPosition", () => {
+  // Primary key is the set bucket: a track in S1 always precedes a track
+  // in S2 regardless of either track's position-within-set.
+  test("sorts by set bucket first", () => {
+    const a = { set: "S1", position: 99 };
+    const b = { set: "S2", position: 1 };
+    expect(compareBySetThenPosition(a, b)).toBeLessThan(0);
+    expect(compareBySetThenPosition(b, a)).toBeGreaterThan(0);
+  });
+
+  // Within the same set, position breaks the tie — restores the canonical
+  // narrative order even after a re-sort on this comparator alone.
+  test("breaks set ties by position", () => {
+    const a = { set: "S1", position: 1 };
+    const b = { set: "S1", position: 5 };
+    expect(compareBySetThenPosition(a, b)).toBeLessThan(0);
+  });
+
+  // Identical set+position is treated as equal — TanStack uses the row's
+  // own id to break further ties downstream.
+  test("returns 0 when set and position match", () => {
+    const a = { set: "E1", position: 3 };
+    const b = { set: "E1", position: 3 };
+    expect(compareBySetThenPosition(a, b)).toBe(0);
+  });
+
+  // Soundcheck → S1 → encores is the full canonical order; the comparator
+  // produces the same result regardless of which two we pick.
+  test("preserves the canonical soundcheck → S* → E* order", () => {
+    const sc = { set: "soundcheck", position: 1 };
+    const s2 = { set: "S2", position: 1 };
+    const e1 = { set: "E1", position: 1 };
+    expect(compareBySetThenPosition(sc, s2)).toBeLessThan(0);
+    expect(compareBySetThenPosition(s2, e1)).toBeLessThan(0);
   });
 });

--- a/apps/web/app/components/setlist/set-label.ts
+++ b/apps/web/app/components/setlist/set-label.ts
@@ -32,3 +32,33 @@ export function countDistinctEncores(rows: ReadonlyArray<{ set: string }>): numb
   }
   return encores.size;
 }
+
+/**
+ * Numeric sort key for a set label so callers can sort tracks by canonical
+ * narrative order: soundcheck first, then S1..S4, then E1..E3, unknowns
+ * last. Pairs with {@link compareBySetThenPosition} for full row ordering.
+ */
+export function setSortKey(label: string): number {
+  const upper = label.toUpperCase();
+  if (label.toLowerCase() === "soundcheck") return 0;
+  if (upper === "S1") return 10;
+  if (upper === "S2") return 20;
+  if (upper === "S3") return 30;
+  if (upper === "S4") return 40;
+  if (upper === "E1") return 50;
+  if (upper === "E2") return 60;
+  if (upper === "E3") return 70;
+  return 999;
+}
+
+/**
+ * Sort comparator for any track-like row: order by set bucket first, then
+ * by track position within the set. Generic over the row shape so it works
+ * for both `SetlistTableRow` (gap chart) and `PersonalSetlistTableRow`
+ * (personal gap chart) — anything with `{set, position}`.
+ */
+export function compareBySetThenPosition<T extends { set: string; position: number }>(a: T, b: T): number {
+  const setDiff = setSortKey(a.set) - setSortKey(b.set);
+  if (setDiff !== 0) return setDiff;
+  return a.position - b.position;
+}

--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -87,6 +87,7 @@ function makeSetlist(overrides: { showDate?: string } = {}): SetlistLight {
     annotations: [],
     averageSongGap: null,
     medianSongGap: null,
+    debutCount: 0,
   };
 }
 
@@ -257,7 +258,7 @@ describe("SetlistCard", () => {
     await user.click(screen.getByRole("button", { name: /gap chart/i }));
     // Average gap formats to one decimal place — terse, matches the rest
     // of the rarity stat presentation on the song-detail page.
-    expect(screen.getByText(/Average \/ Median song gap:\s*7\.5\s*\/\s*6\.0/)).toBeInTheDocument();
+    expect(screen.getByText(/Average \/ median song gap:\s*7\.5\s*\/\s*6\.0/)).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Last Played" })).toBeInTheDocument();
   });
 
@@ -273,7 +274,7 @@ describe("SetlistCard", () => {
         showRating={null}
       />,
     );
-    const summary = screen.getByText(/Average \/ Median song gap:\s*7\.5\s*\/\s*6\.0/);
+    const summary = screen.getByText(/Average \/ median song gap:\s*7\.5\s*\/\s*6\.0/);
     const trackText = screen.getByText("Basis for a Day");
     // DOM order: track text comes before the summary line. compareDocumentPosition
     // returns DOCUMENT_POSITION_FOLLOWING (4) when `summary` follows `trackText`.

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -12,11 +12,12 @@ import { useAttendanceMutation } from "~/hooks/use-show-user-data";
 import { cn } from "~/lib/utils";
 import { AnniversaryBadge } from "./anniversary-badge";
 import { SetlistTable } from "./setlist-table";
-import { SetlistViewControl } from "./setlist-view-control";
+import { SetlistTablePersonal } from "./setlist-table-personal";
+import { SetlistViewControl, type SetlistViewSummary } from "./setlist-view-control";
 import { ShowExternalBadges, type ShowExternalSources } from "./show-external-badges";
 import { TrackRatingOverlay } from "./track-rating-overlay";
 
-export type SetlistView = "setlist" | "gap-chart";
+export type SetlistView = "setlist" | "gap-chart" | "personal";
 
 interface SetlistCardProps {
   setlist: Setlist | SetlistLight;
@@ -60,6 +61,27 @@ function SetlistCardComponent({
     onViewChange?.(next);
   }
   const { user } = useSession();
+  const [personalSummary, setPersonalSummary] = useState<{
+    average: number | null;
+    median: number | null;
+    debutCount: number;
+  }>({ average: null, median: null, debutCount: 0 });
+
+  // Pre-build the two summary shapes so the SetlistViewControl call sites
+  // stay one-liners. The catalog summary is server-computed; the personal
+  // summary is hoisted from SetlistTablePersonal via onSummaryChange.
+  const catalogSummary: SetlistViewSummary = {
+    label: "Average / median song gap",
+    average: setlist.averageSongGap,
+    median: setlist.medianSongGap,
+    debutCount: setlist.debutCount,
+  };
+  const personalSummaryView: SetlistViewSummary = {
+    label: "Your average / median song gap",
+    average: personalSummary.average,
+    median: personalSummary.median,
+    debutCount: personalSummary.debutCount,
+  };
   const [displayedRating, setDisplayedRating] = useState<number>(showRating ?? setlist.show.averageRating ?? 0);
   const [displayedCount, setDisplayedCount] = useState<number>(setlist.show.ratingsCount ?? 0);
   const [isRatingAnimating, setIsRatingAnimating] = useState(false);
@@ -346,10 +368,19 @@ function SetlistCardComponent({
                 <SetlistViewControl
                   view={view}
                   onChange={changeView}
-                  averageSongGap={setlist.averageSongGap}
-                  medianSongGap={setlist.medianSongGap}
+                  summary={catalogSummary}
+                  showPersonal={Boolean(user)}
                 />
                 <SetlistTable tracks={setlist.sets.flatMap((s) => s.tracks)} />
+              </div>
+            ) : view === "personal" && user ? (
+              <div className="space-y-2">
+                <SetlistViewControl view={view} onChange={changeView} summary={personalSummaryView} showPersonal />
+                <SetlistTablePersonal
+                  tracks={setlist.sets.flatMap((s) => s.tracks)}
+                  showDate={setlist.show.date}
+                  onSummaryChange={setPersonalSummary}
+                />
               </div>
             ) : (
               <>
@@ -411,8 +442,8 @@ function SetlistCardComponent({
                   <SetlistViewControl
                     view={view}
                     onChange={changeView}
-                    averageSongGap={setlist.averageSongGap}
-                    medianSongGap={setlist.medianSongGap}
+                    summary={catalogSummary}
+                    showPersonal={Boolean(user)}
                   />
                 </div>
               </>

--- a/apps/web/app/components/setlist/setlist-columns-personal.tsx
+++ b/apps/web/app/components/setlist/setlist-columns-personal.tsx
@@ -1,0 +1,54 @@
+import type { TrackLight } from "@bip/domain";
+import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
+import { SortableHeader } from "~/components/ui/sortable-header";
+import type { PersonalSetlistRow } from "~/lib/personal-setlist-columns";
+import { createGapColumn, createSetlistCommonColumns, createShowDateLinkColumn } from "./setlist-common-columns";
+
+export type PersonalSetlistTableRow = TrackLight & { personal: PersonalSetlistRow };
+
+/**
+ * Columns for the SetlistCard "personal gap chart" view. Order is
+ * [Set, Track #, Song, Your Gap, Last Seen, Seen]. The first three come
+ * from the shared `createSetlistCommonColumns` helper (with the song link
+ * routed to the user's attended-filtered detail view); this factory adds
+ * the user-history columns. "Last Seen" shows the user's most recent
+ * attended performance **strictly before** the current show's date.
+ */
+export function createPersonalSetlistColumns(): ColumnDef<PersonalSetlistTableRow, unknown>[] {
+  return [
+    ...createSetlistCommonColumns<PersonalSetlistTableRow>({ songLinkSearchParams: "attended=attended" }),
+    createGapColumn<PersonalSetlistTableRow>({
+      id: "yourGap",
+      label: "Your Gap",
+      width: "60px",
+      state: (row) => row.personal.yourGap,
+      debutLabel: "Your debut",
+      thisShowLabel: "Earlier this show",
+    }),
+    createShowDateLinkColumn<PersonalSetlistTableRow>({
+      id: "lastSeen",
+      label: "Last Seen",
+      accessor: (row) => row.personal.lastSeen,
+      width: "124px",
+      hideOnMobile: true,
+    }),
+    createSeenCountColumn(),
+  ];
+}
+
+/**
+ * "Seen Before" column — count of attended performances strictly before
+ * this show. Inline factory because no other column shares this shape.
+ */
+function createSeenCountColumn(): ColumnDef<PersonalSetlistTableRow, unknown> {
+  const columnHelper = createColumnHelper<PersonalSetlistTableRow>();
+  return columnHelper.accessor((row) => row.personal.totalTimesSeen, {
+    id: "totalTimesSeen",
+    header: ({ column }) => <SortableHeader column={column} label="Seen Before" />,
+    meta: { width: "92px" },
+    enableSorting: true,
+    sortingFn: "basic",
+    sortDescFirst: false,
+    cell: (info) => <span className="text-content-text-secondary tabular-nums">{info.getValue() as number}</span>,
+  }) as ColumnDef<PersonalSetlistTableRow, unknown>;
+}

--- a/apps/web/app/components/setlist/setlist-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.tsx
@@ -1,9 +1,7 @@
 import type { TrackLight } from "@bip/domain";
-import { type Column, type ColumnDef, createColumnHelper } from "@tanstack/react-table";
-import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon, RotateCcw, Star } from "lucide-react";
-import { GapIcon } from "~/components/gap-icon";
-import { ShowDate } from "~/components/show-date";
-import { countDistinctEncores, formatSetLabel } from "./set-label";
+import type { ColumnDef } from "@tanstack/react-table";
+import { buildGapCellState, isWithinShowRepeat } from "./gap-cell";
+import { createGapColumn, createSetlistCommonColumns, createShowDateLinkColumn } from "./setlist-common-columns";
 
 /**
  * Row shape consumed by the gap-chart table. Narrowed from the full Setlist
@@ -13,184 +11,27 @@ import { countDistinctEncores, formatSetLabel } from "./set-label";
 export type SetlistTableRow = TrackLight;
 
 /**
- * Numeric sort key for a set label. Mirrors the server-side composer so the
- * client default sort matches the order the loader already produced. Sets
- * before encores; soundcheck before everything; unknowns at the end.
- */
-function setSortKey(label: string): number {
-  const upper = label.toUpperCase();
-  if (label.toLowerCase() === "soundcheck") return 0;
-  if (upper === "S1") return 10;
-  if (upper === "S2") return 20;
-  if (upper === "S3") return 30;
-  if (upper === "S4") return 40;
-  if (upper === "E1") return 50;
-  if (upper === "E2") return 60;
-  if (upper === "E3") return 70;
-  return 999;
-}
-
-/**
- * Sort comparator shared by the Set and Track columns. Both produce the
- * same ordering — set bucket first, then track position within the set —
- * because sorting on either should restore the canonical narrative order
- * the composer already returns.
- */
-function compareBySetThenPosition(a: SetlistTableRow, b: SetlistTableRow): number {
-  const setDiff = setSortKey(a.set) - setSortKey(b.set);
-  if (setDiff !== 0) return setDiff;
-  return a.position - b.position;
-}
-
-function SortableHeader({ column, label }: { column: Column<SetlistTableRow, unknown>; label: string }) {
-  if (!column.getCanSort()) return <span>{label}</span>;
-  return (
-    <button
-      type="button"
-      className="cursor-pointer select-none hover:text-content-text-primary text-left"
-      onClick={() => column.toggleSorting()}
-    >
-      <span className={column.getIsSorted() ? "text-content-text-primary font-semibold" : ""}>{label}</span>
-      <span className={column.getIsSorted() ? "text-brand-primary ml-1" : "ml-1"}>
-        {column.getIsSorted() === "asc" ? (
-          <ArrowUpIcon className="h-4 w-4 inline" />
-        ) : column.getIsSorted() === "desc" ? (
-          <ArrowDownIcon className="h-4 w-4 inline" />
-        ) : (
-          <ArrowUpDown className="h-4 w-4 inline" />
-        )}
-      </span>
-    </button>
-  );
-}
-
-/**
  * Columns for the SetlistCard "gap chart" view. Order is locked at
- * [Set, Track #, Song, Gap, Last Played]. Within-show repeats are detected
- * from the row's table context — a track whose songId already appeared at
- * an earlier position in the same render.
+ * [Set, Track #, Song, Gap, Last Played]. The first three come from the
+ * shared `createSetlistCommonColumns` helper; this factory adds the
+ * gap-chart-specific Gap and Last Played columns.
  */
 export function createSetlistColumns(): ColumnDef<SetlistTableRow, unknown>[] {
-  const columnHelper = createColumnHelper<SetlistTableRow>();
-
   return [
-    columnHelper.accessor("set", {
-      id: "set",
-      header: ({ column }) => <SortableHeader column={column} label="Set" />,
-      meta: { width: "48px" },
-      enableSorting: true,
-      sortingFn: (a, b) => compareBySetThenPosition(a.original, b.original),
-      cell: (info) => {
-        const raw = info.getValue();
-        const encoresInSet = countDistinctEncores(info.table.getCoreRowModel().rows.map((r) => r.original));
-        // When the active sort IS the Set column, runs of same-set rows
-        // cluster together — show the label only on the first row of each
-        // run so the grouping is visually obvious. Other sorts (Gap, Last
-        // Played) interleave sets and need every row labeled.
-        const sorting = info.table.getState().sorting;
-        const groupBySet = sorting.length > 0 && sorting[0].id === "set";
-        if (groupBySet) {
-          const sortedRows = info.table.getSortedRowModel().rows;
-          const idx = sortedRows.findIndex((r) => r.id === info.row.id);
-          if (idx > 0 && sortedRows[idx - 1].original.set === info.row.original.set) {
-            return null;
-          }
-        }
-        return <span className="text-content-text-secondary">{formatSetLabel(raw, { encoresInSet })}</span>;
-      },
-    }) as ColumnDef<SetlistTableRow, unknown>,
-    columnHelper.display({
-      id: "track",
-      header: ({ column }) => <SortableHeader column={column} label="Track" />,
-      // Drops on narrow viewports — the Set column already orients the row,
-      // and a tiny "Track #" column would steal width from Song on mobile.
-      meta: { width: "56px", hideOnMobile: true },
-      enableSorting: true,
-      // Track # = position-within-set, computed at render time from the
-      // unsorted row model. The comparator falls through to the same
-      // set+position order as the Set column, so sorting either restores
-      // the canonical narrative.
-      sortingFn: (a, b) => compareBySetThenPosition(a.original, b.original),
-      cell: (info) => {
-        const row = info.row.original;
-        const allRows = info.table.getCoreRowModel().rows;
-        const trackNumber =
-          allRows.filter((r) => r.original.set === row.set && r.original.position < row.position).length + 1;
-        return <span className="text-content-text-secondary tabular-nums">{trackNumber}</span>;
-      },
-    }) as ColumnDef<SetlistTableRow, unknown>,
-    columnHelper.accessor((row) => row.song?.title ?? "", {
-      id: "song",
-      header: "Song",
-      enableSorting: false,
-      cell: (info) => {
-        const title = info.getValue() as string;
-        const slug = info.row.original.song?.slug;
-        const segue = info.row.original.segue;
-        const titleNode = slug ? (
-          <a href={`/songs/${slug}`} className="text-base text-brand-primary hover:text-brand-secondary font-medium">
-            {title}
-          </a>
-        ) : (
-          <span className="text-content-text-secondary">{title}</span>
-        );
-        // Preserve the flow view's segue marker so "Tractorbeam > Above the
-        // Waves" still reads as a continuous run inside the table.
-        return (
-          <>
-            {titleNode}
-            {segue && <span className="text-content-text-secondary ml-1 font-medium">&gt;</span>}
-          </>
-        );
-      },
-    }) as ColumnDef<SetlistTableRow, unknown>,
-    columnHelper.accessor((row) => row.gap ?? Number.POSITIVE_INFINITY, {
+    ...createSetlistCommonColumns<SetlistTableRow>(),
+    createGapColumn<SetlistTableRow>({
       id: "gap",
-      header: ({ column }) => <SortableHeader column={column} label="Gap" />,
-      meta: { width: "64px" },
-      enableSorting: true,
-      // Numeric ascending; debuts (gap=null) become +∞ so they cluster at
-      // the end on asc and at the start on desc. Within-show repeats share
-      // their first occurrence's gap value — sort treats them as equal and
-      // the icon (not the value) tells the story per row.
-      sortingFn: "basic",
-      // First click sorts ascending. TanStack auto-flips to desc-first for
-      // numeric accessors; force asc so "smallest gap first" matches the
-      // mental model "what was the rarest play in this show."
-      sortDescFirst: false,
-      cell: (info) => {
-        const row = info.row.original;
-        const allRows = info.table.getCoreRowModel().rows;
-        const isRepeat = allRows.some(
-          (other) => other.original.songId === row.songId && other.original.position < row.position,
-        );
-        if (isRepeat) {
-          return <GapIcon icon={<RotateCcw className="h-4 w-4 text-content-text-secondary" />} label="This Show" />;
-        }
-        if (row.gap == null) {
-          return <GapIcon icon={<Star className="h-4 w-4 text-content-text-secondary" />} label="Debut" />;
-        }
-        return <span className="text-content-text-secondary tabular-nums">{row.gap}</span>;
-      },
-    }) as ColumnDef<SetlistTableRow, unknown>,
-    columnHelper.accessor((row) => row.previousPerformanceShow?.date ?? "", {
+      label: "Gap",
+      width: "64px",
+      state: (row, allRows) => buildGapCellState({ isRepeat: isWithinShowRepeat(allRows, row), gap: row.gap }),
+      debutLabel: "Debut",
+      thisShowLabel: "This Show",
+    }),
+    createShowDateLinkColumn<SetlistTableRow>({
       id: "lastPlayed",
-      header: ({ column }) => <SortableHeader column={column} label="Last Played" />,
-      meta: { width: "140px" },
-      enableSorting: true,
-      // YYYY-MM-DD strings sort lexicographically the same as chronologically,
-      // so the default alphanumeric comparator is correct here. Empty strings
-      // (debuts) sort to the start ascending, end descending.
-      sortingFn: "alphanumeric",
-      cell: (info) => {
-        const prev = info.row.original.previousPerformanceShow;
-        if (!prev) return <span className="text-content-text-tertiary">—</span>;
-        return (
-          <a href={`/shows/${prev.slug}`} className="text-base text-brand-primary hover:text-brand-secondary">
-            <ShowDate date={prev.date} />
-          </a>
-        );
-      },
-    }) as ColumnDef<SetlistTableRow, unknown>,
+      label: "Last Played",
+      accessor: (row) => row.previousPerformanceShow,
+      width: "140px",
+    }),
   ];
 }

--- a/apps/web/app/components/setlist/setlist-common-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-common-columns.tsx
@@ -1,0 +1,171 @@
+import type { TrackLight } from "@bip/domain";
+import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
+import { ShowDateLink } from "~/components/show-date-link";
+import { SortableHeader } from "~/components/ui/sortable-header";
+import { GapCell, type GapCellState } from "./gap-cell";
+import { compareBySetThenPosition, countDistinctEncores, formatSetLabel } from "./set-label";
+
+/**
+ * Set, Track, and Song columns are identical across every SetlistCard
+ * table view (gap chart, personal gap chart, and anything we add later).
+ * Centralize them here so the per-view column factories can focus on
+ * what's actually different (rarity stats, user-history columns, etc.).
+ *
+ * Generic over the concrete row type because callers attach extra fields
+ * (e.g., `personal` on PersonalSetlistTableRow) — every row must still
+ * extend TrackLight so the column accessors can read `set`/`position`/`song`.
+ */
+/**
+ * Date-with-link column factory used by both view's "last X" columns —
+ * gap-chart's "Last Played" and personal's "Last Seen". Centralizes the
+ * accessor → header → ShowDateLink cell shape so the two call sites
+ * differ only in id/label/width/visibility.
+ */
+export function createShowDateLinkColumn<T>(opts: {
+  id: string;
+  label: string;
+  accessor: (row: T) => { date: string; slug: string | null } | null | undefined;
+  width: string;
+  hideOnMobile?: boolean;
+}): ColumnDef<T, unknown> {
+  const columnHelper = createColumnHelper<T>();
+  return columnHelper.accessor((row) => opts.accessor(row)?.date ?? "", {
+    id: opts.id,
+    header: ({ column }) => <SortableHeader column={column} label={opts.label} />,
+    meta: opts.hideOnMobile ? { width: opts.width, hideOnMobile: true } : { width: opts.width },
+    enableSorting: true,
+    // ISO YYYY-MM-DD strings sort lexicographically the same as
+    // chronologically. Empty strings (no prior performance) sort first asc
+    // and last desc — matches what users expect for "—" rows.
+    sortingFn: "alphanumeric",
+    cell: (info) => <ShowDateLink show={opts.accessor(info.row.original)} />,
+  }) as ColumnDef<T, unknown>;
+}
+
+/**
+ * Gap-style column factory used by both view's gap columns — gap-chart's
+ * "Gap" and personal's "Your Gap". The caller supplies the row-level
+ * state derivation (since the catalog reads from `Track.gap` + repeat
+ * detection while personal reads a pre-computed discriminator) and the
+ * tooltip labels; the column shape (header, width, sort, GapCell render)
+ * is the same on both sides.
+ */
+export function createGapColumn<T>(opts: {
+  id: string;
+  label: string;
+  width: string;
+  /** Row-level state — must be stable per row so sort + cell agree. */
+  state: (row: T, allRows: ReadonlyArray<T>) => GapCellState;
+  debutLabel: string;
+  thisShowLabel: string;
+}): ColumnDef<T, unknown> {
+  const columnHelper = createColumnHelper<T>();
+  // Sort accessor pulls the row's state once and turns non-count states
+  // into +Infinity so debut/this-show rows cluster at the end on asc.
+  return columnHelper.accessor(
+    (row) => {
+      // The accessor doesn't have allRows in scope; non-count states are
+      // intrinsic to the row so pass an empty list — within-show-repeat
+      // detection isn't needed for sorting either side's column.
+      const s = opts.state(row, []);
+      return s.kind === "count" ? s.value : Number.POSITIVE_INFINITY;
+    },
+    {
+      id: opts.id,
+      header: ({ column }) => <SortableHeader column={column} label={opts.label} />,
+      meta: { width: opts.width },
+      enableSorting: true,
+      sortingFn: "basic",
+      // First click sorts ascending — "smallest gap first" matches the
+      // mental model "what was the rarest play."
+      sortDescFirst: false,
+      cell: (info) => {
+        const allRows = info.table.getCoreRowModel().rows.map((r) => r.original);
+        const state = opts.state(info.row.original, allRows);
+        return <GapCell state={state} debutLabel={opts.debutLabel} thisShowLabel={opts.thisShowLabel} />;
+      },
+    },
+  ) as ColumnDef<T, unknown>;
+}
+
+export function createSetlistCommonColumns<T extends TrackLight>(options?: {
+  /** Optional query suffix appended to every Song-cell `/songs/{slug}` link. */
+  songLinkSearchParams?: string;
+}): ColumnDef<T, unknown>[] {
+  const columnHelper = createColumnHelper<T>();
+  const songLinkSuffix = options?.songLinkSearchParams ? `?${options.songLinkSearchParams}` : "";
+
+  return [
+    columnHelper.accessor((row) => row.set, {
+      id: "set",
+      header: ({ column }) => <SortableHeader column={column} label="Set" />,
+      meta: { width: "48px" },
+      enableSorting: true,
+      sortingFn: (a, b) => compareBySetThenPosition(a.original, b.original),
+      cell: (info) => {
+        const raw = info.getValue() as string;
+        const encoresInSet = countDistinctEncores(info.table.getCoreRowModel().rows.map((r) => r.original));
+        // Show the set label only on the first row of a same-set run when
+        // sorted by Set — keeps the grouping visually obvious. Other sorts
+        // interleave sets, so every row keeps its label.
+        const sorting = info.table.getState().sorting;
+        const groupBySet = sorting.length > 0 && sorting[0].id === "set";
+        if (groupBySet) {
+          const sortedRows = info.table.getSortedRowModel().rows;
+          const idx = sortedRows.findIndex((r) => r.id === info.row.id);
+          if (idx > 0 && sortedRows[idx - 1].original.set === info.row.original.set) {
+            return null;
+          }
+        }
+        return <span className="text-content-text-secondary">{formatSetLabel(raw, { encoresInSet })}</span>;
+      },
+    }) as ColumnDef<T, unknown>,
+    columnHelper.display({
+      id: "track",
+      header: ({ column }) => <SortableHeader column={column} label="Track" />,
+      // Drops on narrow viewports — the Set column already orients the row,
+      // and a tiny Track column would steal width from Song on mobile.
+      meta: { width: "56px", hideOnMobile: true },
+      enableSorting: true,
+      // Track # = position-within-set, computed at render time from the
+      // unsorted row model. The comparator falls through to the canonical
+      // set+position order so sorting either restores narrative order.
+      sortingFn: (a, b) => compareBySetThenPosition(a.original, b.original),
+      cell: (info) => {
+        const row = info.row.original;
+        const allRows = info.table.getCoreRowModel().rows;
+        const trackNumber =
+          allRows.filter((r) => r.original.set === row.set && r.original.position < row.position).length + 1;
+        return <span className="text-content-text-secondary tabular-nums">{trackNumber}</span>;
+      },
+    }) as ColumnDef<T, unknown>,
+    columnHelper.accessor((row) => row.song?.title ?? "", {
+      id: "song",
+      header: "Song",
+      enableSorting: false,
+      cell: (info) => {
+        const title = info.getValue() as string;
+        const slug = info.row.original.song?.slug;
+        const segue = info.row.original.segue;
+        const titleNode = slug ? (
+          <a
+            href={`/songs/${slug}${songLinkSuffix}`}
+            className="text-base text-brand-primary hover:text-brand-secondary font-medium"
+          >
+            {title}
+          </a>
+        ) : (
+          <span className="text-content-text-secondary">{title}</span>
+        );
+        // Preserve the flow view's segue marker so "Tractorbeam > Above
+        // the Waves" still reads as a continuous run inside the table.
+        return (
+          <>
+            {titleNode}
+            {segue && <span className="text-content-text-secondary ml-1 font-medium">&gt;</span>}
+          </>
+        );
+      },
+    }) as ColumnDef<T, unknown>,
+  ];
+}

--- a/apps/web/app/components/setlist/setlist-list.test.tsx
+++ b/apps/web/app/components/setlist/setlist-list.test.tsx
@@ -84,6 +84,7 @@ function makeSetlist(id: string, title: string, averageRating: number | null = 4
     annotations: [],
     averageSongGap: null,
     medianSongGap: null,
+    debutCount: 0,
   };
 }
 

--- a/apps/web/app/components/setlist/setlist-table-personal.test.tsx
+++ b/apps/web/app/components/setlist/setlist-table-personal.test.tsx
@@ -1,0 +1,117 @@
+import type { TrackLight } from "@bip/domain";
+import { setupWithRouter } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+// Stub the React Query hook with a fixed payload so the table renders
+// synchronously with known per-song attendance data. This is the same
+// shape the server endpoint returns.
+vi.mock("~/hooks/use-personal-song-history", () => ({
+  usePersonalSongHistory: () => ({
+    data: {
+      attendedShows: [
+        { date: "2018-04-15", slug: "2018-04-15-radio-city" },
+        { date: "2020-06-10", slug: "2020-06-10-port-chester" },
+        { date: "2024-07-19", slug: "2024-07-19-camden" },
+      ],
+      songAttendances: {
+        // Tractorbeam: seen twice, last on 2020-06-10 before this show
+        "song-tractorbeam": [
+          { date: "2018-04-15", slug: "2018-04-15-radio-city" },
+          { date: "2020-06-10", slug: "2020-06-10-port-chester" },
+        ],
+        // Mr. Don: never seen → renders Debut ★
+      },
+    },
+    isLoading: false,
+  }),
+}));
+
+const { SetlistTablePersonal } = await import("./setlist-table-personal");
+
+function makeTrack(overrides: Partial<TrackLight> & { id: string; songId: string; position: number }): TrackLight {
+  return {
+    id: overrides.id,
+    showId: "show-current",
+    songId: overrides.songId,
+    set: overrides.set ?? "S1",
+    position: overrides.position,
+    segue: null,
+    likesCount: 0,
+    note: null,
+    allTimer: false,
+    averageRating: null,
+    ratingsCount: 0,
+    gap: null,
+    previousPerformanceShowId: null,
+    previousPerformanceShow: null,
+    song: overrides.song ?? { id: overrides.songId, title: "Tractorbeam", slug: "tractorbeam" },
+  };
+}
+
+describe("SetlistTablePersonal", () => {
+  // Personal columns render the correct icon per row state: a song the
+  // user has seen before renders a numeric gap; a song they've never seen
+  // renders ★ "Your debut"; a repeat earlier in the same show renders ↺.
+  test("renders ★ for personal debut, ↺ for within-show repeat, numeric gap otherwise", async () => {
+    await setupWithRouter(
+      <SetlistTablePersonal
+        showDate="2024-07-19"
+        tracks={[
+          makeTrack({
+            id: "t1",
+            songId: "song-tractorbeam",
+            position: 1,
+            song: { id: "song-tractorbeam", title: "Tractorbeam", slug: "tractorbeam" },
+          }),
+          makeTrack({
+            id: "t2",
+            songId: "song-mrdon",
+            position: 2,
+            song: { id: "song-mrdon", title: "Mr. Don", slug: "mr-don" },
+          }),
+          // Tractorbeam played a second time later in the same show — ↺
+          makeTrack({
+            id: "t3",
+            songId: "song-tractorbeam",
+            position: 6,
+            set: "S2",
+            song: { id: "song-tractorbeam", title: "Tractorbeam", slug: "tractorbeam" },
+          }),
+        ]}
+      />,
+    );
+
+    // Debut row shows the "Your debut" icon
+    expect(screen.getByLabelText("Your debut")).toBeInTheDocument();
+    // Within-show repeat row shows the "Earlier this show" icon
+    expect(screen.getByLabelText("Earlier this show")).toBeInTheDocument();
+    // Numeric gap renders the bare value (no "show/shows" suffix) so the
+    // column matches the gap-chart visual treatment. Two "0" cells expected:
+    // Tractorbeam's Your Gap (lastBefore == 2020-06-10, no attended dates
+    // strictly between) and Mr. Don's Total Times Seen.
+    expect(screen.getAllByRole("cell", { name: "0" })).toHaveLength(2);
+  });
+
+  // Calls back to the parent with the computed average + median so the
+  // parent can render the summary on the same row as the toggle. The
+  // tracks used here all resolve to numeric gaps (no debuts/repeats).
+  test("invokes onSummaryChange with computed average + median", async () => {
+    const onSummaryChange = vi.fn();
+    await setupWithRouter(
+      <SetlistTablePersonal
+        showDate="2024-07-19"
+        tracks={[
+          makeTrack({
+            id: "t1",
+            songId: "song-tractorbeam",
+            position: 1,
+            song: { id: "song-tractorbeam", title: "Tractorbeam", slug: "tractorbeam" },
+          }),
+        ]}
+        onSummaryChange={onSummaryChange}
+      />,
+    );
+    expect(onSummaryChange).toHaveBeenCalledWith({ average: 0, median: 0, debutCount: 0 });
+  });
+});

--- a/apps/web/app/components/setlist/setlist-table-personal.tsx
+++ b/apps/web/app/components/setlist/setlist-table-personal.tsx
@@ -1,0 +1,88 @@
+import { average, median, type TrackLight } from "@bip/domain";
+import { useEffect, useMemo } from "react";
+import { DataTable } from "~/components/ui/data-table";
+import { usePersonalSongHistory } from "~/hooks/use-personal-song-history";
+import { computePersonalRow, eligiblePersonalGaps, type PersonalSetlistRow } from "~/lib/personal-setlist-columns";
+import { createPersonalSetlistColumns, type PersonalSetlistTableRow } from "./setlist-columns-personal";
+
+interface SetlistTablePersonalProps {
+  tracks: TrackLight[];
+  showDate: string;
+  onSummaryChange?: (summary: { average: number | null; median: number | null; debutCount: number }) => void;
+}
+
+/**
+ * Per-user "personal" view of a setlist. Looks up the viewer's full
+ * attendance + per-song history from React Query (lazy, one fetch per
+ * session), then computes Total Times Seen / Last Seen / Last Before /
+ * Your Gap for each track via the pure helpers in personal-setlist-columns.
+ *
+ * `onSummaryChange` lets the parent SetlistCard hoist the average/median
+ * up to its SetlistViewControl so the summary text stays on the same row
+ * as the toggle — matches the gap-chart layout.
+ */
+export function SetlistTablePersonal({ tracks, showDate, onSummaryChange }: SetlistTablePersonalProps) {
+  const { data, isLoading } = usePersonalSongHistory();
+
+  const setlistTracks = useMemo(
+    () => tracks.map((t) => ({ id: t.id, songId: t.songId, set: t.set, position: t.position })),
+    [tracks],
+  );
+
+  const rows: PersonalSetlistTableRow[] = useMemo(() => {
+    return tracks.map((track) => {
+      const personal: PersonalSetlistRow = computePersonalRow({
+        track: { id: track.id, songId: track.songId, set: track.set, position: track.position },
+        showDate,
+        setlistTracks,
+        songAttendances: data.songAttendances[track.songId] ?? [],
+        attendedShows: data.attendedShows,
+      });
+      return { ...track, personal };
+    });
+  }, [tracks, data, setlistTracks, showDate]);
+
+  const columns = useMemo(() => createPersonalSetlistColumns(), []);
+
+  // Hoist the summary up to the parent so it can render alongside the
+  // toggle. useMemo + useEffect-like trigger via stable identity: compute
+  // here, but only invoke the callback when values change.
+  const summary = useMemo(() => {
+    const personals = rows.map((r) => r.personal);
+    const eligible = eligiblePersonalGaps(personals);
+    // Count distinct personal debuts — the pure helper marks the first
+    // occurrence as `debut` and within-show repeats as `this-show`, so a
+    // simple kind-check already dedupes.
+    const debutCount = personals.filter((p) => p.yourGap.kind === "debut").length;
+    return {
+      average: average(eligible),
+      median: median(eligible),
+      debutCount,
+    };
+  }, [rows]);
+
+  // Notify the parent whenever the computed summary changes so it can
+  // render alongside the toggle. Depending on the value triple gives a
+  // stable dep set without creating a new object identity per render.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: depend on the value triple, not the callback identity
+  useEffect(() => {
+    onSummaryChange?.(summary);
+  }, [summary.average, summary.median, summary.debutCount]);
+
+  if (isLoading && data.attendedShows.length === 0) {
+    return (
+      <div className="text-sm text-content-text-tertiary py-4 text-center">Loading your personal setlist view…</div>
+    );
+  }
+
+  return (
+    <DataTable
+      columns={columns}
+      data={rows}
+      hideSearch
+      hidePagination
+      hidePaginationText
+      initialSorting={[{ id: "set", desc: false }]}
+    />
+  );
+}

--- a/apps/web/app/components/setlist/setlist-view-control.test.tsx
+++ b/apps/web/app/components/setlist/setlist-view-control.test.tsx
@@ -1,0 +1,86 @@
+import { setupWithRouter } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { SetlistViewControl, type SetlistViewSummary } from "./setlist-view-control";
+
+/** Compact summary builder for tests — sane defaults, override what matters. */
+function summary(overrides: Partial<SetlistViewSummary> = {}): SetlistViewSummary {
+  return { label: "Average / median song gap", average: null, median: null, debutCount: 0, ...overrides };
+}
+
+describe("SetlistViewControl", () => {
+  // The "personal" segment is per-user data, so it must be hidden when no
+  // user is logged in. Renders setlist + gap-chart only.
+  test("does not render the 'personal' segment when showPersonal is false", async () => {
+    await setupWithRouter(<SetlistViewControl view="setlist" onChange={vi.fn()} showPersonal={false} />);
+    expect(screen.getByRole("button", { name: "setlist" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "gap chart" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "personal gap chart" })).not.toBeInTheDocument();
+  });
+
+  // Logged-in users see the third segment alongside the other two.
+  test("renders the 'personal' segment when showPersonal is true", async () => {
+    await setupWithRouter(<SetlistViewControl view="setlist" onChange={vi.fn()} showPersonal={true} />);
+    expect(screen.getByRole("button", { name: "personal gap chart" })).toBeInTheDocument();
+  });
+
+  // Debut suffix: when debutCount > 0 the summary appends `· N debuts`
+  // (or `· 1 debut` singular). Debuts aren't included in avg/median —
+  // surfacing the count keeps the rarity signal intact.
+  test("appends '· N debuts' to the summary when debutCount > 0", async () => {
+    await setupWithRouter(
+      <SetlistViewControl
+        view="gap-chart"
+        onChange={vi.fn()}
+        summary={summary({ average: 4.2, median: 3.0, debutCount: 2 })}
+      />,
+    );
+    expect(screen.getByText(/Average \/ median song gap: 4\.2 \/ 3\.0 · 2 debuts/)).toBeInTheDocument();
+  });
+
+  // Singular grammar — `· 1 debut`, not `· 1 debuts`.
+  test("uses singular 'debut' wording when debutCount === 1", async () => {
+    await setupWithRouter(
+      <SetlistViewControl
+        view="gap-chart"
+        onChange={vi.fn()}
+        summary={summary({ average: 4.2, median: 3.0, debutCount: 1 })}
+      />,
+    );
+    expect(screen.getByText(/· 1 debut$/)).toBeInTheDocument();
+  });
+
+  // No avg/median (all-debut show) but debuts present: surface the debut
+  // count alone so the user still sees the rarity signal.
+  test("renders debut count by itself when avg/median are null", async () => {
+    await setupWithRouter(
+      <SetlistViewControl view="gap-chart" onChange={vi.fn()} summary={summary({ debutCount: 3 })} />,
+    );
+    expect(screen.getByText("3 debuts")).toBeInTheDocument();
+    // Neither the "Average / median" prefix nor any numeric value sneaks in.
+    expect(screen.queryByText(/Average/)).not.toBeInTheDocument();
+  });
+
+  // Omitting `summary` hides the summary line entirely — useful while the
+  // personal-view data is still loading.
+  test("hides the summary line entirely when summary is omitted", async () => {
+    await setupWithRouter(<SetlistViewControl view="gap-chart" onChange={vi.fn()} />);
+    expect(screen.queryByText(/song gap/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/debut/i)).not.toBeInTheDocument();
+  });
+
+  // Personal-view caller supplies its own summary with the "Your" label —
+  // the control doesn't branch on view to pick a label any more.
+  test("renders the caller-supplied 'Your' label and values in personal view", async () => {
+    await setupWithRouter(
+      <SetlistViewControl
+        view="personal"
+        onChange={vi.fn()}
+        showPersonal
+        summary={{ label: "Your average / median song gap", average: 6.59, median: 5, debutCount: 2 }}
+      />,
+    );
+    expect(screen.getByText(/Your average \/ median song gap: 6\.6 \/ 5\.0 · 2 debuts/)).toBeInTheDocument();
+    expect(screen.queryByText(/^Average \/ median song gap:/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/setlist/setlist-view-control.tsx
+++ b/apps/web/app/components/setlist/setlist-view-control.tsx
@@ -1,63 +1,108 @@
 import { cn } from "~/lib/utils";
 import type { SetlistView } from "./setlist-card";
 
+/**
+ * Summary line displayed beside the toggle. The caller (SetlistCard) builds
+ * one of these for the active view — catalog stats for setlist/gap-chart,
+ * user-history stats for personal — so the toggle component stays a dumb
+ * renderer without view-specific branching.
+ */
+export interface SetlistViewSummary {
+  /** Prefix text. `"Average / median song gap"` or `"Your average / median song gap"`. */
+  label: string;
+  /** Average gap value. Null when no rows qualify; the line is hidden. */
+  average: number | null;
+  /** Median gap value. Null when no rows qualify; the line is hidden. */
+  median: number | null;
+  /**
+   * Count of debuts. Surfaced as a `· N debut(s)` suffix because debuts are
+   * excluded from avg/median but are themselves a strong rarity signal.
+   */
+  debutCount: number;
+}
+
 interface SetlistViewControlProps {
   view: SetlistView;
   onChange: (next: SetlistView) => void;
-  averageSongGap: number | null;
-  medianSongGap: number | null;
+  /**
+   * When true, renders the third "personal gap chart" segment. Caller
+   * passes Boolean(user) — the option is hidden for anonymous viewers
+   * since the personal-view data is per-user.
+   */
+  showPersonal?: boolean;
+  /**
+   * Computed summary for the active view. Omit to hide the summary line
+   * entirely (e.g. while data is still loading).
+   */
+  summary?: SetlistViewSummary;
 }
 
 /**
- * Toggle for setlist ↔ gap chart, paired on the same row with the
- * "Average song gap" summary so the two pieces of meta-information stay
- * visually grouped. Used both above and below the gap-chart table; the
- * setlist view renders a single instance below the flow text.
+ * Toggle for setlist ↔ gap chart ↔ personal gap chart, paired on the same
+ * row with the active view's "average song gap" summary so toggle and
+ * meta-info stay visually grouped. Used both above and below tabular
+ * views; the flow view renders one instance below the text.
  */
-export function SetlistViewControl({
-  view,
-  onChange,
-  averageSongGap,
-  medianSongGap,
-}: SetlistViewControlProps) {
+export function SetlistViewControl({ view, onChange, showPersonal, summary }: SetlistViewControlProps) {
   return (
     <div className="flex items-center justify-between gap-3 text-sm">
       <div className="inline-flex items-center">
-        <button
-          type="button"
-          aria-pressed={view === "setlist"}
-          onClick={() => onChange("setlist")}
-          className={cn(
-            "px-2 py-1 border-b-2 transition-colors cursor-pointer",
-            view === "setlist"
-              ? "border-brand-primary text-content-text-primary"
-              : "border-transparent text-content-text-tertiary hover:text-content-text-secondary",
-          )}
-        >
-          setlist
-        </button>
-        <button
-          type="button"
-          aria-pressed={view === "gap-chart"}
-          onClick={() => onChange("gap-chart")}
-          className={cn(
-            "px-2 py-1 border-b-2 transition-colors cursor-pointer",
-            view === "gap-chart"
-              ? "border-brand-primary text-content-text-primary"
-              : "border-transparent text-content-text-tertiary hover:text-content-text-secondary",
-          )}
-        >
-          gap chart
-        </button>
+        <SegmentButton view={view} target="setlist" label="setlist" onChange={onChange} />
+        <SegmentButton view={view} target="gap-chart" label="gap chart" onChange={onChange} />
+        {showPersonal && <SegmentButton view={view} target="personal" label="personal gap chart" onChange={onChange} />}
       </div>
-      {averageSongGap !== null && medianSongGap !== null && (
-        // text-right tucks the wrapped numbers under the right edge when
-        // narrow viewports force "Average / Median song gap:" onto its own
-        // line — keeps the numbers anchored where the eye expects them.
-        <span className="text-content-text-secondary text-right">
-          Average / Median song gap: {averageSongGap.toFixed(1)} / {medianSongGap.toFixed(1)}
-        </span>
-      )}
+      {summary && <SummaryLine summary={summary} />}
     </div>
+  );
+}
+
+function SummaryLine({ summary }: { summary: SetlistViewSummary }) {
+  const debutSuffix =
+    summary.debutCount > 0 ? `${summary.debutCount} ${summary.debutCount === 1 ? "debut" : "debuts"}` : "";
+  const { average, median } = summary;
+
+  // text-right tucks the wrapped numbers under the right edge when narrow
+  // viewports force the prefix onto its own line — keeps the numbers
+  // anchored where the eye expects them.
+  if (average !== null && median !== null) {
+    return (
+      <span className="text-content-text-secondary text-right">
+        {summary.label}: {average.toFixed(1)} / {median.toFixed(1)}
+        {debutSuffix && ` · ${debutSuffix}`}
+      </span>
+    );
+  }
+  if (debutSuffix) {
+    return <span className="text-content-text-secondary text-right">{debutSuffix}</span>;
+  }
+  return null;
+}
+
+function SegmentButton({
+  view,
+  target,
+  label,
+  onChange,
+}: {
+  view: SetlistView;
+  target: SetlistView;
+  label: string;
+  onChange: (next: SetlistView) => void;
+}) {
+  const active = view === target;
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={() => onChange(target)}
+      className={cn(
+        "px-2 py-1 border-b-2 transition-colors cursor-pointer",
+        active
+          ? "border-brand-primary text-content-text-primary"
+          : "border-transparent text-content-text-tertiary hover:text-content-text-secondary",
+      )}
+    >
+      {label}
+    </button>
   );
 }

--- a/apps/web/app/components/show-date-link.test.tsx
+++ b/apps/web/app/components/show-date-link.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test } from "vitest";
+import { ShowDateLink } from "./show-date-link";
+
+/** Render ShowDateLink inside a MemoryRouter seeded with a given URL. */
+function renderAtUrl(url: string, show: { date: string; slug: string | null } | null | undefined) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <ShowDateLink show={show} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ShowDateLink", () => {
+  // No show value (null/undefined) renders the em-dash placeholder —
+  // keeps the cell aligned with neighbors in tables.
+  test("renders em-dash when show is null", () => {
+    renderAtUrl("/", null);
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  test("renders em-dash when show is undefined", () => {
+    renderAtUrl("/", undefined);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  // Pre-slug legacy shows have a date but no slug — render the date as
+  // plain text rather than a broken link.
+  test("renders plain date (no link) when slug is null", () => {
+    renderAtUrl("/", { date: "1999-07-18", slug: null });
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.queryByText("—")).not.toBeInTheDocument();
+  });
+
+  // Happy path: slug present, render a link to the show page.
+  test("renders a link to /shows/{slug} when slug is present", () => {
+    renderAtUrl("/", { date: "1999-07-18", slug: "1999-07-18-camden" });
+    expect(screen.getByRole("link").getAttribute("href")).toBe("/shows/1999-07-18-camden");
+  });
+
+  // View preservation: when the current URL has `?view=gap-chart`, the
+  // generated link should keep the user in that view on the destination
+  // page. Same routing helper backs both gap-chart and personal views.
+  test("preserves ?view=gap-chart from the current URL on the link href", () => {
+    renderAtUrl("/shows/foo?view=gap-chart", { date: "1999-07-18", slug: "1999-07-18-camden" });
+    expect(screen.getByRole("link").getAttribute("href")).toBe("/shows/1999-07-18-camden?view=gap-chart");
+  });
+
+  test("preserves ?view=personal from the current URL on the link href", () => {
+    renderAtUrl("/shows/foo?view=personal", { date: "2024-07-19", slug: "2024-07-19-radio-city" });
+    expect(screen.getByRole("link").getAttribute("href")).toBe("/shows/2024-07-19-radio-city?view=personal");
+  });
+
+  // An unrecognized view param (e.g., an old/typoed value) should not
+  // leak into the link — only the two known values are passed through.
+  test("ignores unrecognized ?view= values", () => {
+    renderAtUrl("/shows/foo?view=bogus", { date: "2024-07-19", slug: "2024-07-19-radio-city" });
+    expect(screen.getByRole("link").getAttribute("href")).toBe("/shows/2024-07-19-radio-city");
+  });
+});

--- a/apps/web/app/components/show-date-link.tsx
+++ b/apps/web/app/components/show-date-link.tsx
@@ -1,0 +1,43 @@
+import { useSearchParams } from "react-router-dom";
+import { ShowDate } from "./show-date";
+
+interface ShowDateLinkProps {
+  /**
+   * The show to link to. `null` / `undefined` renders the em-dash
+   * placeholder so the cell stays aligned with neighbors. A row with a
+   * date but no slug (pre-slug legacy data) renders the date as plain
+   * text instead of a broken link.
+   */
+  show: { date: string; slug: string | null } | null | undefined;
+}
+
+/**
+ * Standard cell rendering for a date-that-links-to-a-show. Used wherever
+ * a table column shows a date paired with a slug — gap-chart Last Played,
+ * song-detail performances Last Played, personal-view Last Seen / Last
+ * Before. Empty value is `—` (tertiary), not "Never" or "N/A" — keeps the
+ * visual treatment consistent with the rest of the site's tables.
+ */
+export function ShowDateLink({ show }: ShowDateLinkProps) {
+  // Preserve the current SetlistCard view (gap-chart / personal) when
+  // navigating to another show — keeps the user in the tab they were
+  // already reading instead of dumping them back into the default flow
+  // view. No-op on pages without `?view=`.
+  const [searchParams] = useSearchParams();
+  const view = searchParams.get("view");
+  const suffix = view === "gap-chart" || view === "personal" ? `?view=${view}` : "";
+
+  if (!show) return <span className="text-content-text-tertiary">—</span>;
+  if (!show.slug) {
+    return (
+      <span className="text-content-text-secondary">
+        <ShowDate date={show.date} />
+      </span>
+    );
+  }
+  return (
+    <a href={`/shows/${show.slug}${suffix}`} className="text-base text-brand-primary hover:text-brand-secondary">
+      <ShowDate date={show.date} />
+    </a>
+  );
+}

--- a/apps/web/app/components/song/songs-columns.test.tsx
+++ b/apps/web/app/components/song/songs-columns.test.tsx
@@ -145,7 +145,7 @@ describe("getSongsColumns", () => {
   });
 
   // The three filtered rarity columns ride on the same `showFilteredPlays`
-  // gate as Filtered Plays. They mirror Current Gap / Since Debut / Avg Gap,
+  // gate as Filtered Plays. They mirror Gap to Now / Since Debut / Avg Gap,
   // computed against the active filter scope. Hidden by default so they
   // don't duplicate the all-time columns when no filter narrows the data.
   test("showFilteredPlays=false: filtered rarity columns are not rendered", async () => {
@@ -165,7 +165,7 @@ describe("getSongsColumns", () => {
       />,
     );
 
-    expect(screen.queryByRole("button", { name: /Filtered Current Gap/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Filtered Gap to End/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Filtered Since Debut/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Filtered Avg Gap/i })).not.toBeInTheDocument();
   });
@@ -189,7 +189,7 @@ describe("getSongsColumns", () => {
       />,
     );
 
-    // Filtered Current Gap renders the raw integer.
+    // Filtered Gap to End renders the raw integer.
     expect(screen.getByText("9")).toBeInTheDocument();
     // Filtered Since Debut renders as a percent (matches existing % formatter).
     expect(screen.getByText("42%")).toBeInTheDocument();
@@ -596,10 +596,10 @@ describe("getSongsColumns", () => {
     expect(playsColumn?.meta?.hideOnMobile).toBeFalsy();
   });
 
-  // The Current Gap column shows shows-since-last-played (`showsSinceLastPlayed`)
+  // The Gap to Now column shows shows-since-last-played (`showsSinceLastPlayed`)
   // — same number that drives the "X shows ago" sublabel on the song detail
   // page. It's the most-immediate "is this song missing right now?" signal.
-  test("Current Gap cell renders the integer when showsSinceLastPlayed is set", async () => {
+  test("Gap to Now cell renders the integer when showsSinceLastPlayed is set", async () => {
     await setupWithRouter(
       <DataTable columns={baseColumns} data={[makeSong({ showsSinceLastPlayed: 12 })]} hideSearch hidePagination />,
     );
@@ -610,7 +610,7 @@ describe("getSongsColumns", () => {
   // populated for any other reason) get the em-dash placeholder so the
   // column stays readable instead of showing "0" (which would mean
   // "played at the most recent show").
-  test("Current Gap cell renders em-dash when showsSinceLastPlayed is null", async () => {
+  test("Gap to Now cell renders em-dash when showsSinceLastPlayed is null", async () => {
     await setupWithRouter(
       <DataTable columns={baseColumns} data={[makeSong({ showsSinceLastPlayed: null })]} hideSearch hidePagination />,
     );
@@ -656,7 +656,7 @@ describe("getSongsColumns", () => {
   // All three rarity columns are secondary signals — they hide on mobile
   // so Title + Plays + Last Played stay legible at narrow widths, matching
   // the existing Filtered Plays pattern.
-  test("Current Gap, % Since Debut, Avg Gap all carry meta.hideOnMobile", () => {
+  test("Gap to Now, % Since Debut, Avg Gap all carry meta.hideOnMobile", () => {
     const columns = getSongsColumns({ showFilteredPlays: false });
     const gap = columns.find((c) => "accessorKey" in c && c.accessorKey === "showsSinceLastPlayed");
     const pct = columns.find((c) => "accessorKey" in c && c.accessorKey === "percentSinceDebut");
@@ -666,9 +666,9 @@ describe("getSongsColumns", () => {
     expect(avg?.meta?.hideOnMobile).toBe(true);
   });
 
-  // Column ordering: Current Gap sits immediately to the left of Last
+  // Column ordering: Gap to Now sits immediately to the left of Last
   // Played so the "X shows ago" number reads naturally next to the date
-  // it's measured against. % Since Debut and Avg Gap precede Current Gap
+  // it's measured against. % Since Debut and Avg Gap precede Gap to Now
   // as the broader rarity signals; Last Played + First Played remain
   // rightmost.
   test("rarity columns appear between Plays and Last Played in the expected order", () => {
@@ -687,10 +687,10 @@ describe("getSongsColumns", () => {
     expect(gapIdx).toBeLessThan(lastIdx);
   });
 
-  // Sorting Current Gap asc must put nulls (never-played / unpopulated
+  // Sorting Gap to Now asc must put nulls (never-played / unpopulated
   // songs) at the bottom — otherwise null-coercion-to-0 would surface
   // them at the top, masking the smallest real gaps.
-  test("Current Gap sort puts nulls last on asc and first on desc", async () => {
+  test("Gap to Now sort puts nulls last on asc and first on desc", async () => {
     const songs = [
       makeSong({ id: "a", title: "Basis for a Day", slug: "basis-for-a-day", showsSinceLastPlayed: 5 }),
       makeSong({ id: "b", title: "Above The Waves", slug: "above-the-waves", showsSinceLastPlayed: null }),
@@ -698,11 +698,11 @@ describe("getSongsColumns", () => {
     ];
     const { user } = await setupWithRouter(<DataTable columns={baseColumns} data={songs} hideSearch hidePagination />);
 
-    // Header text is the short "Gap"; the full "Current Gap" lives in the
+    // Header text is the short "Gap"; the full "Gap to Now" lives in the
     // title attribute as hover tooltip. Find the button via title to fail
     // loudly if the tooltip is ever dropped.
-    const sortHeader = screen.getAllByRole("button").find((b) => b.getAttribute("title") === "Current Gap");
-    if (!sortHeader) throw new Error("Current Gap header not found");
+    const sortHeader = screen.getAllByRole("button").find((b) => b.getAttribute("title") === "Gap to Now");
+    if (!sortHeader) throw new Error("Gap to Now header not found");
     await user.click(sortHeader); // asc
 
     const titlesAsc = screen

--- a/apps/web/app/components/song/songs-columns.tsx
+++ b/apps/web/app/components/song/songs-columns.tsx
@@ -101,7 +101,7 @@ function HeaderLabel({
 interface SortableColumnOptions {
   accessorKey: keyof SongWithShows;
   label: ReactNode;
-  /** Hover tooltip; used when `label` is a shorthand (e.g. "Gap" → "Current Gap"). */
+  /** Hover tooltip; used when the visible label needs disambiguation in prose. */
   title?: string;
   width?: string;
   hideOnMobile?: boolean;
@@ -335,8 +335,12 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
 
   const currentGapColumn = makeSortableColumn({ reservesIconRow: showFilteredPlays,
     accessorKey: "showsSinceLastPlayed",
-    label: <HeaderLabel reserveIconRow={showFilteredPlays}>Gap</HeaderLabel>,
-    title: "Current Gap",
+    // Spelled out vs. plain "Gap" so users can't confuse it with "Avg Gap"
+    // on a quick scan. "to Now" anchors that this is the count up to today
+    // (the filtered variant uses "to End" because its denominator stops
+    // at the filter boundary).
+    label: <HeaderLabel reserveIconRow={showFilteredPlays}>Gap to Now</HeaderLabel>,
+    title: "Gap to Now",
     width: "7%",
     hideOnMobile: true,
     cell: (song) => dashOrSpan(song.showsSinceLastPlayed),
@@ -347,10 +351,10 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     accessorKey: "filteredShowsSinceLastPlayed",
     label: (
       <HeaderLabel filtered reserveIconRow>
-        <span>Gap</span>
+        <span>Gap to End</span>
       </HeaderLabel>
     ),
-    title: "Filtered Current Gap",
+    title: "Filtered Gap to End",
     width: "7%",
     hideOnMobile: true,
     cell: (song) => dashOrSpan(song.filteredShowsSinceLastPlayed ?? null),

--- a/apps/web/app/components/ui/sortable-header.test.tsx
+++ b/apps/web/app/components/ui/sortable-header.test.tsx
@@ -1,0 +1,90 @@
+import { type ColumnDef, createColumnHelper, flexRender, getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test } from "vitest";
+import { SortableHeader } from "./sortable-header";
+
+interface Row {
+  id: string;
+  name: string;
+}
+
+/**
+ * Mount a minimal TanStack table with two columns so we can exercise the
+ * SortableHeader component end-to-end: one sortable column, one non-sortable.
+ */
+function setup() {
+  const columnHelper = createColumnHelper<Row>();
+  const columns: ColumnDef<Row, unknown>[] = [
+    columnHelper.accessor("name", {
+      id: "name",
+      enableSorting: true,
+      header: ({ column }) => <SortableHeader column={column} label="Name" />,
+    }) as ColumnDef<Row, unknown>,
+    columnHelper.accessor("id", {
+      id: "id",
+      enableSorting: false,
+      header: ({ column }) => <SortableHeader column={column} label="ID" />,
+    }) as ColumnDef<Row, unknown>,
+  ];
+  function Harness() {
+    const table = useReactTable<Row>({
+      data: [
+        { id: "1", name: "Tractorbeam" },
+        { id: "2", name: "Above the Waves" },
+      ],
+      columns,
+      getCoreRowModel: getCoreRowModel(),
+      getSortedRowModel: getSortedRowModel(),
+    });
+    return (
+      <table>
+        <thead>
+          <tr>
+            {table.getHeaderGroups()[0].headers.map((header) => (
+              <th key={header.id}>{flexRender(header.column.columnDef.header, header.getContext())}</th>
+            ))}
+          </tr>
+        </thead>
+      </table>
+    );
+  }
+  return { user: userEvent.setup(), ...render(<Harness />) };
+}
+
+describe("SortableHeader", () => {
+  // Sortable columns render an interactive button (clickable header) so the
+  // user can toggle sort order. Non-sortable columns must NOT render a
+  // button — clicking the label shouldn't do anything.
+  test("sortable column renders a button; non-sortable renders plain text", () => {
+    setup();
+    expect(screen.getByRole("button", { name: /Name/ })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /ID/ })).not.toBeInTheDocument();
+    // The non-sortable label still shows, just not as a button.
+    expect(screen.getByText("ID")).toBeInTheDocument();
+  });
+
+  // Click cycles asc → desc → off. After each click the up/down indicator
+  // should match the current sort state.
+  test("clicking the sortable header toggles ascending then descending sort", async () => {
+    const { user } = setup();
+    const headerButton = screen.getByRole("button", { name: /Name/ });
+
+    // First click sorts ascending — the active arrow is the up-icon (ArrowUp).
+    await user.click(headerButton);
+    expect(headerButton.querySelector("svg")).toBeTruthy();
+    // The neutral up/down chevron (ArrowUpDown) is replaced by a directional
+    // arrow once sorting is active. We can't easily inspect which icon Lucide
+    // chose, but the "font-semibold" class flips on when sort is active —
+    // use that as the structural signal.
+    expect(headerButton.querySelector(".font-semibold")).toBeTruthy();
+
+    // Second click flips to descending; semibold persists.
+    await user.click(headerButton);
+    expect(headerButton.querySelector(".font-semibold")).toBeTruthy();
+
+    // Third click clears sort. The label loses the active styling.
+    await user.click(headerButton);
+    expect(headerButton.querySelector(".font-semibold")).toBeFalsy();
+  });
+});

--- a/apps/web/app/components/ui/sortable-header.tsx
+++ b/apps/web/app/components/ui/sortable-header.tsx
@@ -1,0 +1,31 @@
+import type { Column } from "@tanstack/react-table";
+import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon } from "lucide-react";
+
+/**
+ * Header cell that toggles its column's sort direction on click. Renders
+ * the active direction with a bold label + accent-colored arrow, and an
+ * idle direction with a neutral chevron pair. Non-sortable columns render
+ * as plain text so callers can use this for every header without branching.
+ * Generic over the row shape — works for any TanStack `Column<T>`.
+ */
+export function SortableHeader<T>({ column, label }: { column: Column<T, unknown>; label: string }) {
+  if (!column.getCanSort()) return <span>{label}</span>;
+  return (
+    <button
+      type="button"
+      className="cursor-pointer select-none hover:text-content-text-primary text-left"
+      onClick={() => column.toggleSorting()}
+    >
+      <span className={column.getIsSorted() ? "text-content-text-primary font-semibold" : ""}>{label}</span>
+      <span className={column.getIsSorted() ? "text-brand-primary ml-1" : "ml-1"}>
+        {column.getIsSorted() === "asc" ? (
+          <ArrowUpIcon className="h-4 w-4 inline" />
+        ) : column.getIsSorted() === "desc" ? (
+          <ArrowDownIcon className="h-4 w-4 inline" />
+        ) : (
+          <ArrowUpDown className="h-4 w-4 inline" />
+        )}
+      </span>
+    </button>
+  );
+}

--- a/apps/web/app/hooks/use-personal-song-history.ts
+++ b/apps/web/app/hooks/use-personal-song-history.ts
@@ -1,0 +1,33 @@
+import type { PersonalSongHistory } from "@bip/core";
+import { useQuery } from "@tanstack/react-query";
+import { useSession } from "~/hooks/use-session";
+
+const EMPTY: PersonalSongHistory = { attendedShows: [], songAttendances: {} };
+
+/**
+ * Lazy fetcher for the current user's full attendance + per-song history.
+ * Backs the SetlistCard "personal" view. Disabled when logged out so the
+ * endpoint is never hit anonymously. 5-minute staleTime — the server is
+ * Redis-cached for 24h and invalidates on attendance toggles, so this is
+ * just to avoid refetch storms during a single browsing session.
+ */
+export function usePersonalSongHistory(): {
+  data: PersonalSongHistory;
+  isLoading: boolean;
+} {
+  const { user } = useSession();
+  const userId = user?.id ?? null;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["users", "song-history", userId],
+    queryFn: async (): Promise<PersonalSongHistory> => {
+      const response = await fetch("/api/users/song-history", { credentials: "include" });
+      if (!response.ok) throw new Error("Failed to load personal song history");
+      return response.json();
+    },
+    enabled: Boolean(userId),
+    staleTime: 5 * 60_000,
+  });
+
+  return { data: data ?? EMPTY, isLoading };
+}

--- a/apps/web/app/hooks/use-setlist-view.test.tsx
+++ b/apps/web/app/hooks/use-setlist-view.test.tsx
@@ -17,6 +17,9 @@ function Harness() {
       <button type="button" onClick={() => setView("gap-chart")}>
         to-gap
       </button>
+      <button type="button" onClick={() => setView("personal")}>
+        to-personal
+      </button>
       <button type="button" onClick={() => setView("setlist")}>
         to-setlist
       </button>
@@ -55,5 +58,39 @@ describe("useSetlistView", () => {
 
     await user.click(screen.getByText("to-setlist"));
     expect(screen.getByTestId("search").textContent).toBe("");
+  });
+
+  // The personal view is a third toggle option (logged-in only) that needs
+  // the same URL round-trip behavior as gap-chart — shareable + persists
+  // across prev/next show navigation.
+  test("reads ?view=personal from the URL on mount", () => {
+    render(
+      <MemoryRouter initialEntries={["/shows/2024-07-26?view=personal"]}>
+        <Harness />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("view").textContent).toBe("personal");
+  });
+
+  test("setting to personal writes ?view=personal; setting back to setlist drops it", async () => {
+    const user = userEvent.setup();
+    await setupWithRouter(<Harness />);
+
+    await user.click(screen.getByText("to-personal"));
+    expect(screen.getByTestId("search").textContent).toBe("?view=personal");
+
+    await user.click(screen.getByText("to-setlist"));
+    expect(screen.getByTestId("search").textContent).toBe("");
+  });
+
+  // Unknown ?view= values (typos, deprecated names) should fall back to
+  // the default rather than render a broken UI.
+  test("falls back to setlist for unrecognized ?view= values", () => {
+    render(
+      <MemoryRouter initialEntries={["/shows/2024-07-26?view=bogus"]}>
+        <Harness />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("view").textContent).toBe("setlist");
   });
 });

--- a/apps/web/app/hooks/use-setlist-view.ts
+++ b/apps/web/app/hooks/use-setlist-view.ts
@@ -3,28 +3,31 @@ import { useSearchParams } from "react-router-dom";
 import type { SetlistView } from "~/components/setlist/setlist-card";
 
 /**
- * URL-syncs the SetlistCard's setlist/gap-chart toggle on /shows/:slug.
- * Reads `?view=gap-chart` on mount and writes the param when the user
- * flips the toggle. Setting back to "setlist" drops the param so the
- * default state has a clean URL. List pages skip this hook so toggling
- * stays local per card.
+ * URL-syncs the SetlistCard view toggle on /shows/:slug. Reads `?view=` on
+ * mount and writes the param when the user flips the toggle. Setting back
+ * to "setlist" (the default) drops the param so the bare URL stays clean.
+ * List pages skip this hook so toggling stays local per card.
  */
 export function useSetlistView(): [SetlistView, (next: SetlistView) => void] {
   const [searchParams, setSearchParams] = useSearchParams();
-  const view: SetlistView = searchParams.get("view") === "gap-chart" ? "gap-chart" : "setlist";
+  const raw = searchParams.get("view");
+  const view: SetlistView = raw === "gap-chart" || raw === "personal" ? raw : "setlist";
 
   const setView = useCallback(
     (next: SetlistView) => {
       setSearchParams(
         (prev) => {
-          if (next === "gap-chart") {
-            prev.set("view", "gap-chart");
-          } else {
+          if (next === "setlist") {
             prev.delete("view");
+          } else {
+            prev.set("view", next);
           }
           return prev;
         },
-        { replace: true },
+        // `preventScrollReset` keeps the user's current scroll position
+        // when the param changes — toggling the view shouldn't yank the
+        // page back to the top.
+        { replace: true, preventScrollReset: true },
       );
     },
     [setSearchParams],

--- a/apps/web/app/lib/personal-setlist-columns.test.ts
+++ b/apps/web/app/lib/personal-setlist-columns.test.ts
@@ -1,0 +1,187 @@
+import { average, median } from "@bip/domain";
+import { describe, expect, test } from "vitest";
+import { computePersonalRow, eligiblePersonalGaps, type PersonalSetlistRow } from "./personal-setlist-columns";
+
+/** Compact builder for a TrackContext entry in setlistTracks. */
+function track(id: string, songId: string, set: string, position: number) {
+  return { id, songId, set, position };
+}
+
+/** Compact builder for a PersonalAttendance — defaults the slug from the date. */
+function attendance(date: string, slug?: string) {
+  return { date, slug: slug ?? `${date}-show` };
+}
+
+describe("computePersonalRow", () => {
+  // Personal debut: user has never seen this song in any attended show.
+  // yourGap = debut (★); lastSeen is null; totalTimesSeen = 0.
+  test("personal debut: never-seen song renders as debut", () => {
+    const row = computePersonalRow({
+      track: track("t1", "song-tractorbeam", "S1", 1),
+      showDate: "2024-07-19",
+      setlistTracks: [track("t1", "song-tractorbeam", "S1", 1)],
+      songAttendances: [],
+      attendedShows: [attendance("2024-07-19")],
+    });
+    expect(row).toEqual({
+      totalTimesSeen: 0,
+      lastSeen: null,
+      yourGap: { kind: "debut" },
+    });
+  });
+
+  // Within-show repeat: when a song appears twice in the same show, the
+  // second occurrence renders ↺ regardless of whether the user attended.
+  test("within-show repeat: second occurrence renders 'this-show' (user attended)", () => {
+    const setlistTracks = [track("t1", "song-mrdon", "S1", 3), track("t2", "song-mrdon", "S2", 8)];
+    const row = computePersonalRow({
+      track: setlistTracks[1],
+      showDate: "2024-07-19",
+      setlistTracks,
+      songAttendances: [attendance("2020-06-10"), attendance("2024-07-19"), attendance("2024-07-19")],
+      attendedShows: [attendance("2020-06-10"), attendance("2024-07-19")],
+    });
+    expect(row.yourGap).toEqual({ kind: "this-show" });
+    // lastSeen = most recent attended performance strictly before the show date
+    expect(row.lastSeen?.date).toBe("2020-06-10");
+  });
+
+  // ↺ is purely a setlist property — applies even when the user did NOT
+  // attend this show. The second occurrence still renders 'this-show'.
+  test("within-show repeat: second occurrence renders 'this-show' (user did not attend)", () => {
+    const setlistTracks = [track("t1", "song-aceofspades", "S1", 2), track("t2", "song-aceofspades", "S2", 5)];
+    const row = computePersonalRow({
+      track: setlistTracks[1],
+      showDate: "2024-07-19",
+      setlistTracks,
+      songAttendances: [attendance("2018-04-15")],
+      attendedShows: [attendance("2018-04-15"), attendance("2020-01-01")],
+    });
+    expect(row.yourGap).toEqual({ kind: "this-show" });
+  });
+
+  // Normal gap: user has seen this song before; show is in the future or
+  // user did not attend. yourGap counts the number of attended shows
+  // strictly between lastSeen and the show's date.
+  test("normal gap: counts user-attended shows strictly between lastSeen and showDate", () => {
+    const row = computePersonalRow({
+      track: track("t1", "song-bombbasis", "S1", 1),
+      showDate: "2024-07-19",
+      setlistTracks: [track("t1", "song-bombbasis", "S1", 1)],
+      songAttendances: [attendance("2018-04-15")],
+      // User attended 5 shows total — 3 are strictly between 2018-04-15 and 2024-07-19
+      attendedShows: [
+        attendance("2018-04-15"),
+        attendance("2019-06-10"),
+        attendance("2020-08-20"),
+        attendance("2021-12-05"),
+        attendance("2024-07-19"),
+      ],
+    });
+    expect(row.totalTimesSeen).toBe(1);
+    expect(row.lastSeen?.date).toBe("2018-04-15");
+    expect(row.yourGap).toEqual({ kind: "count", value: 3 });
+  });
+
+  // Un-attended show: user wasn't at this show but has seen the song
+  // before. Gap is computed off prior attended performances; this show
+  // itself is not counted (user wasn't there).
+  test("un-attended show: gap computed off prior attended performances; this show not counted", () => {
+    const row = computePersonalRow({
+      track: track("t1", "song-spaga", "S1", 1),
+      showDate: "2024-07-19",
+      setlistTracks: [track("t1", "song-spaga", "S1", 1)],
+      songAttendances: [attendance("2018-04-15")],
+      attendedShows: [attendance("2018-04-15"), attendance("2019-06-10"), attendance("2020-08-20")],
+    });
+    expect(row.lastSeen?.date).toBe("2018-04-15");
+    expect(row.yourGap).toEqual({ kind: "count", value: 2 });
+  });
+
+  // Edge: user attended this show AND saw the song at this show. The
+  // attendance array contains showDate, but lastSeen must skip it
+  // (strictly less than) and return the prior attended performance.
+  test("user attended this show: lastSeen skips the current show's date", () => {
+    const row = computePersonalRow({
+      track: track("t1", "song-confrontation", "S1", 1),
+      showDate: "2024-07-19",
+      setlistTracks: [track("t1", "song-confrontation", "S1", 1)],
+      songAttendances: [attendance("2018-04-15"), attendance("2020-06-10"), attendance("2024-07-19")],
+      attendedShows: [
+        attendance("2018-04-15"),
+        attendance("2019-12-31"),
+        attendance("2020-06-10"),
+        attendance("2024-07-19"),
+      ],
+    });
+    // Strictly before the current show: 2018-04-15 + 2020-06-10 = 2.
+    // The 2024-07-19 attendance at this very show doesn't count.
+    expect(row.totalTimesSeen).toBe(2);
+    expect(row.lastSeen?.date).toBe("2020-06-10");
+    // No attended shows strictly between 2020-06-10 and 2024-07-19.
+    expect(row.yourGap).toEqual({ kind: "count", value: 0 });
+  });
+
+  // Back-to-back attended performances of the same song: lastSeen is
+  // the prior attended show; yourGap = 0 (no shows in between).
+  test("back-to-back attended performances: gap=0", () => {
+    const row = computePersonalRow({
+      track: track("t1", "song-pillow", "S1", 1),
+      showDate: "2024-07-20",
+      setlistTracks: [track("t1", "song-pillow", "S1", 1)],
+      songAttendances: [attendance("2024-07-19"), attendance("2024-07-20")],
+      attendedShows: [attendance("2024-07-19"), attendance("2024-07-20")],
+    });
+    expect(row.lastSeen?.date).toBe("2024-07-19");
+    expect(row.yourGap).toEqual({ kind: "count", value: 0 });
+  });
+
+  // First occurrence of a song that repeats later in the same show: the
+  // first instance is NOT a repeat and gets its normal gap value.
+  test("first occurrence of a repeated song: NOT marked as 'this-show'", () => {
+    const setlistTracks = [track("t1", "song-helicopters", "S1", 2), track("t2", "song-helicopters", "S2", 7)];
+    const row = computePersonalRow({
+      track: setlistTracks[0],
+      showDate: "2024-07-19",
+      setlistTracks,
+      songAttendances: [attendance("2020-06-10")],
+      attendedShows: [attendance("2020-06-10"), attendance("2024-07-19")],
+    });
+    expect(row.yourGap).toEqual({ kind: "count", value: 0 });
+  });
+});
+
+describe("eligiblePersonalGaps", () => {
+  function row(kind: "count" | "debut" | "this-show", value = 0): PersonalSetlistRow {
+    return {
+      totalTimesSeen: 0,
+      lastSeen: null,
+      yourGap: kind === "count" ? { kind, value } : { kind },
+    };
+  }
+
+  // The filter mirrors the gap-chart's `eligibleGapsForAggregation`:
+  // debuts and within-show repeats are excluded so callers can feed the
+  // remaining numbers straight into `average` / `median`.
+  test("excludes debuts and within-show repeats", () => {
+    const rows = [row("count", 0), row("count", 4), row("count", 8), row("debut"), row("this-show")];
+    expect(eligiblePersonalGaps(rows)).toEqual([0, 4, 8]);
+  });
+
+  // No eligible numeric gaps → empty array. The `average` / `median`
+  // helpers from `@bip/domain` turn that into a clean `null` at call sites.
+  test("returns an empty array when no row is eligible", () => {
+    expect(eligiblePersonalGaps([row("debut"), row("this-show")])).toEqual([]);
+    expect(average(eligiblePersonalGaps([row("debut")]))).toBeNull();
+    expect(median(eligiblePersonalGaps([row("debut")]))).toBeNull();
+  });
+
+  // End-to-end sanity check that the filter + math pipeline produces the
+  // expected summary numbers — same scenario as before, just composed
+  // explicitly instead of through a wrapper.
+  test("feeds into average + median for a typical setlist", () => {
+    const rows = [row("count", 2), row("count", 4), row("count", 6), row("count", 10)];
+    expect(average(eligiblePersonalGaps(rows))).toBe(5.5);
+    expect(median(eligiblePersonalGaps(rows))).toBe(5);
+  });
+});

--- a/apps/web/app/lib/personal-setlist-columns.ts
+++ b/apps/web/app/lib/personal-setlist-columns.ts
@@ -1,0 +1,127 @@
+import type { PersonalAttendance } from "@bip/core";
+import { buildGapCellState, type GapCellState, isWithinShowRepeat } from "~/components/setlist/gap-cell";
+
+/**
+ * Pure helpers for the SetlistCard "personal" view. Computes per-row
+ * user-history columns (Total Times Seen, Last Seen, Last Before, Your Gap)
+ * from a user-scoped payload of attended-show records and per-song
+ * attendance records. Kept pure so the table component is trivially
+ * testable and the heavy logic doesn't live inside React.
+ *
+ * All dates are ISO `YYYY-MM-DD` strings — lexicographic order matches
+ * chronological order, so we can binary-search them directly.
+ */
+
+// Alias: per-user gap states share the same three-kind shape as the
+// catalog-wide gap cell. Keeping a distinct exported name preserves the
+// per-user vocabulary at call sites while the rendering logic stays DRY.
+export type PersonalGap = GapCellState;
+
+export interface PersonalSetlistRow {
+  /**
+   * Count of attended performances of this song **strictly before** the
+   * current show's date. Mirrors `lastSeen`'s "strictly before" semantic
+   * so the two columns stay consistent — viewing a 2020 show won't pull
+   * a 2024 attendance into the count.
+   */
+  totalTimesSeen: number;
+  /**
+   * The user's most recent attended performance of this song **strictly
+   * before** the current show's date. Null when this is/was the user's
+   * personal debut. The column header in the UI reads "Last Seen" — we
+   * deliberately don't surface a separate "most recent ever" column
+   * because on an attended past show every row would read as the show's
+   * own date, which the card header already shows.
+   */
+  lastSeen: PersonalAttendance | null;
+  yourGap: PersonalGap;
+}
+
+export interface TrackContext {
+  id: string;
+  songId: string;
+  set: string;
+  position: number;
+}
+
+/**
+ * Largest index `i` such that `arr[i].date < target`. Returns -1 if no
+ * element is strictly before target.
+ */
+function indexOfLastStrictlyBefore(arr: PersonalAttendance[], target: string): number {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (arr[mid].date < target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo - 1;
+}
+
+/**
+ * Count of attendances `a` where `lo < a.date < hi` (strict bounds).
+ * Used to compute Your Gap = attended shows strictly between Last Before
+ * and the current show's date.
+ */
+function countStrictlyBetween(arr: PersonalAttendance[], lo: string, hi: string): number {
+  // Smallest index with arr[i].date > lo
+  let left = 0;
+  let right = arr.length;
+  while (left < right) {
+    const mid = (left + right) >>> 1;
+    if (arr[mid].date <= lo) left = mid + 1;
+    else right = mid;
+  }
+  const startIdx = left;
+  // Smallest index with arr[i].date >= hi
+  left = startIdx;
+  right = arr.length;
+  while (left < right) {
+    const mid = (left + right) >>> 1;
+    if (arr[mid].date < hi) left = mid + 1;
+    else right = mid;
+  }
+  return left - startIdx;
+}
+
+export function computePersonalRow(args: {
+  track: TrackContext;
+  showDate: string;
+  setlistTracks: TrackContext[];
+  songAttendances: PersonalAttendance[];
+  attendedShows: PersonalAttendance[];
+}): PersonalSetlistRow {
+  const { track, showDate, setlistTracks, songAttendances, attendedShows } = args;
+
+  const lastSeenIdx = indexOfLastStrictlyBefore(songAttendances, showDate);
+  // The "strictly before" index is also the count of attendances before
+  // the show date — both columns share the same binary-search result.
+  const totalTimesSeen = lastSeenIdx + 1;
+  const lastSeen = lastSeenIdx >= 0 ? songAttendances[lastSeenIdx] : null;
+
+  const isRepeat = isWithinShowRepeat(setlistTracks, track);
+  // Personal "Your Gap" uses the same precedence as the catalog gap cell:
+  // a repeat overrides everything; otherwise null lastSeen means the song
+  // is a personal debut; otherwise count attended shows between.
+  const yourGap: PersonalGap = buildGapCellState({
+    isRepeat,
+    gap: lastSeen === null ? null : countStrictlyBetween(attendedShows, lastSeen.date, showDate),
+  });
+
+  return { totalTimesSeen, lastSeen, yourGap };
+}
+
+/**
+ * The numeric gap values from a list of personal rows, with debuts and
+ * within-show repeats filtered out. Feed to `average` / `median` from
+ * `@bip/domain` at call sites — the wrapper functions were trivial enough
+ * to inline.
+ */
+export function eligiblePersonalGaps(rows: PersonalSetlistRow[]): number[] {
+  const out: number[] = [];
+  for (const row of rows) {
+    if (row.yourGap.kind === "count") out.push(row.yourGap.value);
+  }
+  return out;
+}

--- a/apps/web/app/lib/song-utilities.test.ts
+++ b/apps/web/app/lib/song-utilities.test.ts
@@ -200,7 +200,7 @@ describe("fetchFilteredSongs", () => {
     expect(result.map((s) => s.title)).not.toContain("Shelby Rose");
   });
 
-  // The rarity columns on /songs (Current Gap, % Since Debut, Avg Gap)
+  // The rarity columns on /songs (Gap to Now, % Since Debut, Avg Gap)
   // read showsSinceLastPlayed, percentSinceDebut, and averageShowsPerPlay
   // off each row. Verifies fetchFilteredSongs pulls showsByYear (cached
   // catalogue-level data) + per-song current-gap counts and runs each

--- a/apps/web/app/lib/song-utilities.ts
+++ b/apps/web/app/lib/song-utilities.ts
@@ -113,7 +113,7 @@ export async function fetchFilteredSongs(url: URL, context: PublicContext): Prom
 /**
  * Fills the rarity fields the canonical SongService leaves as null:
  * `showsSinceLastPlayed`, `percentSinceDebut`, `averageShowsPerPlay`.
- * Drives the Current Gap / % Since Debut / Avg Gap columns on /songs.
+ * Drives the Gap to Now / % Since Debut / Avg Gap columns on /songs.
  * Runs inside the cached `fetchFilteredSongs` path so the bulk gap query
  * fires at most once per cache window.
  */

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -124,6 +124,7 @@ export default [
     route("search/feedback", "routes/api/search/feedback.tsx"),
     route("users", "routes/api/users.tsx"),
     route("users/avatar", "routes/api/users/avatar.tsx"),
+    route("users/song-history", "routes/api/users/song-history.tsx"),
     route("contact", "routes/api/contact.tsx"),
     route("cron/:action", "routes/api/cron/$action.tsx"),
     route("images/upload", "routes/api/images/upload.tsx"),

--- a/apps/web/app/routes/api/users/song-history.test.ts
+++ b/apps/web/app/routes/api/users/song-history.test.ts
@@ -1,0 +1,80 @@
+import type { LoaderFunctionArgs } from "react-router-dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// publicLoader normally wraps the inner function with optional auth; bypass
+// it in unit tests so we can drive the loader with whatever context we want.
+vi.mock("~/lib/base-loaders", () => ({
+  publicLoader: <T>(fn: (args: LoaderFunctionArgs & { context: unknown }) => Promise<T>) => fn,
+}));
+
+const findByEmail = vi.fn();
+const getSongHistory = vi.fn();
+vi.mock("~/server/services", () => ({
+  services: {
+    users: { findByEmail },
+    personalSongHistory: { getSongHistory },
+  },
+}));
+
+vi.mock("~/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { loader } = await import("./song-history");
+
+function makeArgs(context: unknown): LoaderFunctionArgs & { context: unknown } {
+  return {
+    request: new Request("http://localhost/api/users/song-history"),
+    params: {},
+    context,
+  } as unknown as LoaderFunctionArgs & { context: unknown };
+}
+
+describe("GET /api/users/song-history", () => {
+  beforeEach(() => {
+    findByEmail.mockReset();
+    getSongHistory.mockReset();
+  });
+
+  // Anonymous caller: return an empty payload (200) so the React Query hook
+  // can run without special-casing. The UI gate prevents the toggle from
+  // ever showing for logged-out users, so this path is defensive.
+  test("anonymous: returns empty payload without hitting services", async () => {
+    const response = (await loader(makeArgs({}))) as Response;
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ attendedShows: [], songAttendances: {} });
+    expect(findByEmail).not.toHaveBeenCalled();
+    expect(getSongHistory).not.toHaveBeenCalled();
+  });
+
+  // Authed: maps Supabase user → local user via email, then delegates to
+  // PersonalSongHistoryService. Returns whatever the service returns.
+  test("authed: delegates to PersonalSongHistoryService and returns its payload", async () => {
+    findByEmail.mockResolvedValue({ id: "user-local-1" });
+    const payload = {
+      attendedShows: [{ date: "2020-06-10", slug: "2020-06-10-radio-city" }],
+      songAttendances: {
+        "song-tractorbeam": [{ date: "2020-06-10", slug: "2020-06-10-radio-city" }],
+      },
+    };
+    getSongHistory.mockResolvedValue(payload);
+
+    const response = (await loader(makeArgs({ currentUser: { email: "fan@biscuits.net", id: "sb-1" } }))) as Response;
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(payload);
+    expect(findByEmail).toHaveBeenCalledWith("fan@biscuits.net");
+    expect(getSongHistory).toHaveBeenCalledWith("user-local-1");
+  });
+
+  // Edge: Supabase user exists but local user record is missing — return
+  // an empty payload rather than 500, so the UI degrades to "show all
+  // debuts" instead of breaking.
+  test("authed but missing local user: returns empty payload", async () => {
+    findByEmail.mockResolvedValue(null);
+
+    const response = (await loader(makeArgs({ currentUser: { email: "ghost@biscuits.net" } }))) as Response;
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ attendedShows: [], songAttendances: {} });
+    expect(getSongHistory).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/routes/api/users/song-history.tsx
+++ b/apps/web/app/routes/api/users/song-history.tsx
@@ -1,0 +1,36 @@
+import type { PersonalSongHistory } from "@bip/core";
+import { publicLoader } from "~/lib/base-loaders";
+import { logger } from "~/lib/logger";
+import { services } from "~/server/services";
+
+const EMPTY_HISTORY: PersonalSongHistory = { attendedShows: [], songAttendances: {} };
+
+/**
+ * Backs the SetlistCard "personal" view. Returns the current user's
+ * attended-show dates and per-song attendance dates as compact sorted
+ * arrays. Logged-out callers get an empty payload (200) so the client
+ * code path stays uniform — the UI gate hides the "personal" toggle
+ * for them anyway.
+ */
+export const loader = publicLoader(async ({ context }) => {
+  const { currentUser } = context;
+  if (!currentUser) {
+    return Response.json(EMPTY_HISTORY);
+  }
+
+  try {
+    const user = await services.users.findByEmail(currentUser.email);
+    if (!user) {
+      logger.warn("Personal song history: local user record missing", { email: currentUser.email });
+      return Response.json(EMPTY_HISTORY);
+    }
+    const history = await services.personalSongHistory.getSongHistory(user.id);
+    return Response.json(history);
+  } catch (error) {
+    logger.error("Error fetching personal song history", { error });
+    return new Response(JSON.stringify({ error: "Failed to fetch song history" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+});

--- a/apps/web/app/routes/shows/$slug.tsx
+++ b/apps/web/app/routes/shows/$slug.tsx
@@ -266,7 +266,7 @@ export default function Show() {
         <div className="flex justify-between items-center gap-2">
           {adjacentShows.previous ? (
             <Link
-              to={`/shows/${adjacentShows.previous.slug}${setlistView === "gap-chart" ? "?view=gap-chart" : ""}`}
+              to={`/shows/${adjacentShows.previous.slug}${setlistView === "setlist" ? "" : `?view=${setlistView}`}`}
               className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors min-w-0"
             >
               <ChevronLeft className="h-3 w-3 shrink-0" />
@@ -292,7 +292,7 @@ export default function Show() {
           </Link>
           {adjacentShows.next ? (
             <Link
-              to={`/shows/${adjacentShows.next.slug}${setlistView === "gap-chart" ? "?view=gap-chart" : ""}`}
+              to={`/shows/${adjacentShows.next.slug}${setlistView === "setlist" ? "" : `?view=${setlistView}`}`}
               className="flex items-center gap-1 text-content-text-tertiary hover:text-content-text-secondary text-sm transition-colors min-w-0 justify-end"
             >
               <span className="truncate">

--- a/packages/core/src/_shared/cache/cache-invalidation-service.test.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.test.ts
@@ -28,6 +28,17 @@ describe("CacheInvalidationService.invalidateAttendanceCaches", () => {
     // user's attendance change.
     expect(cache.delPattern).toHaveBeenCalledTimes(2);
   });
+
+  // The SetlistCard "personal gap chart" view reads this user's song-history
+  // blob — toggling attendance changes its content and must wipe it.
+  test("wipes the per-user song-history blob", async () => {
+    const cache = makeCache();
+    const service = new CacheInvalidationService(cache as never, logger);
+
+    await service.invalidateAttendanceCaches("u-rynow");
+
+    expect(cache.del).toHaveBeenCalledWith(CacheKeys.users.songHistory("u-rynow"));
+  });
 });
 
 describe("CacheInvalidationService.invalidateShowListings", () => {
@@ -57,5 +68,17 @@ describe("CacheInvalidationService.invalidateShowListings", () => {
     expect(cache.delPattern).toHaveBeenCalledWith("home:*");
     expect(cache.del).toHaveBeenCalledWith(CacheKeys.stats.showsByYear());
     expect(cache.del).toHaveBeenCalledWith(CacheKeys.stats.showDates());
+  });
+
+  // Per-user song-history embeds track-level data from every attended show,
+  // so any catalog-level show mutation can shift values. Wildcard wipe
+  // avoids tracking which users were affected.
+  test("wipes per-user song-history across all users", async () => {
+    const cache = makeCache();
+    const service = new CacheInvalidationService(cache as never, logger);
+
+    await service.invalidateShowListings();
+
+    expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.users.allSongHistory());
   });
 });

--- a/packages/core/src/_shared/cache/cache-invalidation-service.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.ts
@@ -51,10 +51,13 @@ export class CacheInvalidationService {
       this.cache.delPattern(CacheKeys.shows.allLists()),
       this.cache.delPattern("home:*"), // Invalidate all home page caches
       this.cache.del(CacheKeys.stats.showsByYear()), // shows-per-year aggregate is tied to the show catalog
-      this.cache.del(CacheKeys.stats.showDates()), // sorted stats-show-dates array backs Current Gap on /songs
+      this.cache.del(CacheKeys.stats.showDates()), // sorted stats-show-dates array backs Gap to Now on /songs
       // Per-user attended-setlists caches include each show's setlist + venue;
       // wipe them all when any show metadata moves.
       this.cache.delPattern(CacheKeys.users.allAttendedSetlists()),
+      // Per-user song-history embeds the catalog of tracks at each attended
+      // show; a show metadata or tracks change can shift values.
+      this.cache.delPattern(CacheKeys.users.allSongHistory()),
       this.cloudflareCache?.purgeYearListings(),
     ]);
   }
@@ -107,6 +110,8 @@ export class CacheInvalidationService {
       this.cache.delPattern(CacheKeys.songs.allFilteredForUser(userId)),
       // User profile's Shows Attended tab uses a per-user paginated setlists payload.
       this.cache.delPattern(CacheKeys.users.allAttendedSetlistsForUser(userId)),
+      // SetlistCard "personal" view reads this user's song-history blob.
+      this.cache.del(CacheKeys.users.songHistory(userId)),
     ]);
   }
 

--- a/packages/core/src/_shared/services.ts
+++ b/packages/core/src/_shared/services.ts
@@ -18,6 +18,7 @@ import { YoutubeService } from "../shows/youtube-service";
 import { SongService } from "../songs/song-service";
 import { StatsService } from "../stats/stats-service";
 import { TrackService } from "../tracks/track-service";
+import { PersonalSongHistoryService } from "../users/personal-song-history-service";
 import { UserService } from "../users/user-service";
 import { VenueService } from "../venues/venue-service";
 import type { CacheService, CloudflareCacheService } from "./cache";
@@ -36,6 +37,7 @@ export interface Services {
   setlists: SetlistService;
   venues: VenueService;
   users: UserService;
+  personalSongHistory: PersonalSongHistoryService;
   reviews: ReviewService;
   ratings: RatingService;
   attendances: AttendanceService;
@@ -76,6 +78,7 @@ export function createServices(container: ServiceContainer): Services {
     setlists: new SetlistService(container.db),
     venues: new VenueService(container.db, container.logger),
     users: new UserService(container.db, container.logger),
+    personalSongHistory: new PersonalSongHistoryService(container.db, container.cache),
     reviews: new ReviewService(container.db, container.logger),
     ratings: new RatingService(container.db, container.cacheInvalidation),
     attendances: new AttendanceService(container.db, container.logger),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,5 +19,6 @@ export * from "./shows/nugs-service";
 export * from "./shows/show-service";
 export * from "./shows/youtube-service";
 export * from "./tracks/track-service";
+export * from "./users/personal-song-history-service";
 export * from "./users/user-service";
 export * from "./venues/venue-service";

--- a/packages/core/src/page-composers/song-page-composer.test.ts
+++ b/packages/core/src/page-composers/song-page-composer.test.ts
@@ -824,7 +824,7 @@ describe("CacheKeys", () => {
   // The on-this-day all-timers cache key must embed the monthDay so each
   // calendar day gets its own cache entry.
   test("allTimersOnThisDay includes the monthDay in the key", () => {
-    expect(CacheKeys.songs.allTimersOnThisDay("04-08")).toBe("songs:all-timers:on-this-day:04-08");
+    expect(CacheKeys.songs.allTimersOnThisDay("04-08")).toBe("songs:all-timers:on-this-day:04-08:v2");
   });
 
   // The on-this-day counts cache key is used by the home page to cache

--- a/packages/core/src/setlists/setlist-service.test.ts
+++ b/packages/core/src/setlists/setlist-service.test.ts
@@ -1,5 +1,6 @@
+import { average, median } from "@bip/domain";
 import { describe, expect, test, vi } from "vitest";
-import { computeAverageSongGap, computeMedianSongGap, SetlistService } from "./setlist-service";
+import { computeDebutCount, eligibleGapsForAggregation, SetlistService } from "./setlist-service";
 
 // Minimal mock DbClient — only the paths used by tests
 function makeMockDb() {
@@ -125,92 +126,91 @@ describe("SetlistService.findManyLight", () => {
   });
 });
 
-describe("computeAverageSongGap", () => {
-  // Standard case: average of two real-gap tracks. Debut (gap=null) is
-  // excluded from both numerator and denominator so it doesn't drag the
+describe("eligibleGapsForAggregation", () => {
+  // Debuts (gap === null) are excluded so they don't drag the eventual
   // average down to "we never played this".
-  test("averages real gaps and ignores debuts", () => {
+  test("excludes debuts", () => {
     const tracks = [
       { songId: "a", position: 1, gap: null }, // Basis for a Day debut
       { songId: "b", position: 2, gap: 5 }, // Above the Waves
       { songId: "c", position: 3, gap: 10 }, // Confrontation
     ];
-    expect(computeAverageSongGap(tracks)).toBe(7.5);
+    expect(eligibleGapsForAggregation(tracks)).toEqual([5, 10]);
   });
 
-  // Within-show repeat: a song that appears twice in the same show carries the
-  // gap of its earlier in-show occurrence (recompute writes the same value to
-  // both rows). Including the repeat would double-count the same song's
-  // recency, so the second occurrence is excluded by (songId already seen).
-  test("excludes within-show repeats by songId", () => {
+  // Within-show repeats inherit their earlier occurrence's gap. Counting
+  // them would double-weight the same song's recency, so the second
+  // occurrence is dropped by songId.
+  test("excludes within-show repeats by songId (keeps the earliest position)", () => {
     const tracks = [
       { songId: "a", position: 1, gap: null }, // Munchkin Invasion debut
       { songId: "b", position: 2, gap: 5 }, // Tempest
       { songId: "c", position: 3, gap: 10 }, // Mindless Dribble
-      { songId: "b", position: 4, gap: 5 }, // Tempest reprise — same songId, drop
+      { songId: "b", position: 4, gap: 5 }, // Tempest reprise — drop
     ];
-    expect(computeAverageSongGap(tracks)).toBe(7.5);
+    expect(eligibleGapsForAggregation(tracks)).toEqual([5, 10]);
   });
 
-  // All debuts (or all repeats of debuts) means there's no meaningful gap to
-  // average — return null so the UI can hide the summary line entirely.
-  test("returns null when no eligible tracks remain", () => {
+  // End-to-end sanity: filter + `average`/`median` from `@bip/domain`
+  // produce the expected summary numbers (the same scenario as the old
+  // wrapper-based tests, just composed explicitly).
+  test("composes with average/median for typical summary numbers", () => {
     const tracks = [
-      { songId: "a", position: 1, gap: null }, // Crickets debut
-      { songId: "b", position: 2, gap: null }, // Spaga debut
+      { songId: "a", position: 1, gap: 30 },
+      { songId: "b", position: 2, gap: 5 },
+      { songId: "c", position: 3, gap: 20 },
+      { songId: "d", position: 4, gap: 10 },
     ];
-    expect(computeAverageSongGap(tracks)).toBeNull();
+    const eligible = eligibleGapsForAggregation(tracks);
+    expect(average(eligible)).toBe(16.25);
+    expect(median(eligible)).toBe(15);
+  });
+
+  // All debuts → empty array. `average` / `median` from the math util
+  // turn that into a clean `null` at call sites so the UI hides the line.
+  test("returns an empty array when nothing is eligible", () => {
+    const tracks = [
+      { songId: "a", position: 1, gap: null },
+      { songId: "b", position: 2, gap: null },
+    ];
+    expect(eligibleGapsForAggregation(tracks)).toEqual([]);
+    expect(average(eligibleGapsForAggregation(tracks))).toBeNull();
+    expect(median(eligibleGapsForAggregation(tracks))).toBeNull();
   });
 });
 
-describe("computeMedianSongGap", () => {
-  // Odd-length eligible list: median is the middle value after sorting.
-  // 5 / 10 / 30 → median = 10. Surfaces "what's the typical gap" without
-  // an outlier dragging it like the average can.
-  test("returns the middle value for an odd-count eligible list", () => {
+describe("computeDebutCount", () => {
+  // Mixed setlist: only `gap === null` rows count as debuts. A song with
+  // a real gap value is a re-play, not a debut.
+  test("counts only tracks with gap === null", () => {
     const tracks = [
-      { songId: "a", position: 1, gap: 30 }, // Basis for a Day
-      { songId: "b", position: 2, gap: 5 }, // Above the Waves
-      { songId: "c", position: 3, gap: 10 }, // Confrontation
+      { songId: "a", gap: null }, // Tractorbeam debut
+      { songId: "b", gap: 5 }, // Spaga, played before
+      { songId: "c", gap: null }, // Mr. Don debut
+      { songId: "d", gap: 0 }, // Helicopters back-to-back, not a debut
     ];
-    expect(computeMedianSongGap(tracks)).toBe(10);
+    expect(computeDebutCount(tracks)).toBe(2);
   });
 
-  // Even-length eligible list: median is the mean of the two middle values
-  // after sorting. 5 / 10 / 20 / 30 → middles are 10 and 20 → 15.
-  test("averages the two middle values for an even-count eligible list", () => {
+  // A song played twice in one show is still ONE debut — both tracks have
+  // gap=null (the within-show repeat inherits the first occurrence's gap)
+  // but it's the same song debuting.
+  test("dedupes within-show repeats by songId", () => {
     const tracks = [
-      { songId: "a", position: 1, gap: 30 }, // Crickets
-      { songId: "b", position: 2, gap: 5 }, // Munchkin Invasion
-      { songId: "c", position: 3, gap: 20 }, // Spaga
-      { songId: "d", position: 4, gap: 10 }, // Tempest
+      { songId: "a", gap: null }, // Bombbasis debut, first occurrence
+      { songId: "a", gap: null }, // Bombbasis reprise — same debut song
     ];
-    expect(computeMedianSongGap(tracks)).toBe(15);
+    expect(computeDebutCount(tracks)).toBe(1);
   });
 
-  // Same exclusion rules as the average: debuts (gap=null) and within-show
-  // repeats (songId already seen at an earlier position) are dropped before
-  // sorting. Without this, a repeated song would distort the middle value.
-  test("excludes debuts and within-show repeats before computing", () => {
+  // All non-debut → 0. The UI uses this to skip the `· N debuts` suffix
+  // when there's nothing to surface.
+  test("returns 0 when no track is a debut", () => {
     const tracks = [
-      { songId: "a", position: 1, gap: null }, // Mindless Dribble debut — drop
-      { songId: "b", position: 2, gap: 5 }, // Tempest
-      { songId: "c", position: 3, gap: 10 }, // Spaga
-      { songId: "d", position: 4, gap: 30 }, // Crickets
-      { songId: "b", position: 5, gap: 5 }, // Tempest reprise — drop
+      { songId: "a", gap: 3 },
+      { songId: "b", gap: 12 },
     ];
-    // Eligible gaps after exclusions: [5, 10, 30] → median = 10.
-    expect(computeMedianSongGap(tracks)).toBe(10);
-  });
-
-  // No eligible tracks (all debuts or all repeats) → null, so the UI can
-  // hide the summary line entirely.
-  test("returns null when no eligible tracks remain", () => {
-    const tracks = [
-      { songId: "a", position: 1, gap: null }, // Basis for a Day debut
-      { songId: "b", position: 2, gap: null }, // Above the Waves debut
-    ];
-    expect(computeMedianSongGap(tracks)).toBeNull();
+    expect(computeDebutCount(tracks)).toBe(0);
   });
 });
 

--- a/packages/core/src/setlists/setlist-service.ts
+++ b/packages/core/src/setlists/setlist-service.ts
@@ -1,4 +1,4 @@
-import type { Annotation, Setlist, SetlistLight, Show, Track, TrackLight, Venue } from "@bip/domain";
+import { type Annotation, average, median, type Setlist, type SetlistLight, type Show, type Track, type TrackLight, type Venue } from "@bip/domain";
 import type { DbAnnotation, DbClient, DbShow, DbSong, DbTrack, DbVenue } from "../_shared/database/models";
 import type { PaginationOptions, SortOptions } from "../_shared/database/types";
 import { resolveShowOrderBy, SHOW_ORDER_ASC, SHOW_ORDER_DESC, STATS_SHOWS_WHERE } from "../_shared/show-ordering";
@@ -53,7 +53,7 @@ type DbTrackLight = {
  * Shared by the average and median computations so both apply identical
  * exclusion rules.
  */
-function eligibleGapsForAggregation(
+export function eligibleGapsForAggregation(
   tracks: ReadonlyArray<{ songId: string; position: number; gap: number | null }>,
 ): number[] {
   const seenSongIds = new Set<string>();
@@ -69,31 +69,19 @@ function eligibleGapsForAggregation(
 }
 
 /**
- * Arithmetic mean of `track.gap` across a setlist's tracks. Returns null
- * when no eligible tracks remain so the gap-chart UI can hide the summary.
+ * Count of distinct catalog debuts in a setlist — tracks with `gap === null`,
+ * deduped by songId so a song played twice in the show counts as one debut.
+ * Surfaced alongside the avg/median gap because debuts are excluded from those
+ * numbers but are themselves a strong rarity signal users want to see.
  */
-export function computeAverageSongGap(
-  tracks: ReadonlyArray<{ songId: string; position: number; gap: number | null }>,
-): number | null {
-  const eligible = eligibleGapsForAggregation(tracks);
-  if (eligible.length === 0) return null;
-  const sum = eligible.reduce((acc, v) => acc + v, 0);
-  return sum / eligible.length;
-}
-
-/**
- * Median of `track.gap` across a setlist's tracks. Resists outliers (one
- * very-high-gap rarity won't drag the typical-gap signal up the way the
- * average does), so it pairs with the average to give users both the
- * typical and the central-tendency view.
- */
-export function computeMedianSongGap(
-  tracks: ReadonlyArray<{ songId: string; position: number; gap: number | null }>,
-): number | null {
-  const sorted = eligibleGapsForAggregation(tracks).sort((a, b) => a - b);
-  if (sorted.length === 0) return null;
-  const mid = Math.floor(sorted.length / 2);
-  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+export function computeDebutCount(
+  tracks: ReadonlyArray<{ songId: string; gap: number | null }>,
+): number {
+  const debutSongIds = new Set<string>();
+  for (const t of tracks) {
+    if (t.gap === null) debutSongIds.add(t.songId);
+  }
+  return debutSongIds.size;
 }
 
 function previousPerformanceShowFromDb(
@@ -253,13 +241,15 @@ function mapSetlistToDomainEntity(
   // Sort sets by their sort order
   sets.sort((a, b) => a.sort - b.sort);
 
+  const eligible = eligibleGapsForAggregation(tracks);
   return {
     show: mapShowToDomainEntity(show),
     venue: mapVenueToDomainEntity(show.venue),
     sets,
     annotations: tracks.flatMap((t) => t.annotations ?? []).map((a) => mapAnnotationToDomainEntity(a)),
-    averageSongGap: computeAverageSongGap(tracks),
-    medianSongGap: computeMedianSongGap(tracks),
+    averageSongGap: average(eligible),
+    medianSongGap: median(eligible),
+    debutCount: computeDebutCount(tracks),
   };
 }
 
@@ -314,13 +304,15 @@ function mapSetlistLightToDomainEntity(
 
   sets.sort((a, b) => a.sort - b.sort);
 
+  const eligible = eligibleGapsForAggregation(tracks);
   return {
     show: mapShowToDomainEntity(show),
     venue: mapVenueToDomainEntity(show.venue),
     sets,
     annotations: tracks.flatMap((t) => t.annotations ?? []).map((a) => mapAnnotationToDomainEntity(a)),
-    averageSongGap: computeAverageSongGap(tracks),
-    medianSongGap: computeMedianSongGap(tracks),
+    averageSongGap: average(eligible),
+    medianSongGap: median(eligible),
+    debutCount: computeDebutCount(tracks),
   };
 }
 

--- a/packages/core/src/stats/stats-service.test.ts
+++ b/packages/core/src/stats/stats-service.test.ts
@@ -108,7 +108,7 @@ describe("songStatsChanged", () => {
 // ---------------------------------------------------------------------------
 
 describe("countShowsAfter", () => {
-  // Drives the songs-list Current Gap column (number of stats-eligible shows
+  // Drives the songs-list Gap to Now column (number of stats-eligible shows
   // since a song's dateLastPlayed) and the song-detail page's "X shows ago"
   // sublabel. Backed by a single cached date array so the binary search
   // runs in O(log n) per song.

--- a/packages/core/src/stats/stats-service.ts
+++ b/packages/core/src/stats/stats-service.ts
@@ -71,7 +71,7 @@ export class StatsService {
   /**
    * Returns sorted ISO date strings (`YYYY-MM-DD`) for every
    * count_for_stats=true show. Cached 24h. Read by callers that need to
-   * count stats-eligible shows after a given date (Current Gap on /songs,
+   * count stats-eligible shows after a given date (Gap to Now on /songs,
    * "X shows ago" sublabel on song detail) — a single fetch backs every
    * such computation across the request.
    */
@@ -98,7 +98,7 @@ export class StatsService {
   /**
    * Number of stats-eligible shows strictly after a song's `dateLastPlayed`
    * — drives the "X shows ago" reading on the song detail page and the
-   * Current Gap column on /songs.
+   * Gap to Now column on /songs.
    */
   async getShowsSinceLastPlayed(dateLastPlayed: Date | string): Promise<number> {
     const dates = await this.getStatsShowDates();
@@ -108,7 +108,7 @@ export class StatsService {
   /**
    * Returns a `Map<songId, gap>` where `gap` is the number of stats-eligible
    * shows that have happened since each song's `dateLastPlayed`. Drives the
-   * Current Gap column on `/songs` — same semantic as `showsSinceLastPlayed`
+   * Gap to Now column on `/songs` — same semantic as `showsSinceLastPlayed`
    * on the song detail page, but computed in bulk for the songs index.
    *
    * Songs without `dateLastPlayed` (never played) and songs not present in

--- a/packages/core/src/users/personal-song-history-service.test.ts
+++ b/packages/core/src/users/personal-song-history-service.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test, vi } from "vitest";
+import { PersonalSongHistoryService } from "./personal-song-history-service";
+
+/**
+ * Build a mock Prisma client wired to return the given attended shows and
+ * tracks. Mirrors the shape the service queries — attendance.findMany
+ * returns `{show: {id, date}}` rows and track.findMany returns
+ * `{showId, songId}` rows.
+ */
+function makeMockDb(opts: {
+  attendances: Array<{ show: { id: string; date: string; slug: string | null } }>;
+  tracks: Array<{ showId: string; songId: string }>;
+}) {
+  return {
+    attendance: {
+      findMany: vi.fn().mockResolvedValue(opts.attendances),
+    },
+    track: {
+      findMany: vi.fn().mockResolvedValue(opts.tracks),
+    },
+  };
+}
+
+describe("PersonalSongHistoryService.getSongHistory", () => {
+  // Brand-new user with no attendances at all — returns empty maps without
+  // crashing or making spurious downstream queries.
+  test("empty user: returns empty arrays and skips track query", async () => {
+    const db = makeMockDb({ attendances: [], tracks: [] });
+    const service = new PersonalSongHistoryService(db as never);
+
+    const result = await service.getSongHistory("user-1");
+
+    expect(result).toEqual({ attendedShows: [], songAttendances: {} });
+    // No shows to look up tracks for — skip the track query entirely.
+    expect(db.track.findMany).not.toHaveBeenCalled();
+  });
+
+  // Populated user: attended two shows, each with some Disco Biscuits
+  // tracks. Service should return chronologically sorted attended dates
+  // and, per song, a sorted list of dates the user saw that song.
+  test("populated user: returns sorted attended dates and per-song attendance dates", async () => {
+    const db = makeMockDb({
+      attendances: [
+        { show: { id: "show-A", date: "2020-06-10", slug: "2020-06-10-radio-city" } },
+        { show: { id: "show-B", date: "2024-07-19", slug: "2024-07-19-port-chester" } },
+      ],
+      tracks: [
+        { showId: "show-A", songId: "song-tractorbeam" },
+        { showId: "show-A", songId: "song-spaga" },
+        { showId: "show-B", songId: "song-tractorbeam" },
+      ],
+    });
+    const service = new PersonalSongHistoryService(db as never);
+
+    const result = await service.getSongHistory("user-1");
+
+    expect(result.attendedShows).toEqual([
+      { date: "2020-06-10", slug: "2020-06-10-radio-city" },
+      { date: "2024-07-19", slug: "2024-07-19-port-chester" },
+    ]);
+    expect(result.songAttendances["song-tractorbeam"]).toEqual([
+      { date: "2020-06-10", slug: "2020-06-10-radio-city" },
+      { date: "2024-07-19", slug: "2024-07-19-port-chester" },
+    ]);
+    expect(result.songAttendances["song-spaga"]).toEqual([{ date: "2020-06-10", slug: "2020-06-10-radio-city" }]);
+  });
+
+  // Same song played twice in one show: the user's attendance list for
+  // that song should contain the show's date once per track (so totalTimesSeen
+  // counts each performance, matching how Total Times Seen is rendered).
+  test("within-show repeat: each occurrence contributes a separate entry", async () => {
+    const db = makeMockDb({
+      attendances: [{ show: { id: "show-A", date: "2024-07-19", slug: "2024-07-19-port-chester" } }],
+      tracks: [
+        { showId: "show-A", songId: "song-mrdon" },
+        { showId: "show-A", songId: "song-mrdon" },
+      ],
+    });
+    const service = new PersonalSongHistoryService(db as never);
+
+    const result = await service.getSongHistory("user-1");
+
+    expect(result.songAttendances["song-mrdon"]).toEqual([
+      { date: "2024-07-19", slug: "2024-07-19-port-chester" },
+      { date: "2024-07-19", slug: "2024-07-19-port-chester" },
+    ]);
+  });
+});

--- a/packages/core/src/users/personal-song-history-service.ts
+++ b/packages/core/src/users/personal-song-history-service.ts
@@ -1,0 +1,100 @@
+import { CacheKeys } from "@bip/domain";
+import type { CacheService } from "../_shared/cache/cache-service";
+import type { DbClient } from "../_shared/database/models";
+
+const ONE_DAY_SECONDS = 86400;
+
+/** A single user attendance, used by both the show-dates list and the per-song lists. */
+export interface PersonalAttendance {
+  date: string;
+  slug: string | null;
+}
+
+export interface PersonalSongHistory {
+  /**
+   * Sorted ASC by date — every show this user has attended, with slug so
+   * the client can link Last Seen / Last Before cells back to the show.
+   * Backs the "Your Gap" denominator (count of attended shows strictly
+   * between Last Before and the current show's date).
+   */
+  attendedShows: PersonalAttendance[];
+  /**
+   * For each song the user has ever seen at an attended show, the sorted
+   * ASC attendances. Within-show repeats produce multiple entries with
+   * the same date+slug — that matches how Total Times Seen counts each
+   * performance.
+   */
+  songAttendances: Record<string, PersonalAttendance[]>;
+}
+
+/**
+ * Per-user attendance/setlist aggregate that backs the SetlistCard
+ * "personal" view. The shape is a deliberately compact map of sorted
+ * ISO dates so the React Query payload is small (a few hundred KB for
+ * heavy users) and per-row column computation is just binary search.
+ */
+export class PersonalSongHistoryService {
+  constructor(
+    private readonly db: DbClient,
+    private readonly cache?: CacheService,
+  ) {}
+
+  async getSongHistory(userId: string): Promise<PersonalSongHistory> {
+    if (this.cache) {
+      return this.cache.getOrSet(CacheKeys.users.songHistory(userId), () => this.compute(userId), {
+        ttl: ONE_DAY_SECONDS,
+      });
+    }
+    return this.compute(userId);
+  }
+
+  private async compute(userId: string): Promise<PersonalSongHistory> {
+    const attendances = await this.db.attendance.findMany({
+      where: { userId },
+      select: { show: { select: { id: true, date: true, slug: true } } },
+      orderBy: { show: { date: "asc" } },
+    });
+
+    if (attendances.length === 0) {
+      return { attendedShows: [], songAttendances: {} };
+    }
+
+    const attendedShows: PersonalAttendance[] = [];
+    const attendanceByShowId = new Map<string, PersonalAttendance>();
+    for (const row of attendances) {
+      const show = row.show;
+      if (!show) continue;
+      const attendance: PersonalAttendance = { date: toIsoDate(show.date), slug: show.slug ?? null };
+      attendedShows.push(attendance);
+      attendanceByShowId.set(show.id, attendance);
+    }
+
+    const showIds = Array.from(attendanceByShowId.keys());
+    const tracks = await this.db.track.findMany({
+      where: { showId: { in: showIds } },
+      select: { showId: true, songId: true },
+    });
+
+    const songAttendances: Record<string, PersonalAttendance[]> = {};
+    for (const track of tracks) {
+      const attendance = attendanceByShowId.get(track.showId);
+      if (!attendance) continue;
+      const arr = songAttendances[track.songId];
+      if (arr) arr.push(attendance);
+      else songAttendances[track.songId] = [attendance];
+    }
+
+    // Tracks were returned in undefined order; sort each song's
+    // attendances by date so the client can binary-search directly.
+    for (const songId of Object.keys(songAttendances)) {
+      songAttendances[songId].sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+    }
+
+    return { attendedShows, songAttendances };
+  }
+}
+
+function toIsoDate(d: Date | string): string {
+  if (typeof d === "string") return d.length > 10 ? d.slice(0, 10) : d;
+  return d.toISOString().slice(0, 10);
+}

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -12,7 +12,7 @@ export const CacheKeys = {
    */
   show: {
     /** Complete show + setlist data for show page */
-    data: (slug: string) => `show:${slug}:data`,
+    data: (slug: string) => `show:${slug}:data:v2`,
 
     // Note: Reviews are loaded fresh from DB, not cached
 
@@ -27,7 +27,7 @@ export const CacheKeys = {
     /** Paginated show listings with filters */
     list: (filters: CacheFilters) => {
       const filterHash = hashFilters(filters);
-      return `shows:list:${filterHash}`;
+      return `shows:list:${filterHash}:v2`;
     },
 
     /** All show listing caches (for pattern deletion) */
@@ -42,7 +42,7 @@ export const CacheKeys = {
    */
   setlist: {
     /** Complete setlist data with tracks and annotations */
-    data: (slug: string) => `setlist:${slug}:data`,
+    data: (slug: string) => `setlist:${slug}:data:v2`,
   },
 
   /**
@@ -64,21 +64,21 @@ export const CacheKeys = {
    */
   songs: {
     /** Full songs index page data */
-    index: () => "songs:index:full",
+    index: () => "songs:index:full:v2",
     /** All-timers page data */
-    allTimers: () => "songs:all-timers",
+    allTimers: () => "songs:all-timers:v2",
     /** Songs with history content */
-    histories: () => "songs:histories",
+    histories: () => "songs:histories:v2",
     /** All-timers for a specific calendar day (On This Day page) */
-    allTimersOnThisDay: (monthDay: string) => `songs:all-timers:on-this-day:${monthDay}`,
+    allTimersOnThisDay: (monthDay: string) => `songs:all-timers:on-this-day:${monthDay}:v2`,
     /** Filtered song results by era/author/cover/tags/attended */
     filtered: (filters: CacheFilters) => {
       const filterHash = hashFilters(filters);
       const attendedUserId = filters.attended;
       if (attendedUserId) {
-        return `songs:filtered:user:${attendedUserId}:${filterHash}`;
+        return `songs:filtered:user:${attendedUserId}:${filterHash}:v2`;
       }
-      return `songs:filtered:${filterHash}`;
+      return `songs:filtered:${filterHash}:v2`;
     },
     /** All filtered song caches (for pattern deletion) */
     allFiltered: () => "songs:filtered:*",
@@ -96,11 +96,20 @@ export const CacheKeys = {
      * have 400+ attended shows and the un-paginated payload is large enough
      * to be slow to deserialize/transport even from Redis.
      */
-    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}`,
+    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}:v2`,
     /** All pages of a single user's attended-setlists caches (for per-user invalidation). */
     allAttendedSetlistsForUser: (userId: string) => `user:${userId}:attended-setlists:*`,
     /** All per-user attended-setlists caches (for pattern deletion on broad show mutations). */
     allAttendedSetlists: () => "user:*:attended-setlists:*",
+    /**
+     * Per-user attendance + setlist aggregate that backs the SetlistCard
+     * "personal" view: sorted attended-show dates plus a {songId: dates[]}
+     * map. Invalidated when the user toggles attendance and when any show
+     * mutation changes the broader catalog.
+     */
+    songHistory: (userId: string) => `user:${userId}:song-history`,
+    /** Pattern for invalidating every user's song-history blob on broad show mutations. */
+    allSongHistory: () => "user:*:song-history",
   },
 
   /**
@@ -108,7 +117,7 @@ export const CacheKeys = {
    */
   home: {
     /** Recent setlists for home page (limit + sort direction) */
-    recentSetlists: (limit: number) => `home:recent-setlists:${limit}`,
+    recentSetlists: (limit: number) => `home:recent-setlists:${limit}:v2`,
   },
 
   /**

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./archive-dot-org";
 export * from "./cache-keys";
+export * from "./math";
 export * from "./models/annotation";
 export * from "./models/attendance";
 export * from "./models/author";

--- a/packages/domain/src/math.test.ts
+++ b/packages/domain/src/math.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import { average, median } from "./math";
+
+describe("average", () => {
+  // Empty input returns null so callers can branch on "render the value
+  // vs. hide the summary line" without a length check at every site.
+  test("returns null for an empty list", () => {
+    expect(average([])).toBeNull();
+  });
+
+  // Arithmetic mean — standard case.
+  test("computes the arithmetic mean of numeric values", () => {
+    expect(average([2, 4, 6])).toBe(4);
+    expect(average([7, 3])).toBe(5);
+  });
+
+  // Single value averages to itself; floating point exact.
+  test("returns the single value when the list has one entry", () => {
+    expect(average([42])).toBe(42);
+  });
+});
+
+describe("median", () => {
+  // Empty input returns null, same convention as average.
+  test("returns null for an empty list", () => {
+    expect(median([])).toBeNull();
+  });
+
+  // Odd count picks the middle element; sorting handled internally so the
+  // input order doesn't matter.
+  test("returns the middle element for an odd-count list", () => {
+    expect(median([1, 5, 3])).toBe(3);
+    expect(median([10, 30, 20, 40, 50])).toBe(30);
+  });
+
+  // Even count averages the two middle elements.
+  test("averages the two middle elements for an even-count list", () => {
+    expect(median([2, 4, 6, 10])).toBe(5);
+    expect(median([1, 2])).toBe(1.5);
+  });
+
+  // Resists outliers — one very-large value barely moves the median while
+  // it would drag the average up significantly. (This is *why* both stats
+  // pair up in the gap-chart UI.)
+  test("is unmoved by a single outlier value", () => {
+    expect(median([1, 2, 3, 4, 1000])).toBe(3);
+  });
+});

--- a/packages/domain/src/math.ts
+++ b/packages/domain/src/math.ts
@@ -1,0 +1,19 @@
+/**
+ * Pure numeric reductions. Kept in the domain package so both the server
+ * (catalog gap aggregates in setlist-service) and the client (per-user
+ * gap aggregates in personal-setlist-columns) share the same arithmetic.
+ * Each function returns `null` on an empty input so callers can branch on
+ * "show the value vs. hide the cell" without a separate length check.
+ */
+
+export function average(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+export function median(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = sorted.length >>> 1;
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}

--- a/packages/domain/src/models/setlist.ts
+++ b/packages/domain/src/models/setlist.ts
@@ -16,6 +16,12 @@ export type Setlist = {
   annotations: Annotation[];
   averageSongGap: number | null;
   medianSongGap: number | null;
+  /**
+   * Number of distinct catalog debuts in this show (tracks with `gap === null`,
+   * counting each song once even if played twice). Shown alongside the avg/median
+   * because debuts are excluded from those numbers but still signal rarity.
+   */
+  debutCount: number;
 };
 
 export type SetLight = {
@@ -31,4 +37,10 @@ export type SetlistLight = {
   annotations: Annotation[];
   averageSongGap: number | null;
   medianSongGap: number | null;
+  /**
+   * Number of distinct catalog debuts in this show (tracks with `gap === null`,
+   * counting each song once even if played twice). Shown alongside the avg/median
+   * because debuts are excluded from those numbers but still signal rarity.
+   */
+  debutCount: number;
 };

--- a/packages/domain/src/models/song.ts
+++ b/packages/domain/src/models/song.ts
@@ -19,7 +19,7 @@ export const songSchema = z.object({
   // the "Filtered Plays" column alongside the all-time Plays column.
   filteredTimesPlayed: z.number().optional(),
   // Filtered analogs of the rarity fields below — populated only when a narrowing
-  // filter is active. Drive the Filtered Current Gap / Filtered Since Debut /
+  // filter is active. Drive the Filtered Gap to End / Filtered Since Debut /
   // Filtered Avg Gap columns on /songs.
   filteredShowsSinceLastPlayed: z.number().nullable().optional(),
   filteredPercentSinceDebut: z.number().nullable().optional(),


### PR DESCRIPTION
## Summary

Logged-in users get a third toggle option on every SetlistCard ("personal gap chart") with per-track columns Set, Track, Song, Your Gap, Last Seen, and Seen Before — all computed from the user's attendance history. Dates link to their shows. Song titles open the song detail page pre-filtered to attended performances (`?attended=attended`). Prev/next show navigation preserves the active view. Summary line surfaces `· N debuts` alongside avg/median for both the existing gap chart and the new personal gap chart.

The `/songs` "Current Gap" / "Filtered Current Gap" column headers are renamed to "Gap to Now" / (funnel) "Gap to End" so the visible label distinguishes them from "Avg Gap" without relying on a hover tooltip.

Bumps cache keys for payloads that changed in this PR and the two PRs immediately preceding it (#113, #122). Redis isn't cleared on deploy and rolling deploys mean old/new workers share Redis; versioning the keys for any changed payload shape keeps stale-format reads from poisoning the new code path. Keys bumped to `:v2`: `show.data`, `shows.list`, `setlist.data`, `songs.index`, `songs.allTimers`, `songs.histories`, `songs.allTimersOnThisDay`, `songs.filtered`, `home.recentSetlists`, `users.attendedSetlists`.


https://github.com/user-attachments/assets/296878d4-4339-4698-a1a6-bfb446420326



## Notes for reviewers

User-history data is fetched once per session as a compact payload (attended-show dates + per-song attendance dates, with slugs) via `/api/users/song-history`; column values are derived client-side via binary search. Toggling personal on every card in a 40-card year page costs zero extra requests. Per-user payload is Redis-cached for 24h and invalidated on attendance toggles + show mutations.

## Test plan

- [ ] `make tc && make test && make lint`
- [ ] `make web`, log in
- [ ] On `/shows/<some past show you attended>`, toggle "personal gap chart" → confirm columns render, dates link to their shows, song titles open `/songs/{slug}?attended=attended`
- [ ] Click prev/next show — `?view=personal` persists
- [ ] Toggle attendance elsewhere, reload a different show's personal view — values update
- [ ] Profile Shows Attended tab — toggle personal on multiple cards, Network panel shows a single `/api/users/song-history` request
- [ ] `/songs?timeRange=2025` — confirm "Gap to End" header renders on the filtered column, "Gap to Now" on the unfiltered one
- [ ] Log out — "personal gap chart" segment disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
