### PR TITLE
Editable Track Notes and per-show YouTube videos on the show edit page

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -27,6 +27,16 @@ If a route component references a runtime value from a `.ts` helper under `app/r
 - Feature components are organized by domain (e.g., `review/`, `setlist/`, `show/`)
 - Form components use React Hook Form with Zod validation
 
+## Keep components and CSS DRY
+
+Before writing markup, grep the className you're about to type. If it's already somewhere, you owe an extraction.
+
+- **Use existing primitives.** Bare `<input>`/`<textarea>` → [Input](app/components/ui/input.tsx)/[Textarea](app/components/ui/textarea.tsx). Hand-rolled selects → [GlassSelect](app/components/ui/glass-select.tsx) (finite options) or [SearchPicker](app/components/ui/search-picker.tsx) (async search). Don't inline `bg-*`/`hover:bg-*` on [Button](app/components/ui/button.tsx) when a `variant` covers the intent.
+- **2+ duplications → className constant** in [form-styles.ts](app/lib/form-styles.ts) (form chrome) or a domain module. See `formInputClass`, `formLabelClass`.
+- **2+ Button (or Badge / Card / …) className overrides → add a `variant`** to the existing CVA. See `variant="brand"`. Don't create `<MyButton>`.
+- **No thin wrappers to hide a className.** `<PremiumCard>` for `<Card className="card-premium">` is indirection, not abstraction. Use a constant or variant.
+- **Don't bake project styling into shadcn defaults.** Auth/search/etc. use the upstream primitive. Project looks → constant or variant.
+
 ## Package-Specific Commands
 
 ```bash

--- a/apps/web/app/components/author/author-form.tsx
+++ b/apps/web/app/components/author/author-form.tsx
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { Button } from "~/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "~/components/ui/form";
 import { Input } from "~/components/ui/input";
+import { formInputClass } from "~/lib/form-styles";
 
 export const authorFormSchema = z.object({
   name: z.string().min(1, "Author name is required"),
@@ -48,11 +49,7 @@ export function AuthorForm({ defaultValues, submitLabel, cancelHref }: AuthorFor
             <FormItem>
               <FormLabel className="text-content-text-secondary">Author Name</FormLabel>
               <FormControl>
-                <Input
-                  placeholder="Enter author name"
-                  {...field}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
-                />
+                <Input placeholder="Enter author name" {...field} className={formInputClass} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -63,7 +60,7 @@ export function AuthorForm({ defaultValues, submitLabel, cancelHref }: AuthorFor
           <Button type="submit" onClick={form.handleSubmit(onSubmit)}>
             {submitLabel}
           </Button>
-          <Button type="button" variant="outline" onClick={() => navigate(cancelHref)}>
+          <Button type="button" variant="cancel" onClick={() => navigate(cancelHref)}>
             Cancel
           </Button>
         </div>

--- a/apps/web/app/components/author/author-search.test.tsx
+++ b/apps/web/app/components/author/author-search.test.tsx
@@ -1,0 +1,138 @@
+import { setup } from "@test/test-utils";
+import { screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { AuthorSearch } from "./author-search";
+
+describe("AuthorSearch", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // loadOnOpen contract: opening the popover with no query hits
+  // /api/authors?top=10 so the user sees the most-active authors before
+  // they type. Without this the list would start empty.
+  test("fetches /api/authors?top=10 when the popover opens with no query", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+
+    const { user } = await setup(<AuthorSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await waitFor(() => {
+      const urls = fetchMock.mock.calls.map((c) => c[0]);
+      expect(urls).toContain("/api/authors?top=10");
+    });
+  });
+
+  // 2+ char query switches to the scoped search endpoint with a higher
+  // limit. Below 2 chars stays on the top-10 endpoint (handled by the
+  // empty-query branch above).
+  test("fetches /api/authors?q=…&limit=20 with a 2+ char query", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+
+    const { user } = await setup(<AuthorSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search authors...");
+    await user.type(input, "tre");
+
+    await waitFor(
+      () => {
+        const urls = fetchMock.mock.calls.map((c) => c[0]);
+        expect(urls).toContain("/api/authors?q=tre&limit=20");
+      },
+      { timeout: 1500 },
+    );
+  });
+
+  // The clear-selection row is labeled "All Authors" (the noneLabel for
+  // this wrapper) so users can drop the current filter from inside the
+  // popover.
+  test("renders the 'All Authors' clear row", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [{ id: "a1", name: "Author One" }] });
+
+    const { user } = await setup(<AuthorSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    expect(await screen.findByText("All Authors")).toBeInTheDocument();
+  });
+
+  // With allowCreate=true, typing a non-matching name and clicking the
+  // "Create …" row POSTs to /api/admin/authors with the trimmed name,
+  // then selects the new author. The admin path is gated by allowCreate
+  // so non-admin consumers don't accidentally surface it.
+  test("allowCreate posts to /api/admin/authors and selects the new row", async () => {
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === "/api/admin/authors" && init?.method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ id: "new-1", name: "New Author" }),
+        } as Response);
+      }
+      // Every other call (top-10, debounced search) returns an empty list.
+      return Promise.resolve({ ok: true, json: async () => [] } as Response);
+    });
+    const onValueChange = vi.fn();
+
+    const { user } = await setup(<AuthorSearch onValueChange={onValueChange} allowCreate />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search authors...");
+    await user.type(input, "New Author");
+
+    const createRow = await screen.findByText('Create "New Author"', undefined, { timeout: 1500 });
+    await user.click(createRow);
+
+    await waitFor(() => {
+      const postCall = fetchMock.mock.calls.find((c) => c[0] === "/api/admin/authors");
+      expect(postCall).toBeDefined();
+      expect(postCall?.[1]?.method).toBe("POST");
+      expect(JSON.parse(postCall?.[1]?.body as string)).toEqual({ name: "New Author" });
+    });
+    await waitFor(() => expect(onValueChange).toHaveBeenCalledWith("new-1"));
+  });
+
+  // Without allowCreate, the create row never appears — even with a
+  // novel query.
+  test("does not show a create row when allowCreate is not set", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+
+    const { user } = await setup(<AuthorSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search authors...");
+    await user.type(input, "Novel Name");
+
+    // Wait for the debounced fetch to settle so any create row would have
+    // had a chance to render.
+    await waitFor(
+      () => {
+        const urls = fetchMock.mock.calls.map((c) => c[0]);
+        expect(urls).toContain("/api/authors?q=Novel%20Name&limit=20");
+      },
+      { timeout: 1500 },
+    );
+    expect(screen.queryByText(/Create "/)).not.toBeInTheDocument();
+  });
+
+  // Selecting "All Authors" fires onValueChange(null) — the parent
+  // (PerformanceFilterControls) maps null to "drop the author filter".
+  test("clicking 'All Authors' fires onValueChange(null)", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [{ id: "a1", name: "Author One" }] });
+    const onValueChange = vi.fn();
+
+    const { user } = await setup(<AuthorSearch value="a1" onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("All Authors"));
+
+    expect(onValueChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/web/app/components/author/author-search.tsx
+++ b/apps/web/app/components/author/author-search.tsx
@@ -1,10 +1,5 @@
 import type { Author } from "@bip/domain";
-import { Check, ChevronsUpDown, Plus } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
-import { Button } from "~/components/ui/button";
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "~/components/ui/command";
-import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
-import { cn } from "~/lib/utils";
+import { SearchPicker } from "~/components/ui/search-picker";
 
 interface AuthorSearchProps {
   value?: string | null;
@@ -14,6 +9,12 @@ interface AuthorSearchProps {
   allowCreate?: boolean;
 }
 
+/**
+ * Author picker for blog posts and admin tools. Loads a top-10 list as soon
+ * as the popover opens and switches to a query-scoped search at 2+ chars.
+ * Optionally exposes a "Create '<name>'" affordance for admins composing
+ * new posts when the author isn't on file yet.
+ */
 export function AuthorSearch({
   value,
   onValueChange,
@@ -21,175 +22,47 @@ export function AuthorSearch({
   className,
   allowCreate = false,
 }: AuthorSearchProps) {
-  const [open, setOpen] = useState(false);
-  const [authors, setAuthors] = useState<Author[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [currentAuthor, setCurrentAuthor] = useState<Author | null>(null);
-  const [creating, setCreating] = useState(false);
-  const [hasLoadedInitial, setHasLoadedInitial] = useState(false);
-
-  const selectedAuthor = authors.find((author) => author.id === value) || currentAuthor;
-
-  const searchAuthors = useCallback(async (query: string) => {
-    setLoading(true);
-    try {
-      const url =
-        query && query.length >= 2 ? `/api/authors?q=${encodeURIComponent(query)}&limit=20` : "/api/authors?top=10";
-
-      const response = await fetch(url);
-      if (response.ok) {
-        const data = await response.json();
-        setAuthors(data);
-      }
-    } catch (_error) {
-      // Swallow errors for now; UI remains unchanged on failure.
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  // Load current author when value changes
-  useEffect(() => {
-    const loadCurrentAuthor = async () => {
-      if (value && !authors.find((a) => a.id === value) && !currentAuthor) {
-        try {
-          const response = await fetch(`/api/authors/${value}`);
-          if (response.ok) {
-            const author = await response.json();
-            setCurrentAuthor(author);
-          }
-        } catch (_error) {
-          // Ignore errors when fetching the initial author; dropdown will just show placeholder.
-        }
-      } else if (!value) {
-        setCurrentAuthor(null);
-      }
-    };
-
-    loadCurrentAuthor();
-  }, [value, authors, currentAuthor]);
-
-  // Load top authors when dropdown opens
-  useEffect(() => {
-    if (open && !hasLoadedInitial) {
-      searchAuthors("");
-      setHasLoadedInitial(true);
-    }
-  }, [open, hasLoadedInitial, searchAuthors]);
-
-  useEffect(() => {
-    const delayedSearch = setTimeout(() => {
-      searchAuthors(searchQuery);
-    }, 300); // Debounce search
-
-    return () => clearTimeout(delayedSearch);
-  }, [searchQuery, searchAuthors]);
-
-  const handleCreateAuthor = async () => {
-    if (!allowCreate || !searchQuery.trim() || creating) return;
-
-    setCreating(true);
-    try {
-      const response = await fetch("/api/admin/authors", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: searchQuery.trim() }),
-      });
-
-      if (response.ok) {
-        const newAuthor = await response.json();
-        // Add to local state
-        setAuthors((prev) => [newAuthor, ...prev]);
-        // Select the newly created author
-        onValueChange(newAuthor.id);
-        setSearchQuery("");
-        setOpen(false);
-      }
-    } catch (_error) {
-      // Fail silently; the button remains available for another attempt.
-    } finally {
-      setCreating(false);
-    }
-  };
-
-  const showCreateOption =
-    allowCreate &&
-    searchQuery.trim().length >= 2 &&
-    !authors.some((a) => a.name.toLowerCase() === searchQuery.toLowerCase());
-
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          aria-expanded={open}
-          className={cn(
-            "justify-between bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20",
-            className,
-          )}
-        >
-          <span className="truncate">{selectedAuthor ? selectedAuthor.name : placeholder}</span>
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        className="p-0 bg-content-bg-primary/95 backdrop-blur-md border border-content-glass-border"
-        align="start"
-      >
-        <Command className="bg-transparent" shouldFilter={false}>
-          <CommandInput
-            placeholder="Search authors..."
-            value={searchQuery}
-            onValueChange={setSearchQuery}
-            className="text-white"
-          />
-          <CommandList className="max-h-[300px] overflow-auto">
-            <CommandEmpty>{loading ? "Loading..." : creating ? "Creating..." : "No authors found."}</CommandEmpty>
-            <CommandGroup>
-              {/* Option to clear selection */}
-              <CommandItem
-                value="none"
-                onSelect={() => {
-                  onValueChange(null);
-                  setOpen(false);
-                }}
-                className="text-white hover:bg-content-bg-secondary"
-              >
-                <Check className={cn("mr-2 h-4 w-4", !value ? "opacity-100" : "opacity-0")} />
-                All Authors
-              </CommandItem>
-
-              {/* Option to create new author */}
-              {showCreateOption && (
-                <CommandItem
-                  value={`create-${searchQuery}`}
-                  onSelect={handleCreateAuthor}
-                  className="text-brand-primary hover:bg-content-bg-secondary font-medium"
-                >
-                  <Plus className="mr-2 h-4 w-4" />
-                  Create "{searchQuery}"
-                </CommandItem>
-              )}
-
-              {authors.map((author) => (
-                <CommandItem
-                  key={author.id}
-                  value={author.id}
-                  onSelect={() => {
-                    onValueChange(author.id);
-                    setOpen(false);
-                  }}
-                  className="text-white hover:bg-content-bg-secondary"
-                >
-                  <Check className={cn("mr-2 h-4 w-4", value === author.id ? "opacity-100" : "opacity-0")} />
-                  {author.name}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+    <SearchPicker<Author>
+      value={value ?? null}
+      onValueChange={onValueChange}
+      className={className}
+      placeholder={placeholder}
+      searchPlaceholder="Search authors..."
+      emptyMessage="No authors found."
+      loadingMessage="Loading..."
+      loadOnOpen
+      itemId={(a) => a.id}
+      itemLabel={(a) => a.name}
+      noneLabel="All Authors"
+      fetchResults={async (query) => {
+        const url =
+          query && query.length >= 2 ? `/api/authors?q=${encodeURIComponent(query)}&limit=20` : "/api/authors?top=10";
+        const response = await fetch(url);
+        if (!response.ok) return [];
+        return (await response.json()) as Author[];
+      }}
+      fetchById={async (id) => {
+        const response = await fetch(`/api/authors/${id}`);
+        if (!response.ok) return null;
+        return (await response.json()) as Author;
+      }}
+      allowCreate={
+        allowCreate
+          ? {
+              label: (query) => `Create "${query}"`,
+              onCreate: async (name) => {
+                const response = await fetch("/api/admin/authors", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ name }),
+                });
+                if (!response.ok) return null;
+                return (await response.json()) as Author;
+              },
+            }
+          : undefined
+      }
+    />
   );
 }

--- a/apps/web/app/components/show/show-form.tsx
+++ b/apps/web/app/components/show/show-form.tsx
@@ -3,13 +3,16 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import type { ControllerRenderProps } from "react-hook-form";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
+import { ShowYoutubeManager } from "~/components/show/show-youtube-manager";
 import { Button } from "~/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "~/components/ui/form";
+import { GlassSelect } from "~/components/ui/glass-select";
 import { Input } from "~/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
 import { Switch } from "~/components/ui/switch";
 import { Textarea } from "~/components/ui/textarea";
 import { VenueSearch } from "~/components/venue/venue-search";
+import { formInputClass } from "~/lib/form-styles";
+import { cn } from "~/lib/utils";
 
 const showFormSchema = z.object({
   date: z.string().min(1, "Date is required"),
@@ -28,9 +31,10 @@ interface ShowFormProps {
   submitLabel?: string;
   cancelHref?: string;
   bands?: Band[];
+  showId?: string;
 }
 
-export function ShowForm({ defaultValues, onSubmit, submitLabel = "Submit", cancelHref }: ShowFormProps) {
+export function ShowForm({ defaultValues, onSubmit, submitLabel = "Submit", cancelHref, showId }: ShowFormProps) {
   const form = useForm<ShowFormValues>({
     resolver: zodResolver(showFormSchema),
     defaultValues: defaultValues || {
@@ -53,11 +57,7 @@ export function ShowForm({ defaultValues, onSubmit, submitLabel = "Submit", canc
             <FormItem>
               <FormLabel className="text-content-text-secondary">Date</FormLabel>
               <FormControl>
-                <Input
-                  type="date"
-                  {...field}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
-                />
+                <Input type="date" {...field} className={formInputClass} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -89,22 +89,18 @@ export function ShowForm({ defaultValues, onSubmit, submitLabel = "Submit", canc
           render={({ field }: { field: ControllerRenderProps<ShowFormValues, "bandId"> }) => (
             <FormItem>
               <FormLabel className="text-content-text-secondary">Band</FormLabel>
-              <Select onValueChange={field.onChange} value={field.value}>
-                <FormControl>
-                  <SelectTrigger className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary">
-                    <SelectValue placeholder="Select a band" />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent className="bg-content-bg-secondary border-content-bg-secondary">
-                  <SelectItem value="none">No band</SelectItem>
-                  <SelectItem
-                    value="db7f2c5d-2727-41fd-bd6f-e91c74164f09"
-                    className="text-content-text-primary hover:bg-content-bg-secondary"
-                  >
-                    The Disco Biscuits
-                  </SelectItem>
-                </SelectContent>
-              </Select>
+              <FormControl>
+                <GlassSelect
+                  value={field.value}
+                  onValueChange={field.onChange}
+                  placeholder="Select a band"
+                  className="w-full"
+                  options={[
+                    { value: "none", label: "No band" },
+                    { value: "db7f2c5d-2727-41fd-bd6f-e91c74164f09", label: "The Disco Biscuits" },
+                  ]}
+                />
+              </FormControl>
               <FormMessage />
             </FormItem>
           )}
@@ -117,16 +113,14 @@ export function ShowForm({ defaultValues, onSubmit, submitLabel = "Submit", canc
             <FormItem>
               <FormLabel className="text-content-text-secondary">Notes</FormLabel>
               <FormControl>
-                <Textarea
-                  placeholder="Enter show notes"
-                  {...field}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary min-h-[100px]"
-                />
+                <Textarea placeholder="Enter show notes" {...field} className={cn(formInputClass, "min-h-[100px]")} />
               </FormControl>
               <FormMessage />
             </FormItem>
           )}
         />
+
+        {showId && <ShowYoutubeManager showId={showId} />}
 
         <FormField
           control={form.control}
@@ -135,11 +129,7 @@ export function ShowForm({ defaultValues, onSubmit, submitLabel = "Submit", canc
             <FormItem>
               <FormLabel className="text-content-text-secondary">Relisten URL</FormLabel>
               <FormControl>
-                <Input
-                  placeholder="Enter Relisten URL"
-                  {...field}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
-                />
+                <Input placeholder="Enter Relisten URL" {...field} className={formInputClass} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -166,16 +156,11 @@ export function ShowForm({ defaultValues, onSubmit, submitLabel = "Submit", canc
         />
 
         <div className="flex gap-4 pt-2">
-          <Button type="submit" className="bg-brand-primary hover:bg-hover-accent text-content-text-primary">
+          <Button type="submit" variant="brand">
             {submitLabel}
           </Button>
           {cancelHref && (
-            <Button
-              type="button"
-              variant="outline"
-              asChild
-              className="border-content-bg-secondary text-content-text-secondary hover:bg-content-bg-secondary hover:text-content-text-primary"
-            >
+            <Button type="button" variant="cancel" asChild>
               <a href={cancelHref}>Cancel</a>
             </Button>
           )}

--- a/apps/web/app/components/show/show-youtube-manager.test.tsx
+++ b/apps/web/app/components/show/show-youtube-manager.test.tsx
@@ -1,0 +1,217 @@
+import { setup } from "@test/test-utils";
+import { screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { success: (...args: unknown[]) => toastSuccess(...args), error: (...args: unknown[]) => toastError(...args) },
+}));
+
+import { ShowYoutubeManager } from "./show-youtube-manager";
+
+describe("ShowYoutubeManager", () => {
+  beforeEach(() => {
+    toastSuccess.mockClear();
+    toastError.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // On mount, the component fetches the show's current videos so the admin
+  // sees what's already curated before adding/removing.
+  test("loads existing videos on mount and renders each URL as a link", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { id: "row-1", videoId: "abc12345678", url: "https://www.youtube.com/watch?v=abc12345678" },
+        { id: "row-2", videoId: "xyz12345678", url: "https://www.youtube.com/watch?v=xyz12345678" },
+      ],
+    });
+
+    await setup(<ShowYoutubeManager showId="show-1" />);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith("/api/show-youtubes?showId=show-1");
+    const first = await screen.findByText("https://www.youtube.com/watch?v=abc12345678");
+    expect(first).toBeInTheDocument();
+    expect(screen.getByText("https://www.youtube.com/watch?v=xyz12345678")).toBeInTheDocument();
+  });
+
+  // The "No videos yet" hint is the empty-state copy that should only appear
+  // when the GET returns zero rows. It's a visual signal that the editor
+  // loaded — not an error.
+  test("shows the empty-state hint when no videos exist", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({ ok: true, json: async () => [] });
+
+    await setup(<ShowYoutubeManager showId="show-1" />);
+
+    expect(await screen.findByPlaceholderText(/YouTube URL/i)).toBeInTheDocument();
+    // No <li> rows render in the empty state.
+    expect(screen.queryAllByRole("listitem")).toHaveLength(0);
+  });
+
+  // Add flow: typing input + clicking Add posts the raw input to the server
+  // (server is responsible for extracting the video id). On success, the new
+  // row is appended to the list optimistically using the server response.
+  test("clicking Add posts the input and appends the returned row", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "row-new",
+          videoId: "dQw4w9WgXcQ",
+          url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        }),
+      });
+    globalThis.fetch = fetchMock;
+
+    const { user } = await setup(<ShowYoutubeManager showId="show-1" />);
+
+    const input = await screen.findByPlaceholderText(/YouTube URL/i);
+    await user.type(input, "https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+    await user.click(screen.getByRole("button", { name: /add/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const [url, options] = fetchMock.mock.calls[1];
+    expect(url).toBe("/api/show-youtubes");
+    expect(options.method).toBe("POST");
+    expect(JSON.parse(options.body)).toEqual({
+      showId: "show-1",
+      input: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+
+    expect(await screen.findByText("https://www.youtube.com/watch?v=dQw4w9WgXcQ")).toBeInTheDocument();
+    expect(toastSuccess).toHaveBeenCalled();
+  });
+
+  // Pressing Enter inside the input fires the same add flow as clicking Add,
+  // so admins curating from the keyboard don't have to reach for the mouse.
+  test("pressing Enter in the input submits the add", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "row-new",
+          videoId: "newvideo123",
+          url: "https://www.youtube.com/watch?v=newvideo123",
+        }),
+      });
+    globalThis.fetch = fetchMock;
+
+    const { user } = await setup(<ShowYoutubeManager showId="show-1" />);
+
+    const input = await screen.findByPlaceholderText(/YouTube URL/i);
+    await user.type(input, "newvideo123{Enter}");
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(fetchMock.mock.calls[1][0]).toBe("/api/show-youtubes");
+    expect(fetchMock.mock.calls[1][1].method).toBe("POST");
+  });
+
+  // The Add button is disabled while the input is empty/whitespace so the
+  // admin can't fire a no-op POST.
+  test("Add button is disabled when the input is empty", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({ ok: true, json: async () => [] });
+
+    await setup(<ShowYoutubeManager showId="show-1" />);
+
+    expect(await screen.findByRole("button", { name: /add/i })).toBeDisabled();
+  });
+
+  // When the server rejects the input (e.g. couldn't extract a video id), the
+  // error message in the response body surfaces to the toast — the admin
+  // sees what went wrong, not a generic "failed".
+  test("surfaces the server error message via toast on a 400", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: "Could not extract a YouTube video id from that input." }),
+      });
+    globalThis.fetch = fetchMock;
+
+    const { user } = await setup(<ShowYoutubeManager showId="show-1" />);
+
+    const input = await screen.findByPlaceholderText(/YouTube URL/i);
+    await user.type(input, "garbage");
+    await user.click(screen.getByRole("button", { name: /add/i }));
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith("Could not extract a YouTube video id from that input."),
+    );
+  });
+
+  // Delete flow: clicking the trash button on a row sends DELETE with the
+  // row's id and removes it from the list on success.
+  test("clicking delete sends DELETE and removes the row", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ id: "row-1", videoId: "abc12345678", url: "https://www.youtube.com/watch?v=abc12345678" }],
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) });
+    globalThis.fetch = fetchMock;
+
+    const { user } = await setup(<ShowYoutubeManager showId="show-1" />);
+
+    await screen.findByText("https://www.youtube.com/watch?v=abc12345678");
+
+    // The list row has exactly one button (trash); pick it by its parent <li>.
+    const row = screen.getByText("https://www.youtube.com/watch?v=abc12345678").closest("li");
+    const deleteBtn = row?.querySelector("button");
+    if (!deleteBtn) throw new Error("delete button not found");
+    await user.click(deleteBtn);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const [url, options] = fetchMock.mock.calls[1];
+    expect(url).toBe("/api/show-youtubes");
+    expect(options.method).toBe("DELETE");
+    expect(JSON.parse(options.body)).toEqual({ id: "row-1" });
+
+    await waitFor(() =>
+      expect(screen.queryByText("https://www.youtube.com/watch?v=abc12345678")).not.toBeInTheDocument(),
+    );
+    expect(toastSuccess).toHaveBeenCalledWith("Video removed");
+  });
+
+  // Delete failure should surface the server's error message — same
+  // contract as the Add flow. Without this, a non-2xx delete would
+  // show a generic "Failed to remove video" even when the API returned
+  // a specific reason (e.g. "Video belongs to a different show").
+  test("surfaces the server error message via toast when delete returns non-ok", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ id: "row-1", videoId: "abc12345678", url: "https://www.youtube.com/watch?v=abc12345678" }],
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: "Video belongs to a different show." }),
+      });
+    globalThis.fetch = fetchMock;
+
+    const { user } = await setup(<ShowYoutubeManager showId="show-1" />);
+
+    await screen.findByText("https://www.youtube.com/watch?v=abc12345678");
+
+    const row = screen.getByText("https://www.youtube.com/watch?v=abc12345678").closest("li");
+    const deleteBtn = row?.querySelector("button");
+    if (!deleteBtn) throw new Error("delete button not found");
+    await user.click(deleteBtn);
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith("Video belongs to a different show."));
+    // Row stays on screen — failed delete shouldn't optimistically remove it.
+    expect(screen.getByText("https://www.youtube.com/watch?v=abc12345678")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/show/show-youtube-manager.tsx
+++ b/apps/web/app/components/show/show-youtube-manager.tsx
@@ -1,0 +1,140 @@
+import { Plus, Trash, Youtube } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { formInputClass, listRowClass } from "~/lib/form-styles";
+import { cn } from "~/lib/utils";
+
+interface ShowYoutubeEntry {
+  id: string;
+  videoId: string;
+  url: string;
+}
+
+interface ShowYoutubeManagerProps {
+  showId: string;
+}
+
+export function ShowYoutubeManager({ showId }: ShowYoutubeManagerProps) {
+  const [entries, setEntries] = useState<ShowYoutubeEntry[]>([]);
+  const [input, setInput] = useState("");
+  const [isAdding, setIsAdding] = useState(false);
+  const [isDeletingId, setIsDeletingId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const response = await fetch(`/api/show-youtubes?showId=${showId}`);
+      if (!response.ok) throw new Error("load failed");
+      const data = (await response.json()) as ShowYoutubeEntry[];
+      setEntries(data);
+    } catch {
+      toast.error("Failed to load YouTube videos");
+    }
+  }, [showId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleAdd = async () => {
+    if (!input.trim() || isAdding) return;
+    setIsAdding(true);
+    try {
+      const response = await fetch("/api/show-youtubes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ showId, input: input.trim() }),
+      });
+      if (!response.ok) {
+        const { error } = (await response.json().catch(() => ({}))) as { error?: string };
+        toast.error(error || "Failed to add video");
+        return;
+      }
+      const entry = (await response.json()) as ShowYoutubeEntry;
+      setEntries((prev) => [...prev, entry]);
+      setInput("");
+      toast.success("Video added");
+    } catch {
+      toast.error("Failed to add video");
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setIsDeletingId(id);
+    try {
+      const response = await fetch("/api/show-youtubes", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id }),
+      });
+      if (!response.ok) {
+        const { error } = (await response.json().catch(() => ({}))) as { error?: string };
+        toast.error(error || "Failed to remove video");
+        return;
+      }
+      setEntries((prev) => prev.filter((e) => e.id !== id));
+      toast.success("Video removed");
+    } catch {
+      toast.error("Failed to remove video");
+    } finally {
+      setIsDeletingId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 text-sm font-medium text-content-text-secondary">
+        <Youtube className="h-4 w-4 text-red-500" />
+        YouTube Videos
+      </div>
+
+      {entries.length > 0 && (
+        <ul className="space-y-2">
+          {entries.map((entry) => (
+            <li key={entry.id} className={cn(listRowClass, "flex items-center justify-between gap-3 p-2")}>
+              <a
+                href={entry.url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-sm text-content-text-primary hover:text-brand-primary underline truncate"
+              >
+                {entry.url}
+              </a>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => handleDelete(entry.id)}
+                disabled={isDeletingId === entry.id}
+                className="h-8 w-8 p-0 md:h-9 md:w-auto md:px-3 border-red-600 text-red-400 hover:bg-red-900/20 shrink-0"
+              >
+                <Trash className="h-3 w-3" />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex gap-2">
+        <Input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="YouTube URL or 11-char video ID"
+          className={formInputClass}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleAdd();
+            }
+          }}
+        />
+        <Button onClick={handleAdd} disabled={!input.trim() || isAdding} variant="brand" className="shrink-0">
+          <Plus className="h-4 w-4 mr-1" />
+          Add
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/components/song/song-form.tsx
+++ b/apps/web/app/components/song/song-form.tsx
@@ -9,6 +9,8 @@ import { Checkbox } from "~/components/ui/checkbox";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "~/components/ui/form";
 import { Input } from "~/components/ui/input";
 import { Textarea } from "~/components/ui/textarea";
+import { formInputClass } from "~/lib/form-styles";
+import { cn } from "~/lib/utils";
 
 // Create a schema for song form (omitting auto-generated fields)
 export const songFormSchema = z.object({
@@ -66,7 +68,7 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
 
   return (
     <Form {...form}>
-      <div className="space-y-6 max-w-2xl" onSubmit={form.handleSubmit(onSubmit)}>
+      <form className="space-y-6 max-w-2xl" onSubmit={form.handleSubmit(onSubmit)}>
         <FormField
           control={form.control}
           name="title"
@@ -74,11 +76,7 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
             <FormItem>
               <FormLabel className="text-content-text-secondary">Song Title</FormLabel>
               <FormControl>
-                <Input
-                  placeholder="Enter song title"
-                  {...field}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
-                />
+                <Input placeholder="Enter song title" {...field} className={formInputClass} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -117,7 +115,7 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
                   {...field}
                   value={field.value || ""}
                   onChange={(e) => field.onChange(e.target.value || null)}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary min-h-[200px]"
+                  className={cn(formInputClass, "min-h-[200px]")}
                 />
               </FormControl>
               <FormMessage />
@@ -137,7 +135,7 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
                   {...field}
                   value={field.value || ""}
                   onChange={(e) => field.onChange(e.target.value || null)}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary min-h-[200px] font-mono"
+                  className={cn(formInputClass, "min-h-[200px] font-mono")}
                 />
               </FormControl>
               <FormMessage />
@@ -157,7 +155,7 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
                   {...field}
                   value={field.value || ""}
                   onChange={(e) => field.onChange(e.target.value || null)}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
+                  className={formInputClass}
                 />
               </FormControl>
               <FormMessage />
@@ -177,7 +175,7 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
                   {...field}
                   value={field.value || ""}
                   onChange={(e) => field.onChange(e.target.value || null)}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
+                  className={formInputClass}
                 />
               </FormControl>
               <FormMessage />
@@ -197,7 +195,7 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
                   {...field}
                   value={field.value || ""}
                   onChange={(e) => field.onChange(e.target.value || null)}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
+                  className={formInputClass}
                 />
               </FormControl>
               <FormMessage />
@@ -217,7 +215,7 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
                   {...field}
                   value={field.value || ""}
                   onChange={(e) => field.onChange(e.target.value || null)}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
+                  className={formInputClass}
                 />
               </FormControl>
               <FormMessage />
@@ -244,23 +242,14 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
         />
 
         <div className="flex gap-4 pt-2">
-          <Button
-            type="button"
-            onClick={form.handleSubmit(onSubmit)}
-            className="bg-brand-primary hover:bg-hover-accent text-content-text-primary"
-          >
+          <Button type="submit" variant="brand">
             {submitLabel}
           </Button>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => navigate(cancelHref)}
-            className="border-content-bg-secondary text-content-text-secondary hover:bg-content-bg-secondary hover:text-content-text-primary"
-          >
+          <Button type="button" variant="cancel" onClick={() => navigate(cancelHref)}>
             Cancel
           </Button>
         </div>
-      </div>
+      </form>
     </Form>
   );
 }

--- a/apps/web/app/components/song/song-search.test.tsx
+++ b/apps/web/app/components/song/song-search.test.tsx
@@ -1,0 +1,148 @@
+import type { Song } from "@bip/domain";
+import { setup } from "@test/test-utils";
+import { screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { SongSearch } from "./song-search";
+
+// SongSearch only reads `id` and `title`; the rest of the Song shape is
+// noise for these tests, so cast through `unknown`.
+function makeSong(id: string, title: string): Song {
+  return { id, title } as unknown as Song;
+}
+
+describe("SongSearch", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // The Disco Biscuits' song catalog is too big to load up front, so
+  // SongSearch requires 2+ chars before hitting the API. Below that, the
+  // user sees a "Type to search" hint and no network call fires.
+  test("does not call the search endpoint for queries shorter than 2 chars", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+
+    const { user } = await setup(<SongSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search songs...");
+    await user.type(input, "a");
+
+    // Give the debounce a chance to fire if it were going to.
+    await new Promise((r) => setTimeout(r, 400));
+    const apiCalls = fetchMock.mock.calls.filter((c) => String(c[0]).startsWith("/api/songs"));
+    expect(apiCalls).toHaveLength(0);
+  });
+
+  // 2+ chars triggers a debounced fetch to /api/songs?q=… with the query
+  // URL-encoded.
+  test("calls /api/songs?q=… for 2+ char queries", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+
+    const { user } = await setup(<SongSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search songs...");
+    await user.type(input, "wav");
+
+    await waitFor(
+      () => {
+        const urls = fetchMock.mock.calls.map((c) => c[0]);
+        expect(urls).toContain("/api/songs?q=wav");
+      },
+      { timeout: 1500 },
+    );
+  });
+
+  // initialSong renders on the trigger before the user opens the
+  // popover — important for the track-edit form, which lands with a
+  // pre-selected song.
+  test("renders the initialSong title on the trigger when value matches", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+    const initialSong = makeSong("s1", "Above the Waves");
+
+    await setup(<SongSearch value="s1" initialSong={initialSong} onValueChange={vi.fn()} />);
+
+    expect(screen.getByRole("combobox")).toHaveTextContent("Above the Waves");
+  });
+
+  // initialSong is kept in the results list even when the user's query
+  // doesn't match — so re-selecting the current value doesn't require
+  // clearing first. Critical for the track-edit form: opening the
+  // popover should always show the currently-selected song.
+  test("keeps initialSong in the results even when the API returns no matches", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+    const initialSong = makeSong("s1", "Above the Waves");
+
+    const { user } = await setup(<SongSearch value="s1" initialSong={initialSong} onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    // initial empty-query branch returns [initialSong] from the wrapper.
+    await screen.findAllByText("Above the Waves");
+  });
+
+  // Above the Waves should still appear when the query returns a list
+  // that doesn't include it (the wrapper prepends initialSong to results).
+  test("prepends initialSong to results when the API returns a non-matching list", async () => {
+    const initialSong = makeSong("s1", "Above the Waves");
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => [makeSong("s2", "Floes"), makeSong("s3", "Run Like Hell")],
+    });
+
+    const { user } = await setup(<SongSearch value="s1" initialSong={initialSong} onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search songs...");
+    await user.type(input, "flo");
+
+    // Wait for the debounced fetch to render its results — "Floes" only
+    // appears once that happens.
+    await screen.findByText("Floes", undefined, { timeout: 1500 });
+    // initialSong appears in the list (in addition to its presence on the
+    // trigger), so it shows up twice in the DOM.
+    expect(screen.getAllByText("Above the Waves").length).toBeGreaterThanOrEqual(2);
+  });
+
+  // The "No song" row is the clear affordance — selecting it should
+  // translate null back to "none" for the form state. The wrapper owns
+  // this translation so consumers using form fields don't have to.
+  test("clicking 'No song' fires onValueChange('none')", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+    const onValueChange = vi.fn();
+    const initialSong = makeSong("s1", "Above the Waves");
+
+    const { user } = await setup(<SongSearch value="s1" initialSong={initialSong} onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("No song"));
+
+    expect(onValueChange).toHaveBeenCalledWith("none");
+  });
+
+  // Selecting a song fires onValueChange with the song's id. Together
+  // with the "No song" test above, this verifies both legs of the
+  // form-state ↔ id translation.
+  test("clicking a song fires onValueChange with the song id", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [makeSong("s2", "Floes")] });
+    const onValueChange = vi.fn();
+
+    const { user } = await setup(<SongSearch onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search songs...");
+    await user.type(input, "flo");
+
+    const row = await screen.findByText("Floes", undefined, { timeout: 1500 });
+    await user.click(row);
+
+    expect(onValueChange).toHaveBeenCalledWith("s2");
+  });
+});

--- a/apps/web/app/components/song/song-search.tsx
+++ b/apps/web/app/components/song/song-search.tsx
@@ -1,10 +1,5 @@
 import type { Song } from "@bip/domain";
-import { Check, ChevronsUpDown } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
-import { Button } from "~/components/ui/button";
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "~/components/ui/command";
-import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
-import { cn } from "~/lib/utils";
+import { SearchPicker } from "~/components/ui/search-picker";
 
 interface SongSearchProps {
   value?: string;
@@ -14,6 +9,13 @@ interface SongSearchProps {
   initialSong?: Song;
 }
 
+/**
+ * Song picker used in the track-edit form. Requires 2+ chars of input
+ * before searching — there are too many songs in the catalog to load up
+ * front. The form layer uses the sentinel value "none" rather than null
+ * because it threads through react-hook-form as a plain string; the
+ * wrapper translates between "none" ↔ null at the boundary.
+ */
 export function SongSearch({
   value,
   onValueChange,
@@ -21,111 +23,32 @@ export function SongSearch({
   className,
   initialSong,
 }: SongSearchProps) {
-  const [open, setOpen] = useState(false);
-  const [songs, setSongs] = useState<Song[]>(initialSong ? [initialSong] : []);
-  const [loading, setLoading] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
-
-  const selectedSong = songs.find((song) => song.id === value) || initialSong;
-
-  const searchSongs = useCallback(
-    async (query: string) => {
-      if (!query || query.length < 2) {
-        setSongs(initialSong ? [initialSong] : []);
-        return;
-      }
-
-      setLoading(true);
-      try {
-        const response = await fetch(`/api/songs?q=${encodeURIComponent(query)}`);
-        if (response.ok) {
-          const data = await response.json();
-
-          // Ensure the initialSong is included if it's not in the search results
-          const songsToSet = [...data];
-          if (initialSong && !data.find((song: Song) => song.id === initialSong.id)) {
-            songsToSet.unshift(initialSong);
-          }
-
-          setSongs(songsToSet);
-        } else {
-        }
-      } catch (_error) {
-      } finally {
-        setLoading(false);
-      }
-    },
-    [initialSong],
-  );
-
-  useEffect(() => {
-    const delayedSearch = setTimeout(() => {
-      searchSongs(searchQuery);
-    }, 300); // Debounce search
-
-    return () => clearTimeout(delayedSearch);
-  }, [searchQuery, searchSongs]);
-
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          className={cn(
-            "justify-between bg-content-bg-secondary border-content-bg-secondary text-white hover:bg-gray-700",
-            className,
-          )}
-        >
-          {selectedSong ? selectedSong.title : placeholder}
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="p-0 bg-content-bg-secondary border-content-bg-secondary" align="start">
-        <Command className="bg-content-bg-secondary" shouldFilter={false}>
-          <CommandInput
-            placeholder="Search songs..."
-            value={searchQuery}
-            onValueChange={setSearchQuery}
-            className="text-white"
-          />
-          <CommandList>
-            <CommandEmpty>
-              {loading ? "Searching..." : searchQuery.length < 2 ? "Type to search songs" : "No songs found."}
-            </CommandEmpty>
-            <CommandGroup>
-              {/* Option to clear selection */}
-              <CommandItem
-                value="none"
-                onSelect={() => {
-                  onValueChange("none");
-                  setOpen(false);
-                }}
-                className="text-white hover:bg-gray-700"
-              >
-                <Check className={cn("mr-2 h-4 w-4", value === "none" ? "opacity-100" : "opacity-0")} />
-                No song
-              </CommandItem>
-
-              {songs.map((song) => (
-                <CommandItem
-                  key={song.id}
-                  value={song.id}
-                  onSelect={() => {
-                    onValueChange(song.id);
-                    setOpen(false);
-                  }}
-                  className="text-white hover:bg-gray-700"
-                >
-                  <Check className={cn("mr-2 h-4 w-4", value === song.id ? "opacity-100" : "opacity-0")} />
-                  {song.title}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+    <SearchPicker<Song>
+      value={value && value !== "none" ? value : null}
+      onValueChange={(v) => onValueChange(v ?? "none")}
+      className={className}
+      placeholder={placeholder}
+      searchPlaceholder="Search songs..."
+      emptyMessage={(q) => (q.length < 2 ? "Type to search songs" : "No songs found.")}
+      loadingMessage="Searching..."
+      itemId={(s) => s.id}
+      itemLabel={(s) => s.title}
+      noneLabel="No song"
+      initialItem={initialSong}
+      fetchResults={async (query) => {
+        if (!query || query.length < 2) return initialSong ? [initialSong] : [];
+        const response = await fetch(`/api/songs?q=${encodeURIComponent(query)}`);
+        if (!response.ok) return [];
+        const data = (await response.json()) as Song[];
+        // Keep the initial song visible in results even when it doesn't
+        // match the query, so the user can re-select the current value
+        // without clearing the field first.
+        if (initialSong && !data.find((song) => song.id === initialSong.id)) {
+          return [initialSong, ...data];
+        }
+        return data;
+      }}
+    />
   );
 }

--- a/apps/web/app/components/track/sortable-track-item.test.tsx
+++ b/apps/web/app/components/track/sortable-track-item.test.tsx
@@ -1,0 +1,232 @@
+import type { Track } from "@bip/domain";
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+// useSortable from @dnd-kit/sortable expects a SortableContext provider in
+// the tree. The tests don't exercise drag-and-drop behavior (that belongs
+// to TrackManager-level tests), so we stub the hook to return inert values
+// and let SortableTrackItem mount in isolation.
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => undefined,
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+import { SortableTrackItem } from "./sortable-track-item";
+
+// Minimal Track factory — the row only reads a handful of fields, so the
+// rest are stubbed with sensible defaults. Tests override what they care
+// about.
+function makeTrack(overrides: Partial<Track> = {}): Track {
+  return {
+    id: "track-1",
+    showId: "show-1",
+    songId: "song-1",
+    set: "S1",
+    position: 1,
+    segue: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    likesCount: 0,
+    slug: "story-of-the-world",
+    note: null,
+    allTimer: false,
+    previousTrackId: null,
+    nextTrackId: null,
+    averageRating: 0,
+    ratingsCount: 0,
+    gap: null,
+    previousPerformanceShowId: null,
+    previousPerformanceShow: null,
+    // Component only reads `song.title`; the rest of the Song shape is
+    // irrelevant for these tests, so cast through `unknown` to avoid
+    // tracking every field on the domain model.
+    song: { id: "song-1", title: "Story of the World" } as unknown as Track["song"],
+    annotations: [],
+    ...overrides,
+  };
+}
+
+describe("SortableTrackItem", () => {
+  // Baseline render: a minimal track shows position number + song title and
+  // none of the optional chrome (no flame, no segue, no note, no annotations).
+  test("renders position and song title for a minimal track", async () => {
+    await setup(<SortableTrackItem track={makeTrack()} onEdit={vi.fn()} onDelete={vi.fn()} />);
+
+    expect(screen.getByText("Story of the World")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  // Notes appear on their OWN line below the title (no parens). Earlier
+  // versions wrapped notes in `(...)` and put them inline with the title;
+  // the redesign moved them below to give long notes the full row width.
+  // This test guards against either regression.
+  test("renders the note on its own line below the title without parens", async () => {
+    await setup(
+      <SortableTrackItem
+        track={makeTrack({ note: "The jam emerges as minimal trance" })}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    const noteEl = screen.getByText("The jam emerges as minimal trance");
+    expect(noteEl).toBeInTheDocument();
+    expect(noteEl.tagName).toBe("P"); // own paragraph element, not inline span in title row
+    // No parens anywhere in the note text. Catches a future "wrap in (…)"
+    // change that would silently regress the display.
+    expect(screen.queryByText(/^\(.+\)$/)).not.toBeInTheDocument();
+  });
+
+  // When the track has no note, the note row is omitted entirely (not
+  // rendered as an empty <p>). Keeps the row compact for tracks without
+  // commentary.
+  test("does not render the note row when note is null", async () => {
+    const { container } = await setup(
+      <SortableTrackItem track={makeTrack({ note: null })} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+
+    // The note paragraph would have italic styling. No <p> with italic class.
+    expect(container.querySelector("p.italic")).toBeNull();
+  });
+
+  // All-timer flame icon renders inline next to the song title (not in a
+  // dedicated leading column). This was the mobile-fit change — the
+  // reserved column ate horizontal space and forced song titles to wrap.
+  test("renders the all-timer flame icon inline when allTimer is true", async () => {
+    const { container } = await setup(
+      <SortableTrackItem track={makeTrack({ allTimer: true })} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+
+    // Flame icon has text-orange-500. Assert one is present.
+    const flames = container.querySelectorAll("svg.text-orange-500");
+    expect(flames.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("does not render the flame icon when allTimer is false", async () => {
+    const { container } = await setup(
+      <SortableTrackItem track={makeTrack({ allTimer: false })} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+
+    expect(container.querySelector("svg.text-orange-500")).toBeNull();
+  });
+
+  // Segue marker (">") renders inline next to the title when present.
+  test("renders the segue marker when track.segue is set", async () => {
+    await setup(<SortableTrackItem track={makeTrack({ segue: ">" })} onEdit={vi.fn()} onDelete={vi.fn()} />);
+
+    expect(screen.getByText(">")).toBeInTheDocument();
+  });
+
+  // Annotations render below the note in their own section. Each annotation
+  // is its own row so multi-line annotations don't collapse together.
+  test("renders each annotation as its own row when annotations exist", async () => {
+    await setup(
+      <SortableTrackItem
+        track={makeTrack({
+          annotations: [
+            {
+              id: "ann-1",
+              trackId: "track-1",
+              desc: "inverted",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+            {
+              id: "ann-2",
+              trackId: "track-1",
+              desc: "with 'Floes' tease",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ],
+        })}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("inverted")).toBeInTheDocument();
+    expect(screen.getByText("with 'Floes' tease")).toBeInTheDocument();
+  });
+
+  // Annotations with empty desc are skipped — they'd render as visual noise
+  // (an empty bordered row). This is a defensive check against bad data.
+  test("skips annotations whose desc is null or empty", async () => {
+    const { container } = await setup(
+      <SortableTrackItem
+        track={makeTrack({
+          annotations: [
+            {
+              id: "ann-1",
+              trackId: "track-1",
+              desc: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+            {
+              id: "ann-2",
+              trackId: "track-1",
+              desc: "real annotation",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ],
+        })}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("real annotation")).toBeInTheDocument();
+    // Only one annotation row (the real one) renders.
+    const annotationRows = container.querySelectorAll("div.border-l-2");
+    expect(annotationRows.length).toBe(1);
+  });
+
+  // Edit button fires onEdit with the full track so the parent can hydrate
+  // an edit form without a re-fetch.
+  test("clicking the edit button fires onEdit with the track", async () => {
+    const onEdit = vi.fn();
+    const track = makeTrack();
+    const { user, container } = await setup(<SortableTrackItem track={track} onEdit={onEdit} onDelete={vi.fn()} />);
+
+    const editButton = container.querySelector('button[class*="border-gray-600"]');
+    if (!editButton) throw new Error("edit button not found");
+    await user.click(editButton);
+
+    expect(onEdit).toHaveBeenCalledWith(track);
+  });
+
+  // Delete button fires onDelete with the track id (not the full track) so
+  // the parent only needs the id for its DELETE request.
+  test("clicking the delete button fires onDelete with the track id", async () => {
+    const onDelete = vi.fn();
+    const { user, container } = await setup(
+      <SortableTrackItem track={makeTrack({ id: "track-xyz" })} onEdit={vi.fn()} onDelete={onDelete} />,
+    );
+
+    const deleteButton = container.querySelector('button[class*="border-red-600"]');
+    if (!deleteButton) throw new Error("delete button not found");
+    await user.click(deleteButton);
+
+    expect(onDelete).toHaveBeenCalledWith("track-xyz");
+  });
+
+  // Delete button disables while isDeleting=true so a slow API can't be
+  // triggered twice by a frustrated double-click.
+  test("delete button is disabled when isDeleting is true", async () => {
+    const { container } = await setup(
+      <SortableTrackItem track={makeTrack()} onEdit={vi.fn()} onDelete={vi.fn()} isDeleting />,
+    );
+
+    const deleteButton = container.querySelector('button[class*="border-red-600"]');
+    expect(deleteButton).toBeDisabled();
+  });
+});

--- a/apps/web/app/components/track/sortable-track-item.tsx
+++ b/apps/web/app/components/track/sortable-track-item.tsx
@@ -3,6 +3,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Edit2, Flame, GripVertical, Trash } from "lucide-react";
 import { Button } from "~/components/ui/button";
+import { listRowClass } from "~/lib/form-styles";
 import { cn } from "~/lib/utils";
 
 interface SortableTrackItemProps {
@@ -24,82 +25,72 @@ export function SortableTrackItem({ track, onEdit, onDelete, isDeleting }: Sorta
     <div
       ref={setNodeRef}
       style={style}
-      className={cn(
-        "p-3 bg-content-bg-secondary/50 rounded-lg border border-content-bg-secondary transition-all",
-        isDragging && "opacity-50 shadow-lg z-50",
-      )}
+      className={cn(listRowClass, "p-3 transition-all", isDragging && "opacity-50 shadow-lg z-50")}
     >
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex items-start space-x-4 flex-1">
-          {/* Drag Handle */}
-          <button
-            className="text-content-text-secondary hover:text-gray-300 cursor-grab active:cursor-grabbing p-1 mt-1"
-            {...attributes}
-            {...listeners}
-          >
-            <GripVertical className="h-4 w-4" />
-          </button>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between gap-2 md:gap-4">
+          <div className="flex items-center space-x-2 md:space-x-4 flex-1 min-w-0">
+            {/* Drag Handle */}
+            <button
+              className="text-content-text-secondary hover:text-gray-300 cursor-grab active:cursor-grabbing p-1 shrink-0"
+              {...attributes}
+              {...listeners}
+            >
+              <GripVertical className="h-4 w-4" />
+            </button>
 
-          {/* Position Number - now just for display */}
-          <span className="text-content-text-secondary font-mono text-sm w-8 mt-1">{track.position}</span>
+            {/* Position Number - now just for display */}
+            <span className="text-content-text-secondary font-mono text-sm w-6 md:w-8 shrink-0">{track.position}</span>
 
-          {/* All-timer indicator (reserved column to keep alignment) */}
-          <span className="w-5 mt-1 flex justify-center">
-            {track.allTimer && <Flame className="h-4 w-4 text-orange-500" />}
-          </span>
-
-          {/* Track Content */}
-          <div className="flex-1">
-            <div className="flex items-center gap-3 flex-wrap">
-              {/* Song Title */}
+            {/* Title + inline markers */}
+            <div className="flex items-center gap-2 md:gap-3 flex-wrap flex-1 min-w-0">
               <span className="text-white font-medium">{track.song?.title || "Unknown Song"}</span>
-
-              {/* Segue */}
+              {track.allTimer && <Flame className="h-4 w-4 text-orange-500 shrink-0" />}
               {track.segue && <span className="text-content-text-secondary text-sm">{track.segue}</span>}
-
-              {/* Notes */}
-              {track.note && <span className="text-content-text-secondary text-sm italic">({track.note})</span>}
             </div>
+          </div>
 
-            {/* Annotations */}
-            {track.annotations && track.annotations.length > 0 && (
-              <div className="mt-2 space-y-1">
-                {track.annotations.map(
-                  (annotation, index) =>
-                    annotation.desc && (
-                      <div
-                        key={annotation.id || index}
-                        className="text-content-text-accent text-sm pl-2 border-l-2 border-content-bg-secondary"
-                      >
-                        {annotation.desc}
-                      </div>
-                    ),
-                )}
-              </div>
-            )}
+          {/* Action Buttons */}
+          <div className="flex items-center gap-1 md:gap-2 shrink-0">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => onEdit(track)}
+              className="h-8 w-8 p-0 md:h-9 md:w-auto md:px-3 border-gray-600 text-gray-300 hover:bg-gray-700"
+            >
+              <Edit2 className="h-3 w-3" />
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => onDelete(track.id)}
+              disabled={isDeleting}
+              className="h-8 w-8 p-0 md:h-9 md:w-auto md:px-3 border-red-600 text-red-400 hover:bg-red-900/20"
+            >
+              <Trash className="h-3 w-3" />
+            </Button>
           </div>
         </div>
 
-        {/* Action Buttons */}
-        <div className="flex items-center gap-2">
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => onEdit(track)}
-            className="border-gray-600 text-gray-300 hover:bg-gray-700"
-          >
-            <Edit2 className="h-3 w-3" />
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => onDelete(track.id)}
-            disabled={isDeleting}
-            className="border-red-600 text-red-400 hover:bg-red-900/20"
-          >
-            <Trash className="h-3 w-3" />
-          </Button>
-        </div>
+        {/* Note (full-width, below title) */}
+        {track.note && <p className="text-content-text-secondary text-sm italic pl-8 md:pl-12">{track.note}</p>}
+
+        {/* Annotations (full-width, below note) */}
+        {track.annotations && track.annotations.length > 0 && (
+          <div className="space-y-1 pl-8 md:pl-12">
+            {track.annotations.map(
+              (annotation, index) =>
+                annotation.desc && (
+                  <div
+                    key={annotation.id || index}
+                    className="text-content-text-accent text-sm pl-2 border-l-2 border-content-bg-secondary"
+                  >
+                    {annotation.desc}
+                  </div>
+                ),
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/app/components/track/track-constants.test.ts
+++ b/apps/web/app/components/track/track-constants.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+
+import { compareSets, SEGUE_OPTIONS, SET_OPTIONS } from "./track-constants";
+
+describe("SET_OPTIONS", () => {
+  // The set dropdown lists S1-S3 then E1-E3. Order matters — it drives the
+  // visual order in the picker, which should match how the band's setlist
+  // pages render the same sets.
+  test("lists all six set values in S1→E3 order", () => {
+    expect(SET_OPTIONS.map((o) => o.value)).toEqual(["S1", "S2", "S3", "E1", "E2", "E3"]);
+  });
+
+  // Display labels expand the codes for humans: "Set 1" / "Encore 1" rather
+  // than the raw "S1" / "E1".
+  test("labels expand codes into 'Set N' / 'Encore N' display text", () => {
+    const byValue = Object.fromEntries(SET_OPTIONS.map((o) => [o.value, o.label]));
+    expect(byValue.S1).toBe("Set 1");
+    expect(byValue.S3).toBe("Set 3");
+    expect(byValue.E1).toBe("Encore 1");
+    expect(byValue.E3).toBe("Encore 3");
+  });
+});
+
+describe("SEGUE_OPTIONS", () => {
+  // Segue dropdown has two states: no segue (the form sentinel is "none")
+  // and ">" for the "song A > song B" continuous-play marker. The API
+  // boundary in track-manager.tsx translates "none" → null before saving.
+  test("offers a 'none' sentinel and the '>' marker", () => {
+    expect(SEGUE_OPTIONS).toEqual([
+      { value: "none", label: "No segue" },
+      { value: ">", label: ">" },
+    ]);
+  });
+});
+
+describe("compareSets", () => {
+  // Within the same type (set vs encore), order by numeric suffix —
+  // setlist views render sets in playback order.
+  test("orders sets numerically within the S group", () => {
+    expect(["S2", "S1", "S3"].sort(compareSets)).toEqual(["S1", "S2", "S3"]);
+  });
+
+  test("orders encores numerically within the E group", () => {
+    expect(["E3", "E1", "E2"].sort(compareSets)).toEqual(["E1", "E2", "E3"]);
+  });
+
+  // Encores always follow the regular sets, regardless of suffix. An
+  // encore is "after the show proper", so E1 > S3 even though 1 < 3.
+  test("places all encores after all sets", () => {
+    expect(["E1", "S3", "S1", "E2"].sort(compareSets)).toEqual(["S1", "S3", "E1", "E2"]);
+  });
+});

--- a/apps/web/app/components/track/track-constants.ts
+++ b/apps/web/app/components/track/track-constants.ts
@@ -1,0 +1,31 @@
+export const SET_OPTIONS = [
+  { value: "S1", label: "Set 1" },
+  { value: "S2", label: "Set 2" },
+  { value: "S3", label: "Set 3" },
+  { value: "E1", label: "Encore 1" },
+  { value: "E2", label: "Encore 2" },
+  { value: "E3", label: "Encore 3" },
+];
+
+export const SEGUE_OPTIONS = [
+  { value: "none", label: "No segue" },
+  { value: ">", label: ">" },
+];
+
+/**
+ * Orders set codes for the setlist UI: regular sets first (S1, S2, S3),
+ * then encores (E1, E2, E3). Within a group, sort numerically by suffix —
+ * an encore is "after the show", so E1 follows S3 even though 1 < 3.
+ */
+export function compareSets(a: string, b: string): number {
+  const setOrder = { S: 0, E: 1 };
+  const aType = a.charAt(0) as "S" | "E";
+  const bType = b.charAt(0) as "S" | "E";
+  const aNum = Number.parseInt(a.slice(1), 10);
+  const bNum = Number.parseInt(b.slice(1), 10);
+
+  if (aType !== bType) {
+    return setOrder[aType] - setOrder[bType];
+  }
+  return aNum - bNum;
+}

--- a/apps/web/app/components/track/track-edit-form.test.tsx
+++ b/apps/web/app/components/track/track-edit-form.test.tsx
@@ -1,0 +1,203 @@
+import { setup } from "@test/test-utils";
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { TrackEditForm } from "./track-edit-form";
+import type { TrackFormData } from "./use-track-api";
+
+const BASE_FORM: TrackFormData = {
+  songId: "none",
+  set: "S1",
+  position: 1,
+  segue: "none",
+  note: null,
+  annotationDesc: null,
+  allTimer: false,
+};
+
+describe("TrackEditForm", () => {
+  // The form is editing-aware: when `isEditing` is true it shows "Update";
+  // otherwise "Add". This drives which CTA the user sees in the same form.
+  test("renders the 'Add' CTA when isEditing is false", async () => {
+    await setup(
+      <TrackEditForm
+        formData={BASE_FORM}
+        onFormDataChange={vi.fn()}
+        isEditing={false}
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /add/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /update/i })).not.toBeInTheDocument();
+  });
+
+  test("renders the 'Update' CTA when isEditing is true", async () => {
+    await setup(
+      <TrackEditForm
+        formData={BASE_FORM}
+        onFormDataChange={vi.fn()}
+        isEditing
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /update/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^add/i })).not.toBeInTheDocument();
+  });
+
+  // While submitting, both CTAs disable so a slow API can't be triggered
+  // twice by a double-click.
+  test("disables the submit button while isSubmitting", async () => {
+    await setup(
+      <TrackEditForm
+        formData={BASE_FORM}
+        onFormDataChange={vi.fn()}
+        isEditing={false}
+        isSubmitting
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /add/i })).toBeDisabled();
+  });
+
+  // Note textarea is pre-populated from formData.note. Editing fires
+  // onFormDataChange with the new value. Empty string normalizes to null
+  // so the form state matches the DB column type.
+  test("seeds the Note textarea from formData.note", async () => {
+    await setup(
+      <TrackEditForm
+        formData={{ ...BASE_FORM, note: "The jam emerges as minimal trance" }}
+        onFormDataChange={vi.fn()}
+        isEditing
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText(/track notes/i)).toHaveValue("The jam emerges as minimal trance");
+  });
+
+  // We drive the change directly via fireEvent because the form is fully
+  // controlled — the parent owns formData and decides when to re-render.
+  // user.type can't progress past the first character on a controlled
+  // input that doesn't receive prop updates, so we synthesize the change
+  // event instead.
+  test("changing Note fires onFormDataChange whose updater sets the new value", async () => {
+    const onFormDataChange = vi.fn();
+    await setup(
+      <TrackEditForm
+        formData={BASE_FORM}
+        onFormDataChange={onFormDataChange}
+        isEditing={false}
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/track notes/i), {
+      target: { value: "The jam emerges" },
+    });
+
+    const updater = onFormDataChange.mock.calls.at(-1)?.[0] as (p: TrackFormData) => TrackFormData;
+    expect(updater(BASE_FORM).note).toBe("The jam emerges");
+  });
+
+  // Clearing the textarea sends null (not empty string) so the column
+  // type matches the DB.
+  test("clearing Note sends null via the updater, not an empty string", async () => {
+    const onFormDataChange = vi.fn();
+    await setup(
+      <TrackEditForm
+        formData={{ ...BASE_FORM, note: "x" }}
+        onFormDataChange={onFormDataChange}
+        isEditing
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/track notes/i), { target: { value: "" } });
+
+    const updater = onFormDataChange.mock.calls.at(-1)?.[0] as (p: TrackFormData) => TrackFormData;
+    expect(updater({ ...BASE_FORM, note: "x" }).note).toBeNull();
+  });
+
+  // Annotations textarea is shown alongside Notes — the "one per line"
+  // hint signals the field's expected format.
+  test("annotations field shows the 'one per line' hint", async () => {
+    await setup(
+      <TrackEditForm
+        formData={BASE_FORM}
+        onFormDataChange={vi.fn()}
+        isEditing
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/one per line/i)).toBeInTheDocument();
+  });
+
+  // All-timer checkbox is checked when formData.allTimer is true.
+  test("all-timer checkbox reflects formData.allTimer", async () => {
+    await setup(
+      <TrackEditForm
+        formData={{ ...BASE_FORM, allTimer: true }}
+        onFormDataChange={vi.fn()}
+        isEditing
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("checkbox", { name: /all-timer/i })).toBeChecked();
+  });
+
+  // Submit / Cancel fire the matching callbacks — the form doesn't own
+  // any submission logic itself.
+  test("clicking the submit CTA fires onSubmit", async () => {
+    const onSubmit = vi.fn();
+    const { user } = await setup(
+      <TrackEditForm
+        formData={BASE_FORM}
+        onFormDataChange={vi.fn()}
+        isEditing={false}
+        isSubmitting={false}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /add/i }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  test("clicking the cancel CTA fires onCancel", async () => {
+    const onCancel = vi.fn();
+    const { user } = await setup(
+      <TrackEditForm
+        formData={BASE_FORM}
+        onFormDataChange={vi.fn()}
+        isEditing={false}
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/app/components/track/track-edit-form.tsx
+++ b/apps/web/app/components/track/track-edit-form.tsx
@@ -1,0 +1,135 @@
+import { Check, X } from "lucide-react";
+import { SongSearch } from "~/components/song/song-search";
+import { Button } from "~/components/ui/button";
+import { Checkbox } from "~/components/ui/checkbox";
+import { GlassSelect } from "~/components/ui/glass-select";
+import { Textarea } from "~/components/ui/textarea";
+import { formInputClass, formLabelClass } from "~/lib/form-styles";
+import { SEGUE_OPTIONS, SET_OPTIONS } from "./track-constants";
+import type { TrackFormData } from "./use-track-api";
+
+interface TrackEditFormProps {
+  formData: TrackFormData;
+  onFormDataChange: (updater: (prev: TrackFormData) => TrackFormData) => void;
+  isEditing: boolean;
+  isSubmitting: boolean;
+  onSubmit: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * The inline form admins use to add or edit a track on a show. Pure
+ * presentational + controlled input — all state lives in the caller
+ * (`TrackManager`), which decides what `formData` to seed it with, when
+ * to flip between add/edit mode, and how to handle submission.
+ */
+export function TrackEditForm({
+  formData,
+  onFormDataChange,
+  isEditing,
+  isSubmitting,
+  onSubmit,
+  onCancel,
+}: TrackEditFormProps) {
+  return (
+    <div className="flex flex-col gap-4 p-4 bg-content-bg/50 rounded-lg border border-content-bg-secondary">
+      <div>
+        <label htmlFor="track-song" className={formLabelClass}>
+          Song
+        </label>
+        <SongSearch
+          value={formData.songId}
+          onValueChange={(value) => onFormDataChange((prev) => ({ ...prev, songId: value }))}
+          placeholder="Select a song..."
+          className="w-full"
+          initialSong={formData.song}
+        />
+      </div>
+
+      <div className="flex flex-wrap items-end gap-4">
+        <div className="w-28">
+          <label htmlFor="track-set" className={formLabelClass}>
+            Set
+          </label>
+          <GlassSelect
+            id="track-set"
+            value={formData.set}
+            onValueChange={(value) => onFormDataChange((prev) => ({ ...prev, set: value }))}
+            options={SET_OPTIONS}
+            className="w-full"
+          />
+        </div>
+
+        <div className="w-32">
+          <label htmlFor="track-segue" className={formLabelClass}>
+            Segue
+          </label>
+          <GlassSelect
+            id="track-segue"
+            value={formData.segue}
+            onValueChange={(value) => onFormDataChange((prev) => ({ ...prev, segue: value }))}
+            options={SEGUE_OPTIONS}
+            className="w-full"
+          />
+        </div>
+
+        <div className="flex items-center gap-2 h-10">
+          <Checkbox
+            id="track-all-timer"
+            checked={formData.allTimer}
+            onCheckedChange={(checked) => onFormDataChange((prev) => ({ ...prev, allTimer: checked === true }))}
+          />
+          <label htmlFor="track-all-timer" className="text-sm font-medium text-content-text-secondary cursor-pointer">
+            All-timer
+          </label>
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="track-note" className={formLabelClass}>
+          Track Notes
+        </label>
+        <Textarea
+          id="track-note"
+          value={formData.note || ""}
+          onChange={(e) => {
+            const value = e.target.value;
+            onFormDataChange((prev) => ({ ...prev, note: value || null }));
+          }}
+          placeholder="Add a note about this track..."
+          className={formInputClass}
+          rows={3}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="track-annotation" className={formLabelClass}>
+          Annotations
+          <span className="ml-2 text-xs text-content-text-tertiary">(one per line)</span>
+        </label>
+        <Textarea
+          id="track-annotation"
+          value={formData.annotationDesc || ""}
+          onChange={(e) => {
+            const value = e.target.value;
+            onFormDataChange((prev) => ({ ...prev, annotationDesc: value || null }));
+          }}
+          placeholder="Add annotations (one per line)..."
+          className={formInputClass}
+          rows={3}
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <Button onClick={onCancel} variant="cancel">
+          <X className="h-4 w-4 mr-1" />
+          Cancel
+        </Button>
+        <Button onClick={onSubmit} disabled={isSubmitting} variant="brand">
+          <Check className="h-4 w-4 mr-1" />
+          {isEditing ? "Update" : "Add"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/components/track/track-manager.test.tsx
+++ b/apps/web/app/components/track/track-manager.test.tsx
@@ -1,0 +1,296 @@
+import type { Track } from "@bip/domain";
+import { setup } from "@test/test-utils";
+import { act, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// Stub the sortable row so we don't have to mount @dnd-kit/sortable
+// machinery — the row's render is covered by sortable-track-item.test.tsx.
+// We just need to know which tracks TrackManager handed it and capture
+// the onEdit / onDelete callbacks so we can invoke them directly.
+const capturedRowProps: Array<{
+  track: Track;
+  onEdit: (track: Track) => void;
+  onDelete: (id: string) => void;
+  isDeleting?: boolean;
+}> = [];
+vi.mock("./sortable-track-item", () => ({
+  SortableTrackItem: (props: {
+    track: Track;
+    onEdit: (track: Track) => void;
+    onDelete: (id: string) => void;
+    isDeleting?: boolean;
+  }) => {
+    capturedRowProps.push(props);
+    return (
+      <div data-testid={`row-${props.track.id}`}>
+        {props.track.song?.title ?? "unknown"}
+        <button type="button" onClick={() => props.onEdit(props.track)}>
+          edit-{props.track.id}
+        </button>
+        <button type="button" onClick={() => props.onDelete(props.track.id)}>
+          delete-{props.track.id}
+        </button>
+      </div>
+    );
+  },
+}));
+
+// DndContext stubbed so tests can capture the `onDragEnd` handler and
+// fire synthetic drag events without simulating real pointer drags in
+// jsdom. The captured ref is reset in `beforeEach`.
+let capturedOnDragEnd: ((event: { active: { id: string }; over: { id: string } | null }) => void) | undefined;
+vi.mock("@dnd-kit/core", async () => {
+  const actual = await vi.importActual<typeof import("@dnd-kit/core")>("@dnd-kit/core");
+  return {
+    ...actual,
+    DndContext: ({ onDragEnd, children }: { onDragEnd?: typeof capturedOnDragEnd; children: React.ReactNode }) => {
+      capturedOnDragEnd = onDragEnd;
+      return <>{children}</>;
+    },
+  };
+});
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { success: (...args: unknown[]) => toastSuccess(...args), error: (...args: unknown[]) => toastError(...args) },
+}));
+
+import { TrackManager } from "./track-manager";
+
+function makeTrack(overrides: Partial<Track> & { id: string }): Track {
+  return {
+    showId: "show-1",
+    songId: "song-1",
+    set: "S1",
+    position: 1,
+    segue: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    likesCount: 0,
+    slug: overrides.id,
+    note: null,
+    allTimer: false,
+    previousTrackId: null,
+    nextTrackId: null,
+    averageRating: 0,
+    ratingsCount: 0,
+    gap: null,
+    previousPerformanceShowId: null,
+    previousPerformanceShow: null,
+    annotations: [],
+    song: { id: "song-1", title: "Story of the World" } as unknown as Track["song"],
+    ...overrides,
+  } as Track;
+}
+
+describe("TrackManager", () => {
+  beforeEach(() => {
+    capturedRowProps.length = 0;
+    capturedOnDragEnd = undefined;
+    toastSuccess.mockClear();
+    toastError.mockClear();
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => [] }) as never;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // When initialTracks is supplied, TrackManager skips the on-mount load
+  // so the parent loader's data is the source of truth.
+  test("does not fetch /api/tracks on mount when initialTracks is provided", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+    globalThis.fetch = fetchMock as never;
+
+    await setup(<TrackManager showId="show-1" initialTracks={[makeTrack({ id: "t-1" })]} />);
+
+    // Wait for any micro-tasks the mount effect would schedule.
+    await new Promise((r) => setTimeout(r, 0));
+    const tracksFetches = fetchMock.mock.calls.filter((c) => String(c[0]).startsWith("/api/tracks"));
+    expect(tracksFetches).toHaveLength(0);
+  });
+
+  // With no initialTracks, the on-mount effect kicks off the GET so the
+  // component can render its current state without needing the parent to
+  // pass data down.
+  test("fetches /api/tracks?showId=… on mount when initialTracks is empty", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+    globalThis.fetch = fetchMock as never;
+
+    await setup(<TrackManager showId="show-1" />);
+
+    await waitFor(() => {
+      const urls = fetchMock.mock.calls.map((c) => c[0]);
+      expect(urls).toContain("/api/tracks?showId=show-1");
+    });
+  });
+
+  // Initial tracks render grouped by set with section headers, in the
+  // order S1, S2, S3, E1, E2, E3 (encore-after-sets).
+  test("groups tracks by set with section headers in S→E order", async () => {
+    await setup(
+      <TrackManager
+        showId="show-1"
+        initialTracks={[
+          makeTrack({ id: "t-e1", set: "E1", position: 1 }),
+          makeTrack({ id: "t-s2", set: "S2", position: 1 }),
+          makeTrack({ id: "t-s1", set: "S1", position: 1 }),
+        ]}
+      />,
+    );
+
+    const headings = screen.getAllByRole("heading", { level: 3 }).map((h) => h.textContent);
+    expect(headings).toEqual(["Set 1", "Set 2", "Encore 1"]);
+  });
+
+  // The "Add Track" button shows the form when clicked. The form itself
+  // is the TrackEditForm component — recognized by its "Add" CTA inside
+  // the section.
+  test("clicking 'Add Track' opens the edit form with an 'Add' CTA", async () => {
+    const { user } = await setup(<TrackManager showId="show-1" initialTracks={[makeTrack({ id: "t-1" })]} />);
+
+    expect(screen.queryByLabelText(/track notes/i)).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /add track/i }));
+
+    expect(screen.getByLabelText(/track notes/i)).toBeInTheDocument();
+    // Add CTA inside the form (distinct from the "Add Track" header button).
+    expect(screen.getAllByRole("button", { name: /^add$/i }).length).toBeGreaterThanOrEqual(1);
+  });
+
+  // Cancel closes the form, returning the component to its list-only
+  // state. Add Track button becomes clickable again.
+  test("cancel closes the open edit form", async () => {
+    const { user } = await setup(<TrackManager showId="show-1" initialTracks={[makeTrack({ id: "t-1" })]} />);
+
+    await user.click(screen.getByRole("button", { name: /add track/i }));
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(screen.queryByLabelText(/track notes/i)).not.toBeInTheDocument();
+  });
+
+  // While the form is open, the "Add Track" header button is disabled so
+  // a user can't open a second form on top of the current one.
+  test("Add Track button disables while the form is open", async () => {
+    const { user } = await setup(<TrackManager showId="show-1" initialTracks={[makeTrack({ id: "t-1" })]} />);
+
+    await user.click(screen.getByRole("button", { name: /add track/i }));
+    expect(screen.getByRole("button", { name: /add track/i })).toBeDisabled();
+  });
+
+  // Clicking the edit pencil on a row opens the form pre-populated with
+  // that row's data. The CTA flips to "Update" so the user knows they're
+  // editing rather than adding.
+  test("clicking edit on a row opens the form with the row's data and an 'Update' CTA", async () => {
+    const { user } = await setup(
+      <TrackManager
+        showId="show-1"
+        initialTracks={[makeTrack({ id: "t-1", note: "The jam emerges as minimal trance" })]}
+      />,
+    );
+
+    // The stub above renders an edit button labeled "edit-<id>".
+    await user.click(screen.getByText("edit-t-1"));
+
+    expect(screen.getByLabelText(/track notes/i)).toHaveValue("The jam emerges as minimal trance");
+    expect(screen.getByRole("button", { name: /update/i })).toBeInTheDocument();
+  });
+
+  describe("drag-and-drop reorder", () => {
+    // Same-set reorder: drop t-2 onto t-1's position. The component should
+    // PUT /api/tracks/reorder with the new index-based positions for the
+    // affected set, and apply the new positions optimistically to local
+    // state (read off the captured row props passed on re-render).
+    test("dropping within the same set PUTs reorder updates and updates positions locally", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { id: "t-1", position: 2 },
+          { id: "t-2", position: 1 },
+        ],
+      });
+      globalThis.fetch = fetchMock as never;
+
+      await setup(
+        <TrackManager
+          showId="show-1"
+          initialTracks={[
+            makeTrack({ id: "t-1", set: "S1", position: 1 }),
+            makeTrack({ id: "t-2", set: "S1", position: 2 }),
+          ]}
+        />,
+      );
+
+      // Fire the drag-end as if the user dropped t-2 on t-1's slot.
+      await act(async () => {
+        capturedOnDragEnd?.({ active: { id: "t-2" }, over: { id: "t-1" } });
+      });
+
+      await waitFor(() => {
+        const reorderCalls = fetchMock.mock.calls.filter((c) => c[0] === "/api/tracks/reorder");
+        expect(reorderCalls).toHaveLength(1);
+        const body = JSON.parse(reorderCalls[0][1].body);
+        expect(body.updates).toEqual([
+          { id: "t-2", position: 1, set: "S1" },
+          { id: "t-1", position: 2, set: "S1" },
+        ]);
+      });
+    });
+
+    // Cross-set drag is rejected: the reorder endpoint expects a single
+    // set per call. The component shows an error toast and skips the PUT.
+    test("dropping across sets shows an error toast and skips the PUT", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+      globalThis.fetch = fetchMock as never;
+
+      await setup(
+        <TrackManager
+          showId="show-1"
+          initialTracks={[
+            makeTrack({ id: "t-s1", set: "S1", position: 1 }),
+            makeTrack({ id: "t-s2", set: "S2", position: 1 }),
+          ]}
+        />,
+      );
+
+      await act(async () => {
+        capturedOnDragEnd?.({ active: { id: "t-s1" }, over: { id: "t-s2" } });
+      });
+
+      expect(toastError).toHaveBeenCalledWith(expect.stringMatching(/between different sets/i));
+      const reorderCalls = fetchMock.mock.calls.filter((c) => c[0] === "/api/tracks/reorder");
+      expect(reorderCalls).toHaveLength(0);
+    });
+
+    // Drop-on-self / drop-outside-target: dnd-kit fires onDragEnd with
+    // active.id === over.id (drop on same slot) or over === null
+    // (released outside any droppable). Both are no-ops — no PUT, no toast.
+    test("dropping on the same row is a no-op (no PUT, no toast)", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+      globalThis.fetch = fetchMock as never;
+
+      await setup(<TrackManager showId="show-1" initialTracks={[makeTrack({ id: "t-1" })]} />);
+
+      await act(async () => {
+        capturedOnDragEnd?.({ active: { id: "t-1" }, over: { id: "t-1" } });
+      });
+
+      expect(fetchMock.mock.calls.filter((c) => c[0] === "/api/tracks/reorder")).toHaveLength(0);
+      expect(toastError).not.toHaveBeenCalled();
+    });
+
+    test("dropping outside any droppable (over=null) is a no-op", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+      globalThis.fetch = fetchMock as never;
+
+      await setup(<TrackManager showId="show-1" initialTracks={[makeTrack({ id: "t-1" })]} />);
+
+      await act(async () => {
+        capturedOnDragEnd?.({ active: { id: "t-1" }, over: null });
+      });
+
+      expect(fetchMock.mock.calls.filter((c) => c[0] === "/api/tracks/reorder")).toHaveLength(0);
+      expect(toastError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/app/components/track/track-manager.tsx
+++ b/apps/web/app/components/track/track-manager.tsx
@@ -10,10 +10,9 @@ import {
 } from "@dnd-kit/core";
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { arrayMove, SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
-import { Check, Plus, X } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { Plus } from "lucide-react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { SongSearch } from "~/components/song/song-search";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -26,242 +25,57 @@ import {
 } from "~/components/ui/alert-dialog";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
-import { Checkbox } from "~/components/ui/checkbox";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
 import { SortableTrackItem } from "./sortable-track-item";
+import { compareSets, SET_OPTIONS } from "./track-constants";
+import { TrackEditForm } from "./track-edit-form";
+import { type TrackFormData, useTrackApi } from "./use-track-api";
 
 interface TrackManagerProps {
   showId: string;
   initialTracks?: Track[];
 }
 
-interface TrackFormData {
-  id?: string;
-  songId: string;
-  set: string;
-  position: number;
-  segue: string;
-  note: string | null;
-  song?: Track["song"];
-  annotationDesc?: string | null;
-  allTimer: boolean;
-}
+const INITIAL_FORM: TrackFormData = {
+  songId: "none",
+  set: "S1",
+  position: 1,
+  segue: "none",
+  note: null,
+  annotationDesc: null,
+  allTimer: false,
+};
 
-const SET_OPTIONS = [
-  { value: "S1", label: "Set 1" },
-  { value: "S2", label: "Set 2" },
-  { value: "S3", label: "Set 3" },
-  { value: "E1", label: "Encore 1" },
-  { value: "E2", label: "Encore 2" },
-  { value: "E3", label: "Encore 3" },
-];
-
-const SEGUE_OPTIONS = [
-  { value: "none", label: "No segue" },
-  { value: ">", label: ">" },
-];
-
+/**
+ * The Track List section on the show edit page. Owns the local tracks
+ * state + the form-open / editing-row UI lifecycle, and delegates network
+ * calls to `useTrackApi` and form rendering to `TrackEditForm`. Drag-and-
+ * drop reorder is handled inline because it needs access to the live
+ * tracks list to compute optimistic position updates.
+ */
 export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) {
   const [tracks, setTracks] = useState<Track[]>(initialTracks);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [isAddingNew, setIsAddingNew] = useState(false);
   const [deleteTrackId, setDeleteTrackId] = useState<string | null>(null);
-  const [isCreating, setIsCreating] = useState(false);
-  const [isUpdating, setIsUpdating] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [formData, setFormData] = useState<TrackFormData>({
-    songId: "none",
-    set: "S1",
-    position: 1,
-    segue: "none",
-    note: null,
-    annotationDesc: null,
-    allTimer: false,
-  });
+  const [formData, setFormData] = useState<TrackFormData>(INITIAL_FORM);
 
-  // Set up drag and drop sensors
   const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor));
+  const api = useTrackApi(showId, setTracks);
 
-  const loadTracks = useCallback(async () => {
-    try {
-      const response = await fetch(`/api/tracks?showId=${showId}`);
-      if (response.ok) {
-        const data = await response.json();
-        setTracks(data);
-      }
-    } catch (_error) {
-      toast.error("Failed to load tracks");
-    }
-  }, [showId]);
-
-  // Load tracks when component mounts
+  // Fetch when the parent didn't seed us — keeps the component usable
+  // standalone (e.g. on routes that haven't been migrated to loader
+  // prefetching yet).
   useEffect(() => {
     if (initialTracks.length === 0) {
-      loadTracks();
+      api.loadTracks();
     }
-  }, [initialTracks.length, loadTracks]);
+    // We only want to load once on mount when initialTracks is empty.
+  }, [initialTracks.length, api.loadTracks]);
 
-  // Helper function to sort sets properly (S1, S2, S3, E1, E2, E3)
-  const sortSets = (a: string, b: string) => {
-    const setOrder = { S: 0, E: 1 };
-    const aType = a.charAt(0) as "S" | "E";
-    const bType = b.charAt(0) as "S" | "E";
-    const aNum = Number.parseInt(a.slice(1), 10);
-    const bNum = Number.parseInt(b.slice(1), 10);
-
-    if (aType !== bType) {
-      return setOrder[aType] - setOrder[bType];
-    }
-    return aNum - bNum;
-  };
-
-  // Create track
-  const createTrack = async (data: TrackFormData) => {
-    setIsCreating(true);
-    try {
-      const response = await fetch("/api/tracks", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          ...data,
-          showId,
-          songId: data.songId === "none" ? undefined : data.songId,
-          segue: data.segue === "none" ? null : data.segue,
-          annotationDesc: data.annotationDesc,
-        }),
-      });
-      if (!response.ok) throw new Error("Failed to create track");
-      const newTrack = await response.json();
-
-      // Fetch song information for the newly created track
-      let trackWithSong = newTrack;
-      if (newTrack.songId && !newTrack.song) {
-        try {
-          const songResponse = await fetch(`/api/songs/${newTrack.songId}`);
-          if (songResponse.ok) {
-            const song = await songResponse.json();
-            trackWithSong = { ...newTrack, song };
-          }
-        } catch (_error) {}
-      }
-
-      setTracks((prev) =>
-        [...prev, trackWithSong].sort((a, b) => {
-          if (a.set !== b.set) return sortSets(a.set, b.set);
-          return a.position - b.position;
-        }),
-      );
-      setIsAddingNew(false);
-      resetForm();
-      toast.success("Track added successfully");
-    } catch {
-      toast.error("Failed to add track");
-    } finally {
-      setIsCreating(false);
-    }
-  };
-
-  // Update track
-  const updateTrack = async ({ id, ...data }: TrackFormData & { id: string }) => {
-    setIsUpdating(true);
-    try {
-      const response = await fetch(`/api/tracks/${id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          ...data,
-          songId: data.songId === "none" ? undefined : data.songId,
-          segue: data.segue === "none" ? null : data.segue,
-          annotationDesc: data.annotationDesc,
-        }),
-      });
-      if (!response.ok) throw new Error("Failed to update track");
-      const updatedTrack = await response.json();
-
-      setTracks((prev) =>
-        prev
-          .map((track) => (track.id === updatedTrack.id ? updatedTrack : track))
-          .sort((a, b) => {
-            if (a.set !== b.set) return sortSets(a.set, b.set);
-            return a.position - b.position;
-          }),
-      );
-      setEditingId(null);
-      resetForm();
-      toast.success("Track updated successfully");
-    } catch {
-      toast.error("Failed to update track");
-    } finally {
-      setIsUpdating(false);
-    }
-  };
-
-  // Delete track
-  const deleteTrack = async (id: string) => {
-    setIsDeleting(true);
-    try {
-      const response = await fetch(`/api/tracks/${id}`, {
-        method: "DELETE",
-      });
-      if (!response.ok) throw new Error("Failed to delete track");
-      setTracks((prev) => prev.filter((track) => track.id !== id));
-      toast.success("Track deleted successfully");
-    } catch {
-      toast.error("Failed to delete track");
-    } finally {
-      setIsDeleting(false);
-    }
-  };
-
-  // Reorder tracks
-  const reorderTracks = async (updates: { id: string; position: number; set: string }[]) => {
-    try {
-      const response = await fetch("/api/tracks/reorder", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ updates }),
-      });
-      if (!response.ok) throw new Error("Failed to reorder tracks");
-      const updatedTracks = await response.json();
-
-      // Update local state with new positions, preserving song data
-      setTracks((prev) =>
-        prev.map((track) => {
-          const updated = updatedTracks.find((t: Track) => t.id === track.id);
-          if (updated) {
-            // Merge updated track data with original track's song data
-            return { ...track, ...updated };
-          }
-          return track;
-        }),
-      );
-      toast.success("Track order updated");
-    } catch {
-      toast.error("Failed to reorder tracks");
-    }
-  };
-
-  const resetForm = () => {
-    setFormData({
-      songId: "none",
-      set: "S1",
-      position: 1,
-      segue: "none",
-      note: null,
-      annotationDesc: null,
-      allTimer: false,
-    });
-  };
+  const resetForm = () => setFormData(INITIAL_FORM);
 
   const startEditing = (track: Track) => {
     setEditingId(track.id);
-    // Join all annotations with line breaks for editing
-    const annotationsText =
-      track.annotations
-        ?.map((annotation) => annotation.desc)
-        .filter((desc) => desc)
-        .join("\n") || null;
-
     setFormData({
       id: track.id,
       songId: track.songId,
@@ -270,7 +84,13 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
       segue: track.segue || "none",
       note: track.note,
       song: track.song,
-      annotationDesc: annotationsText,
+      // Editor displays annotations as a multi-line textarea — one
+      // annotation per line.
+      annotationDesc:
+        track.annotations
+          ?.map((annotation) => annotation.desc)
+          .filter((desc) => desc)
+          .join("\n") || null,
       allTimer: track.allTimer ?? false,
     });
   };
@@ -281,50 +101,50 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
     resetForm();
   };
 
-  const handleSubmit = (position?: number) => {
+  const handleSubmit = async () => {
     if (formData.songId === "none") {
       toast.error("Please select a song");
       return;
     }
 
-    const submitData = {
-      ...formData,
-      position: position || formData.position,
-    };
+    // For a new track, drop it at the end of its target set; for an
+    // edit, keep whatever position the track already has.
+    const nextPosition = editingId
+      ? formData.position
+      : Math.max(0, ...tracks.filter((t) => t.set === formData.set).map((t) => t.position)) + 1;
+    const submitData = { ...formData, position: nextPosition };
 
-    if (editingId) {
-      updateTrack({ ...submitData, id: editingId });
-    } else {
-      createTrack(submitData);
+    const result = editingId
+      ? await api.updateTrack({ ...submitData, id: editingId })
+      : await api.createTrack(submitData);
+
+    if (result) {
+      setEditingId(null);
+      setIsAddingNew(false);
+      resetForm();
     }
   };
 
-  const handleDelete = (id: string) => {
-    setDeleteTrackId(id);
-  };
+  const handleDelete = (id: string) => setDeleteTrackId(id);
 
-  const confirmDelete = () => {
+  const confirmDelete = async () => {
     if (deleteTrackId) {
-      deleteTrack(deleteTrackId);
+      await api.deleteTrack(deleteTrackId);
       setDeleteTrackId(null);
     }
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
-
-    if (!over || active.id === over.id) {
-      return;
-    }
+    if (!over || active.id === over.id) return;
 
     const activeTrack = tracks.find((track) => track.id === active.id);
     const overTrack = tracks.find((track) => track.id === over.id);
+    if (!activeTrack || !overTrack) return;
 
-    if (!activeTrack || !overTrack) {
-      return;
-    }
-
-    // Only allow reordering within the same set for now
+    // Cross-set drag is intentionally rejected — the server reorder
+    // endpoint expects a single set at a time. A toast tells the admin
+    // why nothing happened.
     if (activeTrack.set !== overTrack.set) {
       toast.error("Cannot move tracks between different sets yet");
       return;
@@ -333,32 +153,26 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
     const currentSetTracks = tracks.filter((track) => track.set === activeTrack.set);
     const oldIndex = currentSetTracks.findIndex((track) => track.id === active.id);
     const newIndex = currentSetTracks.findIndex((track) => track.id === over.id);
+    if (oldIndex === newIndex) return;
 
-    if (oldIndex !== newIndex) {
-      // Reorder tracks within the set
-      const reorderedSetTracks = arrayMove(currentSetTracks, oldIndex, newIndex);
+    const reorderedSetTracks = arrayMove(currentSetTracks, oldIndex, newIndex);
+    const updates = reorderedSetTracks.map((track, index) => ({
+      id: track.id,
+      position: index + 1,
+      set: track.set,
+    }));
 
-      // Update positions
-      const updates = reorderedSetTracks.map((track, index) => ({
-        id: track.id,
-        position: index + 1,
-        set: track.set,
-      }));
-
-      // Optimistically update local state
-      const updatedTracks = tracks.map((track) => {
+    // Apply the new positions locally before the server confirms so the
+    // row visibly snaps to its new spot — the server PUT just validates.
+    setTracks((prev) =>
+      prev.map((track) => {
         const update = updates.find((u) => u.id === track.id);
         return update ? { ...track, position: update.position } : track;
-      });
-
-      setTracks(updatedTracks);
-
-      // Send updates to server
-      reorderTracks(updates);
-    }
+      }),
+    );
+    api.reorderTracks(updates);
   };
 
-  // Group tracks by set
   const tracksBySet = tracks.reduce(
     (acc, track) => {
       if (!acc[track.set]) acc[track.set] = [];
@@ -368,126 +182,14 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
     {} as Record<string, Track[]>,
   );
 
-  const renderTrackForm = () => {
-    // Auto-calculate position for new tracks
-    const nextPosition = editingId
-      ? formData.position
-      : Math.max(0, ...tracks.filter((t) => t.set === formData.set).map((t) => t.position)) + 1;
-
-    return (
-      <div className="grid grid-cols-1 md:grid-cols-7 gap-4 p-4 bg-content-bg/50 rounded-lg border border-content-bg-secondary">
-        <div className="md:col-span-2">
-          <label htmlFor="track-song" className="block text-sm font-medium text-content-text-secondary mb-1">
-            Song
-          </label>
-          <SongSearch
-            value={formData.songId}
-            onValueChange={(value) => setFormData((prev) => ({ ...prev, songId: value }))}
-            placeholder="Select a song..."
-            className="w-full"
-            initialSong={formData.song}
-          />
-        </div>
-
-        <div>
-          <label htmlFor="track-set" className="block text-sm font-medium text-content-text-secondary mb-1">
-            Set
-          </label>
-          <Select value={formData.set} onValueChange={(value) => setFormData((prev) => ({ ...prev, set: value }))}>
-            <SelectTrigger
-              id="track-set"
-              className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
-            >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent className="bg-content-bg-secondary border-content-bg-secondary">
-              {SET_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value} className="text-content-text-primary">
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div>
-          <label htmlFor="track-segue" className="block text-sm font-medium text-content-text-secondary mb-1">
-            Segue
-          </label>
-          <Select value={formData.segue} onValueChange={(value) => setFormData((prev) => ({ ...prev, segue: value }))}>
-            <SelectTrigger
-              id="track-segue"
-              className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
-            >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent className="bg-content-bg-secondary border-content-bg-secondary">
-              {SEGUE_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value} className="text-content-text-primary">
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div className="md:col-span-2">
-          <label htmlFor="track-annotation" className="block text-sm font-medium text-content-text-secondary mb-1">
-            Annotations
-            <span className="ml-2 text-xs text-content-text-tertiary">(one per line)</span>
-          </label>
-          <textarea
-            id="track-annotation"
-            value={formData.annotationDesc || ""}
-            onChange={(e) => setFormData((prev) => ({ ...prev, annotationDesc: e.target.value || null }))}
-            placeholder="Add annotations (one per line)..."
-            className="w-full px-3 py-2 bg-content-bg-secondary border border-content-bg-secondary text-content-text-primary rounded-md focus:outline-none focus:ring-2 focus:ring-brand-primary"
-            rows={3}
-          />
-        </div>
-
-        <div className="flex items-end gap-2">
-          <Button
-            onClick={() => handleSubmit(nextPosition)}
-            disabled={isCreating || isUpdating}
-            className="bg-brand-primary hover:bg-hover-accent"
-          >
-            <Check className="h-4 w-4 mr-1" />
-            {editingId ? "Update" : "Add"}
-          </Button>
-          <Button
-            onClick={cancelEditing}
-            variant="outline"
-            className="border-content-bg-secondary text-content-text-secondary"
-          >
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
-
-        <div className="md:col-span-7 flex items-center gap-2">
-          <Checkbox
-            id="track-all-timer"
-            checked={formData.allTimer}
-            onCheckedChange={(checked) => setFormData((prev) => ({ ...prev, allTimer: checked === true }))}
-          />
-          <label htmlFor="track-all-timer" className="text-sm font-medium text-content-text-secondary cursor-pointer">
-            All-timer
-          </label>
-        </div>
-      </div>
-    );
-  };
+  const isFormOpen = isAddingNew || editingId !== null;
 
   return (
-    <Card className="border-content-bg-secondary bg-content-bg/50">
+    <Card className="card-premium">
       <CardHeader>
         <div className="flex justify-between items-center">
           <CardTitle className="text-content-text-primary">Track List</CardTitle>
-          <Button
-            onClick={() => setIsAddingNew(true)}
-            disabled={isAddingNew || editingId !== null}
-            className="bg-brand-primary hover:bg-hover-accent"
-          >
+          <Button onClick={() => setIsAddingNew(true)} disabled={isFormOpen} variant="brand">
             <Plus className="h-4 w-4 mr-1" />
             Add Track
           </Button>
@@ -495,7 +197,16 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
       </CardHeader>
 
       <CardContent className="space-y-4">
-        {isAddingNew && renderTrackForm()}
+        {isAddingNew && (
+          <TrackEditForm
+            formData={formData}
+            onFormDataChange={setFormData}
+            isEditing={false}
+            isSubmitting={api.isCreating}
+            onSubmit={handleSubmit}
+            onCancel={cancelEditing}
+          />
+        )}
 
         {Object.keys(tracksBySet).length === 0 ? (
           <div className="text-center py-8 text-content-text-tertiary">
@@ -509,7 +220,7 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
             modifiers={[restrictToVerticalAxis]}
           >
             {Object.entries(tracksBySet)
-              .sort(([a], [b]) => sortSets(a, b))
+              .sort(([a], [b]) => compareSets(a, b))
               .map(([setName, setTracks]) => {
                 const sortedTracks = setTracks.sort((a, b) => a.position - b.position);
                 const trackIds = sortedTracks.map((track) => track.id);
@@ -522,20 +233,27 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
 
                     <SortableContext items={trackIds} strategy={verticalListSortingStrategy}>
                       <div className="space-y-2">
-                        {sortedTracks.map((track) => (
-                          <div key={track.id}>
-                            {editingId === track.id ? (
-                              renderTrackForm()
-                            ) : (
-                              <SortableTrackItem
-                                track={track}
-                                onEdit={startEditing}
-                                onDelete={handleDelete}
-                                isDeleting={isDeleting}
-                              />
-                            )}
-                          </div>
-                        ))}
+                        {sortedTracks.map((track) =>
+                          editingId === track.id ? (
+                            <TrackEditForm
+                              key={track.id}
+                              formData={formData}
+                              onFormDataChange={setFormData}
+                              isEditing
+                              isSubmitting={api.isUpdating}
+                              onSubmit={handleSubmit}
+                              onCancel={cancelEditing}
+                            />
+                          ) : (
+                            <SortableTrackItem
+                              key={track.id}
+                              track={track}
+                              onEdit={startEditing}
+                              onDelete={handleDelete}
+                              isDeleting={api.isDeleting}
+                            />
+                          ),
+                        )}
                       </div>
                     </SortableContext>
                   </div>

--- a/apps/web/app/components/track/use-track-api.test.tsx
+++ b/apps/web/app/components/track/use-track-api.test.tsx
@@ -1,0 +1,297 @@
+import type { Track } from "@bip/domain";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { success: (...args: unknown[]) => toastSuccess(...args), error: (...args: unknown[]) => toastError(...args) },
+}));
+
+import { useTrackApi } from "./use-track-api";
+
+// Track factory — the hook only cares about a few fields, the rest are
+// stubbed to keep the tests readable.
+function makeTrack(overrides: Partial<Track> & { id: string }): Track {
+  return {
+    showId: "show-1",
+    songId: "song-1",
+    set: "S1",
+    position: 1,
+    segue: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    likesCount: 0,
+    slug: overrides.id,
+    note: null,
+    allTimer: false,
+    previousTrackId: null,
+    nextTrackId: null,
+    averageRating: 0,
+    ratingsCount: 0,
+    gap: null,
+    previousPerformanceShowId: null,
+    previousPerformanceShow: null,
+    annotations: [],
+    ...overrides,
+  } as Track;
+}
+
+const BASE_FORM = {
+  songId: "song-1",
+  set: "S1" as const,
+  position: 1,
+  segue: "none" as const,
+  note: null,
+  annotationDesc: null,
+  allTimer: false,
+};
+
+function setupHook(initialTracks: Track[] = []) {
+  // The hook is driven by an external `tracks` array. We mimic that with
+  // a local closure so the test can assert post-hook state.
+  let tracks = [...initialTracks];
+  const setTracks = vi.fn((updater: (prev: Track[]) => Track[]) => {
+    tracks = updater(tracks);
+  });
+  const hook = renderHook(() => useTrackApi("show-1", setTracks as never));
+  return { hook, getTracks: () => tracks, setTracks };
+}
+
+describe("useTrackApi", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    toastSuccess.mockClear();
+    toastError.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("createTrack", () => {
+    // The POST body translates the "none" form sentinel to undefined for
+    // songId (so it's omitted) and null for segue (the API treats null
+    // and missing differently). showId is injected from the hook arg.
+    test("POSTs to /api/tracks with translated form sentinels and the showId", async () => {
+      // Include a `song` in the mock so the hook doesn't trigger its
+      // hydration fallback — that's covered by the dedicated test below.
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ...makeTrack({ id: "new-1", songId: "song-1", set: "S2", position: 3 }),
+          song: { id: "song-1", title: "Floes" },
+        }),
+      });
+      const { hook } = setupHook();
+
+      await act(async () => {
+        await hook.result.current.createTrack({
+          ...BASE_FORM,
+          songId: "none",
+          set: "S2",
+          position: 3,
+          segue: "none",
+        });
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, options] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/tracks");
+      expect(options.method).toBe("POST");
+      const body = JSON.parse(options.body);
+      expect(body.showId).toBe("show-1");
+      expect(body.songId).toBeUndefined();
+      expect(body.segue).toBeNull();
+      expect(body.set).toBe("S2");
+    });
+
+    // The newly-created track is appended to the local list and re-sorted
+    // so it lands in its set's correct position.
+    test("appends the created track and keeps tracks sorted by set + position", async () => {
+      const existing = [
+        makeTrack({ id: "t-s1-1", set: "S1", position: 1 }),
+        makeTrack({ id: "t-s2-1", set: "S2", position: 1 }),
+      ];
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeTrack({ id: "t-s1-2", set: "S1", position: 2 }),
+      });
+      const { hook, getTracks } = setupHook(existing);
+
+      await act(async () => {
+        await hook.result.current.createTrack({ ...BASE_FORM, set: "S1", position: 2 });
+      });
+
+      const ids = getTracks().map((t) => t.id);
+      expect(ids).toEqual(["t-s1-1", "t-s1-2", "t-s2-1"]);
+    });
+
+    // When the server omits the song relation, the hook hydrates it via
+    // /api/songs/:id so the row label renders without a follow-up reload.
+    test("hydrates song data via /api/songs/:id when missing from the response", async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ ...makeTrack({ id: "new-1" }), songId: "song-99", song: null }),
+        })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "song-99", title: "Floes" }) });
+      const { hook, getTracks } = setupHook();
+
+      await act(async () => {
+        await hook.result.current.createTrack({ ...BASE_FORM, songId: "song-99" });
+      });
+
+      expect(fetchMock.mock.calls[1][0]).toBe("/api/songs/song-99");
+      const created = getTracks().find((t) => t.id === "new-1");
+      expect(created?.song).toEqual({ id: "song-99", title: "Floes" });
+    });
+
+    // POST failures surface a toast and don't touch local state.
+    test("fires an error toast and leaves state unchanged on non-ok response", async () => {
+      fetchMock.mockResolvedValueOnce({ ok: false, status: 500 });
+      const existing = [makeTrack({ id: "t-1" })];
+      const { hook, getTracks } = setupHook(existing);
+
+      await act(async () => {
+        await hook.result.current.createTrack(BASE_FORM);
+      });
+
+      expect(toastError).toHaveBeenCalled();
+      expect(getTracks().map((t) => t.id)).toEqual(["t-1"]);
+    });
+
+    // isCreating flips true during the request and back to false when the
+    // request completes — used by the form to disable the submit button.
+    test("toggles isCreating during the request lifecycle", async () => {
+      let resolveCreate: ((value: unknown) => void) | undefined;
+      const pendingResponse = new Promise((resolve) => {
+        resolveCreate = resolve;
+      });
+      fetchMock.mockReturnValueOnce(pendingResponse);
+      const { hook } = setupHook();
+
+      expect(hook.result.current.isCreating).toBe(false);
+      let createPromise: Promise<unknown>;
+      act(() => {
+        createPromise = hook.result.current.createTrack(BASE_FORM);
+      });
+      await waitFor(() => expect(hook.result.current.isCreating).toBe(true));
+
+      await act(async () => {
+        resolveCreate?.({ ok: true, json: async () => makeTrack({ id: "new-1" }) });
+        await createPromise;
+      });
+      expect(hook.result.current.isCreating).toBe(false);
+    });
+  });
+
+  describe("updateTrack", () => {
+    // PUT /api/tracks/:id with the same form-sentinel translation as POST.
+    test("PUTs to /api/tracks/:id with translated form sentinels", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeTrack({ id: "t-1", segue: ">" }),
+      });
+      const { hook } = setupHook([makeTrack({ id: "t-1" })]);
+
+      await act(async () => {
+        await hook.result.current.updateTrack({ ...BASE_FORM, id: "t-1", segue: ">" });
+      });
+
+      const [url, options] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/tracks/t-1");
+      expect(options.method).toBe("PUT");
+      const body = JSON.parse(options.body);
+      expect(body.segue).toBe(">");
+    });
+
+    // The returned track replaces the existing entry in the local list,
+    // and the list is re-sorted so a set/position change moves the row.
+    test("replaces the matching track and re-sorts the list", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeTrack({ id: "t-1", set: "S2", position: 5 }),
+      });
+      const { hook, getTracks } = setupHook([
+        makeTrack({ id: "t-1", set: "S1", position: 1 }),
+        makeTrack({ id: "t-2", set: "S2", position: 4 }),
+      ]);
+
+      await act(async () => {
+        await hook.result.current.updateTrack({ ...BASE_FORM, id: "t-1", set: "S2", position: 5 });
+      });
+
+      expect(getTracks().map((t) => t.id)).toEqual(["t-2", "t-1"]);
+    });
+  });
+
+  describe("deleteTrack", () => {
+    // DELETE removes the row from local state on success and fires a toast.
+    test("DELETEs /api/tracks/:id and removes the row from state", async () => {
+      fetchMock.mockResolvedValueOnce({ ok: true });
+      const { hook, getTracks } = setupHook([makeTrack({ id: "t-1" }), makeTrack({ id: "t-2" })]);
+
+      await act(async () => {
+        await hook.result.current.deleteTrack("t-1");
+      });
+
+      expect(fetchMock.mock.calls[0][0]).toBe("/api/tracks/t-1");
+      expect(fetchMock.mock.calls[0][1].method).toBe("DELETE");
+      expect(getTracks().map((t) => t.id)).toEqual(["t-2"]);
+    });
+  });
+
+  describe("reorderTracks", () => {
+    // The reorder endpoint takes a list of {id, position, set} updates.
+    // The hook merges the server's response (full track records) into
+    // local state, preserving any client-only fields like `song`.
+    test("PUTs reorder updates and merges the response into local state", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: "t-1", position: 2 },
+          { id: "t-2", position: 1 },
+        ],
+      });
+      const { hook, getTracks } = setupHook([
+        makeTrack({ id: "t-1", position: 1, song: { title: "Floes" } as never }),
+        makeTrack({ id: "t-2", position: 2, song: { title: "Waves" } as never }),
+      ]);
+
+      await act(async () => {
+        await hook.result.current.reorderTracks([
+          { id: "t-1", position: 2, set: "S1" },
+          { id: "t-2", position: 1, set: "S1" },
+        ]);
+      });
+
+      const tracks = getTracks();
+      expect(tracks.find((t) => t.id === "t-1")?.position).toBe(2);
+      // Original song data preserved — the server response only includes
+      // position/set, not the full nested relation.
+      expect((tracks.find((t) => t.id === "t-1")?.song as { title: string } | undefined)?.title).toBe("Floes");
+    });
+  });
+
+  describe("loadTracks", () => {
+    // Initial-load helper: hits /api/tracks?showId=…, fills local state,
+    // and swallows errors with a toast so the form doesn't blow up if the
+    // load fails on mount.
+    test("fetches /api/tracks?showId=… and replaces local state with the response", async () => {
+      const tracks = [makeTrack({ id: "t-loaded-1" }), makeTrack({ id: "t-loaded-2" })];
+      fetchMock.mockResolvedValueOnce({ ok: true, json: async () => tracks });
+      const { hook, getTracks } = setupHook();
+
+      await act(async () => {
+        await hook.result.current.loadTracks();
+      });
+
+      expect(fetchMock.mock.calls[0][0]).toBe("/api/tracks?showId=show-1");
+      expect(getTracks().map((t) => t.id)).toEqual(["t-loaded-1", "t-loaded-2"]);
+    });
+  });
+});

--- a/apps/web/app/components/track/use-track-api.ts
+++ b/apps/web/app/components/track/use-track-api.ts
@@ -1,0 +1,184 @@
+import type { Track } from "@bip/domain";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { compareSets } from "./track-constants";
+
+export interface TrackFormData {
+  id?: string;
+  songId: string;
+  set: string;
+  position: number;
+  segue: string;
+  note: string | null;
+  song?: Track["song"];
+  annotationDesc?: string | null;
+  allTimer: boolean;
+}
+
+type SetTracks = (updater: (prev: Track[]) => Track[]) => void;
+
+function sortTracks(tracks: Track[]): Track[] {
+  return [...tracks].sort((a, b) => {
+    if (a.set !== b.set) return compareSets(a.set, b.set);
+    return a.position - b.position;
+  });
+}
+
+// Translates the form's "none" sentinels to the shape the API expects.
+// "none" songId → undefined (omitted), "none" segue → null (explicitly cleared).
+function buildSavePayload(data: TrackFormData) {
+  return {
+    ...data,
+    songId: data.songId === "none" ? undefined : data.songId,
+    segue: data.segue === "none" ? null : data.segue,
+    annotationDesc: data.annotationDesc,
+  };
+}
+
+/**
+ * Owns the four track-mutation network calls (create / update / delete /
+ * reorder) plus the initial load. Each call updates the parent's tracks
+ * state via the supplied `setTracks` updater and fires a toast on
+ * success/failure. UI state transitions (closing the form, resetting
+ * fields, etc.) stay with the caller.
+ */
+export function useTrackApi(showId: string, setTracks: SetTracks) {
+  const [isCreating, setIsCreating] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const loadTracks = useCallback(async () => {
+    try {
+      const response = await fetch(`/api/tracks?showId=${showId}`);
+      if (response.ok) {
+        const data = (await response.json()) as Track[];
+        setTracks(() => data);
+      }
+    } catch {
+      toast.error("Failed to load tracks");
+    }
+  }, [showId, setTracks]);
+
+  const createTrack = useCallback(
+    async (data: TrackFormData): Promise<Track | null> => {
+      setIsCreating(true);
+      try {
+        const response = await fetch("/api/tracks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...buildSavePayload(data), showId }),
+        });
+        if (!response.ok) throw new Error("Failed to create track");
+        const newTrack = (await response.json()) as Track;
+
+        // Hydrate the song relation if the server didn't include it — keeps
+        // the row label correct without forcing a full reload.
+        let trackWithSong = newTrack;
+        if (newTrack.songId && !newTrack.song) {
+          try {
+            const songResponse = await fetch(`/api/songs/${newTrack.songId}`);
+            if (songResponse.ok) {
+              const song = await songResponse.json();
+              trackWithSong = { ...newTrack, song };
+            }
+          } catch {
+            // Non-fatal — the row still renders, just with whatever the
+            // create endpoint returned.
+          }
+        }
+
+        setTracks((prev) => sortTracks([...prev, trackWithSong]));
+        toast.success("Track added successfully");
+        return trackWithSong;
+      } catch {
+        toast.error("Failed to add track");
+        return null;
+      } finally {
+        setIsCreating(false);
+      }
+    },
+    [showId, setTracks],
+  );
+
+  const updateTrack = useCallback(
+    async ({ id, ...data }: TrackFormData & { id: string }): Promise<Track | null> => {
+      setIsUpdating(true);
+      try {
+        const response = await fetch(`/api/tracks/${id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(buildSavePayload(data)),
+        });
+        if (!response.ok) throw new Error("Failed to update track");
+        const updatedTrack = (await response.json()) as Track;
+
+        setTracks((prev) => sortTracks(prev.map((track) => (track.id === updatedTrack.id ? updatedTrack : track))));
+        toast.success("Track updated successfully");
+        return updatedTrack;
+      } catch {
+        toast.error("Failed to update track");
+        return null;
+      } finally {
+        setIsUpdating(false);
+      }
+    },
+    [setTracks],
+  );
+
+  const deleteTrack = useCallback(
+    async (id: string): Promise<boolean> => {
+      setIsDeleting(true);
+      try {
+        const response = await fetch(`/api/tracks/${id}`, { method: "DELETE" });
+        if (!response.ok) throw new Error("Failed to delete track");
+        setTracks((prev) => prev.filter((track) => track.id !== id));
+        toast.success("Track deleted successfully");
+        return true;
+      } catch {
+        toast.error("Failed to delete track");
+        return false;
+      } finally {
+        setIsDeleting(false);
+      }
+    },
+    [setTracks],
+  );
+
+  const reorderTracks = useCallback(
+    async (updates: { id: string; position: number; set: string }[]): Promise<void> => {
+      try {
+        const response = await fetch("/api/tracks/reorder", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ updates }),
+        });
+        if (!response.ok) throw new Error("Failed to reorder tracks");
+        const updatedTracks = (await response.json()) as Partial<Track>[];
+
+        // Merge server-confirmed positions back into local state while
+        // preserving any client-only relation data the server didn't echo.
+        setTracks((prev) =>
+          prev.map((track) => {
+            const updated = updatedTracks.find((t) => t.id === track.id);
+            return updated ? { ...track, ...updated } : track;
+          }),
+        );
+        toast.success("Track order updated");
+      } catch {
+        toast.error("Failed to reorder tracks");
+      }
+    },
+    [setTracks],
+  );
+
+  return {
+    loadTracks,
+    createTrack,
+    updateTrack,
+    deleteTrack,
+    reorderTracks,
+    isCreating,
+    isUpdating,
+    isDeleting,
+  };
+}

--- a/apps/web/app/components/ui/button.test.tsx
+++ b/apps/web/app/components/ui/button.test.tsx
@@ -1,0 +1,40 @@
+import { setup } from "@test/test-utils";
+import { describe, expect, test } from "vitest";
+
+import { Button } from "./button";
+
+describe("Button variants", () => {
+  // The "brand" variant is the project's primary CTA — the purple
+  // bg-brand-primary + bg-hover-accent on hover. Centralizing the styling
+  // in the Button's variant system lets every primary submit/Add button
+  // declare `variant="brand"` instead of repeating the className string.
+  test("variant='brand' applies the brand primary styling", async () => {
+    const { container } = await setup(<Button variant="brand">Submit</Button>);
+    const btn = container.querySelector("button") as HTMLButtonElement;
+    expect(btn.className).toContain("bg-brand-primary");
+    expect(btn.className).toContain("hover:bg-hover-accent");
+  });
+
+  // Picking variant="brand" should NOT pick up the shadcn default variant
+  // classes — variants are mutually exclusive.
+  test("variant='brand' does not include the default variant's bg-primary", async () => {
+    const { container } = await setup(<Button variant="brand">Submit</Button>);
+    const btn = container.querySelector("button") as HTMLButtonElement;
+    // The default variant uses `bg-primary` (semantic shadcn token); brand
+    // uses `bg-brand-primary`. Match-by-word to avoid `bg-brand-primary`
+    // false-positive matching `bg-primary`.
+    expect(btn.className).not.toMatch(/(^|\s)bg-primary(\s|$)/);
+  });
+
+  // The "cancel" variant is the project's secondary "back / dismiss"
+  // button — outlined with the dark-theme border, secondary text color,
+  // and a fill-on-hover transition that signals the affordance.
+  test("variant='cancel' applies the outlined cancel styling with hover state", async () => {
+    const { container } = await setup(<Button variant="cancel">Cancel</Button>);
+    const btn = container.querySelector("button") as HTMLButtonElement;
+    expect(btn.className).toContain("border-content-bg-secondary");
+    expect(btn.className).toContain("text-content-text-secondary");
+    expect(btn.className).toContain("hover:bg-content-bg-secondary");
+    expect(btn.className).toContain("hover:text-content-text-primary");
+  });
+});

--- a/apps/web/app/components/ui/button.tsx
+++ b/apps/web/app/components/ui/button.tsx
@@ -10,6 +10,15 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        // The project's primary CTA — purple brand bg with the darker
+        // `hover-accent` token on hover. Used for "Save", "Update",
+        // "Add Track", etc. across the admin forms.
+        brand: "bg-brand-primary text-content-text-primary hover:bg-hover-accent",
+        // Secondary "Cancel / back / dismiss" CTA — outlined dark-theme
+        // border with a fill-on-hover transition. Paired with `variant="brand"`
+        // submits across the admin forms.
+        cancel:
+          "border border-content-bg-secondary bg-transparent text-content-text-secondary hover:bg-content-bg-secondary hover:text-content-text-primary",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",

--- a/apps/web/app/components/ui/filters/select-filter.tsx
+++ b/apps/web/app/components/ui/filters/select-filter.tsx
@@ -1,3 +1,4 @@
+import { glassSelectContentClass, glassSelectItemClass, glassSelectTriggerClass } from "~/components/ui/glass-select";
 import {
   Select,
   SelectContent,
@@ -8,10 +9,6 @@ import {
   SelectValue,
 } from "~/components/ui/select";
 
-const selectTriggerClass =
-  "h-[34px] text-sm bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20";
-const selectContentClass = "bg-glass-bg border-glass-border backdrop-blur-md";
-const selectItemClass = "text-content-text-primary hover:bg-hover-glass";
 const labelClass =
   "text-xs font-medium text-content-text-secondary uppercase tracking-wide mb-1.5 h-[18px] flex items-center";
 const groupLabelClass = "text-xs uppercase text-content-text-tertiary tracking-wide py-1";
@@ -48,12 +45,12 @@ export function SelectFilter({
         {label}
       </label>
       <Select value={value} onValueChange={onValueChange}>
-        <SelectTrigger id={id} className={`${width ?? ""} ${selectTriggerClass}`}>
+        <SelectTrigger id={id} className={`${width ?? ""} ${glassSelectTriggerClass}`}>
           <SelectValue placeholder={placeholder} />
         </SelectTrigger>
-        <SelectContent className={selectContentClass}>
+        <SelectContent className={glassSelectContentClass}>
           {options?.map((option) => (
-            <SelectItem key={option.value} value={option.value} className={selectItemClass}>
+            <SelectItem key={option.value} value={option.value} className={glassSelectItemClass}>
               {option.label}
             </SelectItem>
           ))}
@@ -61,7 +58,7 @@ export function SelectFilter({
             <SelectGroup key={group.label}>
               <SelectLabel className={groupLabelClass}>{group.label}</SelectLabel>
               {group.options.map((option) => (
-                <SelectItem key={option.value} value={option.value} className={selectItemClass}>
+                <SelectItem key={option.value} value={option.value} className={glassSelectItemClass}>
                   {option.label}
                 </SelectItem>
               ))}

--- a/apps/web/app/components/ui/glass-select.test.tsx
+++ b/apps/web/app/components/ui/glass-select.test.tsx
@@ -1,0 +1,62 @@
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { GlassSelect, glassSelectContentClass, glassSelectTriggerClass } from "./glass-select";
+
+const OPTIONS = [
+  { value: "S1", label: "Set 1" },
+  { value: "S2", label: "Set 2" },
+];
+
+describe("GlassSelect", () => {
+  // The trigger button shows the label of the currently-selected option
+  // — verified by rendering with `value` matching an option.
+  test("renders the selected option's label on the trigger", async () => {
+    await setup(<GlassSelect value="S2" onValueChange={vi.fn()} options={OPTIONS} />);
+    expect(screen.getByRole("combobox")).toHaveTextContent("Set 2");
+  });
+
+  // No selection + a placeholder renders the placeholder on the trigger.
+  test("renders the placeholder when no value matches", async () => {
+    await setup(<GlassSelect value="" onValueChange={vi.fn()} options={OPTIONS} placeholder="Pick a set" />);
+    expect(screen.getByRole("combobox")).toHaveTextContent("Pick a set");
+  });
+
+  // Selecting an option fires onValueChange with the option's value (not
+  // its label) so the caller can store the canonical key.
+  test("selecting an option fires onValueChange with the value (not the label)", async () => {
+    const onValueChange = vi.fn();
+    const { user } = await setup(<GlassSelect value="S1" onValueChange={onValueChange} options={OPTIONS} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("Set 2"));
+    expect(onValueChange).toHaveBeenCalledWith("S2");
+  });
+
+  // The trigger applies the project's glass styling so it visually
+  // matches the /songs filter dropdowns and other GlassSelect consumers.
+  test("applies the glass trigger styling", async () => {
+    await setup(<GlassSelect value="S1" onValueChange={vi.fn()} options={OPTIONS} />);
+    const trigger = screen.getByRole("combobox");
+    expect(trigger.className).toContain("bg-glass-bg");
+    expect(trigger.className).toContain("border-glass-border");
+  });
+
+  // The shared className constants are exported so other components
+  // (notably SelectFilter, used on /songs) can reuse them and stay in
+  // visual lockstep with GlassSelect.
+  test("exposes shared class-name constants for sibling components", () => {
+    expect(glassSelectTriggerClass).toContain("bg-glass-bg");
+    expect(glassSelectContentClass).toContain("bg-glass-bg");
+  });
+
+  // Caller-supplied className stacks with the glass classes so layouts
+  // can specify width / sizing without losing the visual treatment.
+  test("merges caller-supplied className with the trigger's glass classes", async () => {
+    await setup(<GlassSelect value="S1" onValueChange={vi.fn()} options={OPTIONS} className="w-40" />);
+    const trigger = screen.getByRole("combobox");
+    expect(trigger.className).toContain("w-40");
+    expect(trigger.className).toContain("bg-glass-bg");
+  });
+});

--- a/apps/web/app/components/ui/glass-select.tsx
+++ b/apps/web/app/components/ui/glass-select.tsx
@@ -1,0 +1,53 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
+import { cn } from "~/lib/utils";
+
+export const glassSelectTriggerClass =
+  "h-[34px] text-sm bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20";
+export const glassSelectContentClass = "bg-glass-bg border-glass-border backdrop-blur-md";
+export const glassSelectItemClass = "text-content-text-primary hover:bg-hover-glass";
+
+export interface GlassSelectOption {
+  value: string;
+  label: string;
+}
+
+interface GlassSelectProps {
+  id?: string;
+  value: string;
+  onValueChange: (value: string) => void;
+  options: GlassSelectOption[];
+  placeholder?: string;
+  className?: string;
+  ariaLabel?: string;
+}
+
+/**
+ * Standard select dropdown with the project's "glass" styling — same trigger
+ * and popover treatment as the filter dropdowns on /songs (Time Range, Cover,
+ * Author). Use this anywhere a finite-option select is needed so dropdowns
+ * stay visually consistent across pages.
+ */
+export function GlassSelect({
+  id,
+  value,
+  onValueChange,
+  options,
+  placeholder,
+  className,
+  ariaLabel,
+}: GlassSelectProps) {
+  return (
+    <Select value={value} onValueChange={onValueChange}>
+      <SelectTrigger id={id} aria-label={ariaLabel} className={cn(glassSelectTriggerClass, className)}>
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent className={glassSelectContentClass}>
+        {options.map((option) => (
+          <SelectItem key={option.value} value={option.value} className={glassSelectItemClass}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/web/app/components/ui/search-picker.test.tsx
+++ b/apps/web/app/components/ui/search-picker.test.tsx
@@ -1,0 +1,232 @@
+import { setup } from "@test/test-utils";
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { SearchPicker } from "./search-picker";
+
+interface Item {
+  id: string;
+  name: string;
+}
+
+const ITEMS: Item[] = [
+  { id: "1", name: "Apple" },
+  { id: "2", name: "Banana" },
+  { id: "3", name: "Cherry" },
+];
+
+// Default props shared across happy-path tests. Individual tests override
+// only the props they need so each test reads as a delta from the baseline.
+function baseProps(overrides: Partial<React.ComponentProps<typeof SearchPicker<Item>>> = {}) {
+  return {
+    value: null,
+    onValueChange: vi.fn(),
+    fetchResults: vi.fn().mockResolvedValue([]),
+    itemId: (item: Item) => item.id,
+    itemLabel: (item: Item) => item.name,
+    placeholder: "Pick one…",
+    ...overrides,
+  };
+}
+
+describe("SearchPicker", () => {
+  // Renders the placeholder when no value is selected and no initial item
+  // is provided. This is the cold-start state for most pickers.
+  test("renders the placeholder when value is null and no initial item", async () => {
+    await setup(<SearchPicker<Item> {...baseProps({ placeholder: "Pick a fruit" })} />);
+    expect(screen.getByRole("combobox")).toHaveTextContent("Pick a fruit");
+  });
+
+  // When an initial item is provided (the caller already has the record),
+  // the trigger shows its label without waiting for the user to interact.
+  test("renders the initial item's label on the trigger", async () => {
+    await setup(<SearchPicker<Item> {...baseProps({ value: "1", initialItem: { id: "1", name: "Apple" } })} />);
+    expect(screen.getByRole("combobox")).toHaveTextContent("Apple");
+  });
+
+  // When only `fetchById` is provided (no initialItem), the trigger seeds
+  // its label asynchronously. Useful for forms that only know the id.
+  test("seeds the trigger label by calling fetchById", async () => {
+    const fetchById = vi.fn().mockResolvedValue({ id: "2", name: "Banana" });
+
+    await setup(<SearchPicker<Item> {...baseProps({ value: "2", fetchById })} />);
+
+    await waitFor(() => expect(fetchById).toHaveBeenCalledWith("2"));
+    await waitFor(() => expect(screen.getByRole("combobox")).toHaveTextContent("Banana"));
+  });
+
+  // Debounce contract: fetchResults fires after a 300ms quiet period, not
+  // on every keystroke. We assert via the call count after waiting past
+  // the debounce window. Real timers keep this aligned with production
+  // behavior — fake timers + cmdk's internal scheduling fight each other.
+  test("debounces fetchResults so a burst of input collapses to one call", async () => {
+    const fetchResults = vi.fn().mockResolvedValue(ITEMS);
+
+    const { user } = await setup(<SearchPicker<Item> {...baseProps({ fetchResults })} />);
+
+    // Mount fires the initial empty-query fetch via the debounced effect.
+    await waitFor(() => expect(fetchResults).toHaveBeenCalledWith(""));
+    fetchResults.mockClear();
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search…");
+    await user.type(input, "app");
+
+    await waitFor(() => expect(fetchResults).toHaveBeenCalledWith("app"), { timeout: 1500 });
+    // The intermediate "a" and "ap" debounced away — at most one call for
+    // the final query (a small amount of slop is fine because user.type
+    // delays between keystrokes).
+    const appCalls = fetchResults.mock.calls.filter((args) => args[0] === "app");
+    expect(appCalls.length).toBe(1);
+  });
+
+  // Clicking an item reports its id via onValueChange and closes the
+  // popover. This is the core selection path the wrappers depend on.
+  test("clicking a result fires onValueChange with the item id and closes the popover", async () => {
+    const onValueChange = vi.fn();
+    const fetchResults = vi.fn().mockResolvedValue(ITEMS);
+
+    const { user } = await setup(<SearchPicker<Item> {...baseProps({ onValueChange, fetchResults })} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const cherry = await screen.findByText("Cherry");
+    await user.click(cherry);
+
+    expect(onValueChange).toHaveBeenCalledWith("3");
+    await waitFor(() => expect(screen.queryByPlaceholderText("Search…")).not.toBeInTheDocument());
+  });
+
+  // When `noneLabel` is set, an extra clear-selection row appears at the
+  // top of the list. Selecting it fires onValueChange(null) so callers
+  // can drop the current selection.
+  test("noneLabel renders a clear-selection row that reports null", async () => {
+    const onValueChange = vi.fn();
+    const fetchResults = vi.fn().mockResolvedValue(ITEMS);
+
+    const { user } = await setup(
+      <SearchPicker<Item> {...baseProps({ value: "1", onValueChange, fetchResults, noneLabel: "Clear" })} />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("Clear"));
+
+    expect(onValueChange).toHaveBeenCalledWith(null);
+  });
+
+  // Without `noneLabel`, the clear row is suppressed entirely. Pickers
+  // that require a selection use this to prevent accidental clearing.
+  test("noneLabel undefined suppresses the clear-selection row", async () => {
+    const fetchResults = vi.fn().mockResolvedValue(ITEMS);
+
+    const { user } = await setup(<SearchPicker<Item> {...baseProps({ fetchResults })} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await screen.findByText("Apple");
+    expect(screen.queryByText("Clear")).not.toBeInTheDocument();
+    expect(screen.queryByText(/^No /)).not.toBeInTheDocument();
+  });
+
+  // `loadOnOpen` triggers an immediate fetch when the popover opens —
+  // bypassing the debounce delay — so wrappers like AuthorSearch can
+  // populate a top-N list before the user types anything.
+  test("loadOnOpen fires fetchResults('') immediately on open", async () => {
+    const fetchResults = vi.fn().mockResolvedValue(ITEMS);
+
+    const { user } = await setup(<SearchPicker<Item> {...baseProps({ fetchResults, loadOnOpen: true })} />);
+
+    // Drain the initial mount fetch so we don't conflate it with the open.
+    await waitFor(() => expect(fetchResults).toHaveBeenCalled());
+    fetchResults.mockClear();
+
+    await user.click(screen.getByRole("combobox"));
+    await waitFor(() => expect(fetchResults).toHaveBeenCalledWith(""));
+  });
+
+  // `emptyMessage` accepts a function of the current query so wrappers
+  // can show "Type to search…" until the query is long enough, then
+  // "No results." when it is.
+  test("emptyMessage function receives the current query", async () => {
+    const fetchResults = vi.fn().mockResolvedValue([]);
+
+    const { user } = await setup(
+      <SearchPicker<Item>
+        {...baseProps({
+          fetchResults,
+          emptyMessage: (q) => (q.length < 2 ? "Type more" : "No matches"),
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    expect(await screen.findByText("Type more")).toBeInTheDocument();
+
+    const input = screen.getByPlaceholderText("Search…");
+    await user.type(input, "xyz");
+    expect(await screen.findByText("No matches", undefined, { timeout: 1500 })).toBeInTheDocument();
+  });
+
+  // `allowCreate` exposes a "Create …" row at the top of the list. Default
+  // shouldShow requires 2+ trimmed chars and no exact-match in items.
+  test("allowCreate shows a create row at 2+ chars when no exact match exists", async () => {
+    const fetchResults = vi.fn().mockResolvedValue([]);
+    const onCreate = vi.fn().mockResolvedValue({ id: "9", name: "Durian" });
+    const onValueChange = vi.fn();
+
+    const { user } = await setup(
+      <SearchPicker<Item>
+        {...baseProps({
+          fetchResults,
+          onValueChange,
+          allowCreate: { label: (q) => `Create "${q}"`, onCreate },
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search…");
+    await user.type(input, "Du");
+
+    const createRow = await screen.findByText('Create "Du"', undefined, { timeout: 1500 });
+    await user.click(createRow);
+
+    await waitFor(() => expect(onCreate).toHaveBeenCalledWith("Du"));
+    await waitFor(() => expect(onValueChange).toHaveBeenCalledWith("9"));
+  });
+
+  // Default shouldShow hides the create row when the query matches an
+  // existing item exactly (case-insensitive). Prevents duplicate creation
+  // when the user typed something already in the catalog.
+  test("allowCreate hides the create row when an exact match already exists", async () => {
+    const fetchResults = vi.fn().mockResolvedValue([{ id: "1", name: "Apple" }]);
+
+    const { user } = await setup(
+      <SearchPicker<Item>
+        {...baseProps({
+          fetchResults,
+          allowCreate: { label: (q) => `Create "${q}"`, onCreate: vi.fn() },
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search…");
+    await user.type(input, "apple");
+
+    // Give the debounce + fetch a chance to settle; the existing item is
+    // already in items so the create row should never appear.
+    await screen.findByText("Apple");
+    expect(screen.queryByText(/Create "/)).not.toBeInTheDocument();
+  });
+
+  // fetchResults rejecting (e.g. server 500) is handled gracefully: items
+  // clear and the configured emptyMessage shows. Prevents a transient
+  // network error from corrupting the local items list.
+  test("fetchResults rejecting clears the list without surfacing the error", async () => {
+    const fetchResults = vi.fn().mockRejectedValue(new Error("network down"));
+
+    const { user } = await setup(<SearchPicker<Item> {...baseProps({ fetchResults, emptyMessage: "no results" })} />);
+
+    await user.click(screen.getByRole("combobox"));
+    expect(await screen.findByText("no results")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/ui/search-picker.tsx
+++ b/apps/web/app/components/ui/search-picker.tsx
@@ -1,0 +1,270 @@
+import { Check, ChevronsUpDown, Plus } from "lucide-react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
+import { Button } from "~/components/ui/button";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "~/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
+import { cn } from "~/lib/utils";
+
+export interface SearchPickerCreateOption<T> {
+  // Built from the current query — e.g. `Create "Foo"`.
+  label: (query: string) => string;
+  // Called when the user clicks the create option. Returns the new item, or
+  // null if creation failed. On success, the new item is selected and the
+  // popover closes.
+  onCreate: (query: string) => Promise<T | null>;
+  // Optional predicate to decide whether the create option should show.
+  // Default: query has at least 2 trimmed chars AND no existing item
+  // already matches the query exactly via itemLabel comparison.
+  shouldShow?: (query: string, items: T[]) => boolean;
+}
+
+interface SearchPickerProps<T> {
+  // The selected item's id, or null when nothing is selected.
+  value: string | null;
+  onValueChange: (value: string | null) => void;
+
+  // Returns items matching the current query. Wrappers decide what "empty
+  // query" means — return [] to suppress the list, or return top-N items.
+  fetchResults: (query: string) => Promise<T[]>;
+  // Optional: fetch by id so the trigger label can render before the user
+  // opens the popover. Use this OR `initialItem`.
+  fetchById?: (id: string) => Promise<T | null>;
+  // Pre-seeded initial item — alternative to `fetchById` when the caller
+  // already has the full record (e.g. from a parent loader).
+  initialItem?: T | null;
+
+  itemId: (item: T) => string;
+  itemLabel: (item: T) => ReactNode;
+
+  // Optional clear-selection row at the top of the list. When set, a row
+  // with this label is rendered first; selecting it fires onValueChange(null).
+  noneLabel?: string;
+
+  // Optional create-from-query affordance (AuthorSearch's feature). When
+  // provided, a "Create …" row appears at the top of the list whenever
+  // `shouldShow` returns true.
+  allowCreate?: SearchPickerCreateOption<T>;
+
+  // If true, fires fetchResults("") as soon as the popover opens — used
+  // when the wrapper wants to seed a top-N list before the user types.
+  loadOnOpen?: boolean;
+
+  placeholder?: string;
+  searchPlaceholder?: string;
+  // Static message OR function of the current query. The function form
+  // lets wrappers say things like "Type to search…" until the query is
+  // long enough, then "No results."
+  emptyMessage?: string | ((query: string) => string);
+  loadingMessage?: string;
+
+  className?: string;
+}
+
+/**
+ * Generic popover-combobox for picking a single item from an async search.
+ * Powers AuthorSearch, SongSearch, VenueSearch (and any future "pick a thing
+ * by typing to search" UI). The wrapper supplies the domain-specific bits
+ * (API endpoint, item shape, copy); this component owns the popover shell,
+ * debounced search, selection state, and "glass" styling so all three look
+ * and feel the same.
+ */
+export function SearchPicker<T>({
+  value,
+  onValueChange,
+  fetchResults,
+  fetchById,
+  initialItem,
+  itemId,
+  itemLabel,
+  noneLabel,
+  allowCreate,
+  loadOnOpen = false,
+  placeholder = "Search…",
+  searchPlaceholder = "Search…",
+  emptyMessage = "No results found.",
+  loadingMessage = "Searching…",
+  className,
+}: SearchPickerProps<T>) {
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState<T[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [currentItem, setCurrentItem] = useState<T | null>(initialItem ?? null);
+  const [hasLoadedInitial, setHasLoadedInitial] = useState(false);
+
+  // Pick the matching item from the latest results, falling back to the
+  // pre-seeded `currentItem` (initialItem or fetched-by-id).
+  const selectedItem = (value != null && items.find((it) => itemId(it) === value)) || currentItem;
+
+  // Seed the trigger label by fetching the selected item by id when it
+  // isn't in `items` and no `initialItem` was provided. Re-runs whenever
+  // `value` changes so route navigations / form resets stay in sync.
+  useEffect(() => {
+    if (!fetchById) return;
+    if (value == null) {
+      setCurrentItem(initialItem ?? null);
+      return;
+    }
+    if (currentItem && itemId(currentItem) === value) return;
+    if (items.find((it) => itemId(it) === value)) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const fetched = await fetchById(value);
+        if (!cancelled && fetched) setCurrentItem(fetched);
+      } catch {
+        // Trigger keeps placeholder if the fetch fails — non-fatal.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [value, fetchById, currentItem, items, itemId, initialItem]);
+
+  const runSearch = useCallback(
+    async (query: string) => {
+      setLoading(true);
+      try {
+        const next = await fetchResults(query);
+        setItems(next);
+      } catch {
+        // Empty results on failure; UI shows the configured empty message.
+        setItems([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [fetchResults],
+  );
+
+  // Debounce the search so we don't spam the API on every keystroke.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      runSearch(searchQuery);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery, runSearch]);
+
+  // Optional load-on-open: triggers the first fetch immediately (without
+  // waiting for the debounce) so the user sees a populated list before
+  // they start typing.
+  useEffect(() => {
+    if (open && loadOnOpen && !hasLoadedInitial) {
+      setHasLoadedInitial(true);
+      runSearch("");
+    }
+  }, [open, loadOnOpen, hasLoadedInitial, runSearch]);
+
+  const defaultShouldShowCreate = (query: string, currentItems: T[]) => {
+    const trimmed = query.trim();
+    if (trimmed.length < 2) return false;
+    return !currentItems.some((item) => {
+      const label = itemLabel(item);
+      return typeof label === "string" && label.toLowerCase() === trimmed.toLowerCase();
+    });
+  };
+
+  const showCreate = allowCreate != null && (allowCreate.shouldShow ?? defaultShouldShowCreate)(searchQuery, items);
+
+  const handleCreate = async () => {
+    if (!allowCreate || !searchQuery.trim() || creating) return;
+    setCreating(true);
+    try {
+      const created = await allowCreate.onCreate(searchQuery.trim());
+      if (created) {
+        setItems((prev) => [created, ...prev]);
+        onValueChange(itemId(created));
+        setCurrentItem(created);
+        setSearchQuery("");
+        setOpen(false);
+      }
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const resolveEmptyMessage = () => {
+    if (creating) return "Creating…";
+    if (loading) return loadingMessage;
+    return typeof emptyMessage === "function" ? emptyMessage(searchQuery) : emptyMessage;
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className={cn(
+            "justify-between bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20",
+            className,
+          )}
+        >
+          <span className="truncate">{selectedItem ? itemLabel(selectedItem) : placeholder}</span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="p-0 bg-glass-bg backdrop-blur-md border border-glass-border" align="start">
+        <Command className="bg-transparent" shouldFilter={false}>
+          <CommandInput
+            placeholder={searchPlaceholder}
+            value={searchQuery}
+            onValueChange={setSearchQuery}
+            className="text-white"
+          />
+          <CommandList className="max-h-[300px] overflow-auto">
+            <CommandEmpty>{resolveEmptyMessage()}</CommandEmpty>
+            <CommandGroup>
+              {noneLabel != null && (
+                <CommandItem
+                  value="__none__"
+                  onSelect={() => {
+                    onValueChange(null);
+                    setOpen(false);
+                  }}
+                  className="text-content-text-primary hover:bg-hover-glass"
+                >
+                  <Check className={cn("mr-2 h-4 w-4", value == null ? "opacity-100" : "opacity-0")} />
+                  {noneLabel}
+                </CommandItem>
+              )}
+
+              {showCreate && allowCreate && (
+                <CommandItem
+                  value={`__create__:${searchQuery}`}
+                  onSelect={handleCreate}
+                  className="text-brand-primary hover:bg-hover-glass font-medium"
+                >
+                  <Plus className="mr-2 h-4 w-4" />
+                  {allowCreate.label(searchQuery)}
+                </CommandItem>
+              )}
+
+              {items.map((item) => {
+                const id = itemId(item);
+                return (
+                  <CommandItem
+                    key={id}
+                    value={id}
+                    onSelect={() => {
+                      onValueChange(id);
+                      setCurrentItem(item);
+                      setOpen(false);
+                    }}
+                    className="text-content-text-primary hover:bg-hover-glass"
+                  >
+                    <Check className={cn("mr-2 h-4 w-4", value === id ? "opacity-100" : "opacity-0")} />
+                    {itemLabel(item)}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/app/components/venue/venue-form.test.tsx
+++ b/apps/web/app/components/venue/venue-form.test.tsx
@@ -1,0 +1,154 @@
+import { setupWithRouter } from "@test/test-utils";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { VenueForm } from "./venue-form";
+
+describe("VenueForm", () => {
+  // Default-country branch: with "United States" as the country, the
+  // state field renders as the state-picker dropdown labeled "State"
+  // (not "State/Province"), because we know which list applies.
+  test("renders state as a 'State' dropdown when country is the United States", async () => {
+    await setupWithRouter(<VenueForm onSubmit={vi.fn()} submitLabel="Save" cancelHref="/venues" />);
+
+    // The visible label is exactly "State" + the required marker "*".
+    // It's a <label> with `for=...`; querying via the form-item role
+    // group keeps us off Radix's hidden native `<select>` element.
+    const labels = screen.getAllByText(
+      (_, el) => el?.tagName === "LABEL" && /^State\s*\*?$/.test(el.textContent ?? ""),
+    );
+    expect(labels.length).toBeGreaterThan(0);
+  });
+
+  // Switching to Canada flips the label to "Province" — the wording
+  // matches what Canadian admins expect.
+  test("flips the state field to 'Province' when country becomes Canada", async () => {
+    const { user } = await setupWithRouter(<VenueForm onSubmit={vi.fn()} submitLabel="Save" cancelHref="/venues" />);
+
+    const comboboxes = screen.getAllByRole("combobox");
+    const countryCombobox = comboboxes.find((c) => c.textContent?.includes("United States"));
+    if (!countryCombobox) throw new Error("country combobox not found");
+    await user.click(countryCombobox);
+    // The Radix popover renders options with role="option"; the hidden
+    // native `<option>` Radix injects for accessibility is NOT in the
+    // popover's role tree, so this picks the interactive one.
+    await user.click(await screen.findByRole("option", { name: "Canada" }));
+
+    await waitFor(() => {
+      const provinceLabels = screen.getAllByText(
+        (_, el) => el?.tagName === "LABEL" && /^Province\s*\*?$/.test(el.textContent ?? ""),
+      );
+      expect(provinceLabels.length).toBeGreaterThan(0);
+    });
+  });
+
+  // Any country that isn't US or Canada renders state as a free-text
+  // input labeled "State/Province" — there's no canonical list for
+  // those countries, so the form falls back to manual entry.
+  test("renders state as a free-text input for non-US/Canada countries", async () => {
+    const { user } = await setupWithRouter(<VenueForm onSubmit={vi.fn()} submitLabel="Save" cancelHref="/venues" />);
+
+    const comboboxes = screen.getAllByRole("combobox");
+    const countryCombobox = comboboxes.find((c) => c.textContent?.includes("United States"));
+    if (!countryCombobox) throw new Error("country combobox not found");
+    await user.click(countryCombobox);
+    await user.click(await screen.findByRole("option", { name: "United Kingdom" }));
+
+    await waitFor(() => expect(screen.getByPlaceholderText(/state or province/i)).toBeInTheDocument());
+  });
+
+  // Default values seed the form for the edit flow — the parent route
+  // passes the existing venue and the form renders it pre-populated.
+  test("seeds inputs from defaultValues for the edit flow", async () => {
+    await setupWithRouter(
+      <VenueForm
+        defaultValues={{ name: "Wetlands", city: "New York", state: "NY", country: "United States" }}
+        onSubmit={vi.fn()}
+        submitLabel="Update"
+        cancelHref="/venues"
+      />,
+    );
+
+    expect(screen.getByPlaceholderText(/venue name/i)).toHaveValue("Wetlands");
+    expect(screen.getByPlaceholderText(/enter city/i)).toHaveValue("New York");
+  });
+
+  // Submitting with valid data calls onSubmit with the form values.
+  test("submits the form values via onSubmit when fields are valid", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const { user } = await setupWithRouter(<VenueForm onSubmit={onSubmit} submitLabel="Save" cancelHref="/venues" />);
+
+    // Fill name / city via fireEvent.change (the inputs are controlled
+    // through react-hook-form, which can handle synthetic change events
+    // even when the visible value briefly desyncs).
+    fireEvent.change(screen.getByPlaceholderText(/venue name/i), {
+      target: { value: "Red Rocks" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/enter city/i), {
+      target: { value: "Morrison" },
+    });
+
+    // Pick a state from the dropdown.
+    const comboboxes = screen.getAllByRole("combobox");
+    const stateCombobox = comboboxes.find((c) => c.textContent?.includes("Select state"));
+    if (!stateCombobox) throw new Error("state combobox not found");
+    await user.click(stateCombobox);
+    await user.click(await screen.findByRole("option", { name: "CO" }));
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled();
+      const submitted = onSubmit.mock.calls[0][0];
+      expect(submitted.name).toBe("Red Rocks");
+      expect(submitted.city).toBe("Morrison");
+      expect(submitted.state).toBe("CO");
+      expect(submitted.country).toBe("United States");
+    });
+  });
+
+  // Cities with commas fail Zod validation — the error message bubbles
+  // through FormMessage and the form refuses to call onSubmit.
+  test("rejects cities containing a comma and does not call onSubmit", async () => {
+    const onSubmit = vi.fn();
+    const { user } = await setupWithRouter(<VenueForm onSubmit={onSubmit} submitLabel="Save" cancelHref="/venues" />);
+
+    fireEvent.change(screen.getByPlaceholderText(/venue name/i), {
+      target: { value: "Some Venue" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/enter city/i), {
+      target: { value: "Brooklyn, NY" },
+    });
+
+    const comboboxes = screen.getAllByRole("combobox");
+    const stateCombobox = comboboxes.find((c) => c.textContent?.includes("Select state"));
+    if (!stateCombobox) throw new Error("state combobox not found");
+    await user.click(stateCombobox);
+    await user.click(await screen.findByRole("option", { name: "NY" }));
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(screen.getByText(/should not contain commas/i)).toBeInTheDocument());
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  // US / Canada require a state; if the admin leaves it blank the form
+  // surfaces the schema-level error and refuses to submit.
+  test("requires a state when country is US or Canada", async () => {
+    const onSubmit = vi.fn();
+    const { user } = await setupWithRouter(<VenueForm onSubmit={onSubmit} submitLabel="Save" cancelHref="/venues" />);
+
+    fireEvent.change(screen.getByPlaceholderText(/venue name/i), {
+      target: { value: "Some Venue" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/enter city/i), {
+      target: { value: "Anywhere" },
+    });
+
+    // Don't touch the state combobox. Submit.
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(screen.getByText(/state\/province is required/i)).toBeInTheDocument());
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/components/venue/venue-form.tsx
+++ b/apps/web/app/components/venue/venue-form.tsx
@@ -7,8 +7,9 @@ import { useNavigate } from "react-router-dom";
 import { z } from "zod";
 import { Button } from "~/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "~/components/ui/form";
+import { GlassSelect } from "~/components/ui/glass-select";
 import { Input } from "~/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
+import { formInputClass } from "~/lib/form-styles";
 
 // Create a schema for venue form (omitting auto-generated fields)
 export const venueFormSchema = z
@@ -100,11 +101,7 @@ export function VenueForm({ defaultValues, onSubmit, submitLabel, cancelHref }: 
                 Venue Name <span className="text-error">*</span>
               </FormLabel>
               <FormControl>
-                <Input
-                  placeholder="Enter venue name"
-                  {...field}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
-                />
+                <Input placeholder="Enter venue name" {...field} className={formInputClass} />
               </FormControl>
               <FormMessage className="text-error" />
             </FormItem>
@@ -120,11 +117,7 @@ export function VenueForm({ defaultValues, onSubmit, submitLabel, cancelHref }: 
                 City <span className="text-error">*</span>
               </FormLabel>
               <FormControl>
-                <Input
-                  placeholder="Enter city"
-                  {...field}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
-                />
+                <Input placeholder="Enter city" {...field} className={formInputClass} />
               </FormControl>
               <FormMessage className="text-error" />
             </FormItem>
@@ -151,30 +144,20 @@ export function VenueForm({ defaultValues, onSubmit, submitLabel, cancelHref }: 
                 </FormLabel>
                 <FormControl>
                   {isUSOrCanada ? (
-                    <Select
-                      onValueChange={field.onChange}
-                      value={field.value && stateOptions.includes(field.value) ? field.value : ""}
+                    <GlassSelect
                       key={selectedCountry}
-                    >
-                      <SelectTrigger className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary">
-                        <SelectValue
-                          placeholder={`Select ${selectedCountry === "United States" ? "state" : "province"}`}
-                        />
-                      </SelectTrigger>
-                      <SelectContent className="max-h-[200px] overflow-y-auto bg-dropdown border border-border">
-                        {stateOptions.map((option) => (
-                          <SelectItem key={option} value={option} className="text-dropdown hover:bg-dropdown-hover">
-                            {option}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                      value={field.value && stateOptions.includes(field.value) ? field.value : ""}
+                      onValueChange={field.onChange}
+                      options={stateOptions.map((option) => ({ value: option, label: option }))}
+                      placeholder={`Select ${selectedCountry === "United States" ? "state" : "province"}`}
+                      className="w-full"
+                    />
                   ) : (
                     <Input
                       placeholder="Enter state or province (optional)"
                       {...field}
                       value={field.value || ""}
-                      className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
+                      className={formInputClass}
                     />
                   )}
                 </FormControl>
@@ -192,35 +175,25 @@ export function VenueForm({ defaultValues, onSubmit, submitLabel, cancelHref }: 
               <FormLabel className="text-content-text-primary">
                 Country <span className="text-error">*</span>
               </FormLabel>
-              <Select onValueChange={field.onChange} value={field.value}>
-                <FormControl>
-                  <SelectTrigger className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary">
-                    <SelectValue placeholder="Select a country" />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent className="max-h-[200px] overflow-y-auto bg-dropdown border border-border">
-                  {COUNTRIES.map((country) => (
-                    <SelectItem key={country} value={country} className="text-dropdown hover:bg-dropdown-hover">
-                      {country}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <FormControl>
+                <GlassSelect
+                  value={field.value}
+                  onValueChange={field.onChange}
+                  options={COUNTRIES.map((country) => ({ value: country, label: country }))}
+                  placeholder="Select a country"
+                  className="w-full"
+                />
+              </FormControl>
               <FormMessage className="text-error" />
             </FormItem>
           )}
         />
 
         <div className="flex gap-4 pt-2">
-          <Button type="submit" className="bg-brand-primary hover:bg-hover-accent text-content-text-primary">
+          <Button type="submit" variant="brand">
             {submitLabel}
           </Button>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => navigate(cancelHref)}
-            className="border-border text-foreground hover:bg-accent hover:text-accent-foreground"
-          >
+          <Button type="button" variant="cancel" onClick={() => navigate(cancelHref)}>
             Cancel
           </Button>
         </div>

--- a/apps/web/app/components/venue/venue-search.test.tsx
+++ b/apps/web/app/components/venue/venue-search.test.tsx
@@ -1,0 +1,161 @@
+import type { Venue } from "@bip/domain";
+import { setup } from "@test/test-utils";
+import { screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { VenueSearch } from "./venue-search";
+
+// VenueSearch only reads name/city/state for label formatting; the rest
+// of the Venue shape is irrelevant, so cast through `unknown`.
+function makeVenue(overrides: Partial<Venue> & { id: string; name: string }): Venue {
+  return overrides as unknown as Venue;
+}
+
+describe("VenueSearch", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Same min-query rule as SongSearch: <2 chars never hits the catalog
+  // search endpoint. Below 2 the user sees a "Type to search venues" hint.
+  test("does not call /api/venues for queries shorter than 2 chars", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+
+    const { user } = await setup(<VenueSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search venues...");
+    await user.type(input, "w");
+
+    await new Promise((r) => setTimeout(r, 400));
+    const apiCalls = fetchMock.mock.calls.filter(
+      (c) => String(c[0]).startsWith("/api/venues") && !String(c[0]).match(/\/api\/venues\/[^?]+$/),
+    );
+    expect(apiCalls).toHaveLength(0);
+  });
+
+  // 2+ chars triggers a debounced fetch to /api/venues?q=…
+  test("calls /api/venues?q=… for 2+ char queries", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+
+    const { user } = await setup(<VenueSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search venues...");
+    await user.type(input, "wet");
+
+    await waitFor(
+      () => {
+        const urls = fetchMock.mock.calls.map((c) => c[0]);
+        expect(urls).toContain("/api/venues?q=wet");
+      },
+      { timeout: 1500 },
+    );
+  });
+
+  // The trigger seeds itself by fetching the selected venue by id so a
+  // pre-existing selection (e.g. from a show edit loader) renders
+  // immediately without opening the popover.
+  test("fetches /api/venues/:id to seed the trigger when value is set", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url === "/api/venues/v1") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeVenue({ id: "v1", name: "Wetlands Preserve", city: "New York", state: "NY" }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => [] } as Response);
+    });
+
+    await setup(<VenueSearch value="v1" onValueChange={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByRole("combobox")).toHaveTextContent("Wetlands Preserve (New York, NY)"));
+  });
+
+  // formatVenueLabel: when city + state are present, the label reads
+  // "Name (City, State)" so visually similar venues in different
+  // locations are distinguishable.
+  test("formats venue label as 'Name (City, State)' when location is present", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => [makeVenue({ id: "v1", name: "Red Rocks", city: "Morrison", state: "CO" })],
+    });
+
+    const { user } = await setup(<VenueSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search venues...");
+    await user.type(input, "red");
+
+    expect(await screen.findByText("Red Rocks (Morrison, CO)", undefined, { timeout: 1500 })).toBeInTheDocument();
+  });
+
+  // formatVenueLabel: when both city and state are missing, the label is
+  // just the venue name — no empty parens.
+  test("formats venue label as just 'Name' when city and state are both missing", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => [makeVenue({ id: "v1", name: "Mystery Venue", city: undefined, state: undefined })],
+    });
+
+    const { user } = await setup(<VenueSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search venues...");
+    await user.type(input, "mys");
+
+    expect(await screen.findByText("Mystery Venue", undefined, { timeout: 1500 })).toBeInTheDocument();
+    // No empty "()" should render.
+    expect(screen.queryByText(/Mystery Venue \(\)/)).not.toBeInTheDocument();
+  });
+
+  // Clear path: "No venue" translates null back to "none" for form-state
+  // compatibility.
+  test("clicking 'No venue' fires onValueChange('none')", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url === "/api/venues/v1") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeVenue({ id: "v1", name: "Wetlands", city: "NYC", state: "NY" }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => [] } as Response);
+    });
+    const onValueChange = vi.fn();
+
+    const { user } = await setup(<VenueSearch value="v1" onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("No venue"));
+
+    expect(onValueChange).toHaveBeenCalledWith("none");
+  });
+
+  // Selecting a venue fires onValueChange with the venue's id (the other
+  // half of the form-state ↔ id translation contract).
+  test("clicking a venue fires onValueChange with the venue id", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => [makeVenue({ id: "v2", name: "Red Rocks", city: "Morrison", state: "CO" })],
+    });
+    const onValueChange = vi.fn();
+
+    const { user } = await setup(<VenueSearch onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search venues...");
+    await user.type(input, "red");
+
+    const row = await screen.findByText("Red Rocks (Morrison, CO)", undefined, { timeout: 1500 });
+    await user.click(row);
+
+    expect(onValueChange).toHaveBeenCalledWith("v2");
+  });
+});

--- a/apps/web/app/components/venue/venue-search.tsx
+++ b/apps/web/app/components/venue/venue-search.tsx
@@ -1,10 +1,5 @@
 import type { Venue } from "@bip/domain";
-import { Check, ChevronsUpDown } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
-import { Button } from "~/components/ui/button";
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "~/components/ui/command";
-import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
-import { cn } from "~/lib/utils";
+import { SearchPicker } from "~/components/ui/search-picker";
 
 interface VenueSearchProps {
   value?: string;
@@ -13,129 +8,42 @@ interface VenueSearchProps {
   className?: string;
 }
 
+function formatVenueLabel(venue: Venue) {
+  const location = [venue.city, venue.state].filter(Boolean).join(", ");
+  return location ? `${venue.name} (${location})` : venue.name;
+}
+
+/**
+ * Venue picker for the show edit form. Requires 2+ chars before
+ * searching the catalog; the trigger seeds itself by fetching the
+ * current venue by id so the show's existing venue renders without
+ * needing to open the popover first. Form state uses "none" instead
+ * of null for compatibility with the surrounding form layer.
+ */
 export function VenueSearch({ value, onValueChange, placeholder = "Search venues...", className }: VenueSearchProps) {
-  const [open, setOpen] = useState(false);
-  const [venues, setVenues] = useState<Venue[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [currentVenue, setCurrentVenue] = useState<Venue | null>(null);
-
-  const selectedVenue = venues.find((venue) => venue.id === value) || currentVenue;
-
-  const searchVenues = useCallback(async (query: string) => {
-    if (!query || query.length < 2) {
-      setVenues([]);
-      return;
-    }
-
-    setLoading(true);
-    try {
-      const response = await fetch(`/api/venues?q=${encodeURIComponent(query)}`);
-      if (response.ok) {
-        const data = await response.json();
-        setVenues(data);
-      } else {
-      }
-    } catch (_error) {
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  // Load current venue when value changes
-  useEffect(() => {
-    const loadCurrentVenue = async () => {
-      if (value && value !== "none" && !venues.find((v) => v.id === value) && !currentVenue) {
-        try {
-          const response = await fetch(`/api/venues/${value}`);
-          if (response.ok) {
-            const venue = await response.json();
-            setCurrentVenue(venue);
-          }
-        } catch (_error) {}
-      } else if (!value || value === "none") {
-        setCurrentVenue(null);
-      }
-    };
-
-    loadCurrentVenue();
-  }, [value, venues, currentVenue]);
-
-  useEffect(() => {
-    const delayedSearch = setTimeout(() => {
-      searchVenues(searchQuery);
-    }, 300); // Debounce search
-
-    return () => clearTimeout(delayedSearch);
-  }, [searchQuery, searchVenues]);
-
-  const formatVenueLabel = (venue: Venue) => {
-    const location = [venue.city, venue.state].filter(Boolean).join(", ");
-    return location ? `${venue.name} (${location})` : venue.name;
-  };
-
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          aria-expanded={open}
-          className={cn(
-            "justify-between bg-content-bg border-content-bg-secondary text-white hover:bg-content-bg-secondary",
-            className,
-          )}
-        >
-          {selectedVenue ? formatVenueLabel(selectedVenue) : placeholder}
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        className="p-0 bg-content-bg-primary/95 backdrop-blur-md border border-content-glass-border"
-        align="start"
-      >
-        <Command className="bg-transparent" shouldFilter={false}>
-          <CommandInput
-            placeholder="Search venues..."
-            value={searchQuery}
-            onValueChange={setSearchQuery}
-            className="text-white"
-          />
-          <CommandList>
-            <CommandEmpty>
-              {loading ? "Searching..." : searchQuery.length < 2 ? "Type to search venues" : "No venues found."}
-            </CommandEmpty>
-            <CommandGroup>
-              {/* Option to clear selection */}
-              <CommandItem
-                value="none"
-                onSelect={() => {
-                  onValueChange("none");
-                  setOpen(false);
-                }}
-                className="text-white hover:bg-content-bg-secondary"
-              >
-                <Check className={cn("mr-2 h-4 w-4", value === "none" ? "opacity-100" : "opacity-0")} />
-                No venue
-              </CommandItem>
-
-              {venues.map((venue) => (
-                <CommandItem
-                  key={venue.id}
-                  value={venue.id}
-                  onSelect={() => {
-                    onValueChange(venue.id);
-                    setOpen(false);
-                  }}
-                  className="text-white hover:bg-content-bg-secondary"
-                >
-                  <Check className={cn("mr-2 h-4 w-4", value === venue.id ? "opacity-100" : "opacity-0")} />
-                  {formatVenueLabel(venue)}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+    <SearchPicker<Venue>
+      value={value && value !== "none" ? value : null}
+      onValueChange={(v) => onValueChange(v ?? "none")}
+      className={className}
+      placeholder={placeholder}
+      searchPlaceholder="Search venues..."
+      emptyMessage={(q) => (q.length < 2 ? "Type to search venues" : "No venues found.")}
+      loadingMessage="Searching..."
+      itemId={(v) => v.id}
+      itemLabel={formatVenueLabel}
+      noneLabel="No venue"
+      fetchResults={async (query) => {
+        if (!query || query.length < 2) return [];
+        const response = await fetch(`/api/venues?q=${encodeURIComponent(query)}`);
+        if (!response.ok) return [];
+        return (await response.json()) as Venue[];
+      }}
+      fetchById={async (id) => {
+        const response = await fetch(`/api/venues/${id}`);
+        if (!response.ok) return null;
+        return (await response.json()) as Venue;
+      }}
+    />
   );
 }

--- a/apps/web/app/lib/form-styles.ts
+++ b/apps/web/app/lib/form-styles.ts
@@ -1,0 +1,27 @@
+/**
+ * Dark-theme styling for form Input / Textarea controls used in admin
+ * and edit forms across the app. Centralized here so a token change
+ * (e.g. swapping `--content-bg-secondary` for a different surface)
+ * propagates to every form at once instead of needing 17+ edits.
+ *
+ * Auth forms (login / register / forgot-password) and search inputs use
+ * a different visual treatment and should NOT use this constant.
+ */
+export const formInputClass = "bg-content-bg-secondary border-content-bg-secondary text-content-text-primary";
+
+/**
+ * Block-level label style for native `<label>` elements in forms that
+ * don't run through react-hook-form's `<FormLabel>` (which has its own
+ * styling layer). Sits above the input on its own line with a tight
+ * margin, in the dark-theme secondary-text color.
+ */
+export const formLabelClass = "block text-sm font-medium text-content-text-secondary mb-1";
+
+/**
+ * Surface treatment shared by list rows across the app (track rows,
+ * curated-video rows, etc.): a faint dark fill, rounded corners, and a
+ * subtle border in the project's secondary-border tone. Padding stays
+ * with the caller so denser lists can use `p-2` and content-heavier rows
+ * can use `p-3` without forking the shared treatment.
+ */
+export const listRowClass = "rounded-lg border border-content-bg-secondary bg-content-bg-secondary/50";

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -109,6 +109,7 @@ export default [
     route("attendances", "routes/api/attendances.tsx"),
     route("shows/user-data", "routes/api/shows/user-data.tsx"),
     route("shows/reorder", "routes/api/shows/reorder.tsx"),
+    route("show-youtubes", "routes/api/show-youtubes.tsx"),
     route("authors", "routes/api/authors.tsx"),
     route("authors/:id", "routes/api/authors/$id.tsx"),
     route("venues", "routes/api/venues.tsx"),

--- a/apps/web/app/routes/api/show-youtubes.test.ts
+++ b/apps/web/app/routes/api/show-youtubes.test.ts
@@ -1,0 +1,241 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router-dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// adminAction / publicLoader normally wrap with auth and base loader chrome.
+// For route-level unit tests we bypass them and exercise the inner function
+// directly so we can isolate body parsing, validation, and service delegation.
+vi.mock("~/lib/base-loaders", () => ({
+  adminAction: <T>(fn: (args: ActionFunctionArgs) => Promise<T>) => fn,
+  publicLoader: <T>(fn: (args: LoaderFunctionArgs) => Promise<T>) => fn,
+}));
+
+const listEntriesForShow = vi.fn();
+const createForShow = vi.fn();
+const deleteEntry = vi.fn();
+
+vi.mock("~/server/services", () => ({
+  services: {
+    youtube: {
+      listEntriesForShow: (...args: unknown[]) => listEntriesForShow(...args),
+      createForShow: (...args: unknown[]) => createForShow(...args),
+      deleteEntry: (...args: unknown[]) => deleteEntry(...args),
+    },
+  },
+}));
+
+vi.mock("~/lib/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn() },
+}));
+
+// Imported after mocks so the route picks up our pass-through wrappers.
+const { loader, action } = await import("./show-youtubes");
+
+function makeLoaderRequest(url: string): LoaderFunctionArgs {
+  return {
+    request: new Request(url),
+    params: {},
+    context: {},
+  } as unknown as LoaderFunctionArgs;
+}
+
+function makeActionRequest(body: unknown, method = "POST"): ActionFunctionArgs {
+  const init: RequestInit = { method, headers: { "Content-Type": "application/json" } };
+  if (method !== "GET" && method !== "HEAD") {
+    init.body = JSON.stringify(body);
+  }
+  return {
+    request: new Request("http://localhost/api/show-youtubes", init),
+    params: {},
+    context: {},
+  } as unknown as ActionFunctionArgs;
+}
+
+async function readJson(response: unknown): Promise<{ status: number; body: unknown }> {
+  const res = response as Response;
+  return { status: res.status, body: await res.json() };
+}
+
+describe("GET /api/show-youtubes", () => {
+  beforeEach(() => {
+    listEntriesForShow.mockReset();
+  });
+
+  // Happy path: the loader passes showId through to YoutubeService and
+  // returns whatever the service hands back. Keeps the route a thin shell.
+  test("returns the entry list for a showId", async () => {
+    const entries = [{ id: "row-1", videoId: "abc12345678", url: "https://www.youtube.com/watch?v=abc12345678" }];
+    listEntriesForShow.mockResolvedValue(entries);
+
+    const result = await loader(makeLoaderRequest("http://localhost/api/show-youtubes?showId=show-1"));
+
+    expect(listEntriesForShow).toHaveBeenCalledWith("show-1");
+    expect(result).toEqual(entries);
+  });
+
+  // Without showId, the loader returns a 400 Response — never reaches the
+  // service. (badRequest() returns rather than throws, so we inspect the
+  // returned Response.)
+  test("returns 400 when showId is missing", async () => {
+    const result = await loader(makeLoaderRequest("http://localhost/api/show-youtubes"));
+
+    expect(listEntriesForShow).not.toHaveBeenCalled();
+    expect((result as Response).status).toBe(400);
+  });
+});
+
+describe("POST /api/show-youtubes", () => {
+  beforeEach(() => {
+    createForShow.mockReset();
+  });
+
+  // Happy path: a full youtube.com URL has its video id extracted by the
+  // route and passed to the service. Returning the created row lets the
+  // client append optimistically without a follow-up GET.
+  test("extracts the video id from a full youtube.com URL and creates the row", async () => {
+    createForShow.mockResolvedValue({
+      id: "row-new",
+      videoId: "dQw4w9WgXcQ",
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+
+    const result = await action(
+      makeActionRequest({ showId: "show-1", input: "https://www.youtube.com/watch?v=dQw4w9WgXcQ" }),
+    );
+
+    expect(createForShow).toHaveBeenCalledWith("show-1", "dQw4w9WgXcQ");
+    expect(result).toEqual({
+      id: "row-new",
+      videoId: "dQw4w9WgXcQ",
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+  });
+
+  // youtu.be short-links carry the id in the pathname. They're the format
+  // YouTube's share UI defaults to, so they're a common paste target.
+  test("extracts the video id from a youtu.be short link", async () => {
+    createForShow.mockResolvedValue({ id: "row-x", videoId: "abc12345678", url: "" });
+
+    await action(makeActionRequest({ showId: "show-1", input: "https://youtu.be/abc12345678" }));
+
+    expect(createForShow).toHaveBeenCalledWith("show-1", "abc12345678");
+  });
+
+  // /embed/<id> URLs come from share dialogs and from copying iframe srcs.
+  test("extracts the video id from an /embed/ URL", async () => {
+    createForShow.mockResolvedValue({ id: "row-x", videoId: "embed123456", url: "" });
+
+    await action(makeActionRequest({ showId: "show-1", input: "https://www.youtube.com/embed/embed123456" }));
+
+    expect(createForShow).toHaveBeenCalledWith("show-1", "embed123456");
+  });
+
+  // Power users sometimes paste just the 11-character id rather than a URL.
+  // We accept that directly without re-parsing.
+  test("accepts a raw 11-character video id", async () => {
+    createForShow.mockResolvedValue({ id: "row-x", videoId: "AbCdEfGhIjK", url: "" });
+
+    await action(makeActionRequest({ showId: "show-1", input: "AbCdEfGhIjK" }));
+
+    expect(createForShow).toHaveBeenCalledWith("show-1", "AbCdEfGhIjK");
+  });
+
+  // Input that doesn't look like a video id or a recognizable URL is
+  // rejected with 400 + a human-readable error — the UI surfaces this
+  // straight to the admin.
+  test("rejects garbage input with 400 and an error message", async () => {
+    const result = await action(makeActionRequest({ showId: "show-1", input: "not a url" }));
+
+    expect(createForShow).not.toHaveBeenCalled();
+    const { status, body } = await readJson(result);
+    expect(status).toBe(400);
+    expect(body).toEqual({ error: "Could not extract a YouTube video id from that input." });
+  });
+
+  // A non-youtube URL is also rejected — same path as garbage input. The
+  // route shouldn't try to "make it work" for arbitrary URLs.
+  test("rejects URLs from non-youtube hosts with 400", async () => {
+    const result = await action(makeActionRequest({ showId: "show-1", input: "https://vimeo.com/123" }));
+
+    expect(createForShow).not.toHaveBeenCalled();
+    expect((result as Response).status).toBe(400);
+  });
+
+  // Missing showId or input is rejected before we ever try to extract or
+  // create anything. Catches malformed client calls early.
+  test("returns 400 when showId or input is missing", async () => {
+    const noShowId = await action(makeActionRequest({ input: "AbCdEfGhIjK" }));
+    expect((noShowId as Response).status).toBe(400);
+
+    const noInput = await action(makeActionRequest({ showId: "show-1" }));
+    expect((noInput as Response).status).toBe(400);
+
+    expect(createForShow).not.toHaveBeenCalled();
+  });
+
+  // If the service blows up (db error, etc.), the route returns 500 with a
+  // generic message — the underlying error is logged but not surfaced to
+  // the client (could leak internals).
+  test("returns 500 with a generic message when the service throws", async () => {
+    createForShow.mockRejectedValue(new Error("db is down"));
+
+    const result = await action(makeActionRequest({ showId: "show-1", input: "AbCdEfGhIjK" }));
+
+    const { status, body } = await readJson(result);
+    expect(status).toBe(500);
+    expect(body).toEqual({ error: "Failed to add video." });
+  });
+});
+
+describe("DELETE /api/show-youtubes", () => {
+  beforeEach(() => {
+    deleteEntry.mockReset();
+  });
+
+  // Happy path: pass through the row id and return success. The UI uses
+  // this to remove the row from local state.
+  test("delegates a valid body to YoutubeService.deleteEntry", async () => {
+    deleteEntry.mockResolvedValue(undefined);
+
+    const result = await action(makeActionRequest({ id: "row-1" }, "DELETE"));
+
+    expect(deleteEntry).toHaveBeenCalledWith("row-1");
+    expect(result).toEqual({ success: true });
+  });
+
+  // Missing id is rejected before reaching the service.
+  test("returns 400 when id is missing", async () => {
+    const result = await action(makeActionRequest({}, "DELETE"));
+
+    expect(deleteEntry).not.toHaveBeenCalled();
+    expect((result as Response).status).toBe(400);
+  });
+
+  // Service-level errors become a generic 500 with a logged underlying
+  // error, same shape as POST.
+  test("returns 500 when the service throws", async () => {
+    deleteEntry.mockRejectedValue(new Error("db is down"));
+
+    const result = await action(makeActionRequest({ id: "row-1" }, "DELETE"));
+
+    const { status, body } = await readJson(result);
+    expect(status).toBe(500);
+    expect(body).toEqual({ error: "Failed to delete video." });
+  });
+});
+
+describe("/api/show-youtubes method guards", () => {
+  beforeEach(() => {
+    createForShow.mockReset();
+    deleteEntry.mockReset();
+  });
+
+  // Anything other than POST or DELETE returns 405 without touching the
+  // services.
+  test("rejects unsupported methods with 405", async () => {
+    const result = await action(makeActionRequest({}, "PUT"));
+
+    expect(createForShow).not.toHaveBeenCalled();
+    expect(deleteEntry).not.toHaveBeenCalled();
+    expect((result as Response).status).toBe(405);
+  });
+});

--- a/apps/web/app/routes/api/show-youtubes.tsx
+++ b/apps/web/app/routes/api/show-youtubes.tsx
@@ -1,0 +1,78 @@
+import { adminAction, publicLoader } from "~/lib/base-loaders";
+import { badRequest, methodNotAllowed } from "~/lib/errors";
+import { logger } from "~/lib/logger";
+import { services } from "~/server/services";
+
+// Accept a raw 11-char YouTube video ID, a full youtube.com/watch?v=…
+// URL, or a youtu.be/… short link. Returns null when no id can be extracted.
+function extractVideoId(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  if (/^[A-Za-z0-9_-]{11}$/.test(trimmed)) return trimmed;
+  try {
+    const url = new URL(trimmed);
+    if (url.hostname.endsWith("youtu.be")) {
+      const id = url.pathname.replace(/^\//, "");
+      return /^[A-Za-z0-9_-]{11}$/.test(id) ? id : null;
+    }
+    if (url.hostname.endsWith("youtube.com") || url.hostname.endsWith("youtube-nocookie.com")) {
+      const v = url.searchParams.get("v");
+      if (v && /^[A-Za-z0-9_-]{11}$/.test(v)) return v;
+      const embedMatch = url.pathname.match(/^\/embed\/([A-Za-z0-9_-]{11})/);
+      if (embedMatch) return embedMatch[1];
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+// GET /api/show-youtubes?showId=xxx — list curated videos for a show
+export const loader = publicLoader(async ({ request }) => {
+  const url = new URL(request.url);
+  const showId = url.searchParams.get("showId");
+  if (!showId) return badRequest();
+  const entries = await services.youtube.listEntriesForShow(showId);
+  return entries;
+});
+
+export const action = adminAction(async ({ request }) => {
+  if (request.method === "POST") {
+    const { showId, input } = (await request.json()) as { showId?: string; input?: string };
+    if (!showId || !input) return badRequest();
+    const videoId = extractVideoId(input);
+    if (!videoId) {
+      return new Response(JSON.stringify({ error: "Could not extract a YouTube video id from that input." }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    try {
+      const entry = await services.youtube.createForShow(showId, videoId);
+      return entry;
+    } catch (error) {
+      logger.error("Failed to add show youtube", { error });
+      return new Response(JSON.stringify({ error: "Failed to add video." }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+  }
+
+  if (request.method === "DELETE") {
+    const { id } = (await request.json()) as { id?: string };
+    if (!id) return badRequest();
+    try {
+      await services.youtube.deleteEntry(id);
+      return { success: true };
+    } catch (error) {
+      logger.error("Failed to delete show youtube", { error });
+      return new Response(JSON.stringify({ error: "Failed to delete video." }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+  }
+
+  return methodNotAllowed();
+});

--- a/apps/web/app/routes/shows/$slug.edit.tsx
+++ b/apps/web/app/routes/shows/$slug.edit.tsx
@@ -147,6 +147,7 @@ export default function EditShow() {
               submitLabel="Update Show"
               cancelHref={`/shows/${show.slug}`}
               bands={bands}
+              showId={show.id}
             />
           </CardContent>
         </Card>

--- a/apps/web/app/styles.css
+++ b/apps/web/app/styles.css
@@ -58,6 +58,18 @@
   --color-rating-gold: hsl(38 95% 62%);
 }
 
+/* Radix Popover/Select sets `body[data-scroll-locked]` and adds a
+   margin-right matching the scrollbar width on open. In this app the
+   scroll lives on <html> rather than <body>, so that compensation
+   visually narrows the body and every page-width container (most
+   noticeably the show edit Card) snaps inward when a dropdown opens.
+   Force margin-right to 0 to keep layout stable. The `html` prefix is
+   load-bearing — it raises specificity above Radix's runtime-injected
+   `body[data-scroll-locked] { margin-right: 15px !important }` rule. */
+html body[data-scroll-locked] {
+  margin-right: 0 !important;
+}
+
 @layer base {
   /* Design Token System - Premium Purple & Vibrant Green Palette */
   :root {

--- a/packages/core/src/_shared/services.ts
+++ b/packages/core/src/_shared/services.ts
@@ -86,7 +86,7 @@ export function createServices(container: ServiceContainer): Services {
     tourDatesService: new TourDatesService(container.redis),
     nugs: new NugsService(container.redis, container.logger),
     archiveDotOrg: new ArchiveDotOrgService(container.redis, container.logger),
-    youtube: new YoutubeService(container.db),
+    youtube: new YoutubeService(container.db, container.cacheInvalidation),
     files: new FileService(container.db, container.logger, {
       accountId: container.env.CLOUDFLARE_ACCOUNT_ID,
       apiToken: container.env.CLOUDFLARE_IMAGES_API_TOKEN,

--- a/packages/core/src/shows/youtube-service.test.ts
+++ b/packages/core/src/shows/youtube-service.test.ts
@@ -5,8 +5,19 @@ function makeMockDb() {
   return {
     showYoutube: {
       findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+    },
+    show: {
+      findUnique: vi.fn(),
+      update: vi.fn().mockResolvedValue(undefined),
     },
   };
+}
+
+function makeMockCacheInvalidation() {
+  return { invalidateShowComprehensive: vi.fn().mockResolvedValue(undefined) };
 }
 
 describe("YoutubeService.getVideoUrlsForShow", () => {
@@ -78,5 +89,133 @@ describe("YoutubeService.getFirstVideoUrlByShowIds", () => {
 
     expect(result).toEqual({});
     expect(db.showYoutube.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("YoutubeService.listEntriesForShow", () => {
+  // The admin editor needs row ids alongside URLs so it can target individual
+  // rows for deletion. URLs are still resolved server-side so the UI never
+  // builds the watch URL format on its own.
+  test("returns entries with id, videoId, and resolved url", async () => {
+    const db = makeMockDb();
+    db.showYoutube.findMany.mockResolvedValue([
+      { id: "row-1", videoId: "abc12345678" },
+      { id: "row-2", videoId: "xyz12345678" },
+    ]);
+    const service = new YoutubeService(db as never);
+
+    const result = await service.listEntriesForShow("show-1");
+
+    expect(result).toEqual([
+      { id: "row-1", videoId: "abc12345678", url: "https://www.youtube.com/watch?v=abc12345678" },
+      { id: "row-2", videoId: "xyz12345678", url: "https://www.youtube.com/watch?v=xyz12345678" },
+    ]);
+    expect(db.showYoutube.findMany).toHaveBeenCalledWith({
+      where: { showId: "show-1" },
+      select: { id: true, videoId: true },
+      orderBy: { createdAt: "asc" },
+    });
+  });
+});
+
+describe("YoutubeService.createForShow", () => {
+  // Adding a video must do three things atomically from the caller's
+  // perspective: persist the row, bump the show's denormalized count (so
+  // `hasYoutube` filters see it), and invalidate the show's cached pages so
+  // the public detail page reflects the change on next view.
+  test("persists the row, increments showYoutubesCount, and invalidates show caches", async () => {
+    const db = makeMockDb();
+    db.showYoutube.create.mockResolvedValue({ id: "row-new", videoId: "dQw4w9WgXcQ" });
+    db.show.findUnique.mockResolvedValue({ slug: "2001-09-01-wetlands" });
+    const cache = makeMockCacheInvalidation();
+    const service = new YoutubeService(db as never, cache as never);
+
+    const result = await service.createForShow("show-1", "dQw4w9WgXcQ");
+
+    expect(db.showYoutube.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ showId: "show-1", videoId: "dQw4w9WgXcQ" }),
+      select: { id: true, videoId: true },
+    });
+    expect(db.show.update).toHaveBeenCalledWith({
+      where: { id: "show-1" },
+      data: { showYoutubesCount: { increment: 1 } },
+    });
+    expect(cache.invalidateShowComprehensive).toHaveBeenCalledWith("show-1", "2001-09-01-wetlands");
+    expect(result).toEqual({
+      id: "row-new",
+      videoId: "dQw4w9WgXcQ",
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+  });
+
+  // Cache invalidation must not break the create when the cache service
+  // isn't wired (e.g. in environments where it's optional). The row is still
+  // persisted and the count is still bumped.
+  test("works without a cache invalidation service", async () => {
+    const db = makeMockDb();
+    db.showYoutube.create.mockResolvedValue({ id: "row-new", videoId: "abc12345678" });
+    const service = new YoutubeService(db as never);
+
+    const result = await service.createForShow("show-1", "abc12345678");
+
+    expect(db.showYoutube.create).toHaveBeenCalled();
+    expect(db.show.update).toHaveBeenCalled();
+    expect(result.url).toBe("https://www.youtube.com/watch?v=abc12345678");
+  });
+
+  // If the show row has no slug (data integrity edge case), the cache call
+  // is skipped — there's no slug-keyed cache to invalidate. The mutation
+  // itself still completes.
+  test("skips cache invalidation when the show has no slug", async () => {
+    const db = makeMockDb();
+    db.showYoutube.create.mockResolvedValue({ id: "row-new", videoId: "abc12345678" });
+    db.show.findUnique.mockResolvedValue({ slug: null });
+    const cache = makeMockCacheInvalidation();
+    const service = new YoutubeService(db as never, cache as never);
+
+    await service.createForShow("show-1", "abc12345678");
+
+    expect(cache.invalidateShowComprehensive).not.toHaveBeenCalled();
+  });
+});
+
+describe("YoutubeService.deleteEntry", () => {
+  // Symmetric to createForShow: delete the row, decrement the show's count,
+  // and invalidate caches. The showId is looked up from the row first so
+  // callers only need to pass the row id.
+  test("looks up the show, deletes the row, decrements count, invalidates caches", async () => {
+    const db = makeMockDb();
+    db.showYoutube.findUnique.mockResolvedValue({ showId: "show-1" });
+    db.show.findUnique.mockResolvedValue({ slug: "2001-09-01-wetlands" });
+    const cache = makeMockCacheInvalidation();
+    const service = new YoutubeService(db as never, cache as never);
+
+    await service.deleteEntry("row-1");
+
+    expect(db.showYoutube.findUnique).toHaveBeenCalledWith({
+      where: { id: "row-1" },
+      select: { showId: true },
+    });
+    expect(db.showYoutube.delete).toHaveBeenCalledWith({ where: { id: "row-1" } });
+    expect(db.show.update).toHaveBeenCalledWith({
+      where: { id: "show-1" },
+      data: { showYoutubesCount: { decrement: 1 } },
+    });
+    expect(cache.invalidateShowComprehensive).toHaveBeenCalledWith("show-1", "2001-09-01-wetlands");
+  });
+
+  // Deleting a row that no longer exists is a no-op — no delete, no count
+  // change, no cache churn. Prevents a 500 on a double-click or stale row id.
+  test("silently no-ops when the row does not exist", async () => {
+    const db = makeMockDb();
+    db.showYoutube.findUnique.mockResolvedValue(null);
+    const cache = makeMockCacheInvalidation();
+    const service = new YoutubeService(db as never, cache as never);
+
+    await service.deleteEntry("missing-id");
+
+    expect(db.showYoutube.delete).not.toHaveBeenCalled();
+    expect(db.show.update).not.toHaveBeenCalled();
+    expect(cache.invalidateShowComprehensive).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/shows/youtube-service.ts
+++ b/packages/core/src/shows/youtube-service.ts
@@ -1,7 +1,14 @@
+import type { CacheInvalidationService } from "../_shared/cache";
 import type { DbClient } from "../_shared/database/models";
 
 function videoUrl(videoId: string): string {
   return `https://www.youtube.com/watch?v=${videoId}`;
+}
+
+export interface ShowYoutubeEntry {
+  id: string;
+  videoId: string;
+  url: string;
 }
 
 /**
@@ -12,7 +19,10 @@ function videoUrl(videoId: string): string {
  * data is local.
  */
 export class YoutubeService {
-  constructor(private readonly db: DbClient) {}
+  constructor(
+    private readonly db: DbClient,
+    private readonly cacheInvalidation?: CacheInvalidationService,
+  ) {}
 
   /**
    * Return every curated video URL for a show in insertion order, so the
@@ -48,5 +58,66 @@ export class YoutubeService {
       if (!result[row.showId]) result[row.showId] = videoUrl(row.videoId);
     }
     return result;
+  }
+
+  /**
+   * Lists curated videos for a show with their row ids, so the admin editor
+   * can render a list and target individual rows for deletion.
+   */
+  async listEntriesForShow(showId: string): Promise<ShowYoutubeEntry[]> {
+    const rows = await this.db.showYoutube.findMany({
+      where: { showId },
+      select: { id: true, videoId: true },
+      orderBy: { createdAt: "asc" },
+    });
+    return rows.map((row) => ({ id: row.id, videoId: row.videoId, url: videoUrl(row.videoId) }));
+  }
+
+  /**
+   * Adds a curated video to a show. Also bumps the denormalized
+   * `Show.showYoutubesCount` so the `hasYoutube` filter sees the new row, and
+   * invalidates the show's cached pages.
+   */
+  async createForShow(showId: string, videoId: string): Promise<ShowYoutubeEntry> {
+    const now = new Date();
+    const created = await this.db.showYoutube.create({
+      data: { showId, videoId, createdAt: now, updatedAt: now },
+      select: { id: true, videoId: true },
+    });
+    await this.db.show.update({
+      where: { id: showId },
+      data: { showYoutubesCount: { increment: 1 } },
+    });
+    await this.invalidateShowCaches(showId);
+    return { id: created.id, videoId: created.videoId, url: videoUrl(created.videoId) };
+  }
+
+  /**
+   * Removes a curated video by row id. Decrements the show's count and
+   * invalidates the show's cached pages.
+   */
+  async deleteEntry(id: string): Promise<void> {
+    const existing = await this.db.showYoutube.findUnique({
+      where: { id },
+      select: { showId: true },
+    });
+    if (!existing) return;
+    await this.db.showYoutube.delete({ where: { id } });
+    await this.db.show.update({
+      where: { id: existing.showId },
+      data: { showYoutubesCount: { decrement: 1 } },
+    });
+    await this.invalidateShowCaches(existing.showId);
+  }
+
+  private async invalidateShowCaches(showId: string): Promise<void> {
+    if (!this.cacheInvalidation) return;
+    const show = await this.db.show.findUnique({
+      where: { id: showId },
+      select: { slug: true },
+    });
+    if (show?.slug) {
+      await this.cacheInvalidation.invalidateShowComprehensive(showId, show.slug);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Admins can now edit `Track.note` inline on the show edit page (new Notes textarea on the per-track form).
- New **YouTube Videos** section under the show edit form for adding/removing curated videos per show, via URL or 11-char video ID. Server endpoint maintains `Show.showYoutubesCount` and invalidates show caches.
- Track-edit form redesigned to lay out cleanly on desktop and mobile (Notes / Annotations get their own full-width rows, action buttons collapse to icon-only on narrow viewports).
- Track row display: notes flow full-width below the title (no longer constrained by the action-button column), flame icon renders inline next to the song title, and notes lose their parens.
- `<Button variant="brand">` and `<Button variant="cancel">` added to the existing CVA. Cancel hover-state drift on the track-edit form fixed (it was the only Cancel without hover feedback).
- `song-form` was wrapped in `<div>` instead of `<form>`, so Enter-to-submit silently did nothing. Now a real `<form>` with `type="submit"`.

## Internal refactors

- `TrackManager` split into `TrackEditForm` + `useTrackApi` hook + `track-constants.ts`. The component went from ~570 lines to ~290.
- `AuthorSearch` / `SongSearch` / `VenueSearch` unified behind a generic `SearchPicker` primitive (debounced search, optional clear row, optional create row, glass styling).
- `GlassSelect` added — wraps shadcn `Select` with the project's `bg-glass-bg` treatment for finite-option dropdowns. `SelectFilter` (powering /songs filters) now shares the same class constants.
- Shared className constants in `apps/web/app/lib/form-styles.ts`: `formInputClass`, `formLabelClass`, `listRowClass` — replacing 17+ literal-triplet occurrences across 6 admin forms.
- DRY guideline added to [apps/web/CLAUDE.md](apps/web/CLAUDE.md) covering when to extract a constant, when to add a variant, and which thin-wrapper anti-patterns to avoid.
- `body[data-scroll-locked]` margin-right pinned to 0 to fix a 15-px layout shift when Radix Popover/Select locked scroll (the show edit Card was visibly snapping when the Band dropdown opened).
- Tests added across the new components (`TrackEditForm`, `TrackManager`, `SortableTrackItem`, `SearchPicker`, `GlassSelect`, `ShowYoutubeManager`, `Button` variants), the new API route, and the `YoutubeService` create/delete/list methods.

## Test plan

- [ ] On `/shows/<slug>/edit`, click the pencil on any track → edit the Notes textarea → click Update → row re-renders with new note; back-to-show view shows the updated note under Track Notes highlights
- [ ] Same page: add a YouTube video by pasting a full `youtube.com/watch?v=…` URL or a `youtu.be/…` short link or a bare 11-char ID; remove a video via the trash button; both surface server error messages via toast on a non-2xx
- [ ] Resize to ~390px width; confirm song titles no longer wrap to 3 lines, notes lay out below the title full-width, action buttons collapse to icon-only
- [ ] Open the Band dropdown on `/shows/<slug>/edit`; the Card no longer shrinks 15px when the dropdown opens
- [ ] On `/songs`, open Time Range and Author filters; both render with the glass styling and dismiss correctly
- [ ] On `/songs/<slug>/edit`, press Enter inside an input — the form now actually submits (was a no-op before)
- [ ] `make tc` and `bun run test` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
