### PR TITLE
Surface song/venue page links in global search; mobile UI polish

### DIFF
--- a/apps/web/app/components/performance/performance-filter-controls.test.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.test.tsx
@@ -184,14 +184,15 @@ describe("PerformanceFilterControls", () => {
     expect(handleUpdateFilter).not.toHaveBeenCalled();
   });
 
-  // On mobile the entire filter block is collapsed behind a "Filters"
-  // toggle button so it doesn't eat the viewport before any results show.
-  // The wrapper carries `hidden` until expanded; sm+ breakpoints keep it
-  // visible regardless via `sm:flex`/`sm:block`.
-  test("renders a mobile-only Filters toggle button (sm:hidden)", async () => {
+  // On mobile the entire filter block is collapsed behind a "Search & Filters"
+  // toggle button so it doesn't eat the viewport before any results show, and
+  // the label hints that the search box lives inside the expansion. The wrapper
+  // carries `hidden` until expanded; sm+ breakpoints keep it visible regardless
+  // via `sm:flex`/`sm:block`.
+  test("renders a mobile-only Search & Filters toggle button (sm:hidden)", async () => {
     await setup(<PerformanceFilterControls {...defaultProps} searchValue="" onSearchChange={() => {}} />);
 
-    const toggle = screen.getByRole("button", { name: /^Filters/ });
+    const toggle = screen.getByRole("button", { name: /^Search & Filters/ });
     expect(toggle.className).toContain("sm:hidden");
   });
 
@@ -207,7 +208,7 @@ describe("PerformanceFilterControls", () => {
     expect(wrapper.className).toContain("hidden");
     expect(wrapper.className).toContain("sm:block");
 
-    await user.click(screen.getByRole("button", { name: /^Filters/ }));
+    await user.click(screen.getByRole("button", { name: /^Search & Filters/ }));
 
     // After click, mobile-collapse should release.
     expect(wrapper.className).not.toMatch(/(^|\s)hidden(\s|$)/);
@@ -220,7 +221,7 @@ describe("PerformanceFilterControls", () => {
   test("Filters toggle carries short:!flex so it re-shows on phone landscape", async () => {
     await setup(<PerformanceFilterControls {...defaultProps} searchValue="" onSearchChange={() => {}} />);
 
-    const toggle = screen.getByRole("button", { name: /^Filters/ });
+    const toggle = screen.getByRole("button", { name: /^Search & Filters/ });
     expect(toggle.className).toContain("short:!flex");
   });
 
@@ -248,7 +249,7 @@ describe("PerformanceFilterControls", () => {
       />,
     );
 
-    const toggle = screen.getByRole("button", { name: /^Filters/ });
+    const toggle = screen.getByRole("button", { name: /^Search & Filters/ });
     // Badge is the count of active filters (timeRange + 2 toggles = 3).
     expect(toggle.textContent).toMatch(/3/);
   });

--- a/apps/web/app/components/performance/performance-filter-controls.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.tsx
@@ -84,7 +84,7 @@ export function PerformanceFilterControls({
       >
         <span className="flex items-center gap-2">
           <Filter className="h-4 w-4" aria-hidden="true" />
-          Filters
+          Search &amp; Filters
           {activeFilterCount > 0 && (
             <span className="px-2 py-0.5 rounded-full bg-brand-primary/20 text-brand-primary text-xs">
               {activeFilterCount}

--- a/apps/web/app/components/search/global-search-drawer.tsx
+++ b/apps/web/app/components/search/global-search-drawer.tsx
@@ -5,7 +5,7 @@ import type {
   SegueRunMatchDetails,
   TrackMatchDetails,
 } from "@bip/domain";
-import { Loader2, Search, X } from "lucide-react";
+import { Loader2, MapPin, Music, Search, X } from "lucide-react";
 import { useCallback, useEffect } from "react";
 import { useNavigate } from "react-router";
 import { Input } from "~/components/ui/input";
@@ -35,6 +35,51 @@ function SearchResultItem({ result, onClose }: SearchResultItemProps) {
       onClose();
     }
   };
+
+  // Song-page result: link to /songs/<slug>, distinct icon and styling so
+  // users can tell at a glance it's a song page, not a specific performance.
+  if (result.entityType === "song") {
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        className="block w-full text-left p-3 hover:bg-purple-900/20 active:bg-purple-900/30 rounded-lg transition-colors group cursor-pointer"
+      >
+        <div className="flex items-center gap-3">
+          <Music className="h-4 w-4 text-purple-300 flex-shrink-0" />
+          <div className="flex-1 min-w-0">
+            <div className="text-base text-gray-200 font-medium">{result.songTitle || result.displayText}</div>
+            <div className="text-xs text-purple-400 mt-0.5">Song page</div>
+          </div>
+          {result.score && <span className="text-xs text-purple-400 font-medium">{result.score}%</span>}
+        </div>
+      </button>
+    );
+  }
+
+  // Venue-page result: link to /venues/<slug>, separate from individual shows
+  // at that venue.
+  if (result.entityType === "venue") {
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        className="block w-full text-left p-3 hover:bg-purple-900/20 active:bg-purple-900/30 rounded-lg transition-colors group cursor-pointer"
+      >
+        <div className="flex items-center gap-3">
+          <MapPin className="h-4 w-4 text-purple-300 flex-shrink-0" />
+          <div className="flex-1 min-w-0">
+            <div className="text-base text-gray-200 font-medium">
+              {result.venueName || result.displayText}
+              {result.venueLocation && <span className="text-gray-400 font-normal"> • {result.venueLocation}</span>}
+            </div>
+            <div className="text-xs text-purple-400 mt-0.5">Venue page</div>
+          </div>
+          {result.score && <span className="text-xs text-purple-400 font-medium">{result.score}%</span>}
+        </div>
+      </button>
+    );
+  }
 
   // Use displayText as fallback if individual fields aren't available
   const displayDate = result.date

--- a/apps/web/app/routes/songs/$slug.test.tsx
+++ b/apps/web/app/routes/songs/$slug.test.tsx
@@ -164,18 +164,21 @@ describe("SongPage", () => {
 
   // The TabsList on song-detail clips at narrow widths because there can be
   // up to 6 tabs (All Performances, All-Timers, Stats, History, Lyrics,
-  // Guitar Tabs). Mobile gets a single <select> dropdown instead while sm+
-  // continues to use the horizontal tab strip.
-  test("song tabs render as a select on mobile (sm:hidden) and tab strip on sm+", () => {
+  // Guitar Tabs). Mobile gets a Radix Select instead — a native <select> was
+  // used before, but its OS-styling didn't look like a dropdown to users, so
+  // they didn't realize it was tappable. The Radix trigger renders as a
+  // styled button (role="combobox") with a visible chevron.
+  test("song tabs render as a Radix Select on mobile (sm:hidden) and tab strip on sm+", () => {
     renderSongPage();
 
     const tabList = screen.getByRole("tablist");
     expect(tabList.className).toContain("hidden");
     expect(tabList.className).toContain("sm:flex");
 
-    const select = screen.getByLabelText(/song view/i);
-    const wrapper = select.closest("div");
-    expect(wrapper?.className).toContain("sm:hidden");
+    const trigger = screen.getByRole("combobox", { name: /song view/i });
+    expect(trigger.textContent).toMatch(/All Performances/);
+    const wrapper = screen.getByTestId("mobile-song-view");
+    expect(wrapper.className).toContain("sm:hidden");
   });
 
   // The "last show" sublabel marks the song as having been played at the

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -11,6 +11,7 @@ import { RatingComponent } from "~/components/rating";
 import { ShowDate } from "~/components/show-date";
 import { YearlyPlayChart } from "~/components/song/yearly-play-chart";
 import { Button } from "~/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
@@ -363,26 +364,29 @@ export default function SongPage() {
           clearFilters();
         }}
       >
-        <div className="sm:hidden mb-4">
-          <label htmlFor="song-view-select" className="sr-only">
-            Song view
-          </label>
-          <select
-            id="song-view-select"
+        <div className="sm:hidden mb-4" data-testid="mobile-song-view">
+          <Select
             value={activeTab}
-            onChange={(event) => {
-              setActiveTab(event.target.value);
+            onValueChange={(value) => {
+              setActiveTab(value);
               clearFilters();
             }}
-            className="w-full h-11 px-3 rounded-md bg-glass-bg border border-glass-border text-content-text-primary focus:outline-none focus:ring-1 focus:ring-ring/20"
           >
-            <option value="performances">All Performances</option>
-            {hasAllTimers && <option value="all-timers">All-Timers</option>}
-            <option value="stats">Stats</option>
-            {song.history && <option value="history">History</option>}
-            {song.lyrics && <option value="lyrics">Lyrics</option>}
-            {(song.tabs || song.guitarTabsUrl) && <option value="guitar-tabs">Guitar Tabs</option>}
-          </select>
+            <SelectTrigger
+              aria-label="Song view"
+              className="w-full h-11 bg-glass-bg border border-glass-border text-content-text-primary hover:bg-glass-bg/80 focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="bg-glass-bg border-glass-border backdrop-blur-md">
+              <SelectItem value="performances">All Performances</SelectItem>
+              {hasAllTimers && <SelectItem value="all-timers">All-Timers</SelectItem>}
+              <SelectItem value="stats">Stats</SelectItem>
+              {song.history && <SelectItem value="history">History</SelectItem>}
+              {song.lyrics && <SelectItem value="lyrics">Lyrics</SelectItem>}
+              {(song.tabs || song.guitarTabsUrl) && <SelectItem value="guitar-tabs">Guitar Tabs</SelectItem>}
+            </SelectContent>
+          </Select>
         </div>
         <TabsList className="w-full hidden sm:flex justify-start border-b border-glass-border/30 rounded-none bg-transparent p-0">
           <TabsTrigger

--- a/packages/core/src/search/postgres-search-service.ts
+++ b/packages/core/src/search/postgres-search-service.ts
@@ -1,12 +1,15 @@
 import type { Logger, SearchResult, SearchRowResult } from "@bip/domain";
 import type { DbClient } from "../_shared/database/models";
 import type { SearchHistoryService } from "./search-history-service";
+import { buildMixedSearchResults } from "./search-result-builder";
 import { SegueQueryParser } from "./segue-query-parser";
 
 type VenueResult = {
   venue_id: string;
   venue_name: string;
   venue_slug: string;
+  venue_city: string | null;
+  venue_state: string | null;
   match_score: number;
 };
 
@@ -114,62 +117,34 @@ export class PostgresSearchService {
       const mediumVenueIds = venueResults.filter((v) => v.match_score >= 10).map((v) => v.venue_id);
       const weakVenueIds = venueResults.filter((v) => v.match_score >= 1).map((v) => v.venue_id);
 
-      // Try strong matches first
-      if (strongSongIds.length > 0 || strongVenueIds.length > 0) {
-        const showResults = await this.performShowSearch(
-          searchQuery,
-          strongSongIds,
-          strongVenueIds,
-          options.limit,
-          dateFilter,
-        );
-        if (showResults.length > 0) {
-          return this.convertShowResultsToSearchResults(showResults);
-        }
-      }
+      // Run show search at the strongest tier that has any matches; fall back
+      // through medium/weak so the show list still gets populated for fuzzy
+      // queries.
+      const tieredShows = await this.runTieredShowSearch(
+        searchQuery,
+        { strongSongIds, mediumSongIds, weakSongIds },
+        { strongVenueIds, mediumVenueIds, weakVenueIds },
+        options.limit,
+        dateFilter,
+      );
 
-      // Try medium matches
-      if (mediumSongIds.length > 0 || mediumVenueIds.length > 0) {
-        const showResults = await this.performShowSearch(
-          searchQuery,
-          mediumSongIds,
-          mediumVenueIds,
-          options.limit,
-          dateFilter,
-        );
-        if (showResults.length > 0) {
-          return this.convertShowResultsToSearchResults(showResults);
-        }
-      }
+      // If we found no song/venue matches at all, do a general show text search
+      // as a last resort.
+      const showSearchResults =
+        tieredShows.length === 0 && songResults.length === 0 && venueResults.length === 0
+          ? this.convertShowResultsToSearchResults(
+              await this.performShowSearch(searchQuery, [], [], Math.min(options.limit, 10), dateFilter),
+            )
+          : tieredShows;
 
-      // Try weak matches
-      if (weakSongIds.length > 0 || weakVenueIds.length > 0) {
-        const showResults = await this.performShowSearch(
-          searchQuery,
-          weakSongIds,
-          weakVenueIds,
-          options.limit,
-          dateFilter,
-        );
-        if (showResults.length > 0) {
-          return this.convertShowResultsToSearchResults(showResults);
-        }
-      }
-
-      // Only do general search if no songs or venues found at all
-      if (songResults.length === 0 && venueResults.length === 0) {
-        const generalResults = await this.performShowSearch(
-          searchQuery,
-          [],
-          [],
-          Math.min(options.limit, 10),
-          dateFilter,
-        );
-        return this.convertShowResultsToSearchResults(generalResults);
-      }
-
-      // If we found songs/venues but no shows, return empty
-      return [];
+      // Mix in matching song-page and venue-page links so users can navigate
+      // directly to those entities (e.g. searching "Shadows" surfaces
+      // /songs/shadows above shows that played it).
+      return buildMixedSearchResults({
+        songs: songResults,
+        venues: venueResults,
+        shows: showSearchResults,
+      });
     } catch (error) {
       this.logger.error(`Search failed: ${error}`);
       throw error;
@@ -286,15 +261,18 @@ export class PostgresSearchService {
             OR LOWER(v.city) LIKE '%' || LOWER($1) || '%'
         )
         SELECT
-          venue_id,
-          venue_name,
-          venue_slug,
+          search_matches.venue_id,
+          search_matches.venue_name,
+          search_matches.venue_slug,
+          v2.city as venue_city,
+          v2.state as venue_state,
           GREATEST(
             exact_score * 200,  -- Double weight for exact matches
             fts_rank * 60,
             trgm_sim * 100
           )::INTEGER as match_score
         FROM search_matches
+        JOIN venues v2 ON v2.id = search_matches.venue_id
         ORDER BY match_score DESC
         LIMIT 100
       `,
@@ -344,6 +322,26 @@ export class PostgresSearchService {
 
     this.logger.debug(`Song search SQL for query "${query}"`);
     return this.db.$queryRawUnsafe<SongResult[]>(sql, query);
+  }
+
+  private async runTieredShowSearch(
+    searchQuery: string,
+    songTiers: { strongSongIds: string[]; mediumSongIds: string[]; weakSongIds: string[] },
+    venueTiers: { strongVenueIds: string[]; mediumVenueIds: string[]; weakVenueIds: string[] },
+    limit: number,
+    dateFilter: { year?: number; month?: number; day?: number; remainingQuery: string },
+  ): Promise<SearchResult[]> {
+    const tiers: Array<{ songIds: string[]; venueIds: string[] }> = [
+      { songIds: songTiers.strongSongIds, venueIds: venueTiers.strongVenueIds },
+      { songIds: songTiers.mediumSongIds, venueIds: venueTiers.mediumVenueIds },
+      { songIds: songTiers.weakSongIds, venueIds: venueTiers.weakVenueIds },
+    ];
+    for (const tier of tiers) {
+      if (tier.songIds.length === 0 && tier.venueIds.length === 0) continue;
+      const rows = await this.performShowSearch(searchQuery, tier.songIds, tier.venueIds, limit, dateFilter);
+      if (rows.length > 0) return this.convertShowResultsToSearchResults(rows);
+    }
+    return [];
   }
 
   private async performShowSearch(

--- a/packages/core/src/search/search-result-builder.test.ts
+++ b/packages/core/src/search/search-result-builder.test.ts
@@ -1,0 +1,155 @@
+import type { SearchResult } from "@bip/domain";
+import { describe, expect, test } from "vitest";
+import { buildMixedSearchResults, type SongRowForResults, type VenueRowForResults } from "./search-result-builder";
+
+// Helpers for compact fixtures. Disco Biscuits song/venue choices keep test
+// intent obvious when scanning the assertions.
+function songRow(
+  opts: Partial<SongRowForResults> & Pick<SongRowForResults, "song_id" | "song_title" | "song_slug">,
+): SongRowForResults {
+  return { match_score: 100, ...opts };
+}
+function venueRow(
+  opts: Partial<VenueRowForResults> & Pick<VenueRowForResults, "venue_id" | "venue_name" | "venue_slug">,
+): VenueRowForResults {
+  return { match_score: 100, venue_city: null, venue_state: null, ...opts };
+}
+function showResult(opts: Partial<SearchResult> & Pick<SearchResult, "id" | "score">): SearchResult {
+  return {
+    entityType: "show",
+    entityId: opts.id,
+    entitySlug: opts.id,
+    displayText: "Some show",
+    url: `/shows/${opts.id}`,
+    ...opts,
+  };
+}
+
+describe("buildMixedSearchResults", () => {
+  // Core motivation: searching "Shadows" should surface the song page,
+  // not just the list of shows where it was played.
+  test("includes matching song as a song-entity SearchResult with /songs/<slug> url", () => {
+    const results = buildMixedSearchResults({
+      songs: [songRow({ song_id: "s1", song_title: "Shadows", song_slug: "shadows", match_score: 100 })],
+      venues: [],
+      shows: [],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      entityType: "song",
+      entityId: "s1",
+      entitySlug: "shadows",
+      url: "/songs/shadows",
+      score: 100,
+    });
+  });
+
+  // Songs with a stronger match score must outrank shows so the song-page link
+  // appears at the top of the results list.
+  test("orders a high-scoring song above lower-scoring shows", () => {
+    const results = buildMixedSearchResults({
+      songs: [
+        songRow({ song_id: "s1", song_title: "Basis For A Day", song_slug: "basis-for-a-day", match_score: 100 }),
+      ],
+      venues: [],
+      shows: [showResult({ id: "show1", score: 70 }), showResult({ id: "show2", score: 60 })],
+    });
+
+    expect(results[0].entityType).toBe("song");
+    expect(results.slice(1).map((r) => r.entityType)).toEqual(["show", "show"]);
+  });
+
+  // Venues should also be searchable from the global bar — searching "Camp Bisco"
+  // should surface the venue page, not just shows at that venue.
+  test("includes matching venue as a venue-entity SearchResult with /venues/<slug> url", () => {
+    const results = buildMixedSearchResults({
+      songs: [],
+      venues: [
+        venueRow({
+          venue_id: "v1",
+          venue_name: "Camp Bisco",
+          venue_slug: "camp-bisco",
+          venue_city: "Mariaville",
+          venue_state: "NY",
+          match_score: 100,
+        }),
+      ],
+      shows: [],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      entityType: "venue",
+      entityId: "v1",
+      entitySlug: "camp-bisco",
+      url: "/venues/camp-bisco",
+      venueName: "Camp Bisco",
+      venueLocation: "Mariaville, NY",
+      score: 100,
+    });
+  });
+
+  // Drop weak song matches (e.g., trigram-only hits) so the song bucket doesn't
+  // pollute results when the query doesn't really refer to a song.
+  test("filters out song matches below minSongScore", () => {
+    const results = buildMixedSearchResults({
+      songs: [
+        songRow({ song_id: "strong", song_title: "Shadows", song_slug: "shadows", match_score: 100 }),
+        songRow({ song_id: "weak", song_title: "Spaga", song_slug: "spaga", match_score: 20 }),
+      ],
+      venues: [],
+      shows: [],
+      minSongScore: 50,
+    });
+
+    expect(results.map((r) => r.entityId)).toEqual(["strong"]);
+  });
+
+  // Drop weak venue matches to avoid leaking unrelated venue hits.
+  test("filters out venue matches below minVenueScore", () => {
+    const results = buildMixedSearchResults({
+      songs: [],
+      venues: [
+        venueRow({ venue_id: "strong", venue_name: "Camp Bisco", venue_slug: "camp-bisco", match_score: 100 }),
+        venueRow({ venue_id: "weak", venue_name: "Random Bar", venue_slug: "random-bar", match_score: 5 }),
+      ],
+      shows: [],
+      minVenueScore: 50,
+    });
+
+    expect(results.map((r) => r.entityId)).toEqual(["strong"]);
+  });
+
+  // Cap the number of injected song/venue results so they don't crowd out shows.
+  test("caps songs at songLimit and venues at venueLimit", () => {
+    const results = buildMixedSearchResults({
+      songs: [
+        songRow({ song_id: "s1", song_title: "Shadows", song_slug: "shadows", match_score: 100 }),
+        songRow({ song_id: "s2", song_title: "Spaga", song_slug: "spaga", match_score: 99 }),
+        songRow({ song_id: "s3", song_title: "Basis For A Day", song_slug: "basis-for-a-day", match_score: 98 }),
+        songRow({ song_id: "s4", song_title: "M.E.M.P.H.I.S.", song_slug: "memphis", match_score: 97 }),
+      ],
+      venues: [],
+      shows: [],
+      songLimit: 2,
+    });
+
+    const songs = results.filter((r) => r.entityType === "song");
+    expect(songs.map((r) => r.entityId)).toEqual(["s1", "s2"]);
+  });
+
+  // Final array must be sorted by score descending across all entity types so
+  // the drawer can render it as-is.
+  test("sorts the combined results by score desc across all types", () => {
+    const results = buildMixedSearchResults({
+      songs: [songRow({ song_id: "song-weak", song_title: "Shadows", song_slug: "shadows", match_score: 55 })],
+      venues: [
+        venueRow({ venue_id: "venue-strong", venue_name: "Camp Bisco", venue_slug: "camp-bisco", match_score: 95 }),
+      ],
+      shows: [showResult({ id: "show-mid", score: 75 })],
+    });
+
+    expect(results.map((r) => r.entityId)).toEqual(["venue-strong", "show-mid", "song-weak"]);
+  });
+});

--- a/packages/core/src/search/search-result-builder.ts
+++ b/packages/core/src/search/search-result-builder.ts
@@ -1,0 +1,96 @@
+import type { SearchResult } from "@bip/domain";
+
+/**
+ * Raw song-search SQL row, narrowed to the fields needed for result building.
+ * Decoupled from the larger SongResult type in postgres-search-service.ts so
+ * the builder stays unit-testable without a database.
+ */
+export interface SongRowForResults {
+  song_id: string;
+  song_title: string;
+  song_slug: string;
+  match_score: number;
+}
+
+/**
+ * Raw venue-search SQL row, narrowed to the fields needed for result building.
+ * City/state are optional but used to build the displayed location string.
+ */
+export interface VenueRowForResults {
+  venue_id: string;
+  venue_name: string;
+  venue_slug: string;
+  match_score: number;
+  venue_city?: string | null;
+  venue_state?: string | null;
+}
+
+export interface BuildMixedSearchResultsOptions {
+  songs?: SongRowForResults[];
+  venues?: VenueRowForResults[];
+  shows: SearchResult[];
+  songLimit?: number;
+  venueLimit?: number;
+  minSongScore?: number;
+  minVenueScore?: number;
+}
+
+const DEFAULT_SONG_LIMIT = 3;
+const DEFAULT_VENUE_LIMIT = 3;
+const DEFAULT_MIN_SONG_SCORE = 50;
+const DEFAULT_MIN_VENUE_SCORE = 50;
+
+/**
+ * Compose the global search drawer's final result list from raw song, venue,
+ * and (already-converted) show results. Songs and venues are added as their
+ * own entity-typed SearchResults so the drawer can link directly to
+ * /songs/<slug> and /venues/<slug>, rather than only showing shows that played
+ * the song or were held at the venue. Weak matches are filtered and the
+ * combined list is sorted by score so the drawer can render it as-is.
+ */
+export function buildMixedSearchResults({
+  songs = [],
+  venues = [],
+  shows,
+  songLimit = DEFAULT_SONG_LIMIT,
+  venueLimit = DEFAULT_VENUE_LIMIT,
+  minSongScore = DEFAULT_MIN_SONG_SCORE,
+  minVenueScore = DEFAULT_MIN_VENUE_SCORE,
+}: BuildMixedSearchResultsOptions): SearchResult[] {
+  const songResults: SearchResult[] = songs
+    .filter((s) => s.match_score >= minSongScore)
+    .slice(0, songLimit)
+    .map((s) => ({
+      id: s.song_id,
+      entityType: "song",
+      entityId: s.song_id,
+      entitySlug: s.song_slug,
+      displayText: s.song_title,
+      score: Math.min(100, Math.round(s.match_score)),
+      url: `/songs/${s.song_slug}`,
+      songTitle: s.song_title,
+    }));
+
+  const venueResults: SearchResult[] = venues
+    .filter((v) => v.match_score >= minVenueScore)
+    .slice(0, venueLimit)
+    .map((v) => {
+      const location =
+        v.venue_city && v.venue_state
+          ? `${v.venue_city}, ${v.venue_state}`
+          : v.venue_city || v.venue_state || undefined;
+      return {
+        id: v.venue_id,
+        entityType: "venue",
+        entityId: v.venue_id,
+        entitySlug: v.venue_slug,
+        displayText: location ? `${v.venue_name} • ${location}` : v.venue_name,
+        score: Math.min(100, Math.round(v.match_score)),
+        url: `/venues/${v.venue_slug}`,
+        venueName: v.venue_name,
+        venueLocation: location,
+      };
+    });
+
+  return [...songResults, ...venueResults, ...shows].sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+}


### PR DESCRIPTION
## Summary

- Global search now returns `/songs/<slug>` and `/venues/<slug>` as their own results — searching "shadows" puts the song page above the list of shows that played it, instead of only listing performances. Top 3 song and top 3 venue matches (score ≥ 50) mix with show results, sorted by score.
- Mobile songs-tab filter trigger renamed **"Filters" → "Search & Filters"** so users discover the search box hidden in the expansion.
- Mobile "All Performances" picker on the song page swapped from a native `<select>` (OS styling didn't read as tappable on iOS) to a Radix Select with the same chevron/border treatment used by `SelectFilter` elsewhere.

Based on feedback from christinamarie42:
https://www.phantasytour.com/bands/bisco/threads/5038245/biscuits-internet-project-3-0?page=7

## Test plan

- [ ] Open the global search drawer (Cmd/Ctrl+K) and search `shadows` — `/songs/shadows` link appears at the top with a music icon, above show results.
- [ ] Search `camp bisco` — `/venues/camp-bisco` link appears with a map-pin icon.
- [ ] Search a query that should only return shows (e.g. a date) — no extraneous song/venue rows appear.
- [ ] On a phone-width viewport, visit `/songs` — filter trigger reads "Search & Filters".
- [ ] On a phone-width viewport, visit `/songs/basis-for-a-day` — the tabs collapse into a styled dropdown with a visible chevron; tapping it shows All Performances / Stats / etc.
- [ ] `make tc` and `bun run test` pass.

## Notes for the reviewer

Result composition was extracted into a pure helper (`packages/core/src/search/search-result-builder.ts`) so song/venue injection, score filtering, and limit capping could be unit-tested without a database (7 tests). The DB-touching code in `postgres-search-service.ts` just calls the helper after running its existing tiered show search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
