### PR TITLE
Paint attendance, rating, and admin UI on first frame via SSR

### DIFF
--- a/apps/web/app/components/admin/admin-only.tsx
+++ b/apps/web/app/components/admin/admin-only.tsx
@@ -6,15 +6,11 @@ interface AdminOnlyProps {
 }
 
 export function AdminOnly({ children, fallback = null }: AdminOnlyProps) {
-  const { user, loading: isLoading } = useSession();
+  const { user } = useSession();
 
-  // If Supabase context is not loaded yet, render nothing
-  if (isLoading) {
-    return null;
-  }
-
-  // Check for admin flag in app_metadata (server-controlled, secure)
-  if (user?.app_metadata?.isAdmin === true) {
+  // app_metadata.isAdmin is server-controlled and surfaced into the
+  // SessionUser projection; trust it as the only admin signal here.
+  if (user?.isAdmin) {
     return <>{children}</>;
   }
 

--- a/apps/web/app/components/layout/header.tsx
+++ b/apps/web/app/components/layout/header.tsx
@@ -37,7 +37,7 @@ const navigation = [
 
 export function Header() {
   const isMobile = useIsMobile();
-  const { user, loading } = useSession();
+  const { user } = useSession();
   const { open: _openSearch } = useGlobalSearch();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
@@ -53,7 +53,7 @@ export function Header() {
     };
   }, [mobileMenuOpen]);
 
-  const username = user?.user_metadata?.username ?? user?.email?.split("@")[0];
+  const username = user?.username ?? user?.email?.split("@")[0];
 
   return (
     <>
@@ -100,22 +100,20 @@ export function Header() {
           {/* User Profile/Auth & Mobile Menu */}
           <div className="flex items-center space-x-2">
             {/* User Profile/Auth */}
-            {!loading && (
-              <div className="hidden sm:flex items-center space-x-2">
-                {user ? (
-                  <UserDropdown user={user} />
-                ) : (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    asChild
-                    className="glass-secondary hover:glass-content transition-all duration-200"
-                  >
-                    <Link to="/auth/login">Sign in</Link>
-                  </Button>
-                )}
-              </div>
-            )}
+            <div className="hidden sm:flex items-center space-x-2">
+              {user ? (
+                <UserDropdown user={user} />
+              ) : (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  asChild
+                  className="glass-secondary hover:glass-content transition-all duration-200"
+                >
+                  <Link to="/auth/login">Sign in</Link>
+                </Button>
+              )}
+            </div>
 
             {/* Mobile Menu Button */}
             <div className="md:hidden">
@@ -161,13 +159,12 @@ export function Header() {
 
             {/* Mobile Auth & User Menu */}
             <div className="border-t border-border/10 pt-4 mt-4">
-              {!loading &&
-                (user ? (
+              {user ? (
                   <div className="space-y-1">
                     {/* User Info */}
                     <div className="flex items-center space-x-3 px-4 py-3 rounded-md bg-brand-primary/5">
                       <Avatar className="h-10 w-10">
-                        <AvatarImage src={user.user_metadata?.avatar_url} />
+                        <AvatarImage src={user.avatarUrl ?? undefined} />
                         <AvatarFallback className="bg-brand-primary/20 text-brand-primary text-sm font-medium">
                           {username?.slice(0, 2).toUpperCase()}
                         </AvatarFallback>
@@ -215,7 +212,7 @@ export function Header() {
                     <User className="h-5 w-5 mr-3" />
                     Sign in
                   </Link>
-                ))}
+                )}
             </div>
           </nav>
         </div>

--- a/apps/web/app/components/layout/user-dropdown.tsx
+++ b/apps/web/app/components/layout/user-dropdown.tsx
@@ -11,21 +11,16 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu";
+import type { SessionUser } from "~/lib/session-user";
 import { cn } from "~/lib/utils";
 
 interface UserDropdownProps {
-  user: {
-    email?: string;
-    user_metadata?: {
-      username?: string;
-      avatar_url?: string;
-    };
-  };
+  user: Pick<SessionUser, "email" | "username" | "avatarUrl">;
   className?: string;
 }
 
 export function UserDropdown({ user, className }: UserDropdownProps) {
-  const username = user?.user_metadata?.username ?? user?.email?.split("@")[0];
+  const username = user.username ?? user.email?.split("@")[0];
   const initials = username?.slice(0, 2).toUpperCase() ?? "??";
 
   return (
@@ -42,11 +37,7 @@ export function UserDropdown({ user, className }: UserDropdownProps) {
           )}
         >
           <Avatar className="h-8 w-8 ring-1 ring-brand-primary/20 transition-all duration-200 hover:ring-brand-primary/50">
-            <AvatarImage
-              src={user.user_metadata?.avatar_url}
-              alt={username || "User avatar"}
-              className="object-cover"
-            />
+            <AvatarImage src={user.avatarUrl ?? undefined} alt={username || "User avatar"} className="object-cover" />
             <AvatarFallback className="bg-brand-primary/10 text-brand-primary font-medium text-xs">
               {initials}
             </AvatarFallback>
@@ -70,11 +61,7 @@ export function UserDropdown({ user, className }: UserDropdownProps) {
         <DropdownMenuLabel className="font-normal p-0">
           <div className="flex items-center space-x-3 p-3 rounded-lg bg-brand-primary/5 border border-brand-primary/10">
             <Avatar className="h-10 w-10 ring-1 ring-brand-primary/30">
-              <AvatarImage
-                src={user.user_metadata?.avatar_url}
-                alt={username || "User avatar"}
-                className="object-cover"
-              />
+              <AvatarImage src={user.avatarUrl ?? undefined} alt={username || "User avatar"} className="object-cover" />
               <AvatarFallback className="bg-brand-primary/20 text-brand-primary font-medium">{initials}</AvatarFallback>
             </Avatar>
             <div className="flex flex-col space-y-1">

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -366,17 +366,12 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
         },
       },
     ) as ColumnDef<SongPagePerformance, unknown>,
-    // Explicit width reserves enough room for the widest content (avg +
-    // count + user rating + dividers) so the cell doesn't grow when
-    // client-side user rating data arrives after hydration. Without
-    // this, the post-hydration widening triggers a phantom horizontal
-    // scrollbar on the table wrapper at narrow viewports.
     columnHelper.accessor((row) => row.rating ?? 0, {
       id: "rating",
       header: ({ column }) => <SortableHeader column={column} label="Rating" />,
       enableSorting: true,
       sortingFn: "basic",
-      meta: { width: "132px", hideOnMobile: true },
+      meta: { hideOnMobile: true },
       cell: (info) => {
         const rating = info.getValue();
         const ratingsCount = info.row.original.ratingsCount;

--- a/apps/web/app/components/performance/performance-table.test.tsx
+++ b/apps/web/app/components/performance/performance-table.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 // Mock hooks used internally by PerformanceTable.
 vi.mock("~/hooks/use-session", () => ({
-  useSession: vi.fn(() => ({ user: null, supabase: null, loading: false })),
+  useSession: vi.fn(() => ({ user: null, supabase: null })),
 }));
 vi.mock("~/hooks/use-show-user-data", () => ({
   useShowUserData: vi.fn(() => ({
@@ -201,7 +201,6 @@ describe("PerformanceTable", () => {
     vi.mocked(useSession).mockReturnValue({
       user: { id: "u1" } as never,
       supabase: null,
-      loading: false,
     });
 
     await setupWithRouter(<PerformanceTable performances={[makePerformance()]} />);

--- a/apps/web/app/components/setlist/setlist-list.test.tsx
+++ b/apps/web/app/components/setlist/setlist-list.test.tsx
@@ -16,11 +16,12 @@ vi.mock("./setlist-card", () => ({
 }));
 
 // Mock useShowUserData — SetlistList owns this call. Tests drive the return
-// value to simulate the batched API response and assert on the options the
-// wrapper passes through (notably initialData for SSR cache seeding).
+// value to simulate the batched API response and assert on the arguments the
+// wrapper passes through (just the show id list now; SSR seeding is handled
+// by the root HydrationBoundary, not a per-call initialData option).
 const useShowUserDataMock = vi.fn();
 vi.mock("~/hooks/use-show-user-data", () => ({
-  useShowUserData: (showIds: string[], options?: object) => useShowUserDataMock(showIds, options),
+  useShowUserData: (showIds: string[]) => useShowUserDataMock(showIds),
 }));
 
 import { SetlistList } from "./setlist-list";
@@ -204,27 +205,6 @@ describe("SetlistList", () => {
     expect(useShowUserDataMock).toHaveBeenCalled();
     const passed = useShowUserDataMock.mock.calls[0][0] as string[];
     expect(passed).toEqual(["show-a", "show-b", "show-c"]);
-  });
-
-  // When a loader pre-fetched show user data, SetlistList forwards it to the
-  // hook as initialData so React Query seeds the cache and cards render
-  // attendance / rating badges on first paint (no hydration flicker).
-  test("forwards initialUserData to the hook as initialData", async () => {
-    setMockReturn();
-    const initialUserData = {
-      attendances: { "show-1": null },
-      userRatings: { "show-1": null },
-      averageRatings: { "show-1": { average: 4.2, count: 3 } },
-    };
-    await setupWithRouter(
-      <SetlistList
-        setlists={[makeSetlist("show-1", "Basis for a Day")]}
-        externalSources={{}}
-        initialUserData={initialUserData}
-      />,
-    );
-
-    expect(useShowUserDataMock).toHaveBeenCalledWith(["show-1"], { initialData: initialUserData });
   });
 
   // Empty list with no `empty` prop: render nothing, no cards, no stray DOM.

--- a/apps/web/app/components/setlist/setlist-list.tsx
+++ b/apps/web/app/components/setlist/setlist-list.tsx
@@ -1,7 +1,6 @@
 import type { Setlist, SetlistLight } from "@bip/domain";
 import { Fragment, type ReactNode, useMemo } from "react";
 import { useShowUserData } from "~/hooks/use-show-user-data";
-import type { ShowUserDataResponse } from "~/server/show-user-data";
 import { SetlistCard } from "./setlist-card";
 import type { ShowExternalSources } from "./show-external-badges";
 
@@ -11,13 +10,13 @@ import type { ShowExternalSources } from "./show-external-badges";
  * Callers hand in `setlists` and an `externalSources` map; cards receive the
  * per-show slices internally.
  *
- * `initialUserData`, when supplied by a loader, seeds React Query's cache so
- * attendance and rating badges render on first paint with no hydration flicker.
+ * Loaders that render this list prefetch `showUserDataQueryKey(...)` into a
+ * dehydrated state; the root `<HydrationBoundary>` warms the cache before
+ * this component mounts, so attendance / rating badges paint with the HTML.
  */
 interface SetlistListProps {
   setlists: Array<Setlist | SetlistLight>;
   externalSources: Record<string, ShowExternalSources>;
-  initialUserData?: ShowUserDataResponse;
   /** Rendered when `setlists` is empty. Defaults to nothing. */
   empty?: ReactNode;
   /**
@@ -38,14 +37,13 @@ interface SetlistListProps {
 export function SetlistList({
   setlists,
   externalSources,
-  initialUserData,
   empty,
   groupByMonth,
   numbered,
   collapsible,
 }: SetlistListProps) {
   const showIds = useMemo(() => setlists.map((s) => s.show.id), [setlists]);
-  const { attendanceMap, userRatingMap, averageRatingMap } = useShowUserData(showIds, { initialData: initialUserData });
+  const { attendanceMap, userRatingMap, averageRatingMap } = useShowUserData(showIds);
 
   if (setlists.length === 0) {
     return <>{empty ?? null}</>;

--- a/apps/web/app/components/setlist/setlist-table.test.tsx
+++ b/apps/web/app/components/setlist/setlist-table.test.tsx
@@ -7,7 +7,7 @@ import { describe, expect, test, vi } from "vitest";
 // without network calls. The auth state + rating map are wired through
 // vi.mocked() inside each test that cares; default is anonymous + empty.
 vi.mock("~/hooks/use-session", () => ({
-  useSession: vi.fn(() => ({ user: null, supabase: null, loading: false })),
+  useSession: vi.fn(() => ({ user: null, supabase: null })),
 }));
 vi.mock("~/hooks/use-track-user-ratings", () => ({
   useTrackUserRatings: vi.fn(() => ({ userRatingMap: new Map<string, number>(), isLoading: false })),
@@ -125,7 +125,6 @@ describe("SetlistTable", () => {
       user: { id: "user-1" } as any,
       // biome-ignore lint/suspicious/noExplicitAny: minimal mock
       supabase: null as any,
-      loading: false,
     });
     vi.mocked(useTrackUserRatings).mockReturnValue({
       userRatingMap: new Map([["t-1", 5]]),

--- a/apps/web/app/components/ui/star-rating.test.tsx
+++ b/apps/web/app/components/ui/star-rating.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("~/hooks/use-session", () => ({
-  useSession: vi.fn(() => ({ user: { id: "user-1" }, supabase: null, loading: false })),
+  useSession: vi.fn(() => ({ user: { id: "user-1" }, supabase: null })),
 }));
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
@@ -42,6 +42,33 @@ describe("StarRating clear affordance", () => {
       <StarRating rateableId="track-1" rateableType="Track" showSlug="show-1" initialRating={null} />,
     );
     expect(screen.queryByRole("button", { name: /clear rating/i })).not.toBeInTheDocument();
+  });
+
+  // A `null` initialRating means the caller already knows the user has
+  // no rating yet (e.g. data was prefetched into a route loader). Skip
+  // the on-mount GET — it would just round-trip the same null back.
+  test("does not fetch /api/ratings when initialRating is null", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+    await setupWithRouter(<StarRating rateableId="show-1" rateableType="Show" initialRating={null} />);
+    // Wait a microtask in case the effect was queued.
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // When the caller has no information, omit the prop (or pass
+  // undefined). StarRating falls back to fetching the rating itself so
+  // the badge still appears.
+  test("fetches /api/ratings when initialRating is undefined", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ userRating: 4, averageRating: 4.2, ratingsCount: 12 }),
+    });
+    globalThis.fetch = fetchMock;
+    await setupWithRouter(<StarRating rateableId="show-1" rateableType="Show" />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/ratings?rateableId=show-1&rateableType=Show");
   });
 
   // With a rating present, the clear glyph appears to the left of the

--- a/apps/web/app/components/ui/star-rating.tsx
+++ b/apps/web/app/components/ui/star-rating.tsx
@@ -41,9 +41,9 @@ export function StarRating({
   const [isAnimating, setIsAnimating] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [rating, setRating] = useState<RatingResponse | null>(
-    initialRating != null ? { userRating: initialRating, averageRating: null } : null,
+    initialRating !== undefined ? { userRating: initialRating, averageRating: null } : null,
   );
-  const { user, loading: isSessionLoading } = useSession();
+  const { user } = useSession();
   const revalidator = useRevalidator();
   const queryClient = useQueryClient();
   const isMountedRef = useRef<boolean>(true);
@@ -57,9 +57,12 @@ export function StarRating({
     };
   }, []);
 
-  // Fetch rating if needed (only when user is logged in and no initial rating provided)
+  // Fetch rating if needed (only when user is logged in and the caller
+  // didn't pass an initial value). A `null` initialRating is treated as
+  // "caller knows the user has no rating yet" — skip the fetch. Pass
+  // `undefined` (or omit the prop) when the answer truly is unknown.
   useEffect(() => {
-    if (!user || isSessionLoading || initialRating != null || hasFetchedRef.current) {
+    if (!user || initialRating !== undefined || hasFetchedRef.current) {
       return;
     }
 
@@ -85,7 +88,7 @@ export function StarRating({
     };
 
     fetchRating();
-  }, [user, isSessionLoading, initialRating, rateableId, rateableType]);
+  }, [user, initialRating, rateableId, rateableType]);
 
   const submitRating = async (value: number) => {
     setIsSubmitting(true);

--- a/apps/web/app/hooks/use-attendance-row-highlight.test.ts
+++ b/apps/web/app/hooks/use-attendance-row-highlight.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("~/hooks/use-session", () => ({
-  useSession: vi.fn(() => ({ user: { id: "user-1" }, supabase: null, loading: false })),
+  useSession: vi.fn(() => ({ user: { id: "user-1" }, supabase: null })),
 }));
 
 vi.mock("~/hooks/use-show-user-data", () => ({
@@ -29,7 +29,6 @@ describe("useAttendanceRowHighlight", () => {
     vi.mocked(useSession).mockReturnValue({
       user: { id: "user-1" } as never,
       supabase: null,
-      loading: false,
     });
     vi.mocked(useShowUserData).mockReturnValue({
       attendanceMap: new Map(),
@@ -70,7 +69,6 @@ describe("useAttendanceRowHighlight", () => {
     vi.mocked(useSession).mockReturnValue({
       user: null,
       supabase: null,
-      loading: false,
     });
 
     const items: TestItem[] = [{ id: "1", showId: "show-1" }];

--- a/apps/web/app/hooks/use-session.ts
+++ b/apps/web/app/hooks/use-session.ts
@@ -2,38 +2,13 @@ import { createBrowserClient } from "@supabase/ssr";
 import type { SupabaseClient, User } from "@supabase/supabase-js";
 import { useEffect, useMemo, useState } from "react";
 import { useRouteLoaderData } from "react-router";
+import type { SessionUser } from "~/lib/session-user";
+import { toSessionUser } from "~/lib/session-user";
 import type { RootData } from "~/root";
 
 const syncedUsers = new Set<string>();
 type SyncResult = { refreshedUser: User | null; internalUserId?: string };
 const inflightSyncs = new Map<string, Promise<SyncResult>>();
-
-function normalizeUser(user: User | null): User | null {
-  if (!user) {
-    return user;
-  }
-
-  const rawUsername = user.user_metadata?.username;
-  if (typeof rawUsername !== "string") {
-    return user;
-  }
-
-  const trimmedUsername = rawUsername.trim();
-  const shouldRemoveUsername = trimmedUsername.length === 0;
-  const shouldUpdateUsername = trimmedUsername !== rawUsername;
-
-  if (!shouldUpdateUsername && !shouldRemoveUsername) {
-    return user;
-  }
-
-  const { username: _ignored, ...restMetadata } = user.user_metadata ?? {};
-  const normalizedMetadata = shouldRemoveUsername ? restMetadata : { ...restMetadata, username: trimmedUsername };
-
-  return {
-    ...user,
-    user_metadata: normalizedMetadata,
-  };
-}
 
 async function requestSync(supabase: SupabaseClient): Promise<SyncResult> {
   const response = await fetch("/api/auth/sync", { method: "POST", credentials: "include" });
@@ -114,12 +89,22 @@ async function ensureUserSynced(user: User, supabase: SupabaseClient | null): Pr
   return user;
 }
 
-export function useSession() {
+/**
+ * Returns the current authenticated user (projected to the client-safe
+ * `SessionUser` shape) and the browser Supabase client.
+ *
+ * Initial state is seeded from the root loader's `sessionUser` field so the
+ * first client render already knows who the user is — no flicker on
+ * user-specific UI. The `onAuthStateChange` listener stays mounted to
+ * handle in-tab login / logout transitions.
+ */
+export function useSession(): { user: SessionUser | null; supabase: SupabaseClient | null } {
   const rootData = useRouteLoaderData("root") as RootData | undefined;
   const SUPABASE_URL = rootData?.env?.SUPABASE_URL;
   const SUPABASE_ANON_KEY = rootData?.env?.SUPABASE_ANON_KEY;
-  const [user, setUser] = useState<User | null>(null);
-  const [loading, setLoading] = useState(true);
+  const seededUser = rootData?.sessionUser ?? null;
+
+  const [user, setUser] = useState<SessionUser | null>(seededUser);
 
   // Create the Supabase client only once
   const supabase = useMemo(() => {
@@ -133,55 +118,33 @@ export function useSession() {
     });
   }, [SUPABASE_URL, SUPABASE_ANON_KEY]);
 
-  // Set up session and auth listener in useEffect
+  // Keep `user` in sync with in-tab login / logout. The SSR seed handles
+  // the initial paint; this listener picks up subsequent transitions.
   useEffect(() => {
-    if (!supabase) {
-      setLoading(false);
-      return;
-    }
+    if (!supabase) return;
 
     let isCancelled = false;
 
-    // Get initial session
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      const sessionUser = session?.user ?? null;
-      setUser(normalizeUser(sessionUser));
-      setLoading(false);
-
-      // Fallback: ensure user is synced to PostgreSQL
-      if (sessionUser) {
-        ensureUserSynced(sessionUser, supabase).then((syncedUser) => {
-          if (!isCancelled && syncedUser && syncedUser.id === sessionUser.id) {
-            setUser(normalizeUser(syncedUser));
-          }
-        });
-      }
-    });
-
-    // Set up auth listener
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
       const sessionUser = session?.user ?? null;
-      setUser(normalizeUser(sessionUser));
-      setLoading(false);
+      setUser(sessionUser ? toSessionUser(sessionUser) : null);
 
-      // Fallback: ensure user is synced to PostgreSQL on auth state change
       if (sessionUser) {
         ensureUserSynced(sessionUser, supabase).then((syncedUser) => {
           if (!isCancelled && syncedUser && syncedUser.id === sessionUser.id) {
-            setUser(normalizeUser(syncedUser));
+            setUser(toSessionUser(syncedUser));
           }
         });
       }
     });
 
-    // Cleanup subscription on unmount
     return () => {
       isCancelled = true;
       subscription.unsubscribe();
     };
   }, [supabase]);
 
-  return { user, supabase, loading };
+  return { user, supabase };
 }

--- a/apps/web/app/hooks/use-show-user-data.ts
+++ b/apps/web/app/hooks/use-show-user-data.ts
@@ -2,6 +2,7 @@ import type { Attendance } from "@bip/domain";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { batchedPostFetch } from "~/lib/batched-fetch";
+import { showUserDataQueryKey } from "~/lib/query-keys";
 import type { ShowUserDataResponse } from "~/server/show-user-data";
 
 interface UseShowUserDataResult {
@@ -28,18 +29,8 @@ function mergeShowUserData(results: ShowUserDataResponse[]): ShowUserDataRespons
   return merged;
 }
 
-interface UseShowUserDataOptions {
-  /**
-   * Server-fetched initial data to seed React Query's cache so SetlistCards
-   * render attendance / rating badges on first paint. When present, the data
-   * is treated as fresh (no background refetch within the stale window).
-   */
-  initialData?: ShowUserDataResponse;
-}
-
-export function useShowUserData(showIds: string[], options?: UseShowUserDataOptions): UseShowUserDataResult {
-  // Create a stable key from sorted show IDs
-  const queryKey = useMemo(() => ["shows", "user-data", [...showIds].sort().join(",")], [showIds]);
+export function useShowUserData(showIds: string[]): UseShowUserDataResult {
+  const queryKey = useMemo(() => showUserDataQueryKey(showIds), [showIds]);
 
   const { data, isLoading, error } = useQuery({
     queryKey,
@@ -47,8 +38,6 @@ export function useShowUserData(showIds: string[], options?: UseShowUserDataOpti
       batchedPostFetch<ShowUserDataResponse>("/api/shows/user-data", showIds, "showIds", 200, mergeShowUserData),
     enabled: showIds.length > 0,
     staleTime: 30_000,
-    initialData: options?.initialData,
-    initialDataUpdatedAt: options?.initialData ? Date.now() : undefined,
   });
 
   // Transform response into Maps for O(1) lookup

--- a/apps/web/app/hooks/use-track-user-ratings.ts
+++ b/apps/web/app/hooks/use-track-user-ratings.ts
@@ -1,7 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { batchedPostFetch } from "~/lib/batched-fetch";
-import type { TrackUserRatingsResponse } from "~/routes/api/tracks/user-ratings";
+import { trackUserRatingsQueryKey } from "~/lib/query-keys";
+import type { TrackUserRatingsResponse } from "~/server/track-user-ratings";
 
 function mergeTrackUserRatings(results: TrackUserRatingsResponse[]): TrackUserRatingsResponse {
   const merged: TrackUserRatingsResponse = { userRatings: {} };
@@ -12,7 +13,7 @@ function mergeTrackUserRatings(results: TrackUserRatingsResponse[]): TrackUserRa
 }
 
 export function useTrackUserRatings(trackIds: string[]) {
-  const queryKey = useMemo(() => ["tracks", "user-ratings", [...trackIds].sort().join(",")], [trackIds]);
+  const queryKey = useMemo(() => trackUserRatingsQueryKey(trackIds), [trackIds]);
 
   const { data, isLoading } = useQuery({
     queryKey,

--- a/apps/web/app/lib/base-loaders.ts
+++ b/apps/web/app/lib/base-loaders.ts
@@ -2,8 +2,8 @@ import type { User as SupabaseUser } from "@supabase/supabase-js";
 import type { ActionFunctionArgs, LoaderFunction, LoaderFunctionArgs } from "react-router-dom";
 import { redirect } from "react-router-dom";
 import { logger } from "~/lib/logger";
+import { getRequestUser } from "~/server/request-user";
 import { services } from "~/server/services";
-import { getServerClient } from "~/server/supabase";
 
 interface User {
   id: string;
@@ -120,10 +120,7 @@ async function getUser(
   request: Request,
   options: { requireAuth: boolean; requireAdmin?: boolean },
 ): Promise<User | null> {
-  const { supabase } = getServerClient(request);
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const user = await getRequestUser(request);
 
   if (options?.requireAuth) {
     if (!user) {

--- a/apps/web/app/lib/query-keys.test.ts
+++ b/apps/web/app/lib/query-keys.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+import { showUserDataQueryKey, trackUserRatingsQueryKey } from "./query-keys";
+
+describe("query-keys", () => {
+  // The key is the contract between loader-side prefetch and client-side
+  // useQuery. If input order differs (e.g. loader passes ids in insertion
+  // order, hook receives them in render order), the built key must still
+  // match — otherwise SSR seeding silently fails.
+  test("showUserDataQueryKey is order-independent", () => {
+    expect(showUserDataQueryKey(["c", "a", "b"])).toEqual(showUserDataQueryKey(["a", "b", "c"]));
+  });
+
+  // Different id sets must produce different keys; otherwise two pages would
+  // share a cache entry and one would see the other's prefetched data.
+  test("showUserDataQueryKey differs by id set", () => {
+    expect(showUserDataQueryKey(["a", "b"])).not.toEqual(showUserDataQueryKey(["a", "b", "c"]));
+  });
+
+  // Same invariants for track ratings — different queryFn payload but the
+  // key shape (sorted, comma-joined) must be identical so the merge logic
+  // and assertion patterns in loaders stay symmetrical.
+  test("trackUserRatingsQueryKey is order-independent", () => {
+    expect(trackUserRatingsQueryKey(["t2", "t1"])).toEqual(trackUserRatingsQueryKey(["t1", "t2"]));
+  });
+});

--- a/apps/web/app/lib/query-keys.ts
+++ b/apps/web/app/lib/query-keys.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared React Query keys for hooks that are seeded by loader-side
+ * `prefetchQuery` calls. Loader and hook MUST use the same builder so the
+ * dehydrated cache entry matches the client's `useQuery` lookup — otherwise
+ * the hook treats the cache as empty and refetches client-side.
+ */
+
+export function showUserDataQueryKey(showIds: readonly string[]): readonly unknown[] {
+  return ["shows", "user-data", [...showIds].sort().join(",")];
+}
+
+export function trackUserRatingsQueryKey(trackIds: readonly string[]): readonly unknown[] {
+  return ["tracks", "user-ratings", [...trackIds].sort().join(",")];
+}

--- a/apps/web/app/lib/query-prefetch.test.ts
+++ b/apps/web/app/lib/query-prefetch.test.ts
@@ -1,0 +1,59 @@
+import { dehydrate } from "@tanstack/react-query";
+import { describe, expect, test } from "vitest";
+import { showUserDataQueryKey } from "./query-keys";
+import { createPrefetchClient, mergeDehydratedStates } from "./query-prefetch";
+
+describe("createPrefetchClient", () => {
+  // Loaders must get a fresh client per request. A module-level singleton
+  // would leak one user's attendance data into the next request's
+  // dehydrated payload.
+  test("returns a distinct client each call", () => {
+    const a = createPrefetchClient();
+    const b = createPrefetchClient();
+    expect(a).not.toBe(b);
+  });
+
+  // Prefetched data is what the dehydrate/hydrate cycle actually carries
+  // across the wire. This is the smoke test that the helper produces a
+  // client that prefetchQuery + dehydrate can round-trip.
+  test("prefetched data appears in the dehydrated payload", async () => {
+    const client = createPrefetchClient();
+    await client.prefetchQuery({
+      queryKey: showUserDataQueryKey(["show-1"]),
+      queryFn: async () => ({ attendances: {}, userRatings: {}, averageRatings: {} }),
+    });
+    const state = dehydrate(client);
+    expect(state.queries.length).toBe(1);
+    expect(state.queries[0].queryKey).toEqual(showUserDataQueryKey(["show-1"]));
+  });
+});
+
+describe("mergeDehydratedStates", () => {
+  // Two loaders each prefetch one query; HydrationBoundary needs both. The
+  // merger concatenates queries (and mutations, if any) so a single state
+  // can be handed to one boundary at the root.
+  test("concatenates queries from each input state", async () => {
+    const a = createPrefetchClient();
+    await a.prefetchQuery({ queryKey: ["q", "a"], queryFn: async () => 1 });
+    const b = createPrefetchClient();
+    await b.prefetchQuery({ queryKey: ["q", "b"], queryFn: async () => 2 });
+
+    const merged = mergeDehydratedStates([dehydrate(a), dehydrate(b)]);
+    expect(merged.queries).toHaveLength(2);
+    const keys = merged.queries.map((q) => q.queryKey);
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        ["q", "a"],
+        ["q", "b"],
+      ]),
+    );
+  });
+
+  // Loaders that didn't prefetch anything pass back `undefined` from their
+  // optional `dehydratedState` field. The merger must tolerate that without
+  // throwing or polluting the result.
+  test("ignores undefined entries", () => {
+    const merged = mergeDehydratedStates([undefined, undefined]);
+    expect(merged).toEqual({ mutations: [], queries: [] });
+  });
+});

--- a/apps/web/app/lib/query-prefetch.ts
+++ b/apps/web/app/lib/query-prefetch.ts
@@ -1,0 +1,37 @@
+import { type DehydratedState, QueryClient } from "@tanstack/react-query";
+
+/**
+ * Per-request `QueryClient` for loader-side prefetching. Each call returns a
+ * fresh instance — a module-level shared client would leak user-scoped data
+ * (attendance, ratings) between requests.
+ *
+ * Defaults intentionally mirror the client-side `QueryProvider` so dehydrated
+ * entries keep the same stale/gc semantics once they hydrate on the client.
+ */
+export function createPrefetchClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        gcTime: 5 * 60_000,
+        retry: 1,
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
+}
+
+/**
+ * Combines dehydrated states returned from multiple route loaders into a
+ * single state for `<HydrationBoundary>`. Each route segment's loader
+ * dehydrates its own client; the root Layout merges them via `useMatches()`.
+ */
+export function mergeDehydratedStates(states: Array<DehydratedState | undefined>): DehydratedState {
+  const merged: DehydratedState = { mutations: [], queries: [] };
+  for (const state of states) {
+    if (!state) continue;
+    if (state.mutations.length > 0) merged.mutations.push(...state.mutations);
+    if (state.queries.length > 0) merged.queries.push(...state.queries);
+  }
+  return merged;
+}

--- a/apps/web/app/lib/session-user.test.ts
+++ b/apps/web/app/lib/session-user.test.ts
@@ -1,0 +1,96 @@
+import type { User } from "@supabase/supabase-js";
+import { describe, expect, test } from "vitest";
+import { toSessionUser } from "./session-user";
+
+function makeSupabaseUser(overrides: Partial<User> = {}): User {
+  return {
+    id: "auth-1",
+    email: "evan@foo.net",
+    app_metadata: {},
+    user_metadata: {},
+    aud: "authenticated",
+    created_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  } as User;
+}
+
+describe("toSessionUser", () => {
+  // Happy path: an authenticated user with full metadata. Asserts the
+  // projection picks exactly the fields useSession consumers read and
+  // nothing else (no tokens, no app_metadata.provider, etc.).
+  test("projects the supabase user to the client-safe shape", () => {
+    const result = toSessionUser(
+      makeSupabaseUser({
+        user_metadata: { username: "evan", internal_user_id: "local-1" },
+        app_metadata: { isAdmin: true, provider: "email" },
+      }),
+    );
+
+    expect(result).toEqual({
+      id: "auth-1",
+      email: "evan@foo.net",
+      username: "evan",
+      avatarUrl: null,
+      internalUserId: "local-1",
+      isAdmin: true,
+    });
+  });
+
+  // Avatar URL is shipped when present so the header / user-dropdown
+  // can render the user's profile image on first paint.
+  test("includes avatarUrl from user_metadata.avatar_url", () => {
+    const result = toSessionUser(
+      makeSupabaseUser({ user_metadata: { avatar_url: "https://cdn.example.com/avatar.png" } }),
+    );
+    expect(result.avatarUrl).toBe("https://cdn.example.com/avatar.png");
+  });
+
+  // Sensitive fields must not leak into the seed. The full Supabase user
+  // includes access tokens and provider details — none of those should
+  // appear in the projected SessionUser.
+  test("does not include tokens or extraneous fields", () => {
+    const result = toSessionUser(
+      makeSupabaseUser({
+        // @ts-expect-error: simulating an arbitrary field we don't want shipped
+        access_token: "secret",
+      }),
+    );
+    expect(Object.keys(result)).toEqual(["id", "email", "username", "avatarUrl", "internalUserId", "isAdmin"]);
+    expect(JSON.stringify(result)).not.toContain("secret");
+  });
+
+  // Whitespace-only usernames normalize to null so the SSR seed matches
+  // a client-side re-derive; otherwise an empty username string would
+  // replace null once onAuthStateChange fires, triggering a needless
+  // re-render.
+  test("normalizes whitespace-only usernames to null", () => {
+    const result = toSessionUser(makeSupabaseUser({ user_metadata: { username: "   " } }));
+    expect(result.username).toBeNull();
+  });
+
+  // A user without an internal_user_id yet (newly-signed-in, before
+  // ensureUserSynced fires) still gets a well-formed shape; the
+  // client-side sync fills the id in later.
+  test("returns null internalUserId when metadata lacks it", () => {
+    const result = toSessionUser(makeSupabaseUser({ user_metadata: { username: "evan" } }));
+    expect(result.internalUserId).toBeNull();
+    expect(result.username).toBe("evan");
+  });
+
+  // Supabase types `email` as optional. The helper coerces missing
+  // emails to "" so downstream code that reads user.email doesn't need
+  // to null-check every access.
+  test("coerces missing email to empty string", () => {
+    const result = toSessionUser(makeSupabaseUser({ email: undefined }));
+    expect(result.email).toBe("");
+  });
+
+  // isAdmin must be a strict boolean, not "truthy". Some metadata stores
+  // store "true" as a string; only the literal boolean `true` grants
+  // admin.
+  test("isAdmin is true only when app_metadata.isAdmin === true", () => {
+    expect(toSessionUser(makeSupabaseUser({ app_metadata: { isAdmin: true } })).isAdmin).toBe(true);
+    expect(toSessionUser(makeSupabaseUser({ app_metadata: { isAdmin: "true" } })).isAdmin).toBe(false);
+    expect(toSessionUser(makeSupabaseUser({ app_metadata: {} })).isAdmin).toBe(false);
+  });
+});

--- a/apps/web/app/lib/session-user.ts
+++ b/apps/web/app/lib/session-user.ts
@@ -1,0 +1,45 @@
+import type { User } from "@supabase/supabase-js";
+
+/**
+ * Client-safe projection of the Supabase auth user. Shipped from the root
+ * loader so `useSession`'s initial render already knows who the user is
+ * (no flicker on user-specific UI). Excludes anything sensitive — never
+ * include tokens or full app_metadata; only the named fields below.
+ *
+ * Lives in `~/lib` (not `~/server`) so `use-session.ts` (client) can
+ * value-import `toSessionUser` without dragging server-only deps (env,
+ * supabase server client) into the client bundle.
+ */
+export interface SessionUser {
+  id: string;
+  email: string;
+  username: string | null;
+  avatarUrl: string | null;
+  internalUserId: string | null;
+  isAdmin: boolean;
+}
+
+function normalizeUsername(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Pure projection from a full Supabase `User` to the client-safe shape.
+ * Used by both the server-side loader helper and the client-side
+ * `onAuthStateChange` listener so SSR seed and client-derived values stay
+ * structurally identical (no spurious re-render on auth replay).
+ */
+export function toSessionUser(user: User): SessionUser {
+  const internalUserIdRaw = user.user_metadata?.internal_user_id;
+  const avatarUrlRaw = user.user_metadata?.avatar_url;
+  return {
+    id: user.id,
+    email: user.email ?? "",
+    username: normalizeUsername(user.user_metadata?.username),
+    avatarUrl: typeof avatarUrlRaw === "string" && avatarUrlRaw.length > 0 ? avatarUrlRaw : null,
+    internalUserId: typeof internalUserIdRaw === "string" ? internalUserIdRaw : null,
+    isAdmin: user.app_metadata?.isAdmin === true,
+  };
+}

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -1,4 +1,6 @@
 import type { Route } from ".react-router/types/app/+types/root";
+import { type DehydratedState, HydrationBoundary } from "@tanstack/react-query";
+import { useMemo } from "react";
 import {
   isRouteErrorResponse,
   Links,
@@ -7,6 +9,7 @@ import {
   Scripts,
   ScrollRestoration,
   useLoaderData,
+  useMatches,
   useRouteError,
 } from "react-router-dom";
 import { Toaster } from "sonner";
@@ -16,12 +19,17 @@ import { HeaderLayout } from "~/components/layout/header-layout";
 import { SearchProvider } from "~/components/search/search-provider";
 import { SupabaseProvider } from "~/context/supabase-provider";
 import { GlobalSearchProvider } from "~/hooks/use-global-search";
+import { mergeDehydratedStates } from "~/lib/query-prefetch";
+import type { SessionUser } from "~/lib/session-user";
+import { toSessionUser } from "~/lib/session-user";
 import { QueryProvider } from "~/providers/query-provider";
 import { env } from "~/server/env";
+import { getRequestUser } from "~/server/request-user";
 import stylesheet from "./styles.css?url";
 
 export type RootData = {
   env: ClientSideEnv;
+  sessionUser: SessionUser | null;
 };
 
 export type ClientSideEnv = {
@@ -33,7 +41,7 @@ export type ClientSideEnv = {
 
 export const links: Route.LinksFunction = () => [{ rel: "stylesheet", href: stylesheet }];
 
-export async function loader(): Promise<RootData> {
+export async function loader({ request }: Route.LoaderArgs): Promise<RootData> {
   const clientEnv = {
     SUPABASE_URL: env.SUPABASE_URL,
     SUPABASE_ANON_KEY: env.SUPABASE_ANON_KEY,
@@ -41,14 +49,28 @@ export async function loader(): Promise<RootData> {
     BASE_URL: env.BASE_URL,
   };
 
+  // Seed useSession's initial state so user-specific UI paints on the
+  // first frame instead of after supabase.auth.getSession() resolves.
+  const user = await getRequestUser(request);
+
   return {
     env: clientEnv,
+    sessionUser: user ? toSessionUser(user) : null,
   };
 }
 
 export function Layout({ children }: { children: React.ReactNode }) {
   const data = useLoaderData() as RootData | undefined;
   const env = data?.env;
+
+  const matches = useMatches();
+  const dehydratedState = useMemo(
+    () =>
+      mergeDehydratedStates(
+        matches.map((m) => (m.data as { dehydratedState?: DehydratedState } | undefined)?.dehydratedState),
+      ),
+    [matches],
+  );
 
   return (
     <html lang="en" className="font-quicksand dark overflow-x-hidden">
@@ -62,11 +84,13 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <ConcertLights />
         <SupabaseProvider env={env}>
           <QueryProvider>
-            <GlobalSearchProvider>
-              <SearchProvider>
-                <HeaderLayout>{children}</HeaderLayout>
-              </SearchProvider>
-            </GlobalSearchProvider>
+            <HydrationBoundary state={dehydratedState}>
+              <GlobalSearchProvider>
+                <SearchProvider>
+                  <HeaderLayout>{children}</HeaderLayout>
+                </SearchProvider>
+              </GlobalSearchProvider>
+            </HydrationBoundary>
           </QueryProvider>
         </SupabaseProvider>
         <Toaster position="top-right" theme="dark" />

--- a/apps/web/app/routes/_index.tsx
+++ b/apps/web/app/routes/_index.tsx
@@ -1,4 +1,5 @@
 import { type BlogPostWithUser, CacheKeys, type Setlist, type TourDate } from "@bip/domain";
+import { type DehydratedState, dehydrate } from "@tanstack/react-query";
 import { Calendar } from "lucide-react";
 import { Link } from "react-router-dom";
 import { BlogCard } from "~/components/blog/blog-card";
@@ -9,10 +10,12 @@ import { DonationBanner } from "~/components/ui/donation-banner";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
 import { logger } from "~/lib/logger";
+import { showUserDataQueryKey } from "~/lib/query-keys";
+import { createPrefetchClient } from "~/lib/query-prefetch";
 import { getHomeMeta } from "~/lib/seo";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
-import { computeShowUserData, type ShowUserDataResponse } from "~/server/show-user-data";
+import { computeShowUserData } from "~/server/show-user-data";
 
 interface AcastEpisode {
   id: string;
@@ -35,7 +38,7 @@ interface LoaderData {
   recentShows: Setlist[];
   onThisDayCounts: { showCount: number; allTimerCount: number };
   externalSources: Record<string, ShowExternalSources>;
-  initialUserData: ShowUserDataResponse;
+  dehydratedState: DehydratedState;
 }
 
 export const loader = publicLoader<LoaderData>(async ({ context }) => {
@@ -109,7 +112,11 @@ export const loader = publicLoader<LoaderData>(async ({ context }) => {
     ]),
   ];
 
-  const initialUserData = await computeShowUserData(context, allShowIds);
+  const queryClient = createPrefetchClient();
+  await queryClient.prefetchQuery({
+    queryKey: showUserDataQueryKey(allShowIds),
+    queryFn: () => computeShowUserData(context, allShowIds),
+  });
 
   // Fetch latest podcast episode
   let latestEpisode: AcastEpisode | null = null;
@@ -149,7 +156,7 @@ export const loader = publicLoader<LoaderData>(async ({ context }) => {
     recentShows,
     onThisDayCounts,
     externalSources,
-    initialUserData,
+    dehydratedState: dehydrate(queryClient),
   };
 });
 
@@ -168,7 +175,6 @@ export default function Index() {
     recentShows = [],
     onThisDayCounts,
     externalSources,
-    initialUserData,
   } = useSerializedLoaderData<LoaderData>();
 
   return (
@@ -187,11 +193,7 @@ export default function Index() {
       <div className="md:hidden">
         <div className="mb-6">
           <div className="space-y-4">
-            <SetlistList
-              setlists={recentShows.slice(0, 2)}
-              externalSources={externalSources}
-              initialUserData={initialUserData}
-            />
+            <SetlistList setlists={recentShows.slice(0, 2)} externalSources={externalSources} />
           </div>
         </div>
 
@@ -243,7 +245,6 @@ export default function Index() {
               <SetlistList
                 setlists={desktopRecentShows}
                 externalSources={externalSources}
-                initialUserData={initialUserData}
                 empty={
                   <div className="text-center p-8 border border-dashed rounded-lg">
                     <p className="text-muted-foreground">No recent shows available</p>
@@ -488,7 +489,6 @@ export default function Index() {
             <SetlistList
               setlists={mobileRecentShows}
               externalSources={externalSources}
-              initialUserData={initialUserData}
               empty={
                 <div className="text-center p-8 border border-dashed rounded-lg">
                   <p className="text-muted-foreground">No recent shows available</p>

--- a/apps/web/app/routes/api/tracks/user-ratings.tsx
+++ b/apps/web/app/routes/api/tracks/user-ratings.tsx
@@ -1,11 +1,7 @@
 import { publicAction } from "~/lib/base-loaders";
 import { badRequest } from "~/lib/errors";
 import { logger } from "~/lib/logger";
-import { services } from "~/server/services";
-
-export interface TrackUserRatingsResponse {
-  userRatings: Record<string, number | null>;
-}
+import { computeTrackUserRatings } from "~/server/track-user-ratings";
 
 export const action = publicAction(async ({ request, context }) => {
   let trackIds: string[];
@@ -27,21 +23,8 @@ export const action = publicAction(async ({ request, context }) => {
     });
   }
 
-  const response: TrackUserRatingsResponse = {
-    userRatings: {},
-  };
-
   try {
-    if (context.currentUser) {
-      const user = await services.users.findByEmail(context.currentUser.email);
-      if (user) {
-        const ratings = await services.ratings.findManyByUserIdAndRateableIds(user.id, trackIds, "Track");
-        for (const rating of ratings) {
-          response.userRatings[rating.rateableId] = rating.value;
-        }
-      }
-    }
-
+    const response = await computeTrackUserRatings(context, trackIds);
     return new Response(JSON.stringify(response), {
       status: 200,
       headers: { "Content-Type": "application/json" },

--- a/apps/web/app/routes/on-this-day.$monthDay.tsx
+++ b/apps/web/app/routes/on-this-day.$monthDay.tsx
@@ -1,4 +1,5 @@
 import { CacheKeys, type SetlistLight, type SongPagePerformance } from "@bip/domain";
+import { type DehydratedState, dehydrate } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight, Flame } from "lucide-react";
 import type { ClientLoaderFunctionArgs } from "react-router";
 import { Link, redirect } from "react-router";
@@ -10,10 +11,13 @@ import type { ShowExternalSources } from "~/components/setlist/show-external-bad
 import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
+import { showUserDataQueryKey, trackUserRatingsQueryKey } from "~/lib/query-keys";
+import { createPrefetchClient } from "~/lib/query-prefetch";
 import { addDaysYearAgnostic, formatMonthDay, formatMonthDayShort, isValidMonthDay } from "~/lib/utils";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
-import { computeShowUserData, type ShowUserDataResponse } from "~/server/show-user-data";
+import { computeShowUserData } from "~/server/show-user-data";
+import { computeTrackUserRatings } from "~/server/track-user-ratings";
 
 interface LoaderData {
   setlists: SetlistLight[];
@@ -23,7 +27,7 @@ interface LoaderData {
   previousMonthDay: string;
   nextMonthDay: string;
   externalSources: Record<string, ShowExternalSources>;
-  initialUserData: ShowUserDataResponse;
+  dehydratedState: DehydratedState;
 }
 
 export function headers(): Headers {
@@ -65,6 +69,30 @@ export const loader = publicLoader(async ({ params, context }): Promise<LoaderDa
   const previousMonthDay = addDaysYearAgnostic(monthDay, -1);
   const nextMonthDay = addDaysYearAgnostic(monthDay, 1);
 
+  const setlistShowIds = setlists.map((s) => s.show.id);
+  // Performance rows reference shows from any year that share this month-day,
+  // so they cover a different (and usually larger) id set than the setlists.
+  // PerformanceTable's useAttendanceRowHighlight calls useShowUserData with
+  // those ids, so we must prefetch that key in addition to the setlist key.
+  const performanceShowIds = [...new Set(allTimersResult.performances.map((p) => p.show.id))];
+  const trackIds = allTimersResult.performances.map((p) => p.trackId);
+
+  const queryClient = createPrefetchClient();
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: showUserDataQueryKey(setlistShowIds),
+      queryFn: () => computeShowUserData(context, setlistShowIds),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: showUserDataQueryKey(performanceShowIds),
+      queryFn: () => computeShowUserData(context, performanceShowIds),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: trackUserRatingsQueryKey(trackIds),
+      queryFn: () => computeTrackUserRatings(context, trackIds),
+    }),
+  ]);
+
   return {
     setlists,
     performances: allTimersResult.performances,
@@ -73,10 +101,7 @@ export const loader = publicLoader(async ({ params, context }): Promise<LoaderDa
     previousMonthDay,
     nextMonthDay,
     externalSources: await computeShowExternalSources(setlists.map((s) => s.show)),
-    initialUserData: await computeShowUserData(
-      context,
-      setlists.map((s) => s.show.id),
-    ),
+    dehydratedState: dehydrate(queryClient),
   };
 });
 
@@ -104,7 +129,6 @@ export default function OnThisDay() {
     previousMonthDay,
     nextMonthDay,
     externalSources,
-    initialUserData,
   } = useSerializedLoaderData<LoaderData>();
 
   const {
@@ -204,7 +228,6 @@ export default function OnThisDay() {
           <SetlistList
             setlists={setlists}
             externalSources={externalSources}
-            initialUserData={initialUserData}
             empty={
               <div className="text-center py-8">
                 <p className="text-content-text-secondary text-lg">No shows on {displayLabel}.</p>

--- a/apps/web/app/routes/shows/$slug.tsx
+++ b/apps/web/app/routes/shows/$slug.tsx
@@ -1,12 +1,6 @@
 import type { ShowNavItem } from "@bip/core";
-import {
-  type ArchiveDotOrgRecording,
-  type Attendance,
-  CacheKeys,
-  type ReviewMinimal,
-  type Setlist,
-  type ShowFile,
-} from "@bip/domain";
+import { type ArchiveDotOrgRecording, CacheKeys, type ReviewMinimal, type Setlist, type ShowFile } from "@bip/domain";
+import { type DehydratedState, dehydrate } from "@tanstack/react-query";
 import { ArrowLeft, ChevronLeft, ChevronRight, Edit } from "lucide-react";
 import { Link, useRevalidator } from "react-router-dom";
 import { toast } from "sonner";
@@ -25,14 +19,17 @@ import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { useSession } from "~/hooks/use-session";
 import { useSetlistView } from "~/hooks/use-setlist-view";
 import { useShowUserData } from "~/hooks/use-show-user-data";
-import { type Context, publicLoader } from "~/lib/base-loaders";
+import { publicLoader } from "~/lib/base-loaders";
 import { notFound } from "~/lib/errors";
 import { EXTERNAL_SOURCE_DOMAINS } from "~/lib/favicon";
 import { logger } from "~/lib/logger";
+import { showUserDataQueryKey } from "~/lib/query-keys";
+import { createPrefetchClient } from "~/lib/query-prefetch";
 import { getShowMeta, getShowStructuredData } from "~/lib/seo";
 import { formatDateLong, formatMonthDay } from "~/lib/utils";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
+import { computeShowUserData } from "~/server/show-user-data";
 
 interface ShowLoaderData {
   setlist: Setlist;
@@ -41,30 +38,9 @@ interface ShowLoaderData {
   nugsLinks: ExternalLink[];
   youtubeLinks: ExternalLink[];
   externalSources: ShowExternalSources;
-  userAttendance: Attendance | null;
   photos: ShowFile[];
   adjacentShows: { previous: ShowNavItem | null; next: ShowNavItem | null };
-}
-
-async function fetchUserAttendance(context: Context, showId: string): Promise<Attendance | null> {
-  if (!context.currentUser) {
-    return null;
-  }
-
-  try {
-    const user = await services.users.findByEmail(context.currentUser.email);
-    if (!user) {
-      logger.warn(`User not found with email ${context.currentUser.email}`);
-      return null;
-    }
-
-    const userAttendance = await services.attendances.findByUserIdAndShowId(user.id, showId);
-    logger.info(`Fetch user attendance for show ${showId}: attended? ${!!userAttendance}`);
-    return userAttendance;
-  } catch (error) {
-    logger.warn("Failed to load user attendance", { error });
-    return null;
-  }
+  dehydratedState: DehydratedState;
 }
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
@@ -101,9 +77,6 @@ export const loader = publicLoader(async ({ params, context }): Promise<ShowLoad
     services.shows.findAdjacentShows(setlist.show.date, setlist.show.slug),
   ]);
 
-  // If user is authenticated, fetch their attendance data for search results
-  const userAttendance = await fetchUserAttendance(context, setlist.show.id);
-
   logger.info(`Show data loaded for ${slug} - setlist cached, reviews fresh`);
 
   const [archiveRecordings, nugsReleases, youtubeVideoUrls, externalSourcesMap] = await Promise.all([
@@ -112,6 +85,16 @@ export const loader = publicLoader(async ({ params, context }): Promise<ShowLoad
     services.youtube.getVideoUrlsForShow(setlist.show.id),
     computeShowExternalSources([setlist.show]),
   ]);
+
+  // Prefetch attendance + user rating + community average for this show
+  // so the SetlistCard's badges and the StarRating editor paint on the
+  // first server response with no flicker and no client-side POST.
+  const showIds = [setlist.show.id];
+  const queryClient = createPrefetchClient();
+  await queryClient.prefetchQuery({
+    queryKey: showUserDataQueryKey(showIds),
+    queryFn: () => computeShowUserData(context, showIds),
+  });
 
   const nugsLinks: ExternalLink[] = nugsReleases.map((release) => ({
     url: release.url,
@@ -129,9 +112,9 @@ export const loader = publicLoader(async ({ params, context }): Promise<ShowLoad
     nugsLinks,
     youtubeLinks,
     externalSources: externalSourcesMap[setlist.show.id] ?? {},
-    userAttendance,
     photos,
     adjacentShows,
+    dehydratedState: dehydrate(queryClient),
   };
 });
 
@@ -140,25 +123,16 @@ export function meta({ data }: { data: ShowLoaderData }) {
 }
 
 export default function Show() {
-  const {
-    setlist,
-    reviews,
-    archiveRecordings,
-    nugsLinks,
-    youtubeLinks,
-    externalSources,
-    userAttendance,
-    photos,
-    adjacentShows,
-  } = useSerializedLoaderData<ShowLoaderData>();
+  const { setlist, reviews, archiveRecordings, nugsLinks, youtubeLinks, externalSources, photos, adjacentShows } =
+    useSerializedLoaderData<ShowLoaderData>();
   const { user } = useSession();
   const revalidator = useRevalidator();
   const [setlistView, setSetlistView] = useSetlistView();
-  const { userRatingMap } = useShowUserData([setlist.show.id]);
+  const { userRatingMap, attendanceMap } = useShowUserData([setlist.show.id]);
   const userRating = userRatingMap.get(setlist.show.id) ?? null;
+  const userAttendance = attendanceMap.get(setlist.show.id) ?? null;
 
-  // Get the internal user ID from Supabase metadata
-  const internalUserId = user?.user_metadata?.internal_user_id;
+  const internalUserId = user?.internalUserId ?? undefined;
 
   const handleReviewSubmit = async (data: { content: string }) => {
     try {

--- a/apps/web/app/routes/shows/top-rated-shows.ts
+++ b/apps/web/app/routes/shows/top-rated-shows.ts
@@ -1,10 +1,13 @@
 import type { FilterCondition } from "@bip/core/_shared/database/types";
 import type { Setlist, Show } from "@bip/domain";
+import { type DehydratedState, dehydrate } from "@tanstack/react-query";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
 import type { PublicContext } from "~/lib/base-loaders";
+import { showUserDataQueryKey } from "~/lib/query-keys";
+import { createPrefetchClient } from "~/lib/query-prefetch";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
-import { computeShowUserData, type ShowUserDataResponse } from "~/server/show-user-data";
+import { computeShowUserData } from "~/server/show-user-data";
 
 const MIN_SHOW_RATINGS = 10;
 const TOP_RATED_LIMIT = 100;
@@ -16,7 +19,7 @@ export interface TopRatedShowsLoaderData {
   countsByYear: Record<number, number>;
   allCount: number;
   externalSources: Record<string, ShowExternalSources>;
-  initialUserData: ShowUserDataResponse;
+  dehydratedState: DehydratedState;
 }
 
 export async function getTopRatedShows(
@@ -68,7 +71,12 @@ export async function getTopRatedShows(
   const setlists = showIds.map((id) => byShowId.get(id)).filter((s): s is Setlist => s !== undefined);
 
   const externalSources = await computeShowExternalSources(setlists.map((s) => s.show));
-  const initialUserData = await computeShowUserData(context, showIds);
+
+  const queryClient = createPrefetchClient();
+  await queryClient.prefetchQuery({
+    queryKey: showUserDataQueryKey(showIds),
+    queryFn: () => computeShowUserData(context, showIds),
+  });
 
   // Per-year counts for the year picker, capped by the page's row limit so
   // the number matches what actually appears when the user clicks that year.
@@ -94,6 +102,6 @@ export async function getTopRatedShows(
     countsByYear,
     allCount,
     externalSources,
-    initialUserData,
+    dehydratedState: dehydrate(queryClient),
   };
 }

--- a/apps/web/app/routes/shows/top-rated.tsx
+++ b/apps/web/app/routes/shows/top-rated.tsx
@@ -23,7 +23,7 @@ export function meta({ params }: { params: { year?: string } }) {
 }
 
 export default function TopRated() {
-  const { setlists, year, minShowRatings, countsByYear, allCount, externalSources, initialUserData } =
+  const { setlists, year, minShowRatings, countsByYear, allCount, externalSources } =
     useSerializedLoaderData<TopRatedShowsLoaderData>();
 
   return (
@@ -41,13 +41,7 @@ export default function TopRated() {
           allCount={allCount}
         />
         <div className="space-y-1">
-          <SetlistList
-            setlists={setlists}
-            externalSources={externalSources}
-            initialUserData={initialUserData}
-            numbered
-            collapsible
-          />
+          <SetlistList setlists={setlists} externalSources={externalSources} numbered collapsible />
         </div>
       </div>
     </div>

--- a/apps/web/app/routes/shows/year/$year.tsx
+++ b/apps/web/app/routes/shows/year/$year.tsx
@@ -1,4 +1,5 @@
 import { CacheKeys, type SetlistLight } from "@bip/domain";
+import { type DehydratedState, dehydrate } from "@tanstack/react-query";
 import { ArrowUp, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { ClientLoaderFunctionArgs } from "react-router";
@@ -12,6 +13,8 @@ import { YearFilterNav } from "~/components/year-filter-nav";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
 import { logger } from "~/lib/logger";
+import { showUserDataQueryKey } from "~/lib/query-keys";
+import { createPrefetchClient } from "~/lib/query-prefetch";
 import { getShowsMeta } from "~/lib/seo";
 import { parseTriState, type TriState, triStateToBoolean } from "~/lib/tri-state-filter";
 import { cn } from "~/lib/utils";
@@ -19,7 +22,7 @@ import { applyExternalSourceFilters } from "~/server/apply-external-source-filte
 import { services } from "~/server/services";
 import { computeShowCountsByYear } from "~/server/show-counts-by-year";
 import { computeShowExternalSources } from "~/server/show-external-sources";
-import { computeShowUserData, type ShowUserDataResponse } from "~/server/show-user-data";
+import { computeShowUserData } from "~/server/show-user-data";
 
 interface LoaderData {
   setlists: SetlistLight[];
@@ -29,7 +32,7 @@ interface LoaderData {
   showCountsByYear: Record<number, number>;
   monthCounts: Record<number, number>;
   filters: { photos: TriState; youtube: TriState; nugs: TriState; archive: TriState };
-  initialUserData: ShowUserDataResponse;
+  dehydratedState: DehydratedState;
 }
 
 const months = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"];
@@ -91,6 +94,12 @@ export const loader = publicLoader(async ({ request, params, context }): Promise
       setlists = await services.setlists.findManyByShowIds(showIds);
     }
 
+    const searchShowIds = setlists.map((s) => s.show.id);
+    const searchClient = createPrefetchClient();
+    await searchClient.prefetchQuery({
+      queryKey: showUserDataQueryKey(searchShowIds),
+      queryFn: () => computeShowUserData(context, searchShowIds),
+    });
     return {
       setlists,
       year: yearInt,
@@ -99,10 +108,7 @@ export const loader = publicLoader(async ({ request, params, context }): Promise
       showCountsByYear: emptyCounts,
       monthCounts: emptyCounts,
       filters,
-      initialUserData: await computeShowUserData(
-        context,
-        setlists.map((s) => s.show.id),
-      ),
+      dehydratedState: dehydrate(searchClient),
     };
   }
 
@@ -146,6 +152,13 @@ export const loader = publicLoader(async ({ request, params, context }): Promise
 
   logger.info(`Year ${yearInt} shows loaded: ${filteredSetlists.length} shows`);
 
+  const filteredShowIds = filteredSetlists.map((s) => s.show.id);
+  const queryClient = createPrefetchClient();
+  await queryClient.prefetchQuery({
+    queryKey: showUserDataQueryKey(filteredShowIds),
+    queryFn: () => computeShowUserData(context, filteredShowIds),
+  });
+
   return {
     setlists: filteredSetlists,
     year: yearInt,
@@ -153,10 +166,7 @@ export const loader = publicLoader(async ({ request, params, context }): Promise
     showCountsByYear,
     monthCounts,
     filters,
-    initialUserData: await computeShowUserData(
-      context,
-      filteredSetlists.map((s) => s.show.id),
-    ),
+    dehydratedState: dehydrate(queryClient),
   };
 });
 
@@ -171,7 +181,7 @@ export const clientLoader = async ({ serverLoader }: ClientLoaderFunctionArgs) =
 clientLoader.hydrate = true;
 
 export default function ShowsByYear() {
-  const { setlists, year, searchQuery, externalSources, showCountsByYear, monthCounts, initialUserData } =
+  const { setlists, year, searchQuery, externalSources, showCountsByYear, monthCounts } =
     useSerializedLoaderData<LoaderData>();
   const [showBackToTop, setShowBackToTop] = useState(false);
 
@@ -333,7 +343,6 @@ export default function ShowsByYear() {
               <SetlistList
                 setlists={setlists}
                 externalSources={externalSources}
-                initialUserData={initialUserData}
                 groupByMonth={!searchQuery}
                 empty={
                   <div className="text-center py-8">

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -1,4 +1,5 @@
 import { compareByShowDate, type SongPageView } from "@bip/domain";
+import { type DehydratedState, dehydrate } from "@tanstack/react-query";
 import { ArrowLeft, BarChart3, FileTextIcon, Flame, GuitarIcon, History, ListMusic, Pencil } from "lucide-react";
 import { type ReactNode, useMemo, useState } from "react";
 import type { LoaderFunctionArgs } from "react-router";
@@ -15,15 +16,37 @@ import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-perfor
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
 import { pickGapTier } from "~/lib/gap-tier";
+import { showUserDataQueryKey, trackUserRatingsQueryKey } from "~/lib/query-keys";
+import { createPrefetchClient } from "~/lib/query-prefetch";
 import { getSongMeta, getSongStructuredData } from "~/lib/seo";
 import { cn } from "~/lib/utils";
 import { services } from "~/server/services";
+import { computeShowUserData } from "~/server/show-user-data";
+import { computeTrackUserRatings } from "~/server/track-user-ratings";
 
-export const loader = publicLoader(async ({ params }: LoaderFunctionArgs): Promise<SongPageView> => {
+type LoaderData = SongPageView & { dehydratedState: DehydratedState };
+
+export const loader = publicLoader(async ({ params, context }: LoaderFunctionArgs): Promise<LoaderData> => {
   const slug = params.slug;
   if (!slug) throw new Response("Not Found", { status: 404 });
 
-  return services.songPageComposer.build(slug);
+  const view = await services.songPageComposer.build(slug);
+
+  const trackIds = view.performances.map((p) => p.trackId);
+  const showIds = [...new Set(view.performances.map((p) => p.show.id))];
+  const queryClient = createPrefetchClient();
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: trackUserRatingsQueryKey(trackIds),
+      queryFn: () => computeTrackUserRatings(context, trackIds),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: showUserDataQueryKey(showIds),
+      queryFn: () => computeShowUserData(context, showIds),
+    }),
+  ]);
+
+  return { ...view, dehydratedState: dehydrate(queryClient) };
 });
 
 interface StatBoxProps {
@@ -108,7 +131,7 @@ function ReviewNote({ notes }: { notes: string }) {
   );
 }
 
-export function meta({ data }: { data: SongPageView }) {
+export function meta({ data }: { data: LoaderData }) {
   return getSongMeta({
     ...data.song,
     timesPlayed: data.song.timesPlayed,
@@ -162,7 +185,7 @@ function formatAvgMedianGap(avg: number | null | undefined, median: number | nul
 }
 
 export default function SongPage() {
-  const { song, performances: allPerformances, showsByYear } = useSerializedLoaderData<SongPageView>();
+  const { song, performances: allPerformances, showsByYear } = useSerializedLoaderData<LoaderData>();
   const [searchParams] = useSearchParams();
   const tabParam = searchParams.get("tab");
   const validTabs = ["performances", "all-timers", "stats", "history", "lyrics", "guitar-tabs"];

--- a/apps/web/app/routes/songs/all-timers.tsx
+++ b/apps/web/app/routes/songs/all-timers.tsx
@@ -1,16 +1,43 @@
 import { type AllTimersPageView, CacheKeys } from "@bip/domain";
+import { type DehydratedState, dehydrate } from "@tanstack/react-query";
 import { PerformanceTable } from "~/components/performance";
 import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
 import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
+import { showUserDataQueryKey, trackUserRatingsQueryKey } from "~/lib/query-keys";
+import { createPrefetchClient } from "~/lib/query-prefetch";
 import { services } from "~/server/services";
+import { computeShowUserData } from "~/server/show-user-data";
+import { computeTrackUserRatings } from "~/server/track-user-ratings";
 
-export const loader = publicLoader(async (): Promise<AllTimersPageView> => {
+type LoaderData = AllTimersPageView & { dehydratedState: DehydratedState };
+
+export const loader = publicLoader(async ({ context }): Promise<LoaderData> => {
   const cacheKey = CacheKeys.songs.allTimers();
   const cacheOptions = { ttl: 3600 };
 
-  return await services.cache.getOrSet(cacheKey, async () => services.songPageComposer.buildAllTimers(), cacheOptions);
+  const view = await services.cache.getOrSet(
+    cacheKey,
+    async () => services.songPageComposer.buildAllTimers(),
+    cacheOptions,
+  );
+
+  const trackIds = view.performances.map((p) => p.trackId);
+  const showIds = [...new Set(view.performances.map((p) => p.show.id))];
+  const queryClient = createPrefetchClient();
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: trackUserRatingsQueryKey(trackIds),
+      queryFn: () => computeTrackUserRatings(context, trackIds),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: showUserDataQueryKey(showIds),
+      queryFn: () => computeShowUserData(context, showIds),
+    }),
+  ]);
+
+  return { ...view, dehydratedState: dehydrate(queryClient) };
 });
 
 export function meta() {
@@ -18,7 +45,7 @@ export function meta() {
 }
 
 export default function AllTimersPage() {
-  const { performances: allPerformances } = useSerializedLoaderData<AllTimersPageView>();
+  const { performances: allPerformances } = useSerializedLoaderData<LoaderData>();
   const {
     filteredData: filteredPerformances,
     isLoading,

--- a/apps/web/app/routes/users/$username.test.tsx
+++ b/apps/web/app/routes/users/$username.test.tsx
@@ -35,7 +35,7 @@ const baseLoaderData = {
     },
   ],
   attendedExternalSources: {},
-  attendedInitialUserData: { attendances: [], userRatings: [], averageRatings: [] },
+  dehydratedState: { mutations: [], queries: [] },
   attendedPagination: { page: 1, pageSize: 100, totalPages: 1, total: 1 },
   ratingsPagination: { page: 1, pageSize: 100, totalPages: 1, total: 0 },
   activeTab: "shows" as const,
@@ -67,7 +67,6 @@ vi.mock("~/components/setlist/setlist-list", () => ({
     setlists: Array<{ show: { id: string } }>;
     empty?: React.ReactNode;
     externalSources?: Record<string, unknown>;
-    initialUserData?: unknown;
   }) => {
     if (!props.setlists || props.setlists.length === 0) {
       return <div data-testid="SetlistList">{props.empty}</div>;
@@ -77,7 +76,6 @@ vi.mock("~/components/setlist/setlist-list", () => ({
         data-testid="SetlistList"
         data-setlists-count={props.setlists.length}
         data-first-show-id={props.setlists[0]?.show?.id ?? ""}
-        data-has-initial-user-data={props.initialUserData ? "yes" : "no"}
       >
         {mockShallowComponent("SetlistListShallow", { setlistsCount: props.setlists.length })}
       </div>
@@ -186,9 +184,10 @@ describe("UserProfile", () => {
   });
 
   // The route delegates rendering to SetlistList, passing through the
-  // loader-built setlists, external sources, and initial user-data payload.
-  // Load-bearing wiring test: if the loader keys are renamed without
-  // updating the JSX, this catches it via the stub's surfaced data-attrs.
+  // loader-built setlists and external sources. Load-bearing wiring test:
+  // if the loader keys are renamed without updating the JSX, this catches
+  // it via the stub's surfaced data-attrs. (SSR cache seeding now flows
+  // through the root HydrationBoundary, not a SetlistList prop.)
   test("renders SetlistList with the loader's attended-shows payload", () => {
     renderProfile();
 
@@ -196,7 +195,6 @@ describe("UserProfile", () => {
     expect(setlistList).toBeInTheDocument();
     expect(setlistList.getAttribute("data-setlists-count")).toBe("1");
     expect(setlistList.getAttribute("data-first-show-id")).toBe("show-1");
-    expect(setlistList.getAttribute("data-has-initial-user-data")).toBe("yes");
   });
 
   // Empty attended-shows list: SetlistList renders the `empty` slot when

--- a/apps/web/app/routes/users/$username.tsx
+++ b/apps/web/app/routes/users/$username.tsx
@@ -1,4 +1,5 @@
 import { CacheKeys, compareByShowDate } from "@bip/domain";
+import { dehydrate } from "@tanstack/react-query";
 import { CalendarDays, Edit, MessageSquare, Star, Users } from "lucide-react";
 import type { LoaderFunctionArgs, MetaFunction } from "react-router-dom";
 import { Link, useNavigate } from "react-router-dom";
@@ -11,6 +12,8 @@ import { PaginationControls } from "~/components/ui/pagination-controls";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { type PublicContext, publicLoader } from "~/lib/base-loaders";
+import { showUserDataQueryKey } from "~/lib/query-keys";
+import { createPrefetchClient } from "~/lib/query-prefetch";
 import { formatDateLong } from "~/lib/utils";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
@@ -125,10 +128,12 @@ async function loadUserProfile({ params, request, context }: LoaderFunctionArgs 
 
   // Per-viewer overlay (attendance / rating badges) — not cached; depends on
   // the logged-in user, not the profile being viewed.
-  const attendedInitialUserData = await computeShowUserData(
-    context,
-    attendedSetlists.map((s) => s.show.id),
-  );
+  const attendedShowIds = attendedSetlists.map((s) => s.show.id);
+  const queryClient = createPrefetchClient();
+  await queryClient.prefetchQuery({
+    queryKey: showUserDataQueryKey(attendedShowIds),
+    queryFn: () => computeShowUserData(context, attendedShowIds),
+  });
 
   return {
     user,
@@ -136,7 +141,7 @@ async function loadUserProfile({ params, request, context }: LoaderFunctionArgs 
     blogPosts,
     attendedSetlists,
     attendedExternalSources,
-    attendedInitialUserData,
+    dehydratedState: dehydrate(queryClient),
     attendedPagination: {
       page: clampedAttendedPage,
       pageSize: ATTENDED_SHOWS_PAGE_SIZE,
@@ -190,7 +195,6 @@ export default function UserProfile() {
     blogPosts,
     attendedSetlists,
     attendedExternalSources,
-    attendedInitialUserData,
     attendedPagination,
     showRatings,
     trackRatings,
@@ -690,7 +694,6 @@ export default function UserProfile() {
           <SetlistList
             setlists={attendedSetlists}
             externalSources={attendedExternalSources}
-            initialUserData={attendedInitialUserData}
             collapsible
             empty={
               <Card className="card-premium">

--- a/apps/web/app/routes/venues/$slug.tsx
+++ b/apps/web/app/routes/venues/$slug.tsx
@@ -1,4 +1,5 @@
 import type { Setlist, Venue } from "@bip/domain";
+import { type DehydratedState, dehydrate } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { ArrowLeft, CalendarDays, Edit, MapPin, Ticket } from "lucide-react";
 import { Link } from "react-router-dom";
@@ -9,10 +10,12 @@ import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
+import { showUserDataQueryKey } from "~/lib/query-keys";
+import { createPrefetchClient } from "~/lib/query-prefetch";
 import { getVenueMeta, getVenueStructuredData } from "~/lib/seo";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
-import { computeShowUserData, type ShowUserDataResponse } from "~/server/show-user-data";
+import { computeShowUserData } from "~/server/show-user-data";
 
 export const routeParam = "slug";
 
@@ -26,7 +29,7 @@ interface LoaderData {
     yearsPlayed: number[];
   };
   externalSources: Record<string, ShowExternalSources>;
-  initialUserData: ShowUserDataResponse;
+  dehydratedState: DehydratedState;
 }
 
 export const loader = publicLoader(async ({ params, context }): Promise<LoaderData> => {
@@ -55,9 +58,14 @@ export const loader = publicLoader(async ({ params, context }): Promise<LoaderDa
 
   const showIds = setlists.map((setlist) => setlist.show.id);
   const externalSources = await computeShowExternalSources(setlists.map((s) => s.show));
-  const initialUserData = await computeShowUserData(context, showIds);
 
-  return { venue, setlists, stats, externalSources, initialUserData };
+  const queryClient = createPrefetchClient();
+  await queryClient.prefetchQuery({
+    queryKey: showUserDataQueryKey(showIds),
+    queryFn: () => computeShowUserData(context, showIds),
+  });
+
+  return { venue, setlists, stats, externalSources, dehydratedState: dehydrate(queryClient) };
 });
 
 interface StatBoxProps {
@@ -92,7 +100,7 @@ export function meta({ data }: { data: LoaderData }) {
 }
 
 export default function VenuePage() {
-  const { venue, setlists, stats, externalSources, initialUserData } = useSerializedLoaderData<LoaderData>();
+  const { venue, setlists, stats, externalSources } = useSerializedLoaderData<LoaderData>();
 
   return (
     <div>
@@ -164,7 +172,6 @@ export default function VenuePage() {
           <SetlistList
             setlists={setlists}
             externalSources={externalSources}
-            initialUserData={initialUserData}
             empty={
               <div className="glass-content rounded-lg p-6 text-center text-content-text-secondary">
                 No shows found for this venue.

--- a/apps/web/app/server/request-user.test.ts
+++ b/apps/web/app/server/request-user.test.ts
@@ -1,0 +1,83 @@
+import type { User } from "@supabase/supabase-js";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const supabaseGetUser = vi.fn();
+
+vi.mock("~/server/supabase", () => ({
+  getServerClient: () => ({
+    supabase: { auth: { getUser: supabaseGetUser } },
+    headers: new Headers(),
+  }),
+}));
+
+import { getRequestUser } from "./request-user";
+
+function makeRequest(cookie = "sb-auth=fake-token"): Request {
+  return new Request("http://localhost/anything", { headers: { Cookie: cookie } });
+}
+
+describe("getRequestUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Sibling loaders within one HTTP request receive separate Request
+  // objects (RR v7 dev behavior), but share the same Cookie header. They
+  // must dedupe to one upstream auth call so we don't pay the Supabase
+  // round-trip twice per page.
+  test("dedupes concurrent calls that share a cookie header", async () => {
+    const user = { id: "u1", email: "evan@foo.net" } as User;
+    supabaseGetUser.mockResolvedValue({ data: { user }, error: null });
+
+    const reqA = makeRequest();
+    const reqB = makeRequest();
+    const [a, b] = await Promise.all([getRequestUser(reqA), getRequestUser(reqB)]);
+
+    expect(a).toBe(user);
+    expect(b).toBe(user);
+    expect(supabaseGetUser).toHaveBeenCalledTimes(1);
+  });
+
+  // A subsequent HTTP request after the first resolves must not reuse
+  // the old in-flight entry — entries evict on settle so the next
+  // request's auth state is fetched fresh.
+  test("re-fetches after the first call has resolved", async () => {
+    const user = { id: "u1", email: "evan@foo.net" } as User;
+    supabaseGetUser.mockResolvedValue({ data: { user }, error: null });
+
+    await getRequestUser(makeRequest());
+    await getRequestUser(makeRequest());
+
+    expect(supabaseGetUser).toHaveBeenCalledTimes(2);
+  });
+
+  // Different cookies (different users) must NOT collide on the dedupe
+  // key; otherwise user A's request could return user B's session.
+  test("does not dedupe across different cookie headers", async () => {
+    supabaseGetUser
+      .mockResolvedValueOnce({ data: { user: { id: "u1" } as User }, error: null })
+      .mockResolvedValueOnce({ data: { user: { id: "u2" } as User }, error: null });
+
+    const [a, b] = await Promise.all([
+      getRequestUser(makeRequest("sb-auth=token-1")),
+      getRequestUser(makeRequest("sb-auth=token-2")),
+    ]);
+
+    expect(a?.id).toBe("u1");
+    expect(b?.id).toBe("u2");
+    expect(supabaseGetUser).toHaveBeenCalledTimes(2);
+  });
+
+  // Anonymous requests (no cookie) still dedupe within one HTTP request
+  // — both loaders see Cookie: undefined which normalizes to a single
+  // shared key.
+  test("dedupes concurrent anonymous requests", async () => {
+    supabaseGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    const reqA = new Request("http://localhost/", { headers: {} });
+    const reqB = new Request("http://localhost/", { headers: {} });
+    await Promise.all([getRequestUser(reqA), getRequestUser(reqB)]);
+
+    expect(supabaseGetUser).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/app/server/request-user.ts
+++ b/apps/web/app/server/request-user.ts
@@ -1,0 +1,38 @@
+import type { User } from "@supabase/supabase-js";
+import { getServerClient } from "~/server/supabase";
+
+/**
+ * Per-request memo for `supabase.auth.getUser()`. React Router v7 passes
+ * a freshly-constructed `Request` object to each loader (verified via
+ * tagging — the root loader's request and a child route loader's request
+ * are different identities even for one HTTP hit), so we can't key the
+ * cache on `Request` itself. The Cookie header is identical across
+ * sibling loaders for one HTTP request, so it's the dedupe key.
+ *
+ * The entry is evicted as soon as the underlying auth call settles, so
+ * a follow-up HTTP request from the same browser creates a fresh entry
+ * (no stale-session risk between requests). All sibling loaders are
+ * synchronous-near-simultaneous on the same request, so they see the
+ * inflight Promise before it settles and share its result.
+ */
+const inflight = new Map<string, Promise<User | null>>();
+
+export function getRequestUser(request: Request): Promise<User | null> {
+  const key = request.headers.get("Cookie") ?? "_anon";
+  const cached = inflight.get(key);
+  if (cached) return cached;
+
+  const promise = (async () => {
+    try {
+      const { supabase } = getServerClient(request);
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      return user ?? null;
+    } finally {
+      inflight.delete(key);
+    }
+  })();
+  inflight.set(key, promise);
+  return promise;
+}

--- a/apps/web/app/server/track-user-ratings.test.ts
+++ b/apps/web/app/server/track-user-ratings.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const findManyByUserIdAndRateableIds = vi.fn();
+const findByEmail = vi.fn();
+
+vi.mock("~/server/services", () => ({
+  services: {
+    ratings: {
+      findManyByUserIdAndRateableIds: (...args: unknown[]) => findManyByUserIdAndRateableIds(...args),
+    },
+    users: {
+      findByEmail: (...args: unknown[]) => findByEmail(...args),
+    },
+  },
+}));
+
+vi.mock("~/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+import { computeTrackUserRatings } from "./track-user-ratings";
+
+describe("computeTrackUserRatings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Empty input avoids a DB round-trip. Loaders pass [] when the page renders
+  // no performance/setlist rows (e.g. a venue with no tracked shows yet).
+  test("returns empty response and makes no service calls when trackIds is empty", async () => {
+    const result = await computeTrackUserRatings({ currentUser: undefined }, []);
+    expect(result).toEqual({ userRatings: {} });
+    expect(findManyByUserIdAndRateableIds).not.toHaveBeenCalled();
+    expect(findByEmail).not.toHaveBeenCalled();
+  });
+
+  // Anonymous browsers have no personal rating data; the loader still calls
+  // this so the dehydrated cache entry exists with the right key, but the
+  // payload is just the empty skeleton.
+  test("returns empty response without DB calls when currentUser is missing", async () => {
+    const result = await computeTrackUserRatings({ currentUser: undefined }, ["t1", "t2"]);
+    expect(result).toEqual({ userRatings: {} });
+    expect(findByEmail).not.toHaveBeenCalled();
+  });
+
+  // Edge case: Supabase session exists but the local users row was never
+  // created. Don't blow up; return the empty skeleton.
+  test("returns empty response when local users record is missing", async () => {
+    findByEmail.mockResolvedValue(null);
+    const result = await computeTrackUserRatings(
+      { currentUser: { id: "auth-1", email: "evan@foo.net", isAdmin: false } },
+      ["t1"],
+    );
+    expect(result.userRatings).toEqual({});
+    expect(findManyByUserIdAndRateableIds).not.toHaveBeenCalled();
+  });
+
+  // Happy path: only the tracks the user has rated appear in the response.
+  // Other ids requested but not rated are simply absent from the map (not
+  // explicitly null), matching the previous API route's contract.
+  test("populates userRatings for tracks the user has rated", async () => {
+    findByEmail.mockResolvedValue({ id: "user-1", email: "evan@foo.net" });
+    findManyByUserIdAndRateableIds.mockResolvedValue([
+      { rateableId: "t1", rateableType: "Track", value: 5, userId: "user-1" },
+      { rateableId: "t3", rateableType: "Track", value: 3, userId: "user-1" },
+    ]);
+
+    const result = await computeTrackUserRatings(
+      { currentUser: { id: "auth-1", email: "evan@foo.net", isAdmin: false } },
+      ["t1", "t2", "t3"],
+    );
+
+    expect(result.userRatings).toEqual({ t1: 5, t3: 3 });
+  });
+});

--- a/apps/web/app/server/track-user-ratings.ts
+++ b/apps/web/app/server/track-user-ratings.ts
@@ -1,0 +1,39 @@
+import type { PublicContext } from "~/lib/base-loaders";
+import { logger } from "~/lib/logger";
+import { services } from "~/server/services";
+
+export interface TrackUserRatingsResponse {
+  userRatings: Record<string, number | null>;
+}
+
+/**
+ * Fetches the current user's ratings for a batch of tracks. Returns an empty
+ * `userRatings` map for unauthenticated visitors (track ratings are
+ * user-scoped — there is no public aggregate to surface here, unlike shows).
+ * Shared by the `/api/tracks/user-ratings` action and any loader that wants
+ * to seed React Query's cache so PerformanceTable / setlist gap-chart views
+ * render personal ratings on first paint.
+ */
+export async function computeTrackUserRatings(
+  context: Pick<PublicContext, "currentUser">,
+  trackIds: string[],
+): Promise<TrackUserRatingsResponse> {
+  const response: TrackUserRatingsResponse = { userRatings: {} };
+
+  if (trackIds.length === 0 || !context.currentUser) return response;
+
+  try {
+    const user = await services.users.findByEmail(context.currentUser.email);
+    if (!user) return response;
+
+    const ratings = await services.ratings.findManyByUserIdAndRateableIds(user.id, trackIds, "Track");
+    for (const rating of ratings) {
+      response.userRatings[rating.rateableId] = rating.value;
+    }
+  } catch (error) {
+    logger.error("Error computing track user ratings", { error, trackIds: trackIds.length });
+    throw error;
+  }
+
+  return response;
+}


### PR DESCRIPTION
## Summary
- Attendance badges, your-rating thumbs, attended-row highlights, and admin menus paint with the initial HTML — no more flicker/pop-in once `supabase.auth.getSession()` or React Query's first fetch resolves.
- Zero client-side POSTs to `/api/shows/user-data`, `/api/tracks/user-ratings`, or `/api/ratings` after hydration on the migrated pages: home, `/shows/top-rated`, `/shows/year/<year>`, `/on-this-day`, `/venues/<slug>`, `/users/<name>`, `/songs/<slug>`, `/songs/all-timers`, `/shows/<slug>`.
- Drops the 132px reserved-width hack on the performance rating column (the workaround for the now-fixed flicker).

## Test plan
- [ ] Signed in, hard-reload each migrated route. Network tab: no POST to `/api/shows/user-data`, no POST to `/api/tracks/user-ratings`, no GET to `/api/ratings` after hydration.
- [ ] Avatar (header) + your-rating thumb (setlist cards) + attended-row green border (PerformanceTable) + admin menu items all present on first paint.
- [ ] Signed out, reload same pages: no user-specific UI flashes on then off.
- [ ] Sign in/out via UI in same tab: header and admin menu update without reload (onAuthStateChange listener path).
- [ ] Toggle "Saw it?" attendance → optimistic update + revalidation still works.
- [ ] Submit / clear a star rating → updates correctly; community average refreshes.
- [ ] `make tc && make test && make lint` clean.

## Implementation notes

Tricky bits worth scanning during review:

- **HydrationBoundary placement.** Loaders return a `dehydratedState` field; the root `Layout` collects it from every matched route via `useMatches()`, merges them, and wraps the tree in a single `<HydrationBoundary>` inside `<QueryProvider>`. Each route's loader uses its own per-request `QueryClient` (a module-level shared client would leak per-user data between requests).
- **Query-key parity.** `apps/web/app/lib/query-keys.ts` is the single source of truth for `useShowUserData` / `useTrackUserRatings` query keys — both the loader prefetch and the client hook go through the same builder. They sort ids before joining, so any caller-side ordering hits the same cache entry. Subtle gotcha: a *subset* of ids misses (different sorted-joined string), so loaders must prefetch with the exact id set the hook will request — that bit us on `/songs/all-timers` and `/on-this-day` where `PerformanceTable`'s `useAttendanceRowHighlight` calls with the performances' show ids (a different set from the page's setlists).
- **Supabase session SSR.** Root loader projects `auth.getUser()` into a client-safe `SessionUser` shape (`{id, email, username, avatarUrl, internalUserId, isAdmin}`) and returns it as `sessionUser`. `useSession` seeds initial state from `useRouteLoaderData("root")` instead of `useState(null)` + effect. The `SessionUser` type and `toSessionUser` projection live in `~/lib/` (not `~/server/`) so `use-session.ts` can value-import them without dragging server-only deps into the client bundle.
- **`auth.getUser()` dedup.** Root loader and per-route `publicLoader` both need the user — they used to make two Supabase round-trips. `getRequestUser` memoizes the in-flight promise keyed on the Cookie header (Request objects differ per loader in RR v7, so they can't be the dedupe key) and evicts on settle.
- **StarRating semantics.** `initialRating={null}` now means "caller knows the user hasn't rated, skip the on-mount GET" (used to fire the fetch anyway). Pass `undefined` (or omit) to opt back into the fetch.

## Perf

Measured authenticated `/shows/top-rated` 5×, signed in as a heavy-rater:
- Dev SSR: 1.23s median both before and after.
- Prod build: 0.56s median both before and after.

No measurable regression; the auth dedup saves ~10ms locally (will be more on prod Supabase where each round-trip is 30–150ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
