### PR TITLE
DataTable: weight + fixedWidth column sizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tmp/
 apps/web/.react-router/*
 .beads
 .gitattributes
+.playwright-mcp/*

--- a/apps/web/app/components/author/author-columns.tsx
+++ b/apps/web/app/components/author/author-columns.tsx
@@ -24,7 +24,7 @@ type AuthorWithSongCount = Author & { songCount?: number };
 export const authorColumns: ColumnDef<AuthorWithSongCount>[] = [
   {
     accessorKey: "name",
-    meta: { width: "25%" },
+
     header: ({ column }) => {
       return (
         <Button
@@ -51,7 +51,7 @@ export const authorColumns: ColumnDef<AuthorWithSongCount>[] = [
   },
   {
     accessorKey: "songCount",
-    meta: { width: "25%" },
+
     header: ({ column }) => {
       return (
         <Button
@@ -71,7 +71,7 @@ export const authorColumns: ColumnDef<AuthorWithSongCount>[] = [
   },
   {
     accessorKey: "slug",
-    meta: { width: "25%" },
+
     header: ({ column }) => {
       return (
         <Button
@@ -90,7 +90,7 @@ export const authorColumns: ColumnDef<AuthorWithSongCount>[] = [
   },
   {
     accessorKey: "createdAt",
-    meta: { width: "25%" },
+
     header: ({ column }) => {
       return (
         <Button

--- a/apps/web/app/components/performance/date-venue-cell.test.tsx
+++ b/apps/web/app/components/performance/date-venue-cell.test.tsx
@@ -13,15 +13,17 @@ describe("DateVenueCell", () => {
     expect(screen.getByText("2024-06-15")).toBeInTheDocument();
   });
 
-  // The venue line is rendered, but only visible at sm+ breakpoints. We
-  // verify presence + the responsive class so mobile column overlap (the
-  // bug this component fixes) cannot regress silently.
-  test("renders venue line with hidden sm:block so it is hidden on mobile", async () => {
+  // The venue line is rendered, but only visible once the cell container
+  // is wide enough — a container query on the cell wrapper drives the
+  // toggle so the column collapses to date-only at narrow widths regardless
+  // of viewport. Verifies the CQ class is wired so the auto-collapse can't
+  // regress silently.
+  test("renders venue line with container-query gated visibility", async () => {
     await setup(<DateVenueCell date="2024-06-15" venue={{ name: "The Capitol Theatre", city: "Port Chester" }} />);
 
     const venueLine = screen.getByText(/The Capitol Theatre/);
     expect(venueLine.className).toContain("hidden");
-    expect(venueLine.className).toContain("sm:block");
+    expect(venueLine.className).toContain("@[10rem]/datecell:block");
   });
 
   // City and state are appended to the venue name when present so users
@@ -37,10 +39,10 @@ describe("DateVenueCell", () => {
   // When there is no venue, the venue line is omitted entirely (rather
   // than rendering an empty bullet) so the cell collapses to date-only.
   test("omits venue line when venue is undefined", async () => {
-    const { container } = await setup(<DateVenueCell date="2024-06-15" />);
+    await setup(<DateVenueCell date="2024-06-15" />);
 
     expect(screen.getByText("2024-06-15")).toBeInTheDocument();
-    // Only the date div should render — no second child line.
-    expect(container.querySelectorAll("div").length).toBeLessThanOrEqual(1);
+    // No venue text rendered — keeps the cell visually clean.
+    expect(screen.queryByText(",")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/components/performance/date-venue-cell.tsx
+++ b/apps/web/app/components/performance/date-venue-cell.tsx
@@ -13,17 +13,20 @@ interface DateVenueCellProps {
 
 /**
  * Combined Date + Venue cell for the performance tables (song-detail
- * "All Performances" and /songs/all-timers). The date renders on top; the
- * venue stacks beneath it at sm+ and is hidden on mobile so the column
- * collapses to a single-line date at narrow widths.
+ * "All Performances" and /songs/all-timers). The venue sublabel only
+ * shows at `sm` and above (mobile keeps the row tight to a single line),
+ * AND only when this cell's inline-size container has room — so the row
+ * still collapses cleanly when the column gets squeezed on desktop.
  */
 export function DateVenueCell({ date, venue }: DateVenueCellProps) {
   const venueLabel = venue?.name ? [venue.name, venue.city, venue.state].filter(Boolean).join(", ") : null;
 
   return (
-    <>
+    <div className="@container/datecell">
       <div className="font-medium">{date}</div>
-      {venueLabel && <div className="text-xs text-content-text-tertiary mt-0.5 hidden sm:block">{venueLabel}</div>}
-    </>
+      {venueLabel && (
+        <div className="text-xs text-content-text-tertiary mt-0.5 hidden sm:@[10rem]/datecell:block">{venueLabel}</div>
+      )}
+    </div>
   );
 }

--- a/apps/web/app/components/performance/performance-columns.test.tsx
+++ b/apps/web/app/components/performance/performance-columns.test.tsx
@@ -47,16 +47,16 @@ const defaultOptions = {
 };
 
 describe("createPerformanceColumns", () => {
-  // The default column set renders Date, Set, Song Before, Song After,
+  // The default column set renders Date, Song Before, Song After,
   // Notes, and Rating headers. Each side of the setlist context is its own
   // searchable column. Venue isn't a separate column — it's folded into
-  // the Date cell via DateVenueCell.
-  test("default columns include Date, Set, Song Before, Song After, Notes, Rating headers", async () => {
+  // the Date cell via DateVenueCell. Set was removed since the set number
+  // isn't meaningful when scanning a single song across many shows.
+  test("default columns include Date, Song Before, Song After, Notes, Rating headers", async () => {
     const columns = createPerformanceColumns(defaultOptions);
     await setupWithRouter(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
 
     expect(screen.getByText("Date")).toBeInTheDocument();
-    expect(screen.getByText("Set")).toBeInTheDocument();
     expect(screen.getByText("Song Before")).toBeInTheDocument();
     expect(screen.getByText("Song After")).toBeInTheDocument();
     expect(screen.getByText("Notes")).toBeInTheDocument();
@@ -84,18 +84,20 @@ describe("createPerformanceColumns", () => {
     expect(notesColumn?.meta?.hideOnMobile).toBe(true);
   });
 
-  // Song Before / Song After are context columns: useful when scanning but
-  // not primary signal. They always hide on mobile to keep narrow rows
-  // focused on Date, Set, and Rating regardless of which surface is hosting
-  // the table.
-  test("Song Before and Song After columns hide on mobile regardless of showSongColumn", () => {
+  // Song Before / Song After visibility depends on the surface:
+  // - Single-song view (/songs/:slug, `showSongColumn` false): visible
+  //   on mobile — segue context is the primary reason users scan the
+  //   per-song table.
+  // - Cross-song view (/songs/all-timers, /on-this-day, `showSongColumn`
+  //   true): hidden on mobile — too many columns to fit alongside Song.
+  test("Song Before / Song After hide on mobile only on cross-song surfaces", () => {
     const detailColumns = createPerformanceColumns(defaultOptions);
     const allTimerColumns = createPerformanceColumns({ ...defaultOptions, showSongColumn: true });
 
     const findColumn = (cols: typeof detailColumns, id: string) => cols.find((c) => "id" in c && c.id === id);
 
-    expect(findColumn(detailColumns, "songBefore")?.meta?.hideOnMobile).toBe(true);
-    expect(findColumn(detailColumns, "songAfter")?.meta?.hideOnMobile).toBe(true);
+    expect(findColumn(detailColumns, "songBefore")?.meta?.hideOnMobile).toBeFalsy();
+    expect(findColumn(detailColumns, "songAfter")?.meta?.hideOnMobile).toBeFalsy();
     expect(findColumn(allTimerColumns, "songBefore")?.meta?.hideOnMobile).toBe(true);
     expect(findColumn(allTimerColumns, "songAfter")?.meta?.hideOnMobile).toBe(true);
   });
@@ -317,17 +319,19 @@ describe("createPerformanceColumns", () => {
     expect(screen.queryByText("Song")).not.toBeInTheDocument();
   });
 
-  // The AllTimer flame column marks standout performances. Only shown on
-  // the "All Performances" tab of /songs/$slug, not on /songs/all-timers
-  // (where every row is already an all-timer by definition).
-  test("AllTimer flame column present when showAllTimerColumn is true", async () => {
+  // The AllTimer flame marks standout performances. Renders twice in the
+  // DOM per all-timer row: once in the standalone AllTimer column (hidden
+  // on mobile via CSS), once inline in the Set cell (visible only on
+  // mobile via CSS). jsdom doesn't apply media queries so both instances
+  // appear in this test — the count of 2 is the contract.
+  test("AllTimer flame renders in both the standalone column and inline in the Set cell", async () => {
     const performances = [makePerformance({ allTimer: true })];
     const columns = createPerformanceColumns({ ...defaultOptions, showAllTimerColumn: true });
     const { container } = await setupWithRouter(
       <DataTable columns={columns} data={performances} hideSearch hidePagination />,
     );
 
-    expect(container.querySelectorAll(".lucide-flame").length).toBe(1);
+    expect(container.querySelectorAll(".lucide-flame").length).toBe(2);
   });
 
   // TrackRatingCell receives initialRating from the performance's rating
@@ -377,8 +381,8 @@ describe("createPerformanceColumns", () => {
 
   // Sortable columns (Date, Rating, Song Before, Song After) show an
   // up/down arrow icon even when not actively sorted, so users can see
-  // at a glance which columns support sorting. Non-sortable columns
-  // (Set, Notes) render plain text headers with no icon.
+  // at a glance which columns support sorting. Notes is the only non-
+  // sortable header in the default set.
   test("sortable columns show sort indicator, non-sortable columns do not", async () => {
     const columns = createPerformanceColumns(defaultOptions);
     await setupWithRouter(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
@@ -388,9 +392,9 @@ describe("createPerformanceColumns", () => {
     expect(dateHeader).not.toBeNull();
     expect(dateHeader?.querySelector("svg")).not.toBeNull();
 
-    // Set is not sortable — plain text header
-    const setHeader = screen.getByText("Set").closest("th");
-    expect(setHeader?.querySelector("button")).toBeNull();
+    // Notes is not sortable — plain text header
+    const notesHeader = screen.getByText("Notes").closest("th");
+    expect(notesHeader?.querySelector("button")).toBeNull();
 
     const ratingHeader = screen.getByText("Rating").closest("button");
     expect(ratingHeader).not.toBeNull();
@@ -408,10 +412,10 @@ describe("createPerformanceColumns", () => {
 
   // Column order on the song-detail performances table reads as a
   // narrative: when did this happen (Date) → how rare was it (Gap) → when
-  // was the last time before that (Last Played) → which set was it (Set) →
-  // what came before / after (Song Before, Song After). Pinning the order
-  // so future column additions don't accidentally reshuffle this flow.
-  test("column order is Date, Gap, Last Played, Set, Song Before, Song After", async () => {
+  // was the last time before that (Last Played) → what came before /
+  // after (Song Before, Song After). Pinning the order so future column
+  // additions don't accidentally reshuffle this flow.
+  test("column order is Date, Gap, Last Played, Song Before, Song After", async () => {
     const columns = createPerformanceColumns(defaultOptions);
     await setupWithRouter(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
 
@@ -421,14 +425,12 @@ describe("createPerformanceColumns", () => {
     const dateIdx = headers.findIndex((h) => h.startsWith("Date"));
     const gapIdx = headers.findIndex((h) => h.startsWith("Gap"));
     const lastPlayedIdx = headers.findIndex((h) => h.startsWith("Last Played"));
-    const setIdx = headers.findIndex((h) => h.startsWith("Set"));
     const songBeforeIdx = headers.findIndex((h) => h.startsWith("Song Before"));
     const songAfterIdx = headers.findIndex((h) => h.startsWith("Song After"));
     expect(dateIdx).toBeGreaterThan(-1);
     expect(gapIdx).toBeGreaterThan(dateIdx);
     expect(lastPlayedIdx).toBeGreaterThan(gapIdx);
-    expect(setIdx).toBeGreaterThan(lastPlayedIdx);
-    expect(songBeforeIdx).toBeGreaterThan(setIdx);
+    expect(songBeforeIdx).toBeGreaterThan(lastPlayedIdx);
     expect(songAfterIdx).toBeGreaterThan(songBeforeIdx);
   });
 
@@ -659,16 +661,13 @@ describe("gapSortingFn", () => {
 });
 
 describe("createPerformanceColumns extras", () => {
-  // Columns that need constrained widths (like the narrow allTimer flame
-  // icon and the Set label) set explicit meta.width. Other columns auto-size
-  // to avoid wasted space.
-  test("allTimer and Set columns have explicit meta.width", () => {
+  // Icon-only / ultra-narrow columns declare `fixedWidth` so they never
+  // grow or shrink with the table — they hold a single glyph or 1-2
+  // chars. Other columns flex via `weight` to fill the remainder.
+  test("allTimer column is fixed-width", () => {
     const columns = createPerformanceColumns({ ...defaultOptions, showAllTimerColumn: true });
 
     const allTimerColumn = columns.find((column) => "id" in column && column.id === "allTimer");
-    expect(allTimerColumn?.meta?.width).toBe("16px");
-
-    const setColumn = columns.find((column) => "accessorKey" in column && column.accessorKey === "set");
-    expect(setColumn?.meta?.width).toBe("48px");
+    expect(allTimerColumn?.meta?.fixedWidth).toBeTruthy();
   });
 });

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -133,7 +133,7 @@ function SortableHeader({
   return (
     <button
       type="button"
-      className="cursor-pointer select-none hover:text-content-text-primary w-full text-left flex items-start gap-1"
+      className="cursor-pointer select-none hover:text-content-text-primary w-full text-left flex flex-wrap items-start gap-x-1"
       onClick={() => column.toggleSorting()}
     >
       <span className={column.getIsSorted() ? "text-content-text-primary font-semibold" : ""}>{label}</span>
@@ -162,24 +162,21 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       columnHelper.accessor((row) => row.songTitle || "", {
         id: "song",
         header: ({ column }) => <SortableHeader column={column} label="Song" />,
+        // Cross-song surfaces (this column only renders there): the song
+        // title is the primary signal, so it claims a large share of the
+        // leftover space against the secondary date / context columns.
+        meta: { weight: 3 },
         enableSorting: true,
         sortingFn: "alphanumeric",
         cell: (info) => {
           const title = info.getValue() as string;
           const slug = info.row.original.songSlug;
-          // Title relies on column width + `[overflow-wrap:anywhere]` for
-          // sizing. Setting `min-w` on the inner element would let it stick
-          // out of the table-fixed cell and trigger a horizontal scrollbar
-          // on the wrapping div at narrow widths.
           return slug ? (
-            <a
-              href={`/songs/${slug}`}
-              className="text-base text-brand-primary hover:text-brand-secondary font-medium [overflow-wrap:anywhere]"
-            >
+            <a href={`/songs/${slug}`} className="text-base text-brand-primary hover:text-brand-secondary font-medium">
               {title}
             </a>
           ) : (
-            <span className="text-content-text-secondary [overflow-wrap:anywhere]">{title}</span>
+            <span className="text-content-text-secondary">{title}</span>
           );
         },
       }) as ColumnDef<SongPagePerformance, unknown>,
@@ -191,7 +188,9 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       columnHelper.accessor((row) => row.allTimer ?? false, {
         id: "allTimer",
         header: "",
-        meta: allTimerColumnMeta,
+        // Hidden on mobile here — the Set cell renders the flame inline
+        // on phones to recover the 16px this column would otherwise consume.
+        meta: { ...allTimerColumnMeta, hideOnMobile: true },
         enableSorting: false,
         cell: (info) => (info.getValue() ? <AllTimerCell /> : null),
       }) as ColumnDef<SongPagePerformance, unknown>,
@@ -201,7 +200,12 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
   columns.push(
     columnHelper.accessor("show.date", {
       id: "date",
-      meta: { width: "180px" },
+      // Desktop: weight 3 gives room for "MMM D, YYYY" + a venue line
+      // (DateVenueCell's @container/datecell drops the venue when the
+      // column gets squeezed). Mobile: fixed 5rem fits "M/D/YYYY" on one
+      // line and locks the column so the song-before / song-after flex
+      // columns can claim the rest.
+      meta: { weight: 3, mobileFixedWidth: "5rem" },
       header: ({ column }) => <SortableHeader column={column} label="Date" />,
       enableSorting: true,
       sortingFn: (a, b) => compareByShowDate(a.original, b.original),
@@ -209,13 +213,21 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
         const date = info.getValue();
         const showSlug = info.row.original.show.slug;
         const venue = info.row.original.venue;
+        const isAllTimer = info.row.original.allTimer;
         return (
-          <a href={`/shows/${showSlug}`} className="text-base text-brand-primary hover:text-brand-secondary block">
-            <DateVenueCell
-              date={<ShowDate date={date} />}
-              venue={{ name: venue?.name, city: venue?.city, state: venue?.state }}
-            />
-          </a>
+          <div className="flex flex-col gap-0.5">
+            <a href={`/shows/${showSlug}`} className="text-base text-brand-primary hover:text-brand-secondary block">
+              <DateVenueCell
+                date={<ShowDate date={date} />}
+                venue={{ name: venue?.name, city: venue?.city, state: venue?.state }}
+              />
+            </a>
+            {isAllTimer && !showSongColumn && (
+              <span className="sm:hidden">
+                <AllTimerCell align="start" />
+              </span>
+            )}
+          </div>
         );
       },
     }) as ColumnDef<SongPagePerformance, unknown>,
@@ -225,7 +237,7 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
     columns.push(
       columnHelper.accessor((row) => row.gap ?? Number.NEGATIVE_INFINITY, {
         id: "gap",
-        meta: { width: "64px" },
+        meta: { fixedWidth: "3.5rem", mobileFixedWidth: "2rem" },
         header: ({ column }) => <SortableHeader column={column} label="Gap" />,
         enableSorting: true,
         sortingFn: gapSortingFn,
@@ -242,15 +254,15 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       columns.push(
         columnHelper.accessor((row) => row.filteredGap ?? Number.NEGATIVE_INFINITY, {
           id: "filteredGap",
-          meta: { width: "72px" },
+          meta: { fixedWidth: "3.5rem", mobileFixedWidth: "2rem" },
           header: ({ column }) => (
             <SortableHeader
               column={column}
               label={
-                <span className="inline-flex items-center gap-1">
+                <span className="flex flex-col items-start leading-tight">
                   <Filter className="h-3 w-3" aria-hidden="true" />
                   <span className="sr-only">Filtered</span>
-                  Gap
+                  <span>Gap</span>
                 </span>
               }
             />
@@ -270,7 +282,7 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
     columns.push(
       columnHelper.accessor((row) => row.previousShow?.date ?? "", {
         id: "lastPlayed",
-        meta: { width: "110px", hideOnMobile: true },
+        meta: { fixedWidth: "5rem", hideOnMobile: true },
         header: ({ column }) => <SortableHeader column={column} label="Last Played" />,
         enableSorting: true,
         sortingFn: "alphanumeric",
@@ -279,33 +291,42 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
     );
   }
 
+  if (showSongColumn) {
+    // Cross-song surfaces (e.g. /songs/all-timers, /on-this-day) bring
+    // Set back as a column — when rows span many shows, the set label
+    // ("1", "E1") is the only on-row hint of where in the show this
+    // happened. On the single-song surfaces (/songs/:slug) Set was
+    // removed because every row's set is in the surrounding context.
+    columns.push(
+      columnHelper.accessor("set", {
+        id: "set",
+        header: "Set",
+        meta: { fixedWidth: "2.5rem" },
+        enableSorting: false,
+        cell: (info) => {
+          const set = info.getValue();
+          if (!set) return <span className="text-content-text-tertiary">—</span>;
+          return <span className="text-content-text-secondary">{formatSetLabel(set)}</span>;
+        },
+      }) as ColumnDef<SongPagePerformance, unknown>,
+    );
+  }
+
   columns.push(
-    columnHelper.accessor("set", {
-      header: "Set",
-      meta: { width: "48px" },
-      enableSorting: false,
-      cell: (info) => {
-        const set = info.getValue();
-        if (!set) return <span className="text-content-text-tertiary">—</span>;
-        // Cross-show table — we don't know the encore count of any one
-        // show, so single-encore collapse (E1 → E) is left off here.
-        return <span className="text-content-text-secondary">{formatSetLabel(set)}</span>;
-      },
-    }) as ColumnDef<SongPagePerformance, unknown>,
     columnHelper.accessor((row) => row.songBefore, {
       id: "songBefore",
       header: ({ column }) => <SortableHeader column={column} label="Song Before" />,
       enableSorting: true,
       sortingFn: songBeforeSortingFn,
-      meta: { hideOnMobile: true },
+      // Cross-song surfaces hide adjacency on mobile — too many columns
+      // to fit. Per-song surfaces keep them visible (user-requested).
+      meta: { weight: 1.6, hideOnMobile: showSongColumn },
       cell: (info) => {
         const before = info.getValue();
         if (!before?.songTitle) return null;
-        // Inline text rather than flex items so the title wraps mid-word
-        // instead of pushing past the arrow onto a new line. Arrow renders
-        // only on segues; its absence implicitly signals a non-segue.
+        // Arrow renders only on segues; its absence implicitly signals a non-segue.
         return (
-          <span className="[overflow-wrap:anywhere]">
+          <span>
             <a href={`/songs/${before.songSlug}`} className="text-content-text-secondary hover:text-brand-primary">
               {before.songTitle}
             </a>
@@ -319,13 +340,13 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       header: ({ column }) => <SortableHeader column={column} label="Song After" />,
       enableSorting: true,
       sortingFn: songAfterSortingFn,
-      meta: { hideOnMobile: true },
+      meta: { weight: 1.6, hideOnMobile: showSongColumn },
       cell: (info) => {
         const after = info.getValue();
         if (!after?.songTitle) return null;
         const outgoingSegue = info.row.original.segue;
         return (
-          <span className="[overflow-wrap:anywhere]">
+          <span>
             {outgoingSegue && <span className="text-content-text-tertiary">&gt; </span>}
             <a href={`/songs/${after.songSlug}`} className="text-content-text-secondary hover:text-brand-primary">
               {after.songTitle}
@@ -343,7 +364,7 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
         id: "notes",
         header: "Notes",
         enableSorting: false,
-        meta: { hideOnMobile: true },
+        meta: { weight: 2.8, hideOnMobile: true },
         cell: (info) => {
           const { annotations, notes } = info.getValue();
           const items = [];
@@ -371,7 +392,12 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       header: ({ column }) => <SortableHeader column={column} label="Rating" />,
       enableSorting: true,
       sortingFn: "basic",
-      meta: { hideOnMobile: true },
+      // Desktop 7.25rem (~116px) = badge width (~91px) + cell padding
+      // (24px), no extra. Mobile fits the compact badge at 6rem. The
+      // 5-star editor is no longer inline — it pops in a popover that
+      // overlays the badge — so the column doesn't need to hold the
+      // wider expanded state.
+      meta: { fixedWidth: "7.25rem", mobileFixedWidth: "6rem" },
       cell: (info) => {
         const rating = info.getValue();
         const ratingsCount = info.row.original.ratingsCount;

--- a/apps/web/app/components/rating/rating-badge-button.tsx
+++ b/apps/web/app/components/rating/rating-badge-button.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { RatingComponent } from "~/components/rating/rating";
 import { LoginPromptPopover } from "~/components/ui/login-prompt-popover";
+import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
 import { StarRating } from "~/components/ui/star-rating";
 import { cn } from "~/lib/utils";
 
@@ -111,14 +112,14 @@ export function RatingBadgeButton({
     ? "bg-amber-500/10 border border-amber-500/50 shadow-[0_0_8px_rgba(245,158,11,0.2)]"
     : "glass-secondary border border-dashed border-glass-border hover:border-amber-500/30";
 
-  const ratingButton = (
+  // Badge is always the compact RatingComponent; tapping opens a Popover
+  // with the 5-star picker (overlay rather than inline expansion). Same
+  // behavior on desktop and mobile so the rating column never needs to
+  // hold the wider expanded state.
+  const compactButton = (
     <button
       type="button"
-      onClick={(e) => {
-        if (!isAuthenticated) return;
-        e.stopPropagation();
-        setIsExpanded((open) => !open);
-      }}
+      onClick={(e) => e.stopPropagation()}
       className={cn(
         layoutClass,
         paddingClass,
@@ -127,33 +128,78 @@ export function RatingBadgeButton({
         isAnimating && "animate-[avg-rating-update_0.5s_ease-out]",
       )}
     >
-      {isExpanded ? (
-        <StarRating
-          rateableId={rateableId}
-          rateableType={rateableType}
-          showSlug={showSlug}
-          initialRating={localUserRating}
-          onRatingChange={setLocalUserRating}
-          onAverageRatingChange={handleRatingChange}
-          skipRevalidation={skipRevalidation}
-        />
-      ) : (
-        <RatingComponent
-          rating={displayedRating || null}
-          ratingsCount={displayedCount || null}
-          userRating={localUserRating}
-        />
-      )}
+      <RatingComponent
+        rating={displayedRating || null}
+        ratingsCount={displayedCount || null}
+        userRating={localUserRating}
+      />
     </button>
   );
 
   if (!isAuthenticated) {
     return (
       <div className="w-auto">
-        <LoginPromptPopover message="Sign in to rate">{ratingButton}</LoginPromptPopover>
+        <LoginPromptPopover message="Sign in to rate">{compactButton}</LoginPromptPopover>
       </div>
     );
   }
 
-  return <div className="w-auto">{ratingButton}</div>;
+  return (
+    <div className="w-auto">
+      <Popover open={isExpanded} onOpenChange={setIsExpanded}>
+        <PopoverTrigger asChild>{compactButton}</PopoverTrigger>
+        {/*
+         * `side="top"` + negative sideOffset positions the popover so
+         * its bottom edge sits over the badge, visually replacing the
+         * collapsed star + count with the 5-star picker rather than
+         * floating in empty space below. Styling mirrors the desktop
+         * inline-expanded state — amber tint + border + soft glow when
+         * the user has rated, glass / dashed-border when they haven't —
+         * so opening the picker reads as the same component, just
+         * floated on mobile.
+         *
+         * The inline `background` style uses the raw `--popover` CSS
+         * variable directly because this Tailwind v4 theme registers
+         * `--color-*` tokens (used by Tailwind `bg-*` classes)
+         * separately from the older HSL-component `--popover` token
+         * shared with Radix — `bg-popover` / `bg-background` resolve to
+         * `transparent`. The amber tint layers on top via `bg-amber-500/10`.
+         */}
+        <PopoverContent
+          // Sized + colored to mirror the inline-expanded badge:
+          // same py-1 + px padding, same border + glow as the rated
+          // state. `min-h-8` + `sideOffset={-32}` makes the popover at
+          // least as tall as the underlying badge on desktop (~30px) so
+          // it fully covers the badge with `align="center"` + `side="top"`.
+          //
+          // Background is OPAQUE: rgb(33, 24, 11) = amber-500 (rgb 245,
+          // 158, 11) composited at 10% opacity over the dark page bg
+          // (--background ≈ rgb 9, 9, 11). Same visual color as the
+          // inline `bg-amber-500/10` reads against the row, without
+          // letting other cells show through.
+          className={cn(
+            "w-auto rounded-md flex items-center gap-1 min-h-8",
+            localHasRated ? "!p-1" : "!py-1 !px-2",
+            localHasRated
+              ? "border border-amber-500/50 shadow-[0_0_8px_rgba(245,158,11,0.2)]"
+              : "glass-secondary border border-dashed border-glass-border",
+          )}
+          style={localHasRated ? { backgroundColor: "rgb(33, 24, 11)" } : undefined}
+          align="center"
+          side="top"
+          sideOffset={-32}
+        >
+          <StarRating
+            rateableId={rateableId}
+            rateableType={rateableType}
+            showSlug={showSlug}
+            initialRating={localUserRating}
+            onRatingChange={setLocalUserRating}
+            onAverageRatingChange={handleRatingChange}
+            skipRevalidation={skipRevalidation}
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
 }

--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -343,7 +343,9 @@ describe("SetlistCard", () => {
     // Average gap formats to one decimal place — terse, matches the rest
     // of the rarity stat presentation on the song-detail page.
     expect(screen.getByText(/Average \/ median song gap:\s*7\.5\s*\/\s*6\.0/)).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Last Played" })).toBeInTheDocument();
+    // Label is split into stacked <span>Last</span><span>Played</span>
+    // so the accessible name concatenates without whitespace.
+    expect(screen.getByRole("columnheader", { name: /LastPlayed/i })).toBeInTheDocument();
   });
 
   // The average gap summary lives BELOW the setlist text on the same row
@@ -383,7 +385,9 @@ describe("SetlistCard", () => {
     await user.click(screen.getByRole("button", { name: /gap chart/i }));
     // The card flipped views (table renders), but no callback was invoked
     // because none was passed — the only way list pages preserve local state.
-    expect(screen.getByRole("columnheader", { name: "Last Played" })).toBeInTheDocument();
+    // Label is split into stacked <span>Last</span><span>Played</span>
+    // so the accessible name concatenates without whitespace.
+    expect(screen.getByRole("columnheader", { name: /LastPlayed/i })).toBeInTheDocument();
     expect(onViewChange).not.toHaveBeenCalled();
   });
 

--- a/apps/web/app/components/setlist/setlist-columns-personal.tsx
+++ b/apps/web/app/components/setlist/setlist-columns-personal.tsx
@@ -34,7 +34,7 @@ export function createPersonalSetlistColumns(
     createGapColumn<PersonalSetlistTableRow>({
       id: "yourGap",
       label: "Your Gap",
-      width: "60px",
+      weight: 0.8,
       state: (row) => row.personal.yourGap,
       debutLabel: "Your debut",
       thisShowLabel: "Earlier this show",
@@ -43,7 +43,7 @@ export function createPersonalSetlistColumns(
       id: "lastSeen",
       label: "Last Seen",
       accessor: (row) => row.personal.lastSeen,
-      width: "124px",
+      fixedWidth: "7.5rem",
       hideOnMobile: true,
     }),
     createSeenCountColumn(),
@@ -59,8 +59,21 @@ function createSeenCountColumn(): ColumnDef<PersonalSetlistTableRow, unknown> {
   const columnHelper = createColumnHelper<PersonalSetlistTableRow>();
   return columnHelper.accessor((row) => row.personal.totalTimesSeen, {
     id: "totalTimesSeen",
-    header: ({ column }) => <SortableHeader column={column} label="Seen Before" />,
-    meta: { width: "72px" },
+    header: ({ column }) => (
+      <SortableHeader
+        column={column}
+        label={
+          <span className="flex flex-col items-start leading-tight">
+            <span>Seen</span>
+            <span>Before</span>
+          </span>
+        }
+      />
+    ),
+    // Bounded content (1-3 digit count). Desktop fixedWidth holds the
+    // stacked "Seen / Before" header + sort arrow on its own line below
+    // without leaving any extra slack.
+    meta: { fixedWidth: "4.5rem", mobileFixedWidth: "3rem" },
     enableSorting: true,
     sortingFn: "basic",
     sortDescFirst: false,

--- a/apps/web/app/components/setlist/setlist-columns.test.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.test.tsx
@@ -176,7 +176,8 @@ describe("createSetlistColumns", () => {
         song: { id: "b", title: "Above the Waves", slug: "y" },
       }),
     ]);
-    await user.click(screen.getByRole("button", { name: /Last Played/i }));
+    // Label is split into stacked spans; accessible name is "LastPlayed".
+    await user.click(screen.getByRole("button", { name: /LastPlayed/i }));
     const songCells = screen.getAllByRole("cell").filter((_, i) => i % 7 === 3);
     expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
       "Basis for a Day",
@@ -378,12 +379,16 @@ describe("createSetlistColumns", () => {
     expect(link).toHaveAttribute("href", "/songs/confrontation");
   });
 
-  // Rating column hides on phones to keep the row legible — same pattern
-  // the "Last Seen" column uses on the personal table. Tablet+ shows it.
-  test("Rating column is marked hideOnMobile", () => {
+  // Rating stays visible on phones too — the rating button is the
+  // primary action on the setlist row and dropping it hides a core
+  // affordance. The column shrinks to a fixed `mobileFixedWidth` so it
+  // still fits alongside Song / Gap / Last Played.
+  test("Rating column declares mobileFixedWidth and is NOT hidden on mobile", () => {
     const columns = createSetlistColumns();
     const rating = columns.find((c) => c.id === "rating");
-    expect((rating?.meta as { hideOnMobile?: boolean } | undefined)?.hideOnMobile).toBe(true);
+    const meta = rating?.meta as { hideOnMobile?: boolean; mobileFixedWidth?: string } | undefined;
+    expect(meta?.hideOnMobile).toBeFalsy();
+    expect(meta?.mobileFixedWidth).toBeTruthy();
   });
 
   // Each row's Rating cell renders TrackRatingCell wired with the track's

--- a/apps/web/app/components/setlist/setlist-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.tsx
@@ -35,7 +35,7 @@ export function createSetlistColumns(ctx?: Partial<SetlistRatingContext>): Colum
     createGapColumn<SetlistTableRow>({
       id: "gap",
       label: "Gap",
-      width: "64px",
+      weight: 0.8,
       state: (row, allRows) => buildGapCellState({ isRepeat: isWithinShowRepeat(allRows, row), gap: row.gap }),
       debutLabel: "Debut",
       thisShowLabel: "This Show",
@@ -44,7 +44,7 @@ export function createSetlistColumns(ctx?: Partial<SetlistRatingContext>): Colum
       id: "lastPlayed",
       label: "Last Played",
       accessor: (row) => row.previousPerformanceShow,
-      width: "140px",
+      fixedWidth: "7.5rem",
     }),
     createRatingColumn<SetlistTableRow>(ratingCtx),
   ];

--- a/apps/web/app/components/setlist/setlist-common-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-common-columns.tsx
@@ -49,7 +49,13 @@ export function createRatingColumn<T extends TrackLight>(ctx: SetlistRatingConte
   return columnHelper.accessor((row) => row.averageRating ?? Number.NEGATIVE_INFINITY, {
     id: "rating",
     header: ({ column }) => <SortableHeader column={column} label="Rating" />,
-    meta: { width: "120px", hideOnMobile: true },
+    // Bounded content (star + "X.XX" + dot + count). The 5-star picker
+    // now floats in a popover instead of expanding the badge inline, so
+    // the column only needs to fit the compact badge. Desktop 7rem (~112px)
+    // gives ~96px content area (after 1rem horizontal padding) so the
+    // widest "★ 5.00 · 99" badge (~91px) sits with a few pixels of
+    // breathing room. Mobile 6rem fits the same compact rendering.
+    meta: { fixedWidth: "7rem", mobileFixedWidth: "6rem" },
     enableSorting: true,
     // Ties resolve to canonical set+position so "all unrated tracks" still
     // read top-to-bottom in the order they were played.
@@ -93,14 +99,41 @@ export function createShowDateLinkColumn<T extends TrackLight>(opts: {
   id: string;
   label: string;
   accessor: (row: T) => { date: string; slug: string | null } | null | undefined;
-  width: string;
+  /**
+   * Desktop column width. Date content is bounded ("MMM DD, YYYY" max
+   * ~100px), so callers should generally pass a fixedWidth here rather
+   * than relying on weight — flexing eats space the Song column wants.
+   */
+  fixedWidth: string;
   hideOnMobile?: boolean;
 }): ColumnDef<T, unknown> {
   const columnHelper = createColumnHelper<T>();
   return columnHelper.accessor((row) => opts.accessor(row)?.date ?? "", {
     id: opts.id,
-    header: ({ column }) => <SortableHeader column={column} label={opts.label} />,
-    meta: opts.hideOnMobile ? { width: opts.width, hideOnMobile: true } : { width: opts.width },
+    // Label words stack vertically so the header floor is the widest
+    // single word ("Played" / "Seen" ~ 50px) instead of the full phrase
+    // ("Last Played" ~ 76px). Combined with SortableHeader's flex-wrap,
+    // the sort arrow drops onto its own line below when the column is
+    // narrow, letting the date cells (~80px content) drive the column
+    // width instead of the header.
+    header: ({ column }) => (
+      <SortableHeader
+        column={column}
+        label={
+          <span className="flex flex-col leading-tight">
+            {opts.label.split(" ").map((word) => (
+              <span key={word}>{word}</span>
+            ))}
+          </span>
+        }
+      />
+    ),
+    // Mobile: 4.5rem locks the column to compact "M/D/YY" width — same
+    // pattern as the other date-only mobile cells — so the Rating column
+    // can sit alongside without crowding Song.
+    meta: opts.hideOnMobile
+      ? { fixedWidth: opts.fixedWidth, mobileFixedWidth: "4.5rem", hideOnMobile: true }
+      : { fixedWidth: opts.fixedWidth, mobileFixedWidth: "4.5rem" },
     enableSorting: true,
     // ISO YYYY-MM-DD strings sort lexicographically the same as
     // chronologically. Empty strings (no prior performance) sort first asc
@@ -126,7 +159,7 @@ export function createShowDateLinkColumn<T extends TrackLight>(opts: {
 export function createGapColumn<T extends TrackLight>(opts: {
   id: string;
   label: string;
-  width: string;
+  weight: number;
   /** Row-level state — must be stable per row so sort + cell agree. */
   state: (row: T, allRows: ReadonlyArray<T>) => GapCellState;
   debutLabel: string;
@@ -146,7 +179,10 @@ export function createGapColumn<T extends TrackLight>(opts: {
     {
       id: opts.id,
       header: ({ column }) => <SortableHeader column={column} label={opts.label} />,
-      meta: { width: opts.width },
+      // Gap content is bounded (debut icon, repeat icon, or up to 3
+      // digits) — fix both desktop (3rem) and mobile (2.5rem with the
+      // sort arrow wrapping onto its own line below the "Gap" label).
+      meta: { fixedWidth: "3rem", mobileFixedWidth: "2.5rem" },
       enableSorting: true,
       // Numeric compare with set+position tiebreaker — rows that share the
       // same gap value still read in canonical narrative order.
@@ -179,26 +215,61 @@ export function createSetlistCommonColumns<T extends TrackLight>(options?: {
   return [
     columnHelper.accessor((row) => row.set, {
       id: "set",
-      header: ({ column }) => <SortableHeader column={column} label="Set" />,
-      meta: { width: "36px" },
+      // "Set" label is sr-only on mobile — the column shrinks below the
+      // word's width, and "Set" + sort affordance are redundant when the
+      // cells themselves show "1", "2", "E1" right below.
+      header: ({ column }) => (
+        <SortableHeader
+          column={column}
+          label={
+            <span>
+              <span className="sr-only sm:not-sr-only">Set</span>
+            </span>
+          }
+        />
+      ),
+      // Set values max out at "E2" (2 chars). Bounded content → fixed
+      // 3rem on desktop. On mobile the column also doubles as the home
+      // for the all-timer flame icon (standalone AllTimer column is
+      // hidden on mobile to save space), so it's wide enough for either
+      // the flame or "E1" stacked vertically.
+      meta: {
+        fixedWidth: "2.5rem",
+        mobileFixedWidth: "1.25rem",
+        cellClassName: "!px-0 sm:!px-2",
+        headerClassName: "!px-0 sm:!px-2",
+      },
       enableSorting: true,
       sortingFn: (a, b) => compareBySetThenPosition(a.original, b.original),
       cell: (info) => {
         const raw = info.getValue() as string;
+        const row = info.row.original;
         const encoresInSet = countDistinctEncores(info.table.getCoreRowModel().rows.map((r) => r.original));
         // Show the set label only on the first row of a same-set run when
         // sorted by Set — keeps the grouping visually obvious. Other sorts
         // interleave sets, so every row keeps its label.
         const sorting = info.table.getState().sorting;
         const groupBySet = sorting.length > 0 && sorting[0].id === "set";
+        let hideSetLabel = false;
         if (groupBySet) {
           const sortedRows = info.table.getSortedRowModel().rows;
           const idx = sortedRows.findIndex((r) => r.id === info.row.id);
-          if (idx > 0 && sortedRows[idx - 1].original.set === info.row.original.set) {
-            return null;
+          if (idx > 0 && sortedRows[idx - 1].original.set === row.set) {
+            hideSetLabel = true;
           }
         }
-        return <span className="text-content-text-secondary">{formatSetLabel(raw, { encoresInSet })}</span>;
+        return (
+          <div className="flex flex-col items-center sm:items-start gap-0.5">
+            {!hideSetLabel && (
+              <span className="text-content-text-secondary">{formatSetLabel(raw, { encoresInSet })}</span>
+            )}
+            {row.allTimer && (
+              <span className="sm:hidden">
+                <AllTimerCell />
+              </span>
+            )}
+          </div>
+        );
       },
     }) as ColumnDef<T, unknown>,
     columnHelper.display({
@@ -206,7 +277,10 @@ export function createSetlistCommonColumns<T extends TrackLight>(options?: {
       header: ({ column }) => <SortableHeader column={column} label="Track" />,
       // Drops on narrow viewports — the Set column already orients the row,
       // and a tiny Track column would steal width from Song on mobile.
-      meta: { width: "42px", hideOnMobile: true },
+      // Track # (position within set) — bounded to 3 digits max. 3.5rem
+      // accommodates the "Track" header word + sort arrow + tighter
+      // padding on desktop.
+      meta: { fixedWidth: "3.5rem", hideOnMobile: true },
       enableSorting: true,
       // Track # = position-within-set, computed at render time from the
       // unsorted row model. The comparator falls through to the canonical
@@ -223,7 +297,9 @@ export function createSetlistCommonColumns<T extends TrackLight>(options?: {
     columnHelper.display({
       id: "allTimer",
       header: () => null,
-      meta: allTimerColumnMeta,
+      // Hidden on mobile here — the setlist Set cell renders the flame
+      // inline on phones to recover the 16px this column would consume.
+      meta: { ...allTimerColumnMeta, hideOnMobile: true },
       enableSorting: false,
       cell: (info) => (info.row.original.allTimer ? <AllTimerCell /> : null),
     }) as ColumnDef<T, unknown>,

--- a/apps/web/app/components/show-date-link.tsx
+++ b/apps/web/app/components/show-date-link.tsx
@@ -30,13 +30,16 @@ export function ShowDateLink({ show }: ShowDateLinkProps) {
   if (!show) return <span className="text-content-text-tertiary">—</span>;
   if (!show.slug) {
     return (
-      <span className="text-content-text-secondary">
+      <span className="@container/datecell text-content-text-secondary block">
         <ShowDate date={show.date} />
       </span>
     );
   }
   return (
-    <a href={`/shows/${show.slug}${suffix}`} className="text-base text-brand-primary hover:text-brand-secondary">
+    <a
+      href={`/shows/${show.slug}${suffix}`}
+      className="@container/datecell block text-base text-brand-primary hover:text-brand-secondary"
+    >
       <ShowDate date={show.date} />
     </a>
   );

--- a/apps/web/app/components/show-date.tsx
+++ b/apps/web/app/components/show-date.tsx
@@ -1,28 +1,25 @@
 import { formatDateShort, formatDateShortMobile } from "~/lib/utils";
 
-interface ShowDateProps {
-  date: string | Date;
-  /**
-   * Render the compact `M/D/YY` form at all viewport sizes instead of
-   * only on mobile. For dense surfaces where the four-digit year would
-   * wrap the cell.
-   */
-  compact?: boolean;
-}
-
 /**
- * Single rendering point for show dates across the app. Outputs `M/D/YYYY`
- * at sm+ and the compact `M/D/YY` on mobile so narrow tables (songs list,
- * performance tables) stay readable without overlap. Centralizing here keeps
- * date formatting consistent everywhere a show date is displayed — change
- * the format once and every callsite follows.
+ * Single rendering point for show dates across the app. Outputs both the
+ * full `M/D/YYYY` and compact `M/D/YY` forms; CSS picks which one to display
+ * based on the nearest ancestor labeled `@container/datecell`. When no such
+ * container exists (e.g. the SetlistCard header), the default — full form —
+ * shows and the compact span stays hidden. Cells that DO declare a
+ * `@container/datecell` (DateVenueCell variants, ShowDateLink) swap to the
+ * compact form once the cell tightens below ~6rem, so dense tables and
+ * narrow layouts collapse dates automatically.
+ *
+ * Implementation note: ShowDate must not establish the container itself —
+ * `container-type: inline-size` zeroes the element's intrinsic inline
+ * size, which collapses an inline-block to 0 width and breaks the date
+ * character-by-character. The container lives on a sized parent.
  */
-export function ShowDate({ date, compact }: ShowDateProps) {
-  if (compact) return <span>{formatDateShortMobile(date)}</span>;
+export function ShowDate({ date }: { date: string | Date }) {
   return (
     <>
-      <span className="hidden sm:inline">{formatDateShort(date)}</span>
-      <span className="sm:hidden">{formatDateShortMobile(date)}</span>
+      <span className="inline whitespace-nowrap @max-[6rem]/datecell:hidden">{formatDateShort(date)}</span>
+      <span className="hidden whitespace-nowrap @max-[6rem]/datecell:inline">{formatDateShortMobile(date)}</span>
     </>
   );
 }

--- a/apps/web/app/components/song/songs-columns.test.tsx
+++ b/apps/web/app/components/song/songs-columns.test.tsx
@@ -198,30 +198,6 @@ describe("getSongsColumns", () => {
     expect(screen.getByText("2.4")).toBeInTheDocument();
   });
 
-  // When showFilteredPlays is true, Last Played and First Played drop the
-  // venue sublabel and shrink — the row is wider with the extra filtered
-  // columns, so we trade venue-on-row for horizontal room.
-  test("showFilteredPlays=true: Last Played and First Played cells omit the venue sublabel", async () => {
-    await setupWithRouter(
-      <DataTable
-        columns={filteredColumns}
-        data={[
-          makeSong({
-            lastPlayedShow: makeShow(),
-            firstPlayedShow: makeShow({ slug: "1995-07-04-some-venue" }),
-          }),
-        ]}
-        hideSearch
-        hidePagination
-      />,
-    );
-
-    // Venue text would appear under the date in the no-filter baseline
-    // (see "Last Played venue" test below). Under filtered columns it
-    // must NOT render — neither for Last Played nor for First Played.
-    expect(screen.queryByText(/The Capitol Theatre/)).not.toBeInTheDocument();
-  });
-
   // When showFilteredPlays is true, the factory inserts a "Filtered Plays"
   // column next to Plays showing the count scoped to the active filter.
   test("showFilteredPlays=true: Filtered Plays column renders the scoped count", async () => {
@@ -345,6 +321,9 @@ describe("getSongsColumns", () => {
     ];
     const { user } = await setupWithRouter(<DataTable columns={baseColumns} data={songs} hideSearch hidePagination />);
 
+    // Header label is split into stacked <span>First</span><span>Played</span>
+    // (so it wraps to two lines at narrow widths); accessible name has no
+    // whitespace between the words.
     const sortHeader = screen.getByRole("button", { name: /^First Played/i });
     await user.click(sortHeader);
 
@@ -492,45 +471,46 @@ describe("getSongsColumns", () => {
     expect(titlesDesc.map((el) => el.textContent)).toEqual(["Crickets", "Plan B", "Home Again"]);
   });
 
-  // On mobile, the Last Played and First Played dates render in a compact
-  // M/D/YY format so the column fits without overlap. The long format
-  // ("Jun 15, 2024") is preserved at sm+ so desktop users see the full date.
-  // Both formats are present in the DOM, gated by responsive Tailwind classes.
-  test("Last Played cell renders both compact (mobile) and long (desktop) date formats", async () => {
+  // Both date formats are present in the DOM; the wrapping cell declares
+  // `@container/datecell` and ShowDate's spans use `@max-[6rem]/datecell:`
+  // to swap which one is visible. Wide column → full "Jun 15, 2024";
+  // tight column (many picks or narrow layout) → compact "6/15/24". One
+  // width for dense and sparse column sets, browser does the rest.
+  test("Last Played cell renders both compact and long date formats gated by container width", async () => {
     const song = makeSong({
       dateLastPlayed: new Date("2024-06-15"),
       lastPlayedShow: makeShow({ slug: "2024-06-15-the-cap" }),
     });
     await setupWithRouter(<DataTable columns={baseColumns} data={[song]} hideSearch hidePagination />);
 
-    // Long format visible at sm+ (hidden on mobile)
+    // Long format hidden once the cell tightens below 6rem
     const longFormat = screen.getByText(/6\/15\/2024/);
-    expect(longFormat.className).toContain("hidden");
-    expect(longFormat.className).toContain("sm:inline");
+    expect(longFormat.className).toContain("@max-[6rem]/datecell:hidden");
 
-    // Compact format visible on mobile (hidden at sm+)
+    // Compact format swaps in once the cell tightens below 6rem
     const compactFormat = screen.getByText("6/15/24");
-    expect(compactFormat.className).toContain("sm:hidden");
+    expect(compactFormat.className).toContain("hidden");
+    expect(compactFormat.className).toContain("@max-[6rem]/datecell:inline");
   });
 
   // Same dual-format treatment for First Played, mirroring Last Played so
-  // both date columns line up neatly at the same breakpoint.
-  test("First Played cell renders both compact (mobile) and long (desktop) date formats", async () => {
+  // both date columns collapse at the same threshold.
+  test("First Played cell renders both compact and long date formats gated by container width", async () => {
     const song = makeSong({
       dateFirstPlayed: new Date("1995-07-04"),
       firstPlayedShow: makeShow({ id: "show-first", slug: "1995-07-04-red-rocks" }),
     });
     await setupWithRouter(<DataTable columns={baseColumns} data={[song]} hideSearch hidePagination />);
 
-    expect(screen.getByText(/7\/4\/1995/).className).toContain("hidden");
-    expect(screen.getByText("7/4/95").className).toContain("sm:hidden");
+    expect(screen.getByText(/7\/4\/1995/).className).toContain("@max-[6rem]/datecell:hidden");
+    expect(screen.getByText("7/4/95").className).toContain("@max-[6rem]/datecell:inline");
   });
 
-  // The venue line beneath Last/First Played dates uses `hidden sm:block`
-  // so the cells collapse to date-only on mobile (matching the perf-table
-  // DateVenueCell pattern). Otherwise the wrapped venue text adds two
-  // extra lines per row on phones for marginal value.
-  test("Last Played venue line is hidden on mobile (hidden sm:block)", async () => {
+  // The venue line beneath Last/First Played dates is gated by the cell's
+  // @container/datecell — drops out once the column shrinks below ~10rem
+  // so dense tables collapse to date-only automatically (no viewport or
+  // filter-flag branching required).
+  test("Last Played venue line is gated by datecell container width", async () => {
     const song = makeSong({
       dateLastPlayed: new Date("2024-06-15"),
       lastPlayedShow: makeShow({ slug: "2024-06-15-the-cap" }),
@@ -539,10 +519,10 @@ describe("getSongsColumns", () => {
 
     const venueLine = screen.getByText(/The Capitol Theatre/);
     expect(venueLine.className).toContain("hidden");
-    expect(venueLine.className).toContain("sm:block");
+    expect(venueLine.className).toContain("@[8rem]/datecell:block");
   });
 
-  test("First Played venue line is hidden on mobile (hidden sm:block)", async () => {
+  test("First Played venue line is gated by datecell container width", async () => {
     const song = makeSong({
       dateFirstPlayed: new Date("1995-07-04"),
       firstPlayedShow: makeShow({
@@ -565,7 +545,7 @@ describe("getSongsColumns", () => {
 
     const venueLine = screen.getByText(/Red Rocks Amphitheatre/);
     expect(venueLine.className).toContain("hidden");
-    expect(venueLine.className).toContain("sm:block");
+    expect(venueLine.className).toContain("@[8rem]/datecell:block");
   });
 
   // Plays and Filtered Plays are short-but-prone-to-overlap headers on

--- a/apps/web/app/components/song/songs-columns.tsx
+++ b/apps/web/app/components/song/songs-columns.tsx
@@ -99,7 +99,20 @@ interface SortableColumnOptions {
   label: ReactNode;
   /** Hover tooltip; used when the visible label needs disambiguation in prose. */
   title?: string;
-  width?: string;
+  /**
+   * Relative width share of *leftover* space under `table-layout: fixed`.
+   * Defaults to 1. Use > 1 for text columns; ignored when `fixedWidth` is
+   * set.
+   */
+  weight?: number;
+  /** Fixed column width (e.g. `"3rem"`) for short-content columns that
+   * shouldn't grow when the table widens. Wins over `weight`. */
+  fixedWidth?: string;
+  /** Mobile-specific fixed width — applied below the `sm` breakpoint.
+   * Use when a column's mobile rendering has a knowable max (e.g. dates
+   * without venue) and shouldn't gobble the leftover flex space that
+   * primary columns need. */
+  mobileFixedWidth?: string;
   hideOnMobile?: boolean;
   cell: (row: SongWithShows) => ReactNode;
   sortingFn?: SortingFn<SongWithShows>;
@@ -123,7 +136,12 @@ function makeSortableColumn(opts: SortableColumnOptions): ColumnDef<SongWithShow
   const sortIconWrapperClass = opts.reservesIconRow ? "sm:mt-3" : "";
   const def: ColumnDef<SongWithShows> = {
     accessorKey: opts.accessorKey,
-    meta: { width: opts.width, hideOnMobile: opts.hideOnMobile },
+    meta: {
+      weight: opts.weight,
+      fixedWidth: opts.fixedWidth,
+      mobileFixedWidth: opts.mobileFixedWidth,
+      hideOnMobile: opts.hideOnMobile,
+    },
     header: ({ column }) => (
       <Button
         variant="ghost"
@@ -143,38 +161,35 @@ function makeSortableColumn(opts: SortableColumnOptions): ColumnDef<SongWithShow
 
 /**
  * Renders a date with optional link to the show and a venue sublabel under
- * the date. Used by both Last Played and First Played columns — the only
- * difference between them is which date/show pair feeds in.
+ * the date. The cell is its own inline-size container, so the venue line
+ * drops out automatically when the column gets squeezed (many columns picked
+ * or a narrow layout) without callers passing a `hideVenue` flag. The date
+ * format collapses to compact via ShowDate's own container query.
  */
-function DateVenueCell({
-  date,
-  show,
-  hideVenue,
-  compact,
-}: {
-  date: Date | null;
-  show?: Show | null;
-  hideVenue?: boolean;
-  compact?: boolean;
-}): ReactNode {
+function DateVenueCell({ date, show }: { date: Date | null; show?: Show | null }): ReactNode {
   if (!date) return <span className="text-content-text-tertiary text-sm">—</span>;
-  const dateBlock = <ShowDate date={date} compact={compact} />;
-  const venueLine =
-    show?.venue && !hideVenue ? (
-      <div className="text-content-text-tertiary text-sm hidden sm:block">
-        {show.venue.name}, {show.venue.city} {show.venue.state}
-      </div>
-    ) : null;
+  const dateBlock = <ShowDate date={date} />;
+  // Venue only shows at `sm` and above (mobile keeps each row tight to
+  // a single date line), AND when the column is genuinely wide enough
+  // to hold it on desktop.
+  const venueLine = show?.venue ? (
+    <div className="text-content-text-tertiary text-sm hidden sm:@[8rem]/datecell:block">
+      {show.venue.name}, {show.venue.city} {show.venue.state}
+    </div>
+  ) : null;
   if (show?.slug) {
     return (
-      <Link to={`/shows/${show.slug}`} className="text-brand-primary hover:text-brand-secondary transition-colors">
+      <Link
+        to={`/shows/${show.slug}`}
+        className="@container/datecell block text-brand-primary hover:text-brand-secondary transition-colors"
+      >
         <div>{dateBlock}</div>
         {venueLine}
       </Link>
     );
   }
   return (
-    <div>
+    <div className="@container/datecell">
       <div className="text-content-text-secondary">{dateBlock}</div>
       {venueLine}
     </div>
@@ -200,13 +215,20 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const titleColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "title",
+    // Dense view (filtered + 4 date cols competing): Song needs a healthy
+    // share so single-word titles like "Shem-Rah Boo" fit on one line.
+    // Sparse view (2 date cols): Song should yield space to the date
+    // columns so their venue sublabels read on 1–2 lines instead of being
+    // squeezed to 3+.
+    weight: showFilteredPlays ? 3 : 1.5,
+    // On dense-view mobile the 4-up date columns and Filtered Plays
+    // already exceed the viewport at their fixedWidths — give Song its
+    // own mobile fixedWidth so it can't collapse to 0 leftover and the
+    // body clips overflow on the right (matches the prod behavior).
+    mobileFixedWidth: showFilteredPlays ? "7rem" : undefined,
     label: <HeaderLabel reserveIconRow={showFilteredPlays}>Song</HeaderLabel>,
-    width: showFilteredPlays ? "14%" : "26%",
     cell: (song) => (
-      <Link
-        to={`/songs/${song.slug}`}
-        className="inline-block min-w-[10ch] text-base text-brand-primary hover:text-brand-secondary font-medium [overflow-wrap:anywhere]"
-      >
+      <Link to={`/songs/${song.slug}`} className="text-base text-brand-primary hover:text-brand-secondary font-medium">
         {song.title}
       </Link>
     ),
@@ -215,10 +237,10 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const playsColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "timesPlayed",
+    fixedWidth: "4rem",
     label: <HeaderLabel reserveIconRow={showFilteredPlays}>Plays</HeaderLabel>,
-    width: showFilteredPlays ? "5%" : "8%",
-    // When Filtered Plays is also visible there isn't room for both count
-    // columns on mobile; the all-time count drops out at narrow widths.
+    // When Filtered Plays is also visible the all-time count is paired
+    // beside it; mobile-hide on the dense layout keeps both legible.
     hideOnMobile: showFilteredPlays,
     cell: (song) =>
       song.timesPlayed > 0 ? (
@@ -231,13 +253,16 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const filteredPlaysColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "filteredTimesPlayed",
+    fixedWidth: "4rem",
+    // Mobile shrinks — filtered counts on the all-timer view top out at
+    // ~36 plays, no need for the desktop 4rem.
+    mobileFixedWidth: "3rem",
     label: (
       <HeaderLabel filtered reserveIconRow>
         <span>Plays</span>
       </HeaderLabel>
     ),
     title: "Filtered Plays",
-    width: "5%",
     cell: (song) => {
       const plays = song.filteredTimesPlayed ?? 0;
       return plays > 0 ? (
@@ -265,6 +290,7 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const percentSinceDebutColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "percentSinceDebut",
+    fixedWidth: "4rem",
     label: (
       <HeaderLabel reserveIconRow={showFilteredPlays}>
         <span>Since</span>
@@ -272,7 +298,6 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
       </HeaderLabel>
     ),
     title: "% Since Debut",
-    width: showFilteredPlays ? "7%" : "6%",
     hideOnMobile: true,
     cell: (song) =>
       dashOrSpan(
@@ -286,6 +311,7 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const filteredPercentSinceDebutColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "filteredPercentSinceDebut",
+    fixedWidth: "4rem",
     label: (
       <HeaderLabel filtered reserveIconRow>
         <span>Since</span>
@@ -293,7 +319,6 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
       </HeaderLabel>
     ),
     title: "Filtered Since First",
-    width: "7%",
     hideOnMobile: true,
     cell: (song) =>
       dashOrSpan(
@@ -307,13 +332,13 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const avgGapColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "averageGapShows",
+    fixedWidth: "4rem",
     label: (
       <HeaderLabel reserveIconRow={showFilteredPlays}>
         <span>Avg</span>
         <span>Gap</span>
       </HeaderLabel>
     ),
-    width: "7%",
     hideOnMobile: true,
     cell: (song) => dashOrSpan(song.averageGapShows !== null ? song.averageGapShows.toFixed(1) : null),
     sortingFn: nullsLastNumericSort("averageGapShows"),
@@ -322,6 +347,7 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const filteredAvgGapColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "filteredAverageGapShows",
+    fixedWidth: "4rem",
     label: (
       <HeaderLabel filtered reserveIconRow>
         <span>Avg</span>
@@ -329,7 +355,6 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
       </HeaderLabel>
     ),
     title: "Filtered Avg Gap",
-    width: "7%",
     hideOnMobile: true,
     cell: (song) => dashOrSpan(song.filteredAverageGapShows != null ? song.filteredAverageGapShows.toFixed(1) : null),
     sortingFn: nullsLastNumericSort("filteredAverageGapShows"),
@@ -338,13 +363,13 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const currentGapColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "showsSinceLastPlayed",
+    fixedWidth: "4rem",
     // Spelled out vs. plain "Gap" so users can't confuse it with "Avg Gap"
     // on a quick scan. "to Now" anchors that this is the count up to today
     // (the filtered variant uses "to End" because its denominator stops
     // at the filter boundary).
     label: <HeaderLabel reserveIconRow={showFilteredPlays}>Gap to Now</HeaderLabel>,
     title: "Gap to Now",
-    width: "7%",
     hideOnMobile: true,
     cell: (song) => dashOrSpan(song.showsSinceLastPlayed),
     sortingFn: nullsLastNumericSort("showsSinceLastPlayed"),
@@ -353,85 +378,76 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const filteredCurrentGapColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "filteredShowsSinceLastPlayed",
+    fixedWidth: "4rem",
     label: (
       <HeaderLabel filtered reserveIconRow>
         <span>Gap to End</span>
       </HeaderLabel>
     ),
     title: "Filtered Gap to End",
-    width: "7%",
     hideOnMobile: true,
     cell: (song) => dashOrSpan(song.filteredShowsSinceLastPlayed ?? null),
     sortingFn: nullsLastNumericSort("filteredShowsSinceLastPlayed"),
   });
 
-  // When filtered columns are active the row is wider; drop the venue
-  // sublabel and shrink the date columns to make room.
-  const dateColumnWidth = showFilteredPlays ? "8%" : "22%";
+  // Date columns flex — they share leftover space with the Song column.
+  // On the sparse view (2 date cols, no filtered siblings) the dates
+  // yield extra width to Song so the title column reads cleanly; on the
+  // dense filtered view they're already squeezed by their 4-up layout
+  // so the weight stays higher to keep each date legible.
+  const dateColumnWeight = showFilteredPlays ? 1.4 : 1.0;
+
+  // Date columns on mobile lock to 4.5rem — wide enough for the compact
+  // "M/D/YY" rendered by ShowDate below its 6rem CQ threshold, no wider.
+  // Same width on sparse (2 dates) and dense (4 dates); on dense the
+  // table extends past the viewport and body's overflow-x:hidden clips
+  // the rightmost ("Filtered First") column — matches prod.
+  const dateColumnMobileWidth = "4.5rem";
 
   const lastPlayedColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "dateLastPlayed",
+    weight: dateColumnWeight,
+    mobileFixedWidth: dateColumnMobileWidth,
     label: <HeaderLabel reserveIconRow={showFilteredPlays}>Last Played</HeaderLabel>,
-    width: dateColumnWidth,
-    cell: (song) => (
-      <DateVenueCell
-        date={song.dateLastPlayed}
-        show={song.lastPlayedShow}
-        hideVenue={showFilteredPlays}
-        compact={showFilteredPlays}
-      />
-    ),
+    cell: (song) => <DateVenueCell date={song.dateLastPlayed} show={song.lastPlayedShow} />,
   });
 
   const filteredLastPlayedColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "dateLastFilteredPlayed",
+    weight: dateColumnWeight,
+    mobileFixedWidth: dateColumnMobileWidth,
     label: (
       <HeaderLabel filtered reserveIconRow>
         Last
       </HeaderLabel>
     ),
     title: "Filtered Last Played",
-    width: dateColumnWidth,
-    cell: (song) => (
-      <DateVenueCell date={song.dateLastFilteredPlayed ?? null} show={song.lastFilteredPlayedShow} hideVenue compact />
-    ),
+    cell: (song) => <DateVenueCell date={song.dateLastFilteredPlayed ?? null} show={song.lastFilteredPlayedShow} />,
   });
 
   const firstPlayedColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "dateFirstPlayed",
+    weight: dateColumnWeight,
+    mobileFixedWidth: dateColumnMobileWidth,
     label: <HeaderLabel reserveIconRow={showFilteredPlays}>First Played</HeaderLabel>,
-    width: dateColumnWidth,
-    cell: (song) => (
-      <DateVenueCell
-        date={song.dateFirstPlayed}
-        show={song.firstPlayedShow}
-        hideVenue={showFilteredPlays}
-        compact={showFilteredPlays}
-      />
-    ),
+    cell: (song) => <DateVenueCell date={song.dateFirstPlayed} show={song.firstPlayedShow} />,
   });
 
   const filteredFirstPlayedColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "dateFirstFilteredPlayed",
+    weight: dateColumnWeight,
+    mobileFixedWidth: dateColumnMobileWidth,
     label: (
       <HeaderLabel filtered reserveIconRow>
         First
       </HeaderLabel>
     ),
     title: "Filtered First Played",
-    width: dateColumnWidth,
-    cell: (song) => (
-      <DateVenueCell
-        date={song.dateFirstFilteredPlayed ?? null}
-        show={song.firstFilteredPlayedShow}
-        hideVenue
-        compact
-      />
-    ),
+    cell: (song) => <DateVenueCell date={song.dateFirstFilteredPlayed ?? null} show={song.firstFilteredPlayedShow} />,
   });
 
   const columns: ColumnDef<SongWithShows>[] = [titleColumn, playsColumn];

--- a/apps/web/app/components/track/all-timer-cell.tsx
+++ b/apps/web/app/components/track/all-timer-cell.tsx
@@ -4,10 +4,15 @@ import { Flame } from "lucide-react";
  * Table-cell renderer for the all-timer marker. The `h-6` wrapper matches
  * the default text-base line-height of adjacent cells so the 14px flame
  * sits on the same baseline as song-title text instead of floating high.
+ *
+ * `align` controls horizontal placement: `"center"` (default) suits the
+ * standalone narrow column; `"start"` is used when the flame is rendered
+ * inline beneath other content in a wider host cell (e.g. the perf-table
+ * Date cell or the setlist Set cell on mobile).
  */
-export function AllTimerCell() {
+export function AllTimerCell({ align = "center" }: { align?: "center" | "start" }) {
   return (
-    <div className="flex h-6 items-center justify-center">
+    <div className={`flex h-6 items-center ${align === "center" ? "justify-center" : "justify-start"}`}>
       <Flame className="h-3.5 w-3.5 text-orange-500" aria-label="All-timer" />
     </div>
   );
@@ -16,5 +21,12 @@ export function AllTimerCell() {
 /**
  * Meta options for the all-timer column — narrowest viable slot with no
  * horizontal padding so it never steals width from neighboring columns.
+ * Setlist views override `hideOnMobile: true` since they render the
+ * flame inline in their Set cell on mobile; the perf table keeps it
+ * visible since there's no equivalent host cell there.
  */
-export const allTimerColumnMeta = { width: "16px", cellClassName: "px-0 sm:px-0" } as const;
+export const allTimerColumnMeta = {
+  fixedWidth: "1.5rem",
+  mobileFixedWidth: "1rem",
+  cellClassName: "px-0 sm:px-0",
+} as const;

--- a/apps/web/app/components/ui/data-table.test.tsx
+++ b/apps/web/app/components/ui/data-table.test.tsx
@@ -2,7 +2,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { setup } from "@test/test-utils";
 import { screen } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
-import { DataTable } from "./data-table";
+import { computeColumnWidths, DataTable } from "./data-table";
 
 type Row = { id: string; name: string; count: number };
 
@@ -208,11 +208,16 @@ describe("DataTable", () => {
     expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
   });
 
-  // Columns marked `meta.hideOnMobile` get `hidden sm:table-cell` on both
-  // the header and body cells so they disappear at narrow viewports without
-  // needing a separate mobile column set. Used for the perf-table Notes
-  // column and other long-text columns that crowd phones.
-  test("hideOnMobile meta adds hidden sm:table-cell to header and body cells", async () => {
+  // Columns marked `meta.hideOnMobile` are dropped from rendering below the
+  // `sm` breakpoint — driven through TanStack's `columnVisibility` (not CSS
+  // `hidden sm:table-cell`) so the `<colgroup>` indices stay aligned with
+  // the actually-rendered TDs.
+  //
+  // jsdom doesn't fire ResizeObserver, so wrapperWidth stays 0 here. The
+  // gating treats unmeasured (wrapperWidth=0) as desktop — preferring a
+  // full render over preemptive hiding. So in this test the hideOnMobile
+  // column should still render.
+  test("hideOnMobile meta column renders by default (wrapper unmeasured)", async () => {
     const columnsWithHidden: ColumnDef<Row>[] = [
       { accessorKey: "name", header: "Name" },
       { accessorKey: "count", header: "Count", meta: { hideOnMobile: true } },
@@ -220,47 +225,83 @@ describe("DataTable", () => {
 
     await setup(<DataTable columns={columnsWithHidden} data={rows} hideSearch />);
 
-    const countHeader = screen.getByText("Count").closest("th");
-    expect(countHeader?.className).toContain("hidden");
-    expect(countHeader?.className).toContain("sm:table-cell");
-
-    const nameHeader = screen.getByText("Name").closest("th");
-    expect(nameHeader?.className ?? "").not.toContain("hidden");
-
-    const countCell = screen.getByText("3").closest("td");
-    expect(countCell?.className).toContain("hidden");
-    expect(countCell?.className).toContain("sm:table-cell");
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Count")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
   });
 
-  // The table uses `table-auto` on mobile (lets columns size to content,
-  // avoiding header overlap) and `table-fixed` at sm+ (keeps the
-  // percentage-width sizing predictable on desktop).
-  test("table element uses table-auto on mobile and sm:table-fixed at sm+", async () => {
-    const { container } = await setup(<DataTable columns={basicColumns} data={rows} hideSearch />);
-
-    const tableEl = container.querySelector("table");
-    expect(tableEl?.className).toContain("table-auto");
-    expect(tableEl?.className).toContain("sm:table-fixed");
-  });
-
-  // `meta.width` is exposed as a CSS custom property and only takes effect
-  // at sm+ via a Tailwind class — on mobile the column sizes to content.
-  // Without this gating, desktop-tuned widths would starve other columns
-  // at phone widths (the bug observed on /songs/all-timers and /on-this-day).
-  test("honors meta.width via --col-w + sm:w-[var(--col-w)] on column defs", async () => {
-    const columnsWithWidths: ColumnDef<Row>[] = [
-      { accessorKey: "name", header: "Name", meta: { width: "60%" } },
-      { accessorKey: "count", header: "Count", meta: { width: "40%" } },
+  // Column widths come from a <colgroup>. Each column uses either a
+  // `fixedWidth` (CSS length, applied verbatim) or a `weight` (share of
+  // pixel space left after fixed-width columns claim theirs). The wrapper
+  // width is measured at runtime via ResizeObserver; on first paint
+  // (before measurement) widths fall back to relative percentages.
+  test("first-paint render uses percentage widths for flex columns", async () => {
+    const columnsWithWeights: ColumnDef<Row>[] = [
+      { accessorKey: "name", header: "Name", meta: { weight: 3 } },
+      { accessorKey: "count", header: "Count" /* default weight 1 */ },
     ];
 
-    await setup(<DataTable columns={columnsWithWidths} data={rows} hideSearch />);
+    const { container } = await setup(<DataTable columns={columnsWithWeights} data={rows} hideSearch />);
 
-    const nameHeader = screen.getByText("Name").closest("th");
-    const countHeader = screen.getByText("Count").closest("th");
+    const cols = container.querySelectorAll("colgroup col");
+    expect(cols).toHaveLength(2);
+    // 3 of 4 total weight = 75%; 1 of 4 = 25%. (jsdom doesn't fire
+    // ResizeObserver, so we stay on the percentage fallback path.)
+    expect((cols[0] as HTMLElement).style.width).toBe("75%");
+    expect((cols[1] as HTMLElement).style.width).toBe("25%");
+  });
 
-    expect(nameHeader?.style.getPropertyValue("--col-w")).toBe("60%");
-    expect(countHeader?.style.getPropertyValue("--col-w")).toBe("40%");
-    expect(nameHeader?.className).toContain("sm:w-[var(--col-w)]");
-    expect(countHeader?.className).toContain("sm:w-[var(--col-w)]");
+  // Fixed-width columns get their declared length verbatim regardless of
+  // measurement state — flex columns share whatever's left.
+  test("fixedWidth columns get their length verbatim", async () => {
+    const columns: ColumnDef<Row>[] = [
+      { accessorKey: "name", header: "Name" /* flex weight 1 */ },
+      { accessorKey: "count", header: "Count", meta: { fixedWidth: "3rem" } },
+    ];
+
+    const { container } = await setup(<DataTable columns={columns} data={rows} hideSearch />);
+
+    const cols = container.querySelectorAll("colgroup col");
+    expect((cols[0] as HTMLElement).style.width).toBe("100%");
+    expect((cols[1] as HTMLElement).style.width).toBe("3rem");
+  });
+});
+
+describe("computeColumnWidths", () => {
+  // The DOM render path is exercised in the DataTable tests above but
+  // only on the pre-measurement (percentage) branch — jsdom doesn't fire
+  // ResizeObserver. Drive the post-measurement branch directly so we
+  // catch regressions in the pixel math: fixedWidth columns get their
+  // declared length, the rest split the remainder by weight.
+  type R = { id: string };
+  const c = (
+    id: string,
+    meta?: { weight?: number; fixedWidth?: string },
+  ): { id: string; columnDef: ColumnDef<R, unknown> } => ({
+    id,
+    columnDef: { id, meta } as ColumnDef<R, unknown>,
+  });
+
+  test("with a measured wrapper, flex columns split leftover pixels by weight", () => {
+    const cols = [c("song", { weight: 3 }), c("date", { weight: 1 })];
+    const widths = computeColumnWidths<R, unknown>(cols, /* wrapperWidth */ 1000, /* rootFontSize */ 16);
+    // 100% goes to flex; song gets 3/4 = 750px, date gets 250px.
+    expect(widths).toEqual(["750px", "250px"]);
+  });
+
+  test("fixedWidth columns subtract from leftover; flex columns share the rest", () => {
+    const cols = [c("song", { weight: 3 }), c("plays", { fixedWidth: "4rem" }), c("date", { weight: 1 })];
+    // 4rem = 64px at 16px root; leftover = 1000-64 = 936; song gets 3/4 = 702, date 234.
+    const widths = computeColumnWidths<R, unknown>(cols, 1000, 16);
+    expect(widths).toEqual(["702px", "4rem", "234px"]);
+  });
+
+  test("wrapperWidth=0 (SSR / first paint) falls back to percentage shares for flex columns", () => {
+    const cols = [c("song", { weight: 3 }), c("plays", { fixedWidth: "4rem" }), c("date", { weight: 1 })];
+    const widths = computeColumnWidths<R, unknown>(cols, 0, 16);
+    // Pixel math is suppressed; flex shares fall back to percentages of the full container.
+    // Fixed col still applied. The shares ignore the fixedWidth and may sum > 100% for
+    // a single frame before measurement takes over — intentional, documented in the helper.
+    expect(widths).toEqual(["75%", "4rem", "25%"]);
   });
 });

--- a/apps/web/app/components/ui/data-table.tsx
+++ b/apps/web/app/components/ui/data-table.tsx
@@ -15,18 +15,114 @@ import {
 declare module "@tanstack/react-table" {
   // biome-ignore lint/correctness/noUnusedVariables: required by TanStack's module augmentation pattern
   interface ColumnMeta<TData extends RowData, TValue> {
-    width?: string;
+    /**
+     * Fixed width for this column under `table-layout: fixed` — typically
+     * a `rem` value sized to the column's expected content (e.g. `"3rem"`
+     * for short numbers like "378", `"1.5rem"` for an icon-only column).
+     * Fixed columns never grow or shrink with the table. Leftover space
+     * is divided among the remaining (flex) columns by `weight`.
+     */
+    fixedWidth?: string;
+    /**
+     * Optional mobile override for `fixedWidth`. Applied below the `sm`
+     * breakpoint when the column would otherwise crowd siblings — e.g.
+     * the Rating column wants 8rem on desktop to give the rating-count
+     * button breathing room, but 5rem on phones so Song Before / After
+     * can still hold a word per line.
+     */
+    mobileFixedWidth?: string;
+    /**
+     * Relative share of *leftover* horizontal space — what's left after
+     * fixed-width columns claim theirs. Defaults to 1. Use > 1 for columns
+     * holding long free text (titles, notes); < 1 to bias against. Ignored
+     * when `fixedWidth` is set.
+     */
+    weight?: number;
     cellClassName?: string;
+    /**
+     * Optional extra classes for the header `<th>`. Use when the column
+     * needs to override the default padding so the declared
+     * `fixedWidth` / `mobileFixedWidth` actually controls the cell box
+     * (e.g. icon-only columns with `cellClassName: "!px-0"` want the
+     * matching `headerClassName: "!px-0"`).
+     */
+    headerClassName?: string;
     hideOnMobile?: boolean;
   }
 }
 
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 
 import { Input } from "~/components/ui/input";
 import { PaginationControls } from "~/components/ui/pagination-controls";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/ui/table";
 import { cn } from "~/lib/utils";
+
+/**
+ * Convert a CSS length value (currently `rem` or `px`) to pixels. `rem`
+ * resolves against the root font-size; `px` returns the number as-is.
+ * Only the units actually used by `meta.fixedWidth` callers in this
+ * codebase are supported on purpose — adding more units (`em`, `%`,
+ * viewport units) would invite calling code to depend on context that
+ * isn't reliably available at column-width compute time.
+ */
+function cssLengthToPx(value: string, rootFontSize: number): number {
+  const trimmed = value.trim();
+  if (trimmed.endsWith("rem")) return parseFloat(trimmed) * rootFontSize;
+  if (trimmed.endsWith("px")) return parseFloat(trimmed);
+  return parseFloat(trimmed) || 0;
+}
+
+/**
+ * Tailwind's `sm` breakpoint. Columns with `meta.hideOnMobile` are
+ * dropped from rendering entirely below this width via TanStack's
+ * `columnVisibility` — driving it through TanStack (rather than CSS
+ * `hidden sm:table-cell`) keeps `<colgroup>` indices aligned with the
+ * actually-rendered TDs, so `<col>` widths land on the right columns.
+ */
+const SM_BREAKPOINT_PX = 640;
+
+/**
+ * Compute the `width` style for each visible leaf column. Columns with
+ * `meta.fixedWidth` get their declared length verbatim; remaining columns
+ * share `wrapperWidth - sum(fixedWidth)` by `meta.weight` (default 1).
+ *
+ * Callers pass `table.getVisibleLeafColumns()`, which already filters
+ * out columns hidden via `columnVisibility` (e.g. `hideOnMobile` at
+ * narrow widths). The math here just trusts that visibility decision.
+ *
+ * `wrapperWidth === 0` happens on SSR and on the first client render
+ * before the ResizeObserver fires; in that window we fall back to plain
+ * percentages so the table still renders. The percentages there can sum
+ * to more than 100% if any column is also fixed-width (the percentage
+ * ignores the fixed columns), but the misalignment lasts one paint
+ * before pixel measurement takes over.
+ */
+export function computeColumnWidths<TData, TValue>(
+  cols: readonly { id: string; columnDef: ColumnDef<TData, TValue> }[],
+  wrapperWidth: number,
+  rootFontSize: number,
+): string[] {
+  const isMobile = wrapperWidth > 0 && wrapperWidth < SM_BREAKPOINT_PX;
+  const fixedFor = (c: (typeof cols)[number]): string | undefined =>
+    (isMobile && c.columnDef.meta?.mobileFixedWidth) || c.columnDef.meta?.fixedWidth;
+
+  const fixedSum = cols.reduce((s, c) => {
+    const fw = fixedFor(c);
+    return fw ? s + cssLengthToPx(fw, rootFontSize) : s;
+  }, 0);
+  const totalWeight = cols.reduce((sum, c) => (fixedFor(c) ? sum : sum + (c.columnDef.meta?.weight ?? 1)), 0);
+  const leftoverPx = Math.max(0, wrapperWidth - fixedSum);
+  const usePixels = wrapperWidth > 0;
+
+  return cols.map((column) => {
+    const fixed = fixedFor(column);
+    if (fixed) return fixed;
+    const weight = column.columnDef.meta?.weight ?? 1;
+    const share = totalWeight > 0 ? weight / totalWeight : 0;
+    return usePixels ? `${share * leftoverPx}px` : `${share * 100}%`;
+  });
+}
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -66,6 +162,44 @@ export function DataTable<TData, TValue>({
   const [sorting, setSorting] = useState<SortingState>(initialSorting ?? []);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+
+  // Measure the table wrapper so col widths can be computed in pixels.
+  // Chrome's `table-layout: fixed` algorithm distributes leftover space
+  // equally across flex `<col>`s when their widths are declared as
+  // `calc()` expressions mixing % and rem — declared `weight` ratios are
+  // ignored. Computing widths in pixels (resolved against the measured
+  // wrapper) sidesteps that algorithm path so weights actually apply.
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [wrapperWidth, setWrapperWidth] = useState<number>(0);
+  useEffect(() => {
+    const el = wrapperRef.current;
+    if (!el) return;
+    setWrapperWidth(el.clientWidth);
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) setWrapperWidth(entry.contentRect.width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Drop `hideOnMobile` columns below the `sm` breakpoint via TanStack's
+  // columnVisibility (not CSS) so `<colgroup>` indices stay aligned with
+  // the rendered TDs — CSS-hiding leaves phantom column slots in the
+  // colgroup that Chrome's table-fixed layout mis-allocates space to.
+  const hideOnMobileColumnIds = columns
+    .map((c) => (c.meta?.hideOnMobile ? (c as { id?: string; accessorKey?: string }) : null))
+    .filter((c): c is { id?: string; accessorKey?: string } => Boolean(c))
+    .map((c) => c.id ?? (c.accessorKey as string))
+    .filter(Boolean) as string[];
+  const isMobile = wrapperWidth > 0 && wrapperWidth < SM_BREAKPOINT_PX;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: hideOnMobileColumnIds is derived from columns and stable across renders for a given table.
+  useEffect(() => {
+    setColumnVisibility((prev) => {
+      const next: VisibilityState = { ...prev };
+      for (const id of hideOnMobileColumnIds) next[id] = !isMobile;
+      return next;
+    });
+  }, [isMobile, hideOnMobileColumnIds.join(",")]);
 
   const table = useReactTable({
     data,
@@ -131,33 +265,36 @@ export function DataTable<TData, TValue>({
 
       {!hidePagination && paginationBlock}
 
-      <div className="overflow-x-auto w-full min-w-0">
-        <Table className="w-full table-auto sm:table-fixed">
+      <div ref={wrapperRef} className="@container/datatable w-full min-w-0">
+        <Table className="w-full">
+          <colgroup>
+            {(() => {
+              const cols = table.getVisibleLeafColumns();
+              const rootFontSize =
+                typeof window === "undefined"
+                  ? 16
+                  : parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+              const widths = computeColumnWidths(cols, wrapperWidth, rootFontSize);
+              return cols.map((column, i) => <col key={column.id} style={{ width: widths[i] }} />);
+            })()}
+          </colgroup>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id} className="text-left text-sm text-content-text-secondary">
-                {headerGroup.headers.map((header) => {
-                  const hideOnMobile = header.column.columnDef.meta?.hideOnMobile;
-                  // Width hint applies only at sm+ — on mobile we let
-                  // table-auto size columns to content. Without this,
-                  // desktop-tuned widths (e.g. 180px for the perf-table
-                  // Date column) would starve other columns on phones.
-                  const width = header.column.columnDef.meta?.width;
-                  const widthStyle = width ? ({ "--col-w": width } as React.CSSProperties) : undefined;
-                  return (
-                    <TableHead
-                      key={header.id}
-                      className={cn(
-                        "px-1.5 py-2 sm:p-3 text-sm text-content-text-secondary align-top",
-                        hideOnMobile && "hidden sm:table-cell",
-                        width && "sm:w-[var(--col-w)]",
-                      )}
-                      style={widthStyle}
-                    >
-                      {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
-                    </TableHead>
-                  );
-                })}
+                {headerGroup.headers.map((header) => (
+                  <TableHead
+                    key={header.id}
+                    // text-xs on mobile keeps multi-word headers ("Last
+                    // Played", "Avg Gap") from forcing fixed-width columns
+                    // wider than their numeric content actually needs.
+                    className={cn(
+                      "px-1.5 py-2 sm:px-2 sm:py-2.5 text-xs sm:text-sm text-content-text-secondary align-top",
+                      header.column.columnDef.meta?.headerClassName,
+                    )}
+                  >
+                    {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
               </TableRow>
             ))}
           </TableHeader>
@@ -184,8 +321,7 @@ export function DataTable<TData, TValue>({
                     <TableCell
                       key={cell.id}
                       className={cn(
-                        "px-1.5 py-2 sm:p-3 align-top break-words",
-                        cell.column.columnDef.meta?.hideOnMobile && "hidden sm:table-cell",
+                        "px-1.5 py-2 sm:px-2 sm:py-2.5 align-top break-words",
                         cell.column.columnDef.meta?.cellClassName,
                       )}
                     >

--- a/apps/web/app/components/ui/sortable-header.tsx
+++ b/apps/web/app/components/ui/sortable-header.tsx
@@ -1,5 +1,6 @@
 import type { Column } from "@tanstack/react-table";
 import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon } from "lucide-react";
+import type { ReactNode } from "react";
 
 /**
  * Header cell that toggles its column's sort direction on click. Renders
@@ -8,22 +9,25 @@ import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon } from "lucide-react";
  * as plain text so callers can use this for every header without branching.
  * Generic over the row shape — works for any TanStack `Column<T>`.
  */
-export function SortableHeader<T>({ column, label }: { column: Column<T, unknown>; label: string }) {
+export function SortableHeader<T>({ column, label }: { column: Column<T, unknown>; label: ReactNode }) {
   if (!column.getCanSort()) return <span>{label}</span>;
   return (
     <button
       type="button"
-      className="cursor-pointer select-none hover:text-content-text-primary text-left"
+      // `flex flex-wrap` so the sort arrow drops onto its own line when
+      // the column gets too narrow to hold both label + arrow inline
+      // (lets narrow columns like Set squeeze to 1.5rem on mobile).
+      className="cursor-pointer select-none hover:text-content-text-primary text-left flex flex-wrap items-start gap-x-1"
       onClick={() => column.toggleSorting()}
     >
       <span className={column.getIsSorted() ? "text-content-text-primary font-semibold" : ""}>{label}</span>
-      <span className={column.getIsSorted() ? "text-brand-primary ml-1" : "ml-1"}>
+      <span className={column.getIsSorted() ? "text-brand-primary" : ""}>
         {column.getIsSorted() === "asc" ? (
-          <ArrowUpIcon className="h-4 w-4 inline" />
+          <ArrowUpIcon className="h-3 w-3 sm:h-4 sm:w-4 inline" />
         ) : column.getIsSorted() === "desc" ? (
-          <ArrowDownIcon className="h-4 w-4 inline" />
+          <ArrowDownIcon className="h-3 w-3 sm:h-4 sm:w-4 inline" />
         ) : (
-          <ArrowUpDown className="h-4 w-4 inline" />
+          <ArrowUpDown className="h-3 w-3 sm:h-4 sm:w-4 inline" />
         )}
       </span>
     </button>

--- a/apps/web/app/components/ui/star-rating.tsx
+++ b/apps/web/app/components/ui/star-rating.tsx
@@ -346,7 +346,7 @@ const StarIcon = ({
   <div className="relative">
     {/* Empty star (background) */}
     <svg
-      className={cn("w-4 h-4 ms-1", filled || half ? "text-content-text-tertiary" : "text-content-text-tertiary")}
+      className={cn("w-4 h-4", filled || half ? "text-content-text-tertiary" : "text-content-text-tertiary")}
       aria-hidden="true"
       xmlns="http://www.w3.org/2000/svg"
       fill="currentColor"
@@ -366,7 +366,7 @@ const StarIcon = ({
         style={{ animationDelay: delay ? `${delay}ms` : undefined }}
       >
         <svg
-          className={cn("w-4 h-4 ms-1", isAnimating && "animate-star-glow")}
+          className={cn("w-4 h-4", isAnimating && "animate-star-glow")}
           style={{
             animationDelay: delay ? `${delay}ms` : undefined,
             color: "hsl(var(--rating-gold))",

--- a/apps/web/app/routes/songs/histories.tsx
+++ b/apps/web/app/routes/songs/histories.tsx
@@ -108,7 +108,7 @@ function HistoryPreview({ text }: { text: string }) {
 const historiesColumns: ColumnDef<HistorySong>[] = [
   {
     accessorKey: "title",
-    meta: { width: "25%", cellClassName: "align-top" },
+    meta: { weight: 1, cellClassName: "align-top" },
     header: "Song",
     cell: ({ row }) => (
       <Link
@@ -121,7 +121,7 @@ const historiesColumns: ColumnDef<HistorySong>[] = [
   },
   {
     accessorKey: "history",
-    meta: { width: "75%", cellClassName: "align-top" },
+    meta: { weight: 3, cellClassName: "align-top" },
     header: "Preview",
     cell: ({ row }) => <HistoryPreview text={normalizeHistoryText(row.original.history)} />,
   },


### PR DESCRIPTION
## Summary
- Every DataTable column declares `fixedWidth` (icons/numerics), `mobileFixedWidth` (responsive override), or `weight` (share of leftover space) instead of hand-tuned percentages. Adding a column no longer requires re-balancing every other column.
- Rating editor: the 5-star picker floats in a Radix popover overlaying the badge instead of expanding the column inline, so the Rating cell stays compact whether collapsed or open.
- Mobile pass on every affected table: narrower cell padding, smaller sort arrows, hidden columns driven by `columnVisibility` (not CSS so `<colgroup>` indices stay aligned), and the all-timer flame renders inline beneath the Date or Set cell to recover the standalone column's width.
- Long song names wrap at word boundaries instead of mid-word ("Morph Dusseldo / rf" → "Morph / Dusseldorf").

## Test plan
- [ ] `/songs`, `/songs?filters=allTimer`, `/songs/recent`, `/songs/histories` on desktop + ~390px mobile
- [ ] `/songs/:slug` and `/songs/:slug?filters=allTimer` (perf table)
- [ ] `/songs/all-timers` and `/on-this-day/:monthDay` (cross-song perf tables)
- [ ] `/shows/:slug?view=gap-chart` and `?view=personal` (setlist tables)
- [ ] Rate a song — picker opens as an overlay over the badge, doesn't widen the column
- [ ] `/admin/authors` — sanity check the no-meta default still splits evenly

## Technical detail
Chrome's `table-layout: fixed` ignores `weight` ratios on `<col>` widths declared with `calc()` mixing percentages and rem — leftover gets distributed equally across flex cols. The DataTable measures its wrapper with `ResizeObserver` and emits widths in pixels (resolved against the measured wrapper), sidestepping that path. SSR / first paint falls back to percentages, corrected on mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
