### PR TITLE
Admins can mark tracks as all-timers

### DIFF
--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -1,10 +1,11 @@
 import { compareByShowDate, type SongPagePerformance } from "@bip/domain";
 import { type Column, type ColumnDef, createColumnHelper, type Row } from "@tanstack/react-table";
-import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon, Filter, Flame, RotateCcw, Star } from "lucide-react";
+import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon, Filter, RotateCcw, Star } from "lucide-react";
 import { GapIcon } from "~/components/gap-icon";
 import { formatSetLabel } from "~/components/setlist/set-label";
 import { ShowDate } from "~/components/show-date";
 import { ShowDateLink } from "~/components/show-date-link";
+import { AllTimerCell, allTimerColumnMeta } from "~/components/track/all-timer-cell";
 import { CombinedNotes } from "./combined-notes";
 import { DateVenueCell } from "./date-venue-cell";
 import { TrackRatingCell } from "./track-rating-cell";
@@ -190,20 +191,9 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       columnHelper.accessor((row) => row.allTimer ?? false, {
         id: "allTimer",
         header: "",
-        // Tightest possible slot: zero horizontal padding and a 16px
-        // width — just enough to hold the 14px flame icon — so the column
-        // takes the least space possible from its neighbors.
-        meta: { width: "16px", cellClassName: "px-0 sm:px-0" },
+        meta: allTimerColumnMeta,
         enableSorting: false,
-        cell: (info) =>
-          info.getValue() ? (
-            // h-6 matches the default text-base line-height in adjacent
-            // cells; items-center vertically centers the 14px icon so it
-            // sits on the same baseline as text-row content.
-            <div className="flex h-6 items-center justify-center">
-              <Flame className="h-3.5 w-3.5 text-orange-500" />
-            </div>
-          ) : null,
+        cell: (info) => (info.getValue() ? <AllTimerCell /> : null),
       }) as ColumnDef<SongPagePerformance, unknown>,
     );
   }
@@ -386,7 +376,7 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       header: ({ column }) => <SortableHeader column={column} label="Rating" />,
       enableSorting: true,
       sortingFn: "basic",
-      meta: { width: "118px", hideOnMobile: true },
+      meta: { width: "132px", hideOnMobile: true },
       cell: (info) => {
         const rating = info.getValue();
         const ratingsCount = info.row.original.ratingsCount;

--- a/apps/web/app/components/setlist/setlist-columns.test.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.test.tsx
@@ -78,9 +78,9 @@ describe("createSetlistColumns", () => {
   // as "Song / Gap" before the user's eye jumps to the older Last Played
   // date. Rating anchors the right edge — it's the action column (click to
   // rate) so it lives where the eye lands at the end of the row scan.
-  test("returns columns in order [Set, Track, Song, Gap, Last Played, Rating]", () => {
+  test("returns columns in order [Set, Track, All-timer, Song, Gap, Last Played, Rating]", () => {
     const columns = createSetlistColumns();
-    expect(columns.map((c) => c.id)).toEqual(["set", "track", "song", "gap", "lastPlayed", "rating"]);
+    expect(columns.map((c) => c.id)).toEqual(["set", "track", "allTimer", "song", "gap", "lastPlayed", "rating"]);
   });
 
   // Every column is sortable. Set and Track # share the canonical
@@ -115,7 +115,7 @@ describe("createSetlistColumns", () => {
     // the Set header puts the table into "sorted by set" mode.
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /^Set$/i }));
-    const setCells = screen.getAllByRole("cell").filter((_, i) => i % 6 === 0);
+    const setCells = screen.getAllByRole("cell").filter((_, i) => i % 7 === 0);
     expect(setCells.map((c) => c.textContent)).toEqual(["1", "", "2", ""]);
   });
 
@@ -142,7 +142,7 @@ describe("createSetlistColumns", () => {
       makeTrack({ songId: "c", position: 3, set: "S2", gap: 20, song: { id: "c", title: "Confrontation", slug: "z" } }),
     ]);
     await user.click(screen.getByRole("button", { name: /Gap/i }));
-    const setCells = screen.getAllByRole("cell").filter((_, i) => i % 6 === 0);
+    const setCells = screen.getAllByRole("cell").filter((_, i) => i % 7 === 0);
     // After asc-by-gap: gap=5 (S1), gap=10 (S1), gap=20 (S2). Every row
     // displays its set label.
     expect(setCells.map((c) => c.textContent)).toEqual(["1", "1", "2"]);
@@ -177,7 +177,7 @@ describe("createSetlistColumns", () => {
       }),
     ]);
     await user.click(screen.getByRole("button", { name: /Last Played/i }));
-    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 6 === 2);
+    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 7 === 3);
     expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
       "Basis for a Day",
       "Above the Waves",
@@ -208,7 +208,7 @@ describe("createSetlistColumns", () => {
       }),
     ]);
     await user.click(screen.getByRole("button", { name: /Gap/i }));
-    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 6 === 2);
+    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 7 === 3);
     expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
       "Basis for a Day",
       "Above the Waves",
@@ -226,11 +226,11 @@ describe("createSetlistColumns", () => {
       makeTrack({ songId: "d", position: 4, set: "E1", song: { id: "d", title: "Crickets", slug: "w" } }),
     ]);
     const cells = screen.getAllByRole("cell");
-    // Each row produces 6 cells; cells[1], cells[7], cells[13], cells[19] are Track #.
+    // Each row produces 7 cells; cells[1], cells[8], cells[15], cells[22] are Track #.
     expect(cells[1].textContent).toBe("1");
-    expect(cells[7].textContent).toBe("2");
-    expect(cells[13].textContent).toBe("1");
-    expect(cells[19].textContent).toBe("1");
+    expect(cells[8].textContent).toBe("2");
+    expect(cells[15].textContent).toBe("1");
+    expect(cells[22].textContent).toBe("1");
   });
 
   // Set column drops the "S" prefix (S1 → 1, S2 → 2, etc.) — the column
@@ -243,9 +243,9 @@ describe("createSetlistColumns", () => {
       makeTrack({ songId: "b", position: 2, set: "S2", song: { id: "b", title: "Tempest", slug: "t" } }),
     ]);
     const cells = screen.getAllByRole("cell");
-    // 6 cells per row; cells[0] = Set of row 0, cells[6] = Set of row 1.
+    // 7 cells per row; cells[0] = Set of row 0, cells[7] = Set of row 1.
     expect(cells[0].textContent).toBe("1");
-    expect(cells[6].textContent).toBe("2");
+    expect(cells[7].textContent).toBe("2");
   });
 
   // Single encore collapses E1 → E because there's no second encore to
@@ -257,9 +257,9 @@ describe("createSetlistColumns", () => {
       makeTrack({ songId: "b", position: 2, set: "E1", song: { id: "b", title: "Crickets", slug: "c" } }),
     ]);
     const singleCells = screen.getAllByRole("cell");
-    // 6 cells per row; cells[0] = Set row 0, cells[6] = Set row 1.
+    // 7 cells per row; cells[0] = Set row 0, cells[7] = Set row 1.
     expect(singleCells[0].textContent).toBe("1");
-    expect(singleCells[6].textContent).toBe("E");
+    expect(singleCells[7].textContent).toBe("E");
 
     // Re-render with two encores to confirm we keep the numbering.
     document.body.innerHTML = "";
@@ -269,7 +269,7 @@ describe("createSetlistColumns", () => {
     ]);
     const multiCells = screen.getAllByRole("cell");
     expect(multiCells[0].textContent).toBe("E1");
-    expect(multiCells[6].textContent).toBe("E2");
+    expect(multiCells[7].textContent).toBe("E2");
   });
 
   // Normal row: gap renders as the integer; Last Played renders the prior

--- a/apps/web/app/components/setlist/setlist-common-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-common-columns.tsx
@@ -2,6 +2,7 @@ import type { TrackLight } from "@bip/domain";
 import { type ColumnDef, createColumnHelper, type Row, type SortingFn } from "@tanstack/react-table";
 import { TrackRatingCell } from "~/components/performance/track-rating-cell";
 import { ShowDateLink } from "~/components/show-date-link";
+import { AllTimerCell, allTimerColumnMeta } from "~/components/track/all-timer-cell";
 import { SortableHeader } from "~/components/ui/sortable-header";
 import { GapCell, type GapCellState } from "./gap-cell";
 import { compareBySetThenPosition, countDistinctEncores, formatSetLabel } from "./set-label";
@@ -218,6 +219,13 @@ export function createSetlistCommonColumns<T extends TrackLight>(options?: {
           allRows.filter((r) => r.original.set === row.set && r.original.position < row.position).length + 1;
         return <span className="text-content-text-secondary tabular-nums">{trackNumber}</span>;
       },
+    }) as ColumnDef<T, unknown>,
+    columnHelper.display({
+      id: "allTimer",
+      header: () => null,
+      meta: allTimerColumnMeta,
+      enableSorting: false,
+      cell: (info) => (info.row.original.allTimer ? <AllTimerCell /> : null),
     }) as ColumnDef<T, unknown>,
     columnHelper.accessor((row) => row.song?.title ?? "", {
       id: "song",

--- a/apps/web/app/components/setlist/setlist-table.test.tsx
+++ b/apps/web/app/components/setlist/setlist-table.test.tsx
@@ -80,7 +80,7 @@ describe("SetlistTable", () => {
         ]}
       />,
     );
-    const cells = screen.getAllByRole("cell").filter((_, i) => i % 6 === 2);
+    const cells = screen.getAllByRole("cell").filter((_, i) => i % 7 === 3);
     expect(cells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
       "Basis for a Day",
       "Above the Waves",

--- a/apps/web/app/components/track/all-timer-cell.tsx
+++ b/apps/web/app/components/track/all-timer-cell.tsx
@@ -1,0 +1,20 @@
+import { Flame } from "lucide-react";
+
+/**
+ * Table-cell renderer for the all-timer marker. The `h-6` wrapper matches
+ * the default text-base line-height of adjacent cells so the 14px flame
+ * sits on the same baseline as song-title text instead of floating high.
+ */
+export function AllTimerCell() {
+  return (
+    <div className="flex h-6 items-center justify-center">
+      <Flame className="h-3.5 w-3.5 text-orange-500" aria-label="All-timer" />
+    </div>
+  );
+}
+
+/**
+ * Meta options for the all-timer column — narrowest viable slot with no
+ * horizontal padding so it never steals width from neighboring columns.
+ */
+export const allTimerColumnMeta = { width: "16px", cellClassName: "px-0 sm:px-0" } as const;

--- a/apps/web/app/components/track/sortable-track-item.tsx
+++ b/apps/web/app/components/track/sortable-track-item.tsx
@@ -1,7 +1,7 @@
 import type { Track } from "@bip/domain";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { Edit2, GripVertical, Trash } from "lucide-react";
+import { Edit2, Flame, GripVertical, Trash } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import { cn } from "~/lib/utils";
 
@@ -42,6 +42,11 @@ export function SortableTrackItem({ track, onEdit, onDelete, isDeleting }: Sorta
 
           {/* Position Number - now just for display */}
           <span className="text-content-text-secondary font-mono text-sm w-8 mt-1">{track.position}</span>
+
+          {/* All-timer indicator (reserved column to keep alignment) */}
+          <span className="w-5 mt-1 flex justify-center">
+            {track.allTimer && <Flame className="h-4 w-4 text-orange-500" />}
+          </span>
 
           {/* Track Content */}
           <div className="flex-1">

--- a/apps/web/app/components/track/track-manager.tsx
+++ b/apps/web/app/components/track/track-manager.tsx
@@ -26,6 +26,7 @@ import {
 } from "~/components/ui/alert-dialog";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Checkbox } from "~/components/ui/checkbox";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
 import { SortableTrackItem } from "./sortable-track-item";
 
@@ -43,6 +44,7 @@ interface TrackFormData {
   note: string | null;
   song?: Track["song"];
   annotationDesc?: string | null;
+  allTimer: boolean;
 }
 
 const SET_OPTIONS = [
@@ -74,6 +76,7 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
     segue: "none",
     note: null,
     annotationDesc: null,
+    allTimer: false,
   });
 
   // Set up drag and drop sensors
@@ -246,6 +249,7 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
       segue: "none",
       note: null,
       annotationDesc: null,
+      allTimer: false,
     });
   };
 
@@ -267,6 +271,7 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
       note: track.note,
       song: track.song,
       annotationDesc: annotationsText,
+      allTimer: track.allTimer ?? false,
     });
   };
 
@@ -457,6 +462,17 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
           >
             <X className="h-4 w-4" />
           </Button>
+        </div>
+
+        <div className="md:col-span-7 flex items-center gap-2">
+          <Checkbox
+            id="track-all-timer"
+            checked={formData.allTimer}
+            onCheckedChange={(checked) => setFormData((prev) => ({ ...prev, allTimer: checked === true }))}
+          />
+          <label htmlFor="track-all-timer" className="text-sm font-medium text-content-text-secondary cursor-pointer">
+            All-timer
+          </label>
         </div>
       </div>
     );

--- a/apps/web/app/routes/api/tracks.tsx
+++ b/apps/web/app/routes/api/tracks.tsx
@@ -39,6 +39,7 @@ export const action = adminAction(async ({ request }) => {
         position: data.position,
         segue: data.segue,
         note: data.note,
+        allTimer: data.allTimer,
       });
 
       // Create annotations if provided


### PR DESCRIPTION
## Summary
- Admin track editor on `/shows/:slug/edit` has an All-timer checkbox; the flame icon appears immediately on the track row when toggled.
- Gap charts (community + personal views in SetlistCard) show the all-timer flame in a narrow column between Track # and Song.

## Test plan
- [ ] On `/shows/:slug/edit`, edit a track → toggle All-timer → Update; flame icon appears/disappears on the row.
- [ ] On a show with at least one all-timer, open the gap chart view in SetlistCard — flame icon column sits between Track # and Song.
- [ ] Same for the personal gap chart view.
- [ ] Existing setlist + performance tables still align cleanly (no floating icons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)