### PR TITLE
Jam Charts page, tap-to-read notes, compressed Show Highlights

### DIFF
--- a/apps/web/.react-router/types/app/routes/songs/+types/$slug.ts
+++ b/apps/web/.react-router/types/app/routes/songs/+types/$slug.ts
@@ -18,6 +18,15 @@ type Matches = [{
 }, {
   id: "routes/songs/$slug";
   module: typeof import("../$slug.js");
+}] | [{
+  id: "root";
+  module: typeof import("../../../root.js");
+}, {
+  id: "routes/songs/_layout";
+  module: typeof import("../_layout.js");
+}, {
+  id: "song-tab";
+  module: typeof import("../$slug.js");
 }];
 
 type Annotations = GetAnnotations<Info & { module: Module, matches: Matches }, false>;

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -38,6 +38,27 @@ export const gapSortingFn = makeGapSortingFn("gap");
 export const filteredGapSortingFn = makeGapSortingFn("filteredGap");
 
 /**
+ * Adapt a SongPagePerformance row to the minimal Track-like shape the
+ * shared AllTimerCell + TrackRatingOverlay expect. The performance DTO
+ * uses `notes` (plural) for the note field and exposes the song title
+ * at the top level rather than under `song.title`; this normalizes both.
+ * Returns a structural subset of TrackLight — only the fields the
+ * overlay actually reads — since fabricating a full TrackLight with
+ * never-read defaults would be misleading.
+ */
+function trackFromPerformance(row: SongPagePerformance) {
+  return {
+    id: row.trackId,
+    allTimer: row.allTimer ?? null,
+    note: row.notes ?? null,
+    song: { title: row.songTitle ?? "", slug: row.songSlug ?? "" },
+    averageRating: row.rating ?? null,
+    ratingsCount: row.ratingsCount ?? null,
+    likesCount: 0,
+  };
+}
+
+/**
  * Sort comparator factory for the Song Before / Song After columns. The
  * primary axis is the adjacent song's title (case-insensitive). The
  * tiebreaker reads the relevant segue field — segue rows sort ahead of
@@ -107,6 +128,13 @@ interface PerformanceColumnOptions {
   showSongColumn?: boolean;
   showAllTimerColumn?: boolean;
   /**
+   * When true (and `showAllTimerColumn` is on), keep the flame column
+   * visible on mobile and instead hide the Set column there — the
+   * noteworthy marker is the critical signal on jam-charts surfaces,
+   * while the set number is secondary in that context.
+   */
+  mobileFlamePriority?: boolean;
+  /**
    * Gap + Last Played are per-song signals. On surfaces that mix songs
    * (all-timers, on-this-day), pass `false` to hide both. Defaults true.
    */
@@ -151,11 +179,39 @@ function SortableHeader({
 }
 
 export function createPerformanceColumns(options: PerformanceColumnOptions): ColumnDef<SongPagePerformance, unknown>[] {
-  const { showSongColumn, showAllTimerColumn, showGapColumns, hasNarrowingFilter, userRatingMap, isAuthenticated } =
-    options;
+  const {
+    showSongColumn,
+    showAllTimerColumn,
+    mobileFlamePriority,
+    showGapColumns,
+    hasNarrowingFilter,
+    userRatingMap,
+    isAuthenticated,
+  } = options;
   const includeGapColumns = showGapColumns !== false;
   const columnHelper = createColumnHelper<SongPagePerformance>();
   const columns: ColumnDef<SongPagePerformance, unknown>[] = [];
+
+  // AllTimer column comes first so the flame anchors the leftmost slot
+  // on the surfaces that show it (jam-charts, song-detail jam-charts +
+  // all-performances tabs) — the visual hierarchy reads "noteworthy
+  // marker → song/date → context columns" left to right.
+  if (showAllTimerColumn) {
+    columns.push(
+      columnHelper.accessor((row) => row.allTimer ?? false, {
+        id: "allTimer",
+        header: "",
+        // Hidden on mobile by default — the Set cell renders the flame
+        // inline on phones to recover the 16px this column would
+        // otherwise consume. `mobileFlamePriority` flips that on
+        // jam-charts surfaces where the marker is the critical signal
+        // and the Set column hides on mobile instead.
+        meta: { ...allTimerColumnMeta, hideOnMobile: !mobileFlamePriority },
+        enableSorting: false,
+        cell: (info) => <AllTimerCell track={trackFromPerformance(info.row.original)} />,
+      }) as ColumnDef<SongPagePerformance, unknown>,
+    );
+  }
 
   if (showSongColumn) {
     columns.push(
@@ -183,20 +239,6 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
     );
   }
 
-  if (showAllTimerColumn) {
-    columns.push(
-      columnHelper.accessor((row) => row.allTimer ?? false, {
-        id: "allTimer",
-        header: "",
-        // Hidden on mobile here — the Set cell renders the flame inline
-        // on phones to recover the 16px this column would otherwise consume.
-        meta: { ...allTimerColumnMeta, hideOnMobile: true },
-        enableSorting: false,
-        cell: (info) => (info.getValue() ? <AllTimerCell /> : null),
-      }) as ColumnDef<SongPagePerformance, unknown>,
-    );
-  }
-
   columns.push(
     columnHelper.accessor("show.date", {
       id: "date",
@@ -213,7 +255,7 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
         const date = info.getValue();
         const showSlug = info.row.original.show.slug;
         const venue = info.row.original.venue;
-        const isAllTimer = info.row.original.allTimer;
+        const track = trackFromPerformance(info.row.original);
         return (
           <div className="flex flex-col gap-0.5">
             <a href={`/shows/${showSlug}`} className="text-base text-brand-primary hover:text-brand-secondary block">
@@ -222,9 +264,9 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
                 venue={{ name: venue?.name, city: venue?.city, state: venue?.state }}
               />
             </a>
-            {isAllTimer && !showSongColumn && (
+            {!showSongColumn && (
               <span className="sm:hidden">
-                <AllTimerCell align="start" />
+                <AllTimerCell track={track} align="start" />
               </span>
             )}
           </div>
@@ -301,7 +343,7 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       columnHelper.accessor("set", {
         id: "set",
         header: "Set",
-        meta: { fixedWidth: "2.5rem" },
+        meta: { fixedWidth: "2.5rem", hideOnMobile: mobileFlamePriority },
         enableSorting: false,
         cell: (info) => {
           const set = info.getValue();

--- a/apps/web/app/components/performance/performance-filter-controls.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.tsx
@@ -9,8 +9,6 @@ import { cn } from "~/lib/utils";
 
 const ALL_TOGGLE_FILTERS = TOGGLE_FILTER_DEFINITIONS as unknown as Array<{ key: string; label: string }>;
 
-const TOGGLE_FILTERS_WITHOUT_ALL_TIMER = ALL_TOGGLE_FILTERS.filter((filter) => filter.key !== "allTimer");
-
 const labelClass =
   "text-xs font-medium text-content-text-secondary uppercase tracking-wide mb-1.5 h-[18px] flex items-center";
 
@@ -22,6 +20,14 @@ interface PerformanceFilterControlsProps {
   clearFilters: () => void;
   extraSelectFilters?: ReactNode;
   showAllTimerToggle?: boolean;
+  /**
+   * When false, hide the "Jam Chart" toggle chip. Set on the dedicated
+   * Jam Charts page (the whole result set is already jam-charts there)
+   * and on the All-Timers page (same reasoning as why "All-Timer" is
+   * hidden there) so toggle filters within those views express
+   * additional narrowing rather than redundant scope.
+   */
+  showJamChartToggle?: boolean;
   hideTimeRange?: boolean;
   coverFilter?: string;
   selectedAuthor?: string | null;
@@ -39,6 +45,7 @@ export function PerformanceFilterControls({
   clearFilters,
   extraSelectFilters,
   showAllTimerToggle = true,
+  showJamChartToggle = true,
   hideTimeRange = false,
   coverFilter,
   selectedAuthor,
@@ -47,7 +54,11 @@ export function PerformanceFilterControls({
   onSearchChange,
   hasActiveFilters = false,
 }: PerformanceFilterControlsProps) {
-  const toggleFilters = showAllTimerToggle ? ALL_TOGGLE_FILTERS : TOGGLE_FILTERS_WITHOUT_ALL_TIMER;
+  const toggleFilters = ALL_TOGGLE_FILTERS.filter((filter) => {
+    if (!showAllTimerToggle && filter.key === "allTimer") return false;
+    if (!showJamChartToggle && filter.key === "jamChart") return false;
+    return true;
+  });
   const showPlayedFilter =
     playedFilter !== undefined &&
     (hideTimeRange ||

--- a/apps/web/app/components/performance/performance-table.tsx
+++ b/apps/web/app/components/performance/performance-table.tsx
@@ -13,6 +13,13 @@ interface PerformanceTableProps {
   performances: SongPagePerformance[];
   showSongColumn?: boolean;
   showAllTimerColumn?: boolean;
+  /**
+   * When true (and `showAllTimerColumn` is on), keep the flame column
+   * visible on mobile and hide the Set column there instead. Used on
+   * jam-charts surfaces where the noteworthy marker is the critical
+   * signal at narrow viewports.
+   */
+  mobileFlamePriority?: boolean;
   showGapColumns?: boolean;
   /**
    * When true, render the Filtered Gap column. Route is responsible for
@@ -34,6 +41,7 @@ export function PerformanceTable({
   performances,
   showSongColumn,
   showAllTimerColumn,
+  mobileFlamePriority,
   showGapColumns,
   hasNarrowingFilter,
   headerContent,
@@ -67,12 +75,21 @@ export function PerformanceTable({
       createPerformanceColumns({
         showSongColumn,
         showAllTimerColumn,
+        mobileFlamePriority,
         showGapColumns,
         hasNarrowingFilter,
         userRatingMap,
         isAuthenticated,
       }),
-    [showSongColumn, showAllTimerColumn, showGapColumns, hasNarrowingFilter, userRatingMap, isAuthenticated],
+    [
+      showSongColumn,
+      showAllTimerColumn,
+      mobileFlamePriority,
+      showGapColumns,
+      hasNarrowingFilter,
+      userRatingMap,
+      isAuthenticated,
+    ],
   );
 
   return (

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -1,9 +1,10 @@
 import type { Attendance, Rating, Setlist, SetlistLight } from "@bip/domain";
-import { Check, Flame } from "lucide-react";
+import { Check } from "lucide-react";
 import { memo, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { RatingBadgeButton } from "~/components/rating/rating-badge-button";
 import { ShowDate } from "~/components/show-date";
+import { NoteworthyMarker } from "~/components/track/noteworthy-marker";
 import { Card, CardContent, CardHeader } from "~/components/ui/card";
 import { useSession } from "~/hooks/use-session";
 import { useAttendanceMutation } from "~/hooks/use-show-user-data";
@@ -351,9 +352,10 @@ function SetlistCardComponent({
                                   track.allTimer && "font-medium",
                                 )}
                               >
-                                {track.allTimer && (
-                                  <Flame className="h-3 w-3 md:h-4 md:w-4 inline-block mr-1 transform -translate-y-0.5 text-orange-500" />
-                                )}
+                                <NoteworthyMarker
+                                  track={track}
+                                  iconClassName="h-3 w-3 md:h-4 md:w-4 inline-block mr-1 transform -translate-y-0.5"
+                                />
                                 <Link to={`/songs/${track.song?.slug}`}>{track.song?.title}</Link>
                                 {trackAnnotationMap.has(track.id) && (
                                   <sup className="text-brand-secondary ml-0.5 font-medium text-xs">

--- a/apps/web/app/components/setlist/setlist-common-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-common-columns.tsx
@@ -263,11 +263,9 @@ export function createSetlistCommonColumns<T extends TrackLight>(options?: {
             {!hideSetLabel && (
               <span className="text-content-text-secondary">{formatSetLabel(raw, { encoresInSet })}</span>
             )}
-            {row.allTimer && (
-              <span className="sm:hidden">
-                <AllTimerCell />
-              </span>
-            )}
+            <span className="sm:hidden">
+              <AllTimerCell track={row} />
+            </span>
           </div>
         );
       },
@@ -301,7 +299,7 @@ export function createSetlistCommonColumns<T extends TrackLight>(options?: {
       // inline on phones to recover the 16px this column would consume.
       meta: { ...allTimerColumnMeta, hideOnMobile: true },
       enableSorting: false,
-      cell: (info) => (info.row.original.allTimer ? <AllTimerCell /> : null),
+      cell: (info) => <AllTimerCell track={info.row.original} />,
     }) as ColumnDef<T, unknown>,
     columnHelper.accessor((row) => row.song?.title ?? "", {
       id: "song",

--- a/apps/web/app/components/setlist/setlist-highlights.test.tsx
+++ b/apps/web/app/components/setlist/setlist-highlights.test.tsx
@@ -1,0 +1,285 @@
+import type { Setlist, Track } from "@bip/domain";
+import { setupWithRouter } from "@test/test-utils";
+import { screen, within } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { SetlistHighlights } from "./setlist-highlights";
+
+// Setlist-wide fixture defaults are stubbed where the component never
+// reads them — these tests focus on the tracks/sets the highlights panel
+// actually iterates over.
+function makeSetlist(sets: Array<{ label: string; tracks: Partial<Track>[] }>): Setlist {
+  return {
+    show: { id: "show-1", slug: "1995-10-21" } as Setlist["show"],
+    venue: { id: "venue-1", name: "The Wetlands" } as Setlist["venue"],
+    annotations: [],
+    averageSongGap: null,
+    medianSongGap: null,
+    debutCount: 0,
+    sets: sets.map((set, sortIdx) => ({
+      label: set.label,
+      sort: sortIdx,
+      tracks: set.tracks.map((t, i) => makeTrack({ set: set.label, position: i + 1, ...t })),
+    })),
+  };
+}
+
+function makeTrack(overrides: Partial<Track>): Track {
+  const song =
+    (overrides.song as Track["song"]) ??
+    ({
+      id: "song-default",
+      title: "Sound One",
+      slug: "sound-one",
+    } as unknown as Track["song"]);
+  return {
+    id: overrides.id ?? `track-${overrides.position ?? 0}-${song?.slug ?? "x"}`,
+    showId: "show-1",
+    songId: song?.id ?? "song-default",
+    set: overrides.set ?? "S1",
+    position: overrides.position ?? 1,
+    segue: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    likesCount: 0,
+    slug: null,
+    note: overrides.note ?? null,
+    allTimer: overrides.allTimer ?? false,
+    previousTrackId: null,
+    nextTrackId: null,
+    averageRating: 0,
+    ratingsCount: 0,
+    gap: null,
+    previousPerformanceShowId: null,
+    previousPerformanceShow: null,
+    song,
+    annotations: [],
+  } as unknown as Track;
+}
+
+describe("SetlistHighlights (compressed)", () => {
+  // When no track is an all-timer or has a note, there is nothing to
+  // highlight — the whole section is omitted so the right rail doesn't
+  // show an empty placeholder.
+  test("renders nothing when no tracks have allTimer or notes", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S1",
+        tracks: [{ song: { id: "a", title: "Above the Waves", slug: "above-the-waves" } as Track["song"] }],
+      },
+    ]);
+    const { container } = await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  // The compressed section is one list — not two subsections. Verifies
+  // we don't render separate "All-Timers" / "Track Notes" / "Jam Charts"
+  // sub-headers on the show page.
+  test("does not render separate All-Timers / Track Notes / Jam Charts subsection headers", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S1",
+        tracks: [
+          { allTimer: true, song: { id: "a", title: "Aceetobee", slug: "aceetobee" } as Track["song"] },
+          {
+            note: "Type II exploration.",
+            song: { id: "b", title: "Basis for a Day", slug: "basis-for-a-day" } as Track["song"],
+          },
+        ],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    expect(screen.queryByText("All-Timers")).not.toBeInTheDocument();
+    expect(screen.queryByText("Track Notes")).not.toBeInTheDocument();
+    expect(screen.queryByText("Jam Charts")).not.toBeInTheDocument();
+    // The single section heading does remain.
+    expect(screen.getByText("Show Highlights")).toBeInTheDocument();
+  });
+
+  // Both all-timers (no note) and noted-but-not-all-timer tracks land in
+  // the compressed list, with the song title as a link to /songs/{slug}.
+  test("lists both all-timer and noted tracks with song-page links", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S1",
+        tracks: [
+          { allTimer: true, song: { id: "a", title: "Aceetobee", slug: "aceetobee" } as Track["song"] },
+          {
+            note: "Glow-stick frenzy.",
+            song: { id: "b", title: "Basis for a Day", slug: "basis-for-a-day" } as Track["song"],
+          },
+        ],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    expect(screen.getByRole("link", { name: "Aceetobee" })).toHaveAttribute("href", "/songs/aceetobee");
+    expect(screen.getByRole("link", { name: "Basis for a Day" })).toHaveAttribute("href", "/songs/basis-for-a-day");
+  });
+
+  // The note text renders inline below the song name so users can read
+  // the curated commentary without a popover hop — the compressed section
+  // is the canonical place to scan notes.
+  test("renders note text below the song name", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S1",
+        tracks: [
+          {
+            note: "Type II Spaga, near 20 minutes.",
+            song: { id: "s", title: "Spaga", slug: "spaga" } as Track["song"],
+          },
+        ],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    expect(screen.getByText(/Type II Spaga, near 20 minutes/)).toBeInTheDocument();
+  });
+
+  // Set labels in the highlights panel match the rest of the app's
+  // formatting via `formatSetLabel` — "S1" → "1", and the encore drops
+  // its number when the show has exactly one encore.
+  test("formats set labels via formatSetLabel: S1 -> 1, single E1 -> E", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S1",
+        tracks: [{ allTimer: true, song: { id: "a", title: "Aceetobee", slug: "aceetobee" } as Track["song"] }],
+      },
+      {
+        label: "E1",
+        tracks: [{ allTimer: true, song: { id: "c", title: "Crickets", slug: "crickets" } as Track["song"] }],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    // "S1" never appears — only "1".
+    expect(screen.queryByText("S1")).not.toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    // Single encore collapses to "E", not "E1".
+    expect(screen.queryByText("E1")).not.toBeInTheDocument();
+    expect(screen.getByText("E")).toBeInTheDocument();
+  });
+
+  // With more than one encore in the show, the encore numerals stay so
+  // users can distinguish E1 from E2.
+  test("keeps the encore numeral when the show has multiple encores", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "E1",
+        tracks: [{ allTimer: true, song: { id: "x", title: "Aceetobee", slug: "aceetobee" } as Track["song"] }],
+      },
+      {
+        label: "E2",
+        tracks: [{ allTimer: true, song: { id: "y", title: "Crickets", slug: "crickets" } as Track["song"] }],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    expect(screen.getByText("E1")).toBeInTheDocument();
+    expect(screen.getByText("E2")).toBeInTheDocument();
+  });
+
+  // The flame icon sits to the LEFT of the song title — same reading
+  // order as the rest of the app, and visually anchors each row.
+  test("renders the flame icon to the left of the song title", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S1",
+        tracks: [{ allTimer: true, song: { id: "a", title: "Aceetobee", slug: "aceetobee" } as Track["song"] }],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    const row = screen.getByRole("link", { name: "Aceetobee" }).closest("li") as HTMLElement;
+    const flame = within(row).getByLabelText("All-timer");
+    const link = within(row).getByRole("link", { name: "Aceetobee" });
+    expect(flame.compareDocumentPosition(link) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  // The set label prints once per set-bucket transition; consecutive rows
+  // in the same set leave the slot blank so the reader's eye groups the
+  // rows under the single label. Matches how setlists are spoken aloud.
+  test("displays the set label only on the first row of each set group", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S1",
+        tracks: [
+          { allTimer: true, song: { id: "a", title: "Aceetobee", slug: "aceetobee" } as Track["song"] },
+          { allTimer: true, song: { id: "b", title: "Basis for a Day", slug: "basis-for-a-day" } as Track["song"] },
+          { note: "Slow ramp.", song: { id: "c", title: "Crickets", slug: "crickets" } as Track["song"] },
+        ],
+      },
+      {
+        label: "S2",
+        tracks: [{ allTimer: true, song: { id: "d", title: "Dribble", slug: "dribble" } as Track["song"] }],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    const rows = screen.getAllByRole("listitem");
+    expect(rows).toHaveLength(4);
+    // First row in S1 shows the label
+    expect(within(rows[0]).queryByText("1")).toBeInTheDocument();
+    // Subsequent S1 rows do not repeat the label
+    expect(within(rows[1]).queryByText("1")).not.toBeInTheDocument();
+    expect(within(rows[2]).queryByText("1")).not.toBeInTheDocument();
+    // First S2 row prints "2" since it's a new set
+    expect(within(rows[3]).queryByText("2")).toBeInTheDocument();
+  });
+
+  // Each row carries the corresponding flame icon. All-timer rows get the
+  // orange flame; jam-chart rows (note only) get the off-white flame so
+  // the two categories are visually distinct in the same list.
+  test("orange flame on all-timer rows, off-white flame on jam-chart rows", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S1",
+        tracks: [
+          { allTimer: true, song: { id: "a", title: "Aceetobee", slug: "aceetobee" } as Track["song"] },
+          { note: "Slow burn.", song: { id: "b", title: "Basis for a Day", slug: "basis-for-a-day" } as Track["song"] },
+        ],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    const aceeRow = screen.getByRole("link", { name: "Aceetobee" }).closest("li");
+    const basisRow = screen.getByRole("link", { name: "Basis for a Day" }).closest("li");
+    expect(aceeRow).not.toBeNull();
+    expect(basisRow).not.toBeNull();
+    const aceeFlame = within(aceeRow as HTMLElement).getByLabelText("All-timer");
+    const basisFlame = within(basisRow as HTMLElement).getByLabelText("Jam chart");
+    expect(aceeFlame.getAttribute("class") ?? "").toMatch(/text-orange-500/);
+    expect(basisFlame.getAttribute("class") ?? "").toMatch(/text-content-text-primary/);
+  });
+
+  // Tracks render in canonical show order (set bucket → position within
+  // set), not insertion order. Verifies the row sequence matches what a
+  // user expects when reading the show top to bottom.
+  test("orders rows by set then position", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S2",
+        tracks: [
+          { allTimer: true, position: 2, song: { id: "c", title: "Crickets", slug: "crickets" } as Track["song"] },
+        ],
+      },
+      {
+        label: "S1",
+        tracks: [
+          { allTimer: true, position: 3, song: { id: "a", title: "Aceetobee", slug: "aceetobee" } as Track["song"] },
+          {
+            allTimer: true,
+            position: 1,
+            song: { id: "b", title: "Basis for a Day", slug: "basis-for-a-day" } as Track["song"],
+          },
+        ],
+      },
+      {
+        label: "E1",
+        tracks: [
+          {
+            allTimer: true,
+            position: 1,
+            song: { id: "d", title: "Story of the World", slug: "story-of-the-world" } as Track["song"],
+          },
+        ],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    const links = screen.getAllByRole("link").map((el) => el.textContent);
+    expect(links).toEqual(["Basis for a Day", "Aceetobee", "Crickets", "Story of the World"]);
+  });
+});

--- a/apps/web/app/components/setlist/setlist-highlights.tsx
+++ b/apps/web/app/components/setlist/setlist-highlights.tsx
@@ -1,88 +1,64 @@
-import type { Setlist } from "@bip/domain";
-import { FileText, Flame } from "lucide-react";
-import { Link } from "react-router";
+import type { Setlist, TrackLight } from "@bip/domain";
+import { Link } from "react-router-dom";
+import { TrackIcon } from "~/components/track/track-icon";
+import { compareBySetThenPosition, countDistinctEncores, formatSetLabel } from "./set-label";
 
 interface SetlistHighlightsProps {
   setlist: Setlist;
 }
 
+/**
+ * Right-rail panel listing every track from the show that is either an
+ * all-timer or carries a curated jam-chart note, in canonical show order.
+ * Each row shows the position label (printed only on the first row of
+ * each set group), a flame (orange for all-timer, off-white for
+ * jam-chart), a song-page link, and the note text underneath when
+ * present. Hidden entirely when no track is noteworthy.
+ */
 export function SetlistHighlights({ setlist }: SetlistHighlightsProps) {
-  // Collect all tracks that are all-timers or have notes
-  const allTimerTracks = [];
-  const tracksWithNotes = [];
+  const highlights = setlist.sets.flatMap((set) => set.tracks).filter((track) => track.allTimer || hasNote(track));
+  if (highlights.length === 0) return null;
 
-  for (const set of setlist.sets) {
-    for (const track of set.tracks) {
-      if (track.allTimer) {
-        allTimerTracks.push({ ...track, set: set.label });
-      }
-
-      if (track.note && track.note.trim() !== "") {
-        tracksWithNotes.push({ ...track, set: set.label });
-      }
-    }
-  }
-
-  // If there are no highlights, don't render the component
-  if (allTimerTracks.length === 0 && tracksWithNotes.length === 0) {
-    return null;
-  }
+  const encoresInSet = countDistinctEncores(highlights);
+  const ordered = [...highlights].sort(compareBySetThenPosition);
 
   return (
     <div className="card-premium rounded-lg px-3 py-2 space-y-3">
       <h3 className="text-sm font-medium text-content-text-secondary">Show Highlights</h3>
-      {allTimerTracks.length > 0 && (
-        <div>
-          <h4 className="text-sm font-medium text-content-text-primary flex items-center gap-2 mb-1.5">
-            <Flame className="h-4 w-4 text-orange-500 shrink-0" />
-            <span>All-Timers</span>
-          </h4>
-          <ul className="space-y-0.5 pl-6">
-            {allTimerTracks.map((track) => (
-              <li key={track.id} className="text-content-text-secondary text-sm">
-                <div className="flex items-baseline gap-2">
-                  <span className="text-xs text-content-text-tertiary font-medium">{track.set}</span>
-                  <Link
-                    to={`/songs/${track.song?.slug}`}
-                    className="text-brand-tertiary hover:text-brand-primary hover:underline transition-colors"
-                  >
-                    {track.song?.title}
-                  </Link>
-                </div>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      {tracksWithNotes.length > 0 && (
-        <div>
-          <h4 className="text-sm font-medium text-content-text-primary flex items-center gap-2 mb-1.5">
-            <FileText className="h-4 w-4 text-info shrink-0" />
-            <span>Track Notes</span>
-          </h4>
-          <ul className="space-y-2 pl-6">
-            {tracksWithNotes.map((track) => (
-              <li key={track.id} className="text-content-text-secondary text-sm">
-                <div className="flex items-baseline gap-2">
-                  <span className="text-xs text-content-text-tertiary font-medium">{track.set}</span>
-                  <div className="flex-1">
+      <ul className="space-y-2">
+        {ordered.map((track, idx) => {
+          const showSetLabel = idx === 0 || ordered[idx - 1].set !== track.set;
+          return (
+            <li key={track.id} className="text-sm">
+              <div className="flex items-baseline gap-2">
+                <span className="text-xs text-content-text-tertiary font-medium w-5 shrink-0">
+                  {showSetLabel ? formatSetLabel(track.set, { encoresInSet }) : ""}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <span className="flex items-center gap-1.5">
+                    <TrackIcon track={track} iconClassName="h-3.5 w-3.5" />
                     <Link
                       to={`/songs/${track.song?.slug}`}
                       className="text-brand-primary hover:text-brand-secondary hover:underline transition-colors"
                     >
                       {track.song?.title}
                     </Link>
-                    <p className="text-xs text-content-text-tertiary mt-0.5 pl-2 border-l-2 border-glass-border">
-                      {track.note}
+                  </span>
+                  {hasNote(track) && (
+                    <p className="text-xs text-content-text-secondary mt-0.5 pl-2 border-l-2 border-glass-border">
+                      {track.note?.trim()}
                     </p>
-                  </div>
+                  )}
                 </div>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
+}
+
+function hasNote(track: Pick<TrackLight, "note">): boolean {
+  return !!track.note?.trim();
 }

--- a/apps/web/app/components/setlist/track-rating-overlay.test.tsx
+++ b/apps/web/app/components/setlist/track-rating-overlay.test.tsx
@@ -1,0 +1,78 @@
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+// Stub the session hook so the overlay can render without a data router.
+vi.mock("~/hooks/use-session", () => ({
+  useSession: () => ({ user: null, supabase: null }),
+}));
+
+import { TrackRatingOverlay, type TrackRatingOverlayTrack } from "./track-rating-overlay";
+
+function makeTrack(overrides: Partial<TrackRatingOverlayTrack> = {}): TrackRatingOverlayTrack {
+  return {
+    id: "track-1",
+    allTimer: false,
+    note: null,
+    song: { title: "Aceetobee" },
+    averageRating: 4.5,
+    ratingsCount: 10,
+    likesCount: 0,
+    ...overrides,
+  };
+}
+
+describe('TrackRatingOverlay trigger="click"', () => {
+  // The click variant uses Radix Popover so taps on touch devices
+  // surface the overlay — the hover-only variant is invisible on
+  // mobile. Verifies the trigger primitive is wired up to clicks.
+  test("opens the overlay on click and shows the note text", async () => {
+    const NOTE = "Type II Spaga, near 20 minutes.";
+    const { user } = await setup(
+      <TrackRatingOverlay track={makeTrack({ note: NOTE })} showRating={false} trigger="click">
+        <button type="button">flame</button>
+      </TrackRatingOverlay>,
+    );
+
+    expect(screen.queryByText(NOTE)).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "flame" }));
+    expect(await screen.findByText(NOTE)).toBeInTheDocument();
+  });
+
+  // `showRating={false}` is the variant used wherever the surrounding
+  // table already has a Rating column. The overlay should hide the
+  // rating UI even though the track carries averageRating data.
+  test("suppresses the rating display when showRating is false", async () => {
+    const { user } = await setup(
+      <TrackRatingOverlay
+        track={makeTrack({ note: "Big jam.", averageRating: 4.75, ratingsCount: 12 })}
+        showRating={false}
+        trigger="click"
+      >
+        <button type="button">flame</button>
+      </TrackRatingOverlay>,
+    );
+    await user.click(screen.getByRole("button", { name: "flame" }));
+    // Note still surfaces…
+    expect(await screen.findByText("Big jam.")).toBeInTheDocument();
+    // …but the rating number does not.
+    expect(screen.queryByText("4.75")).not.toBeInTheDocument();
+  });
+});
+
+describe("TrackRatingOverlay trigger default", () => {
+  // The default trigger is hover (Radix HoverCard). A click on the
+  // trigger should NOT open it — only hover does. Locks in the
+  // distinction so a regression won't silently turn every call site
+  // into click-only behavior on mobile.
+  test("does not open on click in hover mode", async () => {
+    const NOTE = "Should not appear on click.";
+    const { user } = await setup(
+      <TrackRatingOverlay track={makeTrack({ note: NOTE })}>
+        <button type="button">row</button>
+      </TrackRatingOverlay>,
+    );
+    await user.click(screen.getByRole("button", { name: "row" }));
+    expect(screen.queryByText(NOTE)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/setlist/track-rating-overlay.tsx
+++ b/apps/web/app/components/setlist/track-rating-overlay.tsx
@@ -1,14 +1,47 @@
-import type { Track, TrackLight } from "@bip/domain";
 import { useEffect, useRef, useState } from "react";
 import { RatingComponent } from "~/components/rating";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "~/components/ui/hover-card";
+import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
 import { Skeleton } from "~/components/ui/skeleton";
 import { StarRating } from "~/components/ui/star-rating";
 import { useSession } from "~/hooks/use-session";
 
+/**
+ * Minimal structural type for any track shape this overlay can read.
+ * Wider call sites pass a full `Track` / `TrackLight`; surfaces with
+ * their own track-like row shape (e.g. SongPagePerformance) adapt at
+ * the call site. Listed inline so consumers don't have to import the
+ * full domain types just to satisfy the prop.
+ */
+export interface TrackRatingOverlayTrack {
+  id: string;
+  allTimer?: boolean | null;
+  note?: string | null;
+  song?: { title?: string | null } | null;
+  averageRating?: number | null;
+  ratingsCount?: number | null;
+  likesCount?: number | null;
+}
+
 interface TrackRatingOverlayProps {
-  track: Track | TrackLight;
+  track: TrackRatingOverlayTrack;
   children: React.ReactNode;
+  /**
+   * When false, suppress the rating display, likes count, and user
+   * rating editor — and skip the /api/tracks/:id refetch. Use this
+   * variant when the surrounding view already shows rating in its own
+   * column (e.g. the gap-chart tables) so the overlay reduces to
+   * "song title + note" without redundant scoring data.
+   */
+  showRating?: boolean;
+  /**
+   * `"hover"` (default) wraps the trigger in a hover card — opens on
+   * pointer hover, works on desktop only. `"click"` uses a popover so
+   * the overlay also opens on tap on touch devices; use it on small
+   * targets like the standalone flame icon where mobile users have no
+   * other way to surface the note.
+   */
+  trigger?: "hover" | "click";
 }
 
 interface TrackDataResponse {
@@ -23,7 +56,7 @@ interface TrackDataResponse {
   userRating: number | null;
 }
 
-export function TrackRatingOverlay({ track, children }: TrackRatingOverlayProps) {
+export function TrackRatingOverlay({ track, children, showRating = true, trigger = "hover" }: TrackRatingOverlayProps) {
   const { user } = useSession();
   const [isOpen, setIsOpen] = useState(false);
   const [data, setData] = useState<TrackDataResponse | null>(null);
@@ -37,9 +70,12 @@ export function TrackRatingOverlay({ track, children }: TrackRatingOverlayProps)
     };
   }, []);
 
-  // Fetch fresh track data when hover card opens
+  // Fetch fresh track data when hover card opens. Skipped in note-only
+  // mode — the rating display is hidden anyway, and the note text on
+  // the row already comes from the same source.
   useEffect(() => {
     if (!isOpen) return;
+    if (!showRating) return;
 
     const fetchTrackData = async () => {
       setIsLoading(true);
@@ -62,80 +98,98 @@ export function TrackRatingOverlay({ track, children }: TrackRatingOverlayProps)
     };
 
     fetchTrackData();
-  }, [isOpen, track.id]);
+  }, [isOpen, track.id, showRating]);
 
   // Use fetched data if available, otherwise fall back to initial track data
   const displayRating = data?.track.averageRating ?? track.averageRating ?? 0;
   const ratingCount = data?.track.ratingsCount ?? track.ratingsCount ?? 0;
   const userRating = data?.userRating ?? null;
 
+  const content = (
+    <div className="space-y-3">
+      <div className="text-lg font-medium text-brand-primary">{track.song?.title}</div>
+
+      {showRating &&
+        (isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-6 w-32" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+        ) : (
+          <RatingComponent rating={displayRating} ratingsCount={ratingCount} userRating={userRating} />
+        ))}
+
+      {showRating && (data?.track.likesCount ?? track.likesCount ?? 0) > 0 && (
+        <div className="text-xs text-content-text-secondary">
+          {data?.track.likesCount ?? track.likesCount}{" "}
+          {(data?.track.likesCount ?? track.likesCount) === 1 ? "like" : "likes"}
+        </div>
+      )}
+
+      {(data?.track.note ?? track.note) && (
+        <div className="text-xs text-content-text-secondary border-t border-glass-border pt-2 mt-2">
+          {data?.track.note ?? track.note}
+        </div>
+      )}
+
+      {showRating && user && (
+        <div className="border-t border-glass-border pt-3 mt-3">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-content-text-secondary">Your Rating:</span>
+            <StarRating
+              rateableId={track.id}
+              rateableType="Track"
+              className="scale-110 [&_fieldset]:border-0"
+              initialRating={userRating}
+              onRatingChange={() => {
+                // Refetch track data after rating
+                setData(null);
+                setIsLoading(true);
+                fetch(`/api/tracks/${track.id}`, { credentials: "include" })
+                  .then((res) => res.json())
+                  .then((newData) => {
+                    if (isMountedRef.current) {
+                      setData(newData);
+                      setIsLoading(false);
+                    }
+                  })
+                  .catch(() => {
+                    if (isMountedRef.current) {
+                      setIsLoading(false);
+                    }
+                  });
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
+  // Shared content styling between the hover-card and popover variants
+  // so the panel looks identical regardless of trigger mode.
+  const contentClassName = "w-80 p-4 bg-black/90 backdrop-blur-md border-glass-border shadow-xl";
+
+  if (trigger === "click") {
+    return (
+      <Popover open={isOpen} onOpenChange={setIsOpen}>
+        <PopoverTrigger asChild className="cursor-pointer">
+          {children}
+        </PopoverTrigger>
+        <PopoverContent className={contentClassName} side="top" align="start">
+          {content}
+        </PopoverContent>
+      </Popover>
+    );
+  }
+
   return (
     <HoverCard openDelay={600} closeDelay={200} onOpenChange={setIsOpen}>
       <HoverCardTrigger asChild className="cursor-pointer">
         {children}
       </HoverCardTrigger>
-      <HoverCardContent
-        className="w-80 p-4 bg-black/90 backdrop-blur-md border-glass-border shadow-xl"
-        side="top"
-        align="start"
-      >
-        <div className="space-y-3">
-          <div className="text-lg font-medium text-brand-primary">{track.song?.title}</div>
-
-          {isLoading ? (
-            <div className="space-y-2">
-              <Skeleton className="h-6 w-32" />
-              <Skeleton className="h-4 w-20" />
-            </div>
-          ) : (
-            <RatingComponent rating={displayRating} ratingsCount={ratingCount} userRating={userRating} />
-          )}
-
-          {(data?.track.likesCount ?? track.likesCount) > 0 && (
-            <div className="text-xs text-content-text-secondary">
-              {data?.track.likesCount ?? track.likesCount}{" "}
-              {(data?.track.likesCount ?? track.likesCount) === 1 ? "like" : "likes"}
-            </div>
-          )}
-
-          {(data?.track.note ?? track.note) && (
-            <div className="text-xs text-content-text-secondary border-t border-glass-border pt-2 mt-2">
-              {data?.track.note ?? track.note}
-            </div>
-          )}
-
-          {user && (
-            <div className="border-t border-glass-border pt-3 mt-3">
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-content-text-secondary">Your Rating:</span>
-                <StarRating
-                  rateableId={track.id}
-                  rateableType="Track"
-                  className="scale-110 [&_fieldset]:border-0"
-                  initialRating={userRating}
-                  onRatingChange={() => {
-                    // Refetch track data after rating
-                    setData(null);
-                    setIsLoading(true);
-                    fetch(`/api/tracks/${track.id}`, { credentials: "include" })
-                      .then((res) => res.json())
-                      .then((newData) => {
-                        if (isMountedRef.current) {
-                          setData(newData);
-                          setIsLoading(false);
-                        }
-                      })
-                      .catch(() => {
-                        if (isMountedRef.current) {
-                          setIsLoading(false);
-                        }
-                      });
-                  }}
-                />
-              </div>
-            </div>
-          )}
-        </div>
+      <HoverCardContent className={contentClassName} side="top" align="start">
+        {content}
       </HoverCardContent>
     </HoverCard>
   );

--- a/apps/web/app/components/track/all-timer-cell.tsx
+++ b/apps/web/app/components/track/all-timer-cell.tsx
@@ -1,29 +1,64 @@
-import { Flame } from "lucide-react";
+import { TrackRatingOverlay, type TrackRatingOverlayTrack } from "~/components/setlist/track-rating-overlay";
+import { TrackIcon } from "./track-icon";
 
 /**
- * Table-cell renderer for the all-timer marker. The `h-6` wrapper matches
- * the default text-base line-height of adjacent cells so the 14px flame
- * sits on the same baseline as song-title text instead of floating high.
+ * Table-cell renderer for the noteworthy-track marker. The `h-6` wrapper
+ * matches the default text-base line-height of adjacent cells so the
+ * 14px flame sits on the same baseline as song-title text.
+ *
+ * Renders nothing when the track is neither an all-timer nor carries a
+ * note. When a note IS present, the flame is wrapped in the shared
+ * TrackRatingOverlay (rating-suppressed variant) so hovering it
+ * surfaces the song title + note text without duplicating the rating
+ * data that already lives in the row's Rating column.
  *
  * `align` controls horizontal placement: `"center"` (default) suits the
- * standalone narrow column; `"start"` is used when the flame is rendered
+ * standalone narrow column; `"start"` is used when the flame sits
  * inline beneath other content in a wider host cell (e.g. the perf-table
  * Date cell or the setlist Set cell on mobile).
  */
-export function AllTimerCell({ align = "center" }: { align?: "center" | "start" }) {
-  return (
+export function AllTimerCell({
+  track,
+  align = "center",
+}: {
+  /**
+   * Carries `allTimer`, `note`, and the minimal fields TrackRatingOverlay
+   * reads (id, song?.title, etc.). Wider call sites pass a full
+   * TrackLight; the perf-table cell adapts SongPagePerformance to the
+   * same shape with `trackFromPerformance`.
+   */
+  track: TrackRatingOverlayTrack;
+  align?: "center" | "start";
+}) {
+  const hasMarker = !!track.allTimer || !!track.note?.trim();
+  if (!hasMarker) return null;
+
+  const flame = (
     <div className={`flex h-6 items-center ${align === "center" ? "justify-center" : "justify-start"}`}>
-      <Flame className="h-3.5 w-3.5 text-orange-500" aria-label="All-timer" />
+      <TrackIcon track={track} iconClassName="h-3.5 w-3.5" />
     </div>
+  );
+
+  // No note → no information to surface in an overlay; the flame alone
+  // already says "all-timer". Avoid wrapping in the hover card to keep
+  // the cell inert.
+  if (!track.note?.trim()) return flame;
+
+  return (
+    <TrackRatingOverlay track={track} showRating={false} trigger="click">
+      {flame}
+    </TrackRatingOverlay>
   );
 }
 
 /**
  * Meta options for the all-timer column — narrowest viable slot with no
  * horizontal padding so it never steals width from neighboring columns.
- * Setlist views override `hideOnMobile: true` since they render the
- * flame inline in their Set cell on mobile; the perf table keeps it
- * visible since there's no equivalent host cell there.
+ * Mobile visibility is decided by the caller: setlist views and the
+ * perf table both default to hiding the column on mobile and rendering
+ * the flame inline in a neighboring cell instead; jam-charts surfaces
+ * keep the column visible on mobile (via the caller's
+ * `mobileFlamePriority`) so the marker stays at the leftmost slot.
  */
 export const allTimerColumnMeta = {
   fixedWidth: "1.5rem",

--- a/apps/web/app/components/track/noteworthy-marker.test.tsx
+++ b/apps/web/app/components/track/noteworthy-marker.test.tsx
@@ -1,0 +1,87 @@
+import { setup } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+// TrackRatingOverlay (used internally when a note exists) calls
+// useSession → useRouteLoaderData("root"); the test harness doesn't
+// run inside a data router, so stub the hook to return a logged-out
+// session.
+vi.mock("~/hooks/use-session", () => ({
+  useSession: () => ({ user: null, supabase: null }),
+}));
+
+import { isNoteworthy, NoteworthyMarker } from "./noteworthy-marker";
+
+describe("isNoteworthy", () => {
+  // A track with neither an all-timer flag nor a note has nothing to
+  // surface — every UI surface should treat it as a plain track.
+  test("returns false when both flags are absent", () => {
+    expect(isNoteworthy({ allTimer: false, note: null })).toBe(false);
+    expect(isNoteworthy({})).toBe(false);
+  });
+
+  // The all-timer flag alone qualifies a track as noteworthy — the
+  // orange flame stands on its own without a note.
+  test("returns true for all-timer-only tracks", () => {
+    expect(isNoteworthy({ allTimer: true })).toBe(true);
+    expect(isNoteworthy({ allTimer: true, note: null })).toBe(true);
+  });
+
+  // Empty-string and whitespace-only notes are how the data layer
+  // historically records "no note", so they must not pass the gate —
+  // matches the server's `tracks.note <> ''` SQL filter.
+  test("treats blank-string notes as absent", () => {
+    expect(isNoteworthy({ allTimer: false, note: "" })).toBe(false);
+    expect(isNoteworthy({ allTimer: false, note: "   " })).toBe(false);
+  });
+
+  // A non-empty curated note qualifies a track as noteworthy even
+  // when it's not an all-timer — drives the off-white "Jam Chart"
+  // flame variant.
+  test("returns true when note is present", () => {
+    expect(isNoteworthy({ allTimer: false, note: "Massive Spaga jam." })).toBe(true);
+  });
+
+  // SongPagePerformance carries the same data under `notes` (plural).
+  // The predicate accepts both shapes so cross-song surfaces don't have
+  // to adapt before calling.
+  test("accepts the SongPagePerformance shape with `notes` (plural)", () => {
+    expect(isNoteworthy({ allTimer: false, notes: "Type II exploration." })).toBe(true);
+    expect(isNoteworthy({ allTimer: false, notes: "" })).toBe(false);
+    expect(isNoteworthy({ allTimer: true, notes: null })).toBe(true);
+  });
+});
+
+describe("NoteworthyMarker", () => {
+  // Non-noteworthy tracks render nothing — callers don't need to gate
+  // on the flag pair before dropping the marker into a row.
+  test("renders nothing when track is neither all-timer nor noted", () => {
+    const { container } = render(<NoteworthyMarker track={{ id: "t1", allTimer: false, note: null }} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // All-timer without a note: bare flame (no click target). There's
+  // no popover-worthy content for this case.
+  test("renders the bare flame for all-timer without a note", async () => {
+    const { user } = await setup(<NoteworthyMarker track={{ id: "t1", allTimer: true, note: null }} />);
+    const flame = screen.getByLabelText("All-timer");
+    expect(flame).toBeInTheDocument();
+    // Clicking does not open a popover: there's no dialog/popover element
+    // because there's nothing to surface.
+    await user.click(flame);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  // When the track carries a note, clicking the flame opens the
+  // shared TrackRatingOverlay (rating-suppressed variant) so the note
+  // is reachable on touch devices too.
+  test("clicking the flame on a noted track opens a popover with the note text", async () => {
+    const NOTE = "Bombshell into Crickets is the rare full-band reprise.";
+    const { user } = await setup(
+      <NoteworthyMarker track={{ id: "t1", allTimer: false, note: NOTE, song: { title: "Bombshell" } }} />,
+    );
+    expect(screen.queryByText(NOTE)).not.toBeInTheDocument();
+    await user.click(screen.getByLabelText("Jam chart"));
+    expect(await screen.findByText(NOTE)).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/track/noteworthy-marker.tsx
+++ b/apps/web/app/components/track/noteworthy-marker.tsx
@@ -1,0 +1,48 @@
+import { TrackRatingOverlay, type TrackRatingOverlayTrack } from "~/components/setlist/track-rating-overlay";
+import { TrackIcon } from "./track-icon";
+
+/**
+ * "A track worth surfacing": all-timer OR a curated note. The single
+ * predicate used wherever the UI gates on noteworthy-ness, so the
+ * "marker exists" definition can't drift between call sites. Mirrors
+ * the server's SQL: `tracks.all_timer = true OR (tracks.note IS NOT
+ * NULL AND tracks.note <> '')` — keep them in sync.
+ *
+ * Accepts both `note` (Track / TrackLight shape) and `notes` (the
+ * SongPagePerformance projection) so cross-song surfaces don't have to
+ * adapt before calling.
+ */
+export function isNoteworthy(t: { allTimer?: boolean | null; note?: string | null; notes?: string | null }): boolean {
+  return !!t.allTimer || !!(t.note ?? t.notes)?.trim();
+}
+
+/**
+ * The standard noteworthy-track flame: renders nothing for plain
+ * tracks, the bare flame for all-timers without a note, and the flame
+ * wrapped in a click-triggered note popover when a note exists.
+ * Encapsulates the "is the track marker-worthy" + "does it carry a
+ * tap-target popover" decisions so call sites can just drop the
+ * component in without re-implementing either check.
+ *
+ * Use this on inline-flow surfaces (setlist flow view, song-title
+ * rows). Table cells with a fixed-height wrapper should use
+ * `AllTimerCell`, which composes this with the sized container.
+ */
+export function NoteworthyMarker({
+  track,
+  iconClassName,
+  className,
+}: {
+  track: TrackRatingOverlayTrack;
+  iconClassName?: string;
+  className?: string;
+}) {
+  if (!isNoteworthy(track)) return null;
+  const icon = <TrackIcon track={track} iconClassName={iconClassName} className={className} />;
+  if (!track.note?.trim()) return icon;
+  return (
+    <TrackRatingOverlay track={track} showRating={false} trigger="click">
+      <span className="cursor-pointer">{icon}</span>
+    </TrackRatingOverlay>
+  );
+}

--- a/apps/web/app/components/track/sortable-track-item.tsx
+++ b/apps/web/app/components/track/sortable-track-item.tsx
@@ -1,7 +1,8 @@
 import type { Track } from "@bip/domain";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { Edit2, Flame, GripVertical, Trash } from "lucide-react";
+import { Edit2, GripVertical, Trash } from "lucide-react";
+import { TrackIcon } from "~/components/track/track-icon";
 import { Button } from "~/components/ui/button";
 import { listRowClass } from "~/lib/form-styles";
 import { cn } from "~/lib/utils";
@@ -45,7 +46,7 @@ export function SortableTrackItem({ track, onEdit, onDelete, isDeleting }: Sorta
             {/* Title + inline markers */}
             <div className="flex items-center gap-2 md:gap-3 flex-wrap flex-1 min-w-0">
               <span className="text-white font-medium">{track.song?.title || "Unknown Song"}</span>
-              {track.allTimer && <Flame className="h-4 w-4 text-orange-500 shrink-0" />}
+              <TrackIcon track={track} iconClassName="h-4 w-4" />
               {track.segue && <span className="text-content-text-secondary text-sm">{track.segue}</span>}
             </div>
           </div>

--- a/apps/web/app/components/track/track-icon.test.tsx
+++ b/apps/web/app/components/track/track-icon.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { TrackIcon } from "./track-icon";
+
+describe("TrackIcon", () => {
+  // A track with neither flag set is not noteworthy, so the component
+  // renders nothing rather than leave an invisible marker.
+  test("renders nothing when neither allTimer nor note is set", () => {
+    const { container } = render(<TrackIcon track={{ allTimer: false, note: null }} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // Empty-string / whitespace-only notes carry no information; they
+  // should not flip the icon into the jam-chart variant.
+  test("treats blank-string notes as absent", () => {
+    const { container } = render(<TrackIcon track={{ allTimer: false, note: "   " }} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // All-timer (with or without a note) takes the orange flame — it's the
+  // stronger of the two signals and the user-facing color contract.
+  test("renders an orange flame when allTimer is true", () => {
+    render(<TrackIcon track={{ allTimer: true, note: null }} />);
+    const flame = screen.getByLabelText("All-timer");
+    expect(flame.getAttribute("class") ?? "").toMatch(/text-orange-500/);
+  });
+
+  // Jam-chart (note only) gets the off-white flame so it reads as a
+  // quieter signal next to the orange all-timer flame on the same list.
+  test("renders an off-white flame when only note is set", () => {
+    render(<TrackIcon track={{ allTimer: false, note: "Big Type II Spaga." }} />);
+    const flame = screen.getByLabelText("Jam chart");
+    expect(flame.getAttribute("class") ?? "").toMatch(/text-content-text-primary/);
+    expect(flame.getAttribute("class") ?? "").not.toMatch(/text-orange-500/);
+  });
+
+  // When both flags are set, orange (all-timer) wins — it's the stronger
+  // signal. Callers that want to surface the note do so via the
+  // surrounding hover overlay, not via this icon's color.
+  test("orange flame wins when both allTimer and note are set", () => {
+    render(<TrackIcon track={{ allTimer: true, note: "Story of the World > Crickets." }} />);
+    const flame = screen.getByLabelText("All-timer");
+    expect(flame.getAttribute("class") ?? "").toMatch(/text-orange-500/);
+  });
+
+  // Allow callers to pin a custom size — the same component is used in
+  // dense table cells (smaller) and standalone sections (larger).
+  test("iconClassName overrides the default size classes on the flame", () => {
+    render(<TrackIcon track={{ allTimer: true, note: null }} iconClassName="h-3 w-3" />);
+    const flame = screen.getByLabelText("All-timer");
+    expect(flame.getAttribute("class") ?? "").toMatch(/h-3/);
+    expect(flame.getAttribute("class") ?? "").toMatch(/w-3/);
+  });
+});

--- a/apps/web/app/components/track/track-icon.tsx
+++ b/apps/web/app/components/track/track-icon.tsx
@@ -1,0 +1,43 @@
+import { Flame } from "lucide-react";
+import { cn } from "~/lib/utils";
+
+interface TrackIconProps {
+  /**
+   * Track-like shape carrying the two flags the icon dispatches on.
+   * Accepts a narrow shape (not full `Track`) so call sites can pass
+   * partial projections without ceremony.
+   */
+  track: { allTimer?: boolean | null; note?: string | null };
+  /**
+   * Sizing/layout classes applied to the flame. Default `h-4 w-4` matches
+   * standalone-section sizing; dense table cells override to smaller.
+   */
+  iconClassName?: string;
+  /** Extra classes applied to the outer wrapper span. */
+  className?: string;
+}
+
+/**
+ * Visual marker for noteworthy tracks. Renders the orange flame when the
+ * track is an all-timer, the off-white flame when it carries a curated
+ * jam-chart note but isn't an all-timer, and nothing otherwise. The
+ * surrounding hover/click affordance for showing the note text is
+ * provided by the caller (e.g. AllTimerCell wraps the flame in a
+ * TrackRatingOverlay; the setlist flow view does the same for the whole
+ * row); this component is intentionally inert.
+ */
+export function TrackIcon({ track, iconClassName, className }: TrackIconProps) {
+  const allTimer = !!track.allTimer;
+  const note = !!track.note?.trim();
+
+  if (!allTimer && !note) return null;
+
+  const colorClass = allTimer ? "text-orange-500" : "text-content-text-primary";
+  const sizeClass = iconClassName ?? "h-4 w-4";
+  const label = allTimer ? "All-timer" : "Jam chart";
+  return (
+    <span className={cn("inline-flex items-center", className)}>
+      <Flame className={cn(sizeClass, "shrink-0", colorClass)} aria-label={label} />
+    </span>
+  );
+}

--- a/apps/web/app/components/ui/tabs.tsx
+++ b/apps/web/app/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      "inline-flex cursor-pointer items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
       className,
     )}
     {...props}

--- a/apps/web/app/lib/noteworthy-performance-api.ts
+++ b/apps/web/app/lib/noteworthy-performance-api.ts
@@ -1,0 +1,32 @@
+import type { PerformanceFilterOptions } from "@bip/core/page-composers/song-page-composer";
+import type { AllTimersPageView } from "@bip/domain";
+import { publicLoader } from "~/lib/base-loaders";
+import { buildFilteredCacheKey, parsePerformanceFilters } from "~/lib/performance-filter-params";
+import { services } from "~/server/services";
+
+/**
+ * Shared API loader for the cross-song noteworthy-performance endpoints
+ * (`/api/all-timers`, `/api/jam-charts`). Parses URL filters, derives a
+ * filter-aware cache key, and delegates to the route-specific `build`
+ * function (which carries the base WHERE condition). Returns just the
+ * performances array — the routes are consumed by client-side refetch,
+ * not by SSR loaders that also need a dehydrated query client.
+ */
+export function createNoteworthyApiLoader({
+  cacheSuffix,
+  build,
+}: {
+  /** Cache-key suffix passed through `buildFilteredCacheKey` — e.g. `"all-timers"` or `"jam-charts"`. */
+  cacheSuffix: string;
+  build: (filters: PerformanceFilterOptions) => Promise<AllTimersPageView>;
+}) {
+  return publicLoader(async ({ request, context }) => {
+    const url = new URL(request.url);
+    const filters = await parsePerformanceFilters(url, context);
+    const cacheKey = buildFilteredCacheKey(url, cacheSuffix, filters.attendedUserId);
+
+    const result = await services.cache.getOrSet(cacheKey, async () => build(filters), { ttl: 3600 });
+
+    return result.performances;
+  });
+}

--- a/apps/web/app/lib/noteworthy-performance-loader.ts
+++ b/apps/web/app/lib/noteworthy-performance-loader.ts
@@ -1,0 +1,51 @@
+import type { AllTimersPageView } from "@bip/domain";
+import { type DehydratedState, dehydrate } from "@tanstack/react-query";
+import { type PublicContext, publicLoader } from "~/lib/base-loaders";
+import { showUserDataQueryKey, trackUserRatingsQueryKey } from "~/lib/query-keys";
+import { createPrefetchClient } from "~/lib/query-prefetch";
+import { services } from "~/server/services";
+import { computeShowUserData } from "~/server/show-user-data";
+import { computeTrackUserRatings } from "~/server/track-user-ratings";
+
+export type NoteworthyLoaderData = AllTimersPageView & { dehydratedState: DehydratedState };
+
+/**
+ * Server-only loader factory for the cross-song noteworthy-performance
+ * pages (`/songs/all-timers`, `/songs/jam-charts`). Caches the composer
+ * result and prefetches per-track rating + per-show attendance data so
+ * the first frame paints with hydrated chrome.
+ *
+ * Kept in its own file (no JSX, no client imports) because route
+ * components reference `NoteworthyPerformancePage` as a runtime value;
+ * if the loader factory and the component lived in the same module,
+ * Vite would pull `~/server/*` into the client bundle through the
+ * component import and break `<Link>` navigation (see PR #58 +
+ * apps/web/CLAUDE.md).
+ */
+export function createNoteworthyLoader({
+  cacheKey,
+  build,
+}: {
+  cacheKey: string;
+  build: () => Promise<AllTimersPageView>;
+}) {
+  return publicLoader(async ({ context }: { context: PublicContext }): Promise<NoteworthyLoaderData> => {
+    const view = await services.cache.getOrSet(cacheKey, build, { ttl: 3600 });
+
+    const trackIds = view.performances.map((p) => p.trackId);
+    const showIds = [...new Set(view.performances.map((p) => p.show.id))];
+    const queryClient = createPrefetchClient();
+    await Promise.all([
+      queryClient.prefetchQuery({
+        queryKey: trackUserRatingsQueryKey(trackIds),
+        queryFn: () => computeTrackUserRatings(context, trackIds),
+      }),
+      queryClient.prefetchQuery({
+        queryKey: showUserDataQueryKey(showIds),
+        queryFn: () => computeShowUserData(context, showIds),
+      }),
+    ]);
+
+    return { ...view, dehydratedState: dehydrate(queryClient) };
+  });
+}

--- a/apps/web/app/lib/noteworthy-performance-page.tsx
+++ b/apps/web/app/lib/noteworthy-performance-page.tsx
@@ -1,0 +1,77 @@
+import { PerformanceTable } from "~/components/performance";
+import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
+import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
+import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
+import type { NoteworthyLoaderData } from "~/lib/noteworthy-performance-loader";
+
+/**
+ * Shared page body for the cross-song noteworthy-performance pages
+ * (`/songs/all-timers`, `/songs/jam-charts`). The two routes differ
+ * only in (a) the API endpoint they refetch from when filters change
+ * and (b) which toggle chip is hidden because it matches the page's
+ * base condition (All-Timer chip on all-timers, Jam Chart chip on
+ * jam-charts).
+ *
+ * Kept in its own client-safe module — the loader factory lives in
+ * `noteworthy-performance-loader.ts` so route components can render
+ * this component without dragging server imports into the client
+ * bundle (see PR #58 + apps/web/CLAUDE.md).
+ */
+export function NoteworthyPerformancePage({
+  apiUrl,
+  hideAllTimerToggle = false,
+  hideJamChartToggle = false,
+}: {
+  apiUrl: string;
+  hideAllTimerToggle?: boolean;
+  hideJamChartToggle?: boolean;
+}) {
+  const { performances: allPerformances } = useSerializedLoaderData<NoteworthyLoaderData>();
+  const {
+    filteredData: filteredPerformances,
+    isLoading,
+    selectedTimeRange,
+    coverFilter,
+    selectedAuthor,
+    activeToggleSet,
+    hasActiveFilters,
+    searchText,
+    setSearchText,
+    updateFilter,
+    toggleFilter,
+    clearFilters,
+  } = usePerformancePageFilters({
+    initialData: allPerformances,
+    apiUrl,
+    searchFilter: searchPerformance,
+  });
+
+  return (
+    <div>
+      <PerformanceTable
+        performances={filteredPerformances}
+        isLoading={isLoading}
+        showSongColumn
+        showAllTimerColumn
+        mobileFlamePriority
+        showGapColumns={false}
+        headerContent={
+          <PerformanceFilterControls
+            selectedTimeRange={selectedTimeRange}
+            activeToggleSet={activeToggleSet}
+            updateFilter={updateFilter}
+            toggleFilter={toggleFilter}
+            clearFilters={clearFilters}
+            coverFilter={coverFilter}
+            selectedAuthor={selectedAuthor}
+            showAllTimerToggle={!hideAllTimerToggle}
+            showJamChartToggle={!hideJamChartToggle}
+            searchValue={searchText}
+            onSearchChange={setSearchText}
+            hasActiveFilters={hasActiveFilters}
+          />
+        }
+      />
+    </div>
+  );
+}

--- a/apps/web/app/lib/performance-filter-params.ts
+++ b/apps/web/app/lib/performance-filter-params.ts
@@ -15,6 +15,7 @@ const VALID_FILTER_KEYS = new Set([
   "standalone",
   "inverted",
   "dyslexic",
+  "jamChart",
   "allTimer",
 ]);
 

--- a/apps/web/app/lib/server-import-leak.test.ts
+++ b/apps/web/app/lib/server-import-leak.test.ts
@@ -93,20 +93,31 @@ function valueImports(sourceFile: ts.SourceFile): ValueImport[] {
 
 /**
  * Build a set of spans (start/end offsets) that belong to server-only exports
- * — the code inside `export const loader = ...` and friends. A reference to
- * an imported identifier inside these spans is stripped from the client
- * bundle by React Router's vite plugin and is therefore safe.
+ * — the code inside `export const loader = ...`, `export async function
+ * action(...)`, and friends. A reference to an imported identifier inside
+ * these spans is stripped from the client bundle by React Router's vite
+ * plugin and is therefore safe.
+ *
+ * Recognizes both export forms because route authors mix them freely: the
+ * variable form (`export const loader = publicLoader(...)`) and the
+ * function-declaration form (`export async function action(args) {...}`).
  */
 function serverOnlySpans(sourceFile: ts.SourceFile): Array<[number, number]> {
   const spans: Array<[number, number]> = [];
   for (const statement of sourceFile.statements) {
-    if (!ts.isVariableStatement(statement)) continue;
-    const hasExport = statement.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+    const modifiers = ts.canHaveModifiers(statement) ? ts.getModifiers(statement) : undefined;
+    const hasExport = modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
     if (!hasExport) continue;
-    for (const decl of statement.declarationList.declarations) {
-      if (!ts.isIdentifier(decl.name)) continue;
-      if (!SERVER_ONLY_EXPORT_NAMES.has(decl.name.text)) continue;
-      if (decl.initializer) spans.push([decl.initializer.getStart(sourceFile), decl.initializer.getEnd()]);
+
+    if (ts.isVariableStatement(statement)) {
+      for (const decl of statement.declarationList.declarations) {
+        if (!ts.isIdentifier(decl.name)) continue;
+        if (!SERVER_ONLY_EXPORT_NAMES.has(decl.name.text)) continue;
+        if (decl.initializer) spans.push([decl.initializer.getStart(sourceFile), decl.initializer.getEnd()]);
+      }
+    } else if (ts.isFunctionDeclaration(statement) && statement.name && statement.body) {
+      if (!SERVER_ONLY_EXPORT_NAMES.has(statement.name.text)) continue;
+      spans.push([statement.body.getStart(sourceFile), statement.body.getEnd()]);
     }
   }
   return spans;
@@ -144,10 +155,13 @@ describe("loader helper modules must not leak server code into the client bundle
   // References inside the default component or at module top level trigger a
   // violation — those would pull the helper into the client bundle.
   test("route .tsx files reference server-helper imports only in server-only exports", async () => {
-    const helperFiles = await fg("**/*.ts", {
-      cwd: ROUTES_ROOT,
+    // Scan helpers under both `app/routes/` (per the original PR #58
+    // failure mode) and `app/lib/` — both are common places to put
+    // loader plumbing that route components import.
+    const helperFiles = await fg(["routes/**/*.{ts,tsx}", "lib/**/*.{ts,tsx}"], {
+      cwd: APP_ROOT,
       absolute: true,
-      ignore: ["**/*.test.ts"],
+      ignore: ["**/*.test.ts", "**/*.test.tsx"],
     });
     const serverHelpers = new Set(helperFiles.filter((f) => directlyImportsServerCode(parse(f))));
 

--- a/apps/web/app/lib/song-filters.ts
+++ b/apps/web/app/lib/song-filters.ts
@@ -84,6 +84,7 @@ export const TOGGLE_FILTER_DEFINITIONS = [
   { key: "standalone", label: "Standalone" },
   { key: "inverted", label: "Inverted" },
   { key: "dyslexic", label: "Dyslexic" },
+  { key: "jamChart", label: "Jam Chart" },
   { key: "allTimer", label: "All-Timer" },
   { key: "attended", label: "Attended" },
 ] as const;

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -92,11 +92,17 @@ export default [
     ...prefix("songs", [
       index("routes/songs/_index.tsx"),
       route("all-timers", "routes/songs/all-timers.tsx"),
+      route("jam-charts", "routes/songs/jam-charts.tsx"),
       route("histories", "routes/songs/histories.tsx"),
       route("recent", "routes/songs/recent.tsx"),
       route("this-year", "routes/songs/this-year.tsx"),
       route("new", "routes/songs/new.tsx"),
       route(":slug", "routes/songs/$slug.tsx"),
+      // Same file backs `/songs/:slug/:tab` (jam-charts, all-timers,
+      // stats, history, lyrics, guitar-tabs) so the in-song tabs are
+      // shareable URLs. A unique `id` is required because RR v7 keys
+      // routes by module path.
+      route(":slug/:tab", "routes/songs/$slug.tsx", { id: "song-tab" }),
       route(":slug/edit", "routes/songs/$slug.edit.tsx"),
     ]),
   ]),
@@ -115,6 +121,7 @@ export default [
     route("venues", "routes/api/venues.tsx"),
     route("venues/:id", "routes/api/venues/$id.tsx"),
     route("all-timers", "routes/api/all-timers.tsx"),
+    route("jam-charts", "routes/api/jam-charts.tsx"),
     route("songs", "routes/api/songs.tsx"),
     route("songs/performances", "routes/api/songs/performances.tsx"),
     route("songs/:id", "routes/api/songs/$id.tsx"),

--- a/apps/web/app/routes/api/jam-charts.tsx
+++ b/apps/web/app/routes/api/jam-charts.tsx
@@ -2,6 +2,6 @@ import { createNoteworthyApiLoader } from "~/lib/noteworthy-performance-api";
 import { services } from "~/server/services";
 
 export const loader = createNoteworthyApiLoader({
-  cacheSuffix: "all-timers",
-  build: (filters) => services.songPageComposer.buildAllTimers(filters),
+  cacheSuffix: "jam-charts",
+  build: (filters) => services.songPageComposer.buildJamCharts(filters),
 });

--- a/apps/web/app/routes/songs/$slug.test.tsx
+++ b/apps/web/app/routes/songs/$slug.test.tsx
@@ -4,6 +4,20 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
+// Mock `useNavigate` + `useParams` to drive the URL-syncing tab logic
+// without needing a Routes definition. Other react-router exports
+// (MemoryRouter, Link, etc.) keep their real implementations.
+const mockNavigate = vi.fn();
+const mockParams: { slug?: string; tab?: string } = { slug: "basis-for-a-day" };
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => mockParams,
+  };
+});
+
 // Mock server-side modules
 vi.mock("~/server/services", () => ({ services: {} }));
 vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
@@ -91,6 +105,51 @@ function renderSongPage() {
 describe("SongPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset URL params to the default (no :tab) between tests so each
+    // test starts on the "All Performances" tab.
+    mockParams.slug = "basis-for-a-day";
+    mockParams.tab = undefined;
+  });
+
+  // The :tab URL segment is the source of truth for the active tab —
+  // back/forward and shareable links should land on the right pane.
+  test("activates the tab specified by the URL :tab segment", () => {
+    mockParams.tab = "stats";
+    renderSongPage();
+
+    const statsTab = screen.getByRole("tab", { name: /graphs/i });
+    expect(statsTab).toHaveAttribute("data-state", "active");
+  });
+
+  // A typo'd or unknown :tab segment falls back to "All Performances"
+  // instead of rendering nothing — guards against broken inbound links.
+  test("falls back to the All Performances tab when :tab is unknown", () => {
+    mockParams.tab = "definitely-not-a-tab";
+    renderSongPage();
+
+    const performancesTab = screen.getByRole("tab", { name: /all performances/i });
+    expect(performancesTab).toHaveAttribute("data-state", "active");
+  });
+
+  // Clicking a non-default tab navigates to the nested URL so the new
+  // URL can be bookmarked / shared / used by the back button.
+  test("clicking a tab navigates to /songs/:slug/:tab", async () => {
+    const user = userEvent.setup();
+    renderSongPage();
+
+    await user.click(screen.getByRole("tab", { name: /graphs/i }));
+    expect(mockNavigate).toHaveBeenCalledWith("/songs/basis-for-a-day/stats");
+  });
+
+  // The default ("performances") tab navigates back to the bare song
+  // URL so there's no redundant `/performances` suffix in the URL.
+  test("clicking the All Performances tab navigates to bare /songs/:slug", async () => {
+    mockParams.tab = "stats";
+    const user = userEvent.setup();
+    renderSongPage();
+
+    await user.click(screen.getByRole("tab", { name: /all performances/i }));
+    expect(mockNavigate).toHaveBeenCalledWith("/songs/basis-for-a-day");
   });
 
   // The All-Timers tab visibility should be based on the unfiltered data,

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -3,13 +3,14 @@ import { type DehydratedState, dehydrate } from "@tanstack/react-query";
 import { ArrowLeft, BarChart3, FileTextIcon, Flame, GuitarIcon, History, ListMusic, Pencil } from "lucide-react";
 import { type ReactNode, useMemo, useState } from "react";
 import type { LoaderFunctionArgs } from "react-router";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { AdminOnly } from "~/components/admin/admin-only";
 import { PerformanceTable } from "~/components/performance";
 import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
 import { RatingComponent } from "~/components/rating";
 import { ShowDate } from "~/components/show-date";
 import { YearlyPlayChart } from "~/components/song/yearly-play-chart";
+import { isNoteworthy } from "~/components/track/noteworthy-marker";
 import { Button } from "~/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
@@ -185,13 +186,21 @@ function formatAvgMedianGap(avg: number | null | undefined, median: number | nul
   return `${fmt(avg)} / ${fmt(median)}`;
 }
 
+// Allowlist used to validate the `:tab` URL segment so a typo'd path
+// like /songs/triumph/foo falls back to the default tab instead of
+// rendering nothing. Order is informational only.
+const VALID_TABS = ["performances", "jam-charts", "all-timers", "stats", "history", "lyrics", "guitar-tabs"] as const;
+type TabValue = (typeof VALID_TABS)[number];
+
 export default function SongPage() {
   const { song, performances: allPerformances, showsByYear } = useSerializedLoaderData<LoaderData>();
-  const [searchParams] = useSearchParams();
-  const tabParam = searchParams.get("tab");
-  const validTabs = ["performances", "all-timers", "stats", "history", "lyrics", "guitar-tabs"];
-  const defaultTab = tabParam && validTabs.includes(tabParam) ? tabParam : "performances";
-  const [activeTab, setActiveTab] = useState(defaultTab);
+  const params = useParams<{ tab?: string }>();
+  const navigate = useNavigate();
+  // The :tab segment is the source of truth — Tabs renders whatever
+  // the URL says, and clicking a tab navigates so back/forward and
+  // shareable links work.
+  const activeTab: TabValue =
+    params.tab && (VALID_TABS as readonly string[]).includes(params.tab) ? (params.tab as TabValue) : "performances";
   const {
     filteredData: filteredPerformances,
     isLoading,
@@ -209,14 +218,31 @@ export default function SongPage() {
     extraParams: useMemo(() => ({ slug: song.slug }), [song.slug]),
     searchFilter: searchPerformance,
   });
+  const handleTabChange = (value: string) => {
+    clearFilters();
+    // "performances" is the default; navigate to bare /songs/:slug so
+    // the URL doesn't carry a redundant /performances suffix.
+    navigate(value === "performances" ? `/songs/${song.slug}` : `/songs/${song.slug}/${value}`);
+  };
 
   const hasAllTimers = useMemo(() => allPerformances.some((p) => p.allTimer), [allPerformances]);
   const filteredAllTimers = useMemo(() => filteredPerformances.filter((p) => p.allTimer), [filteredPerformances]);
+  // Jam Charts: all-timer OR any track with a curated note (non-empty).
+  // Superset of all-timers; the tab only appears when the song has at
+  // least one such performance.
+  const hasJamCharts = useMemo(() => allPerformances.some(isNoteworthy), [allPerformances]);
+  const filteredJamCharts = useMemo(() => filteredPerformances.filter(isNoteworthy), [filteredPerformances]);
   // Server-narrowing filter active = any UI filter that affects the
   // performance set the server returned. Excludes `searchText` (client-only).
   // Used to render the Filtered Gap column in the performances table.
   const hasServerNarrowingFilter = selectedTimeRange !== "all" || activeToggleSet.size > 0;
-  const filterContent = (
+  // Tab-specific noteworthy-toggle suppression: when the active tab is
+  // already scoped to "all-timers" or "jam-charts", the matching chip
+  // (and the chip that strictly subsets it) shouldn't reappear in the
+  // filter row because toggling it would either be a no-op or
+  // contradict the tab's scope. Mirrors how the global pages hide
+  // those chips on their own routes.
+  const renderFilterContent = (overrides?: { hideAllTimerToggle?: boolean; hideJamChartToggle?: boolean }) => (
     <PerformanceFilterControls
       selectedTimeRange={selectedTimeRange}
       activeToggleSet={activeToggleSet}
@@ -226,6 +252,8 @@ export default function SongPage() {
       searchValue={searchText}
       onSearchChange={setSearchText}
       hasActiveFilters={hasActiveFilters}
+      showAllTimerToggle={!overrides?.hideAllTimerToggle}
+      showJamChartToggle={!overrides?.hideJamChartToggle}
     />
   );
 
@@ -356,22 +384,9 @@ export default function SongPage() {
         </div>
       )}
 
-      <Tabs
-        value={activeTab}
-        className="w-full"
-        onValueChange={(value) => {
-          setActiveTab(value);
-          clearFilters();
-        }}
-      >
+      <Tabs value={activeTab} className="w-full" onValueChange={handleTabChange}>
         <div className="sm:hidden mb-4" data-testid="mobile-song-view">
-          <Select
-            value={activeTab}
-            onValueChange={(value) => {
-              setActiveTab(value);
-              clearFilters();
-            }}
-          >
+          <Select value={activeTab} onValueChange={handleTabChange}>
             <SelectTrigger
               aria-label="Song view"
               className="w-full h-11 bg-glass-bg border border-glass-border text-content-text-primary hover:bg-glass-bg/80 focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20"
@@ -380,6 +395,7 @@ export default function SongPage() {
             </SelectTrigger>
             <SelectContent className="bg-glass-bg border-glass-border backdrop-blur-md">
               <SelectItem value="performances">All Performances</SelectItem>
+              {hasJamCharts && <SelectItem value="jam-charts">Jam Charts</SelectItem>}
               {hasAllTimers && <SelectItem value="all-timers">All-Timers</SelectItem>}
               <SelectItem value="stats">Stats</SelectItem>
               {song.history && <SelectItem value="history">History</SelectItem>}
@@ -400,6 +416,19 @@ export default function SongPage() {
             <ListMusic className="h-4 w-4" />
             All Performances
           </TabsTrigger>
+          {hasJamCharts && (
+            <TabsTrigger
+              value="jam-charts"
+              className={cn(
+                "flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-none data-[state=active]:shadow-none",
+                "data-[state=active]:border-b-2 data-[state=active]:border-brand-primary data-[state=active]:bg-transparent",
+                "data-[state=inactive]:bg-transparent data-[state=inactive]:text-content-text-tertiary",
+              )}
+            >
+              <Flame className="h-4 w-4" />
+              Jam Charts
+            </TabsTrigger>
+          )}
           {hasAllTimers && (
             <TabsTrigger
               value="all-timers"
@@ -465,6 +494,18 @@ export default function SongPage() {
           )}
         </TabsList>
 
+        {hasJamCharts && (
+          <TabsContent value="jam-charts" className="mt-6">
+            <PerformanceTable
+              performances={filteredJamCharts}
+              isLoading={isLoading}
+              showAllTimerColumn
+              hasNarrowingFilter={hasServerNarrowingFilter}
+              headerContent={renderFilterContent({ hideJamChartToggle: true })}
+            />
+          </TabsContent>
+        )}
+
         {hasAllTimers && (
           <TabsContent value="all-timers" className="mt-6 space-y-8">
             {/* Featured cards for performances with notes */}
@@ -504,7 +545,7 @@ export default function SongPage() {
               performances={filteredAllTimers}
               isLoading={isLoading}
               hasNarrowingFilter={hasServerNarrowingFilter}
-              headerContent={filterContent}
+              headerContent={renderFilterContent({ hideAllTimerToggle: true, hideJamChartToggle: true })}
             />
           </TabsContent>
         )}
@@ -515,7 +556,7 @@ export default function SongPage() {
             showAllTimerColumn
             isLoading={isLoading}
             hasNarrowingFilter={hasServerNarrowingFilter}
-            headerContent={filterContent}
+            headerContent={renderFilterContent()}
           />
         </TabsContent>
 

--- a/apps/web/app/routes/songs/_layout.tsx
+++ b/apps/web/app/routes/songs/_layout.tsx
@@ -16,6 +16,7 @@ const TABS: Tab[] = [
   { label: "All Songs", path: "/songs", icon: ListMusic },
   { label: "Last 10 Shows", path: "/songs/recent", icon: Clock },
   { label: "This Year", path: "/songs/this-year", icon: Calendar },
+  { label: "Jam Charts", path: "/songs/jam-charts", icon: Flame },
   { label: "All-Timers", path: "/songs/all-timers", icon: Flame, iconClassName: "text-orange-500" },
   { label: "Histories", path: "/songs/histories", icon: History },
 ];

--- a/apps/web/app/routes/songs/all-timers.test.tsx
+++ b/apps/web/app/routes/songs/all-timers.test.tsx
@@ -6,7 +6,16 @@ import { describe, expect, test, vi } from "vitest";
 // Mock server-side modules
 vi.mock("~/server/services", () => ({ services: {} }));
 vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
-vi.mock("@bip/domain", () => ({}));
+vi.mock("@bip/domain", () => ({
+  // Loader imports CacheKeys.songs.allTimers() at module top level.
+  CacheKeys: { songs: { allTimers: () => "test-key" } },
+}));
+vi.mock("~/lib/noteworthy-performance-loader", () => ({
+  createNoteworthyLoader: vi.fn(),
+}));
+vi.mock("~/lib/noteworthy-performance-page", () => ({
+  NoteworthyPerformancePage: (props: object) => mockShallowComponent("NoteworthyPerformancePage", props),
+}));
 
 // Mock hooks
 vi.mock("~/hooks/use-serialized-loader-data", () => ({
@@ -64,12 +73,17 @@ describe("AllTimersPage", () => {
     expect(screen.queryByRole("link", { name: /back to songs/i })).not.toBeInTheDocument();
   });
 
-  // The PerformanceTable should still render as the main content.
-  test("renders the PerformanceTable with showSongColumn", () => {
+  // The page delegates to NoteworthyPerformancePage with the
+  // all-timers-specific endpoint and both noteworthy toggle chips
+  // hidden (All-Timer because the whole page is all-timers, Jam Chart
+  // for the same scope-redundancy reason).
+  test("renders NoteworthyPerformancePage with the all-timers API url and both toggles hidden", () => {
     renderAllTimers();
 
-    const table = screen.getByTestId("PerformanceTable");
-    expect(table).toBeInTheDocument();
-    expect(table.textContent).toContain('"showSongColumn":true');
+    const page = screen.getByTestId("NoteworthyPerformancePage");
+    expect(page).toBeInTheDocument();
+    expect(page.textContent).toContain('"apiUrl":"/api/all-timers"');
+    expect(page.textContent).toContain('"hideAllTimerToggle":true');
+    expect(page.textContent).toContain('"hideJamChartToggle":true');
   });
 });

--- a/apps/web/app/routes/songs/all-timers.tsx
+++ b/apps/web/app/routes/songs/all-timers.tsx
@@ -1,43 +1,11 @@
-import { type AllTimersPageView, CacheKeys } from "@bip/domain";
-import { type DehydratedState, dehydrate } from "@tanstack/react-query";
-import { PerformanceTable } from "~/components/performance";
-import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
-import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
-import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
-import { publicLoader } from "~/lib/base-loaders";
-import { showUserDataQueryKey, trackUserRatingsQueryKey } from "~/lib/query-keys";
-import { createPrefetchClient } from "~/lib/query-prefetch";
+import { CacheKeys } from "@bip/domain";
+import { createNoteworthyLoader } from "~/lib/noteworthy-performance-loader";
+import { NoteworthyPerformancePage } from "~/lib/noteworthy-performance-page";
 import { services } from "~/server/services";
-import { computeShowUserData } from "~/server/show-user-data";
-import { computeTrackUserRatings } from "~/server/track-user-ratings";
 
-type LoaderData = AllTimersPageView & { dehydratedState: DehydratedState };
-
-export const loader = publicLoader(async ({ context }): Promise<LoaderData> => {
-  const cacheKey = CacheKeys.songs.allTimers();
-  const cacheOptions = { ttl: 3600 };
-
-  const view = await services.cache.getOrSet(
-    cacheKey,
-    async () => services.songPageComposer.buildAllTimers(),
-    cacheOptions,
-  );
-
-  const trackIds = view.performances.map((p) => p.trackId);
-  const showIds = [...new Set(view.performances.map((p) => p.show.id))];
-  const queryClient = createPrefetchClient();
-  await Promise.all([
-    queryClient.prefetchQuery({
-      queryKey: trackUserRatingsQueryKey(trackIds),
-      queryFn: () => computeTrackUserRatings(context, trackIds),
-    }),
-    queryClient.prefetchQuery({
-      queryKey: showUserDataQueryKey(showIds),
-      queryFn: () => computeShowUserData(context, showIds),
-    }),
-  ]);
-
-  return { ...view, dehydratedState: dehydrate(queryClient) };
+export const loader = createNoteworthyLoader({
+  cacheKey: CacheKeys.songs.allTimers(),
+  build: () => services.songPageComposer.buildAllTimers(),
 });
 
 export function meta() {
@@ -45,49 +13,5 @@ export function meta() {
 }
 
 export default function AllTimersPage() {
-  const { performances: allPerformances } = useSerializedLoaderData<LoaderData>();
-  const {
-    filteredData: filteredPerformances,
-    isLoading,
-    selectedTimeRange,
-    coverFilter,
-    selectedAuthor,
-    activeToggleSet,
-    hasActiveFilters,
-    searchText,
-    setSearchText,
-    updateFilter,
-    toggleFilter,
-    clearFilters,
-  } = usePerformancePageFilters({
-    initialData: allPerformances,
-    apiUrl: "/api/all-timers",
-    searchFilter: searchPerformance,
-  });
-
-  return (
-    <div>
-      <PerformanceTable
-        performances={filteredPerformances}
-        isLoading={isLoading}
-        showSongColumn
-        showGapColumns={false}
-        headerContent={
-          <PerformanceFilterControls
-            selectedTimeRange={selectedTimeRange}
-            activeToggleSet={activeToggleSet}
-            updateFilter={updateFilter}
-            toggleFilter={toggleFilter}
-            clearFilters={clearFilters}
-            coverFilter={coverFilter}
-            selectedAuthor={selectedAuthor}
-            showAllTimerToggle={false}
-            searchValue={searchText}
-            onSearchChange={setSearchText}
-            hasActiveFilters={hasActiveFilters}
-          />
-        }
-      />
-    </div>
-  );
+  return <NoteworthyPerformancePage apiUrl="/api/all-timers" hideAllTimerToggle hideJamChartToggle />;
 }

--- a/apps/web/app/routes/songs/jam-charts.test.tsx
+++ b/apps/web/app/routes/songs/jam-charts.test.tsx
@@ -1,0 +1,37 @@
+import { mockShallowComponent } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("~/server/services", () => ({ services: {} }));
+vi.mock("@bip/domain", () => ({
+  CacheKeys: { songs: { jamCharts: () => "test-key" } },
+}));
+vi.mock("~/lib/noteworthy-performance-loader", () => ({
+  createNoteworthyLoader: vi.fn(),
+}));
+vi.mock("~/lib/noteworthy-performance-page", () => ({
+  NoteworthyPerformancePage: (props: object) => mockShallowComponent("NoteworthyPerformancePage", props),
+}));
+
+import JamChartsPage from "./jam-charts";
+
+describe("JamChartsPage", () => {
+  // The page delegates to NoteworthyPerformancePage with the
+  // jam-charts API endpoint. Only the Jam Chart toggle chip is hidden
+  // — the All-Timer chip stays visible because jam-charts is a
+  // superset of all-timers and users may want to narrow further.
+  test("renders NoteworthyPerformancePage with the jam-charts API url and only the Jam Chart toggle hidden", () => {
+    render(
+      <MemoryRouter initialEntries={["/songs/jam-charts"]}>
+        <JamChartsPage />
+      </MemoryRouter>,
+    );
+
+    const page = screen.getByTestId("NoteworthyPerformancePage");
+    expect(page).toBeInTheDocument();
+    expect(page.textContent).toContain('"apiUrl":"/api/jam-charts"');
+    expect(page.textContent).toContain('"hideJamChartToggle":true');
+    expect(page.textContent).not.toContain('"hideAllTimerToggle":true');
+  });
+});

--- a/apps/web/app/routes/songs/jam-charts.tsx
+++ b/apps/web/app/routes/songs/jam-charts.tsx
@@ -1,0 +1,20 @@
+import { CacheKeys } from "@bip/domain";
+import { createNoteworthyLoader } from "~/lib/noteworthy-performance-loader";
+import { NoteworthyPerformancePage } from "~/lib/noteworthy-performance-page";
+import { services } from "~/server/services";
+
+export const loader = createNoteworthyLoader({
+  cacheKey: CacheKeys.songs.jamCharts(),
+  build: () => services.songPageComposer.buildJamCharts(),
+});
+
+export function meta() {
+  return [
+    { title: "Jam Charts | Songs" },
+    { name: "description", content: "Noteworthy performances: all-timers and curated jam-chart picks" },
+  ];
+}
+
+export default function JamChartsPage() {
+  return <NoteworthyPerformancePage apiUrl="/api/jam-charts" hideJamChartToggle />;
+}

--- a/packages/core/src/page-composers/song-page-composer.test.ts
+++ b/packages/core/src/page-composers/song-page-composer.test.ts
@@ -486,6 +486,125 @@ describe("buildSongPerformanceCounts", () => {
 });
 
 // ---------------------------------------------------------------------------
+// buildJamCharts — all-timers ∪ tracks-with-notes
+// ---------------------------------------------------------------------------
+
+describe("buildJamCharts", () => {
+  // Flattens a $queryRaw mock call (TemplateStringsArray + Prisma.Sql
+  // interpolations) into a single SQL string so the test can assert the
+  // base WHERE clause is composed of the right two conditions. Prisma.Sql
+  // exposes its raw template parts under `.strings`.
+  function flattenSqlFromMockCall(call: unknown[]): string {
+    const [templateStrings, ...interpolations] = call as [readonly string[], ...unknown[]];
+    const interpolated = interpolations
+      .map((v) => {
+        if (v && typeof v === "object" && Array.isArray((v as { strings?: unknown[] }).strings)) {
+          return (v as { strings: string[] }).strings.join(" ");
+        }
+        return "";
+      })
+      .join(" ");
+    return `${[...templateStrings].join(" ")} ${interpolated}`;
+  }
+
+  function createComposer(rows: Array<Partial<PerformanceDto>>) {
+    const mockDb = {
+      $queryRaw: vi.fn().mockResolvedValue(rows.map((r) => makeDto(r as Partial<PerformanceDto>))),
+      // enrichPerformances looks up annotations + previous-show data per
+      // returned track. Stub both to empty so the test focuses on the
+      // base WHERE composition and the result shape.
+      annotation: { findMany: vi.fn().mockResolvedValue([]) },
+    };
+    const mockSongService = {} as never;
+    return { composer: new SongPageComposer(mockDb as never, mockSongService), mockDb };
+  }
+
+  // The whole point of the jam-charts page: include tracks flagged as
+  // all-timers AND tracks that carry a curated note, in a single result.
+  // The WHERE clause must OR the two conditions so neither set is
+  // dropped on the way to the UI.
+  test("base WHERE clause unions all_timer with note IS NOT NULL", async () => {
+    const { composer, mockDb } = createComposer([]);
+    await composer.buildJamCharts();
+    expect(mockDb.$queryRaw).toHaveBeenCalledTimes(1);
+    const sql = flattenSqlFromMockCall(mockDb.$queryRaw.mock.calls[0]);
+    expect(sql).toMatch(/tracks\.all_timer\s*=\s*true/);
+    expect(sql).toMatch(/tracks\.note\s+IS\s+NOT\s+NULL/);
+    // Empty-string notes must be filtered out too — the note column
+    // historically allows '' as well as NULL for "no note", and the UI
+    // treats both as absent.
+    expect(sql).toMatch(/tracks\.note\s*<>\s*''/);
+    // Both branches must be ORed together (otherwise note-only tracks
+    // get filtered out when all_timer is false).
+    expect(sql).toMatch(/all_timer.*OR.*note/s);
+  });
+
+  // The method returns the standard AllTimersPageView shape so the route
+  // can drop it straight into PerformanceTable without bespoke wiring.
+  test("returns AllTimersPageView shape (performances array) populated from rows", async () => {
+    const { composer } = createComposer([
+      { track_id: "t-allTimer", all_timer: true, note: null, song_id: "song-1" },
+      { track_id: "t-note", all_timer: false, note: "Big Type II Spaga." },
+    ]);
+    const result = await composer.buildJamCharts();
+    expect(result.performances).toHaveLength(2);
+    const ids = result.performances.map((p) => p.trackId).sort();
+    expect(ids).toEqual(["t-allTimer", "t-note"]);
+  });
+
+  // Filter options compose: jam-charts plus, say, a year range or cover
+  // filter, should AND together. Verifies the call still goes through and
+  // the additional filter shows up in the SQL.
+  test("forwards filter options through buildFilterQuery", async () => {
+    const { composer, mockDb } = createComposer([]);
+    await composer.buildJamCharts({ monthDay: "07-26" });
+    const sql = flattenSqlFromMockCall(mockDb.$queryRaw.mock.calls[0]);
+    expect(sql).toMatch(/shows\.date\s+LIKE/);
+  });
+});
+
+describe("buildSongPerformances populates songTitle/songSlug", () => {
+  // The single-song composer queries without a song join (the song is
+  // already known in context). The cross-song UI components that
+  // consume `SongPagePerformance` (TrackRatingOverlay's popover header,
+  // for instance) read `songTitle` / `songSlug` directly — so the
+  // composer must fill those fields from the page's song context, or
+  // the popover renders with an empty title.
+  test("propagates the page song's title and slug onto every returned performance", async () => {
+    const mockDb = {
+      $queryRaw: vi.fn().mockResolvedValue([makeDto({ track_id: "t-1" }), makeDto({ track_id: "t-2" })]),
+      annotation: { findMany: vi.fn().mockResolvedValue([]) },
+    };
+    const mockSongService = {
+      findBySlug: vi.fn().mockResolvedValue({
+        id: "song-1",
+        title: "King of the World",
+        slug: "king-of-the-world",
+        cover: false,
+        authorId: null,
+      }),
+    };
+    const composer = new SongPageComposer(mockDb as never, mockSongService as never);
+
+    const performances = await composer.buildSongPerformances("king-of-the-world");
+
+    expect(performances).toHaveLength(2);
+    for (const p of performances) {
+      expect(p.songTitle).toBe("King of the World");
+      expect(p.songSlug).toBe("king-of-the-world");
+    }
+  });
+});
+
+describe("CacheKeys.songs.jamCharts", () => {
+  // Mirrors the cache-key shape of `allTimers`. Versioned suffix is
+  // bumped together with the rest of the songs cache family.
+  test("returns a stable, versioned key string", () => {
+    expect(CacheKeys.songs.jamCharts()).toBe("songs:jam-charts:v4");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // isNarrowingFilter — gate for filteredGap computation
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/page-composers/song-page-composer.ts
+++ b/packages/core/src/page-composers/song-page-composer.ts
@@ -34,6 +34,8 @@ export interface PerformanceFilterOptions {
   standalone?: boolean;
   inverted?: boolean;
   dyslexic?: boolean;
+  /** Narrow to tracks carrying a curated jam-chart note (non-empty). */
+  jamChart?: boolean;
   allTimer?: boolean;
   monthDay?: string;
 }
@@ -142,6 +144,11 @@ export class SongPageComposer {
       ...this.transformToSongPagePerformanceView(row),
       cover: song.cover ?? undefined,
       authorId: song.authorId ?? null,
+      // Single-song rows skip the song join; fill in title/slug from the
+      // page's song context so cross-song renderers (e.g. the
+      // noteworthy-track popover header) see a populated title.
+      songTitle: song.title,
+      songSlug: song.slug,
     }));
     await this.enrichPerformances(performances);
 
@@ -207,11 +214,34 @@ export class SongPageComposer {
 
   /** Build the all-timers page view, optionally filtered by date range, cover, author, attendance, and performance tags. */
   async buildAllTimers(options?: PerformanceFilterOptions): Promise<AllTimersPageView> {
-    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery(
-      [Prisma.sql`tracks.all_timer = true`],
+    return this.buildCrossSongPerformanceView(Prisma.sql`tracks.all_timer = true`, options);
+  }
+
+  /**
+   * Build the Jam Charts page view. Includes any track that is either an
+   * all-timer OR carries a curated note — the union of the two
+   * noteworthy categories surfaced throughout the app. The note column
+   * historically allows empty strings as well as NULL for "no note", so
+   * both are filtered out to match what the UI treats as a real note.
+   */
+  async buildJamCharts(options?: PerformanceFilterOptions): Promise<AllTimersPageView> {
+    return this.buildCrossSongPerformanceView(
+      Prisma.sql`(tracks.all_timer = true OR (tracks.note IS NOT NULL AND tracks.note <> ''))`,
       options,
     );
+  }
 
+  /**
+   * Shared body of the cross-song page views (all-timers, jam-charts).
+   * The two endpoints differ only in their base WHERE condition; this
+   * helper composes the rest of the pipeline — filter merging, the
+   * cross-song SELECT with song title/slug, and per-track enrichment.
+   */
+  private async buildCrossSongPerformanceView(
+    baseCondition: Prisma.Sql,
+    options?: PerformanceFilterOptions,
+  ): Promise<AllTimersPageView> {
+    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery([baseCondition], options);
     const whereClause = Prisma.join(conditions, " AND ");
     const result = await this.queryPerformances({
       whereClause,
@@ -246,6 +276,13 @@ export class SongPageComposer {
       ...this.transformToSongPagePerformanceView(row),
       cover: song.cover ?? undefined,
       authorId: song.authorId ?? null,
+      // The per-song composer queries without a song join (the song is
+      // already known), so the raw rows don't carry song_title/song_slug.
+      // Fill them in from the page's song context so downstream renderers
+      // (e.g. the noteworthy-track popover header) don't see an empty
+      // title when this projection lands in a cross-song UI component.
+      songTitle: song.title,
+      songSlug: song.slug,
     }));
     await this.enrichPerformances(performances);
 
@@ -443,6 +480,7 @@ export class SongPageComposer {
           }
         : null,
     allTimer: (o) => (o.allTimer ? { condition: Prisma.sql`tracks.all_timer = true` } : null),
+    jamChart: (o) => (o.jamChart ? { condition: Prisma.sql`tracks.note IS NOT NULL AND tracks.note <> ''` } : null),
     monthDay: (o) => (o.monthDay ? { condition: Prisma.sql`shows.date LIKE ${`%-${o.monthDay}`}` } : null),
     inverted: (o) =>
       o.inverted
@@ -645,6 +683,7 @@ export function isNarrowingFilter(options: PerformanceFilterOptions | undefined)
       options.standalone ||
       options.inverted ||
       options.dyslexic ||
+      options.jamChart ||
       options.allTimer ||
       options.monthDay,
   );

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -67,6 +67,8 @@ export const CacheKeys = {
     index: () => "songs:index:full:v3",
     /** All-timers page data */
     allTimers: () => "songs:all-timers:v3",
+    /** Jam Charts page data (tracks that are all-timers OR carry a curated note) */
+    jamCharts: () => "songs:jam-charts:v4",
     /** Songs with history content */
     histories: () => "songs:histories:v3",
     /** All-timers for a specific calendar day (On This Day page) */


### PR DESCRIPTION
## Summary

- **New `/songs/jam-charts` page** lists every performance that is an all-timer OR carries a curated note (~1900 results). Linked from the songs layout tab bar between "This Year" and "All-Timers".
- **New "Jam Charts" tab on `/songs/:slug`** shows the same filter scoped to the current song. In-song tabs now sync to the URL (`/songs/triumph/jam-charts`, `.../stats`, `.../history`, ...) so back/forward and direct links work.
- **New "Jam Chart" filter chip** in the toggle row, between "Dyslexic" and "All-Timer". Hidden on `/songs/jam-charts` and `/songs/all-timers` (and on the matching in-song tabs) because its scope is already implied there.
- **Shared flame marker** on every noteworthy track: orange for all-timer, off-white for jam-chart (note only). Renders next to song titles in setlist flow view, gap charts, the admin track manager, and the cross-song tables. Click (or hover on desktop) opens a popover with the song title + note, reachable on touch devices too.
- **Show Highlights right rail collapsed** from two subsections (All-Timers / Track Notes) into one ordered list. Set label printed once per set group, flame left of the song title, note text inline below. Labels now use `formatSetLabel` like the rest of the app ("1" / "E" instead of "S1" / "E1").
- **All-Timers page** also shows the flame column and tap-to-read note popover, matching the jam-charts surface.
- On mobile, the jam-charts / all-timers tables keep the flame column visible and hide the Set column instead (`mobileFlamePriority`).

## Internal refactors

- `songPageComposer` gains `buildJamCharts` plus a private `buildCrossSongPerformanceView` helper that `buildAllTimers` also calls; the two cross-song endpoints differ only in their base WHERE condition.
- `PerformanceFilterOptions` adds a `jamChart` toggle wired through `FILTER_BUILDERS`, `isNarrowingFilter`, the URL parser, and the chip definition. SQL filters non-empty notes (`tracks.note IS NOT NULL AND tracks.note <> ''`) to match what the UI treats as a real note.
- `TrackRatingOverlay` grows a `trigger="click"` (Radix Popover) variant and a `showRating=false` mode that skips the rating UI plus the `/api/tracks/:id` refetch; both are used wherever the standalone flame is the trigger. `AllTimerCell` takes a track prop and wraps the flame in that overlay when a note exists.
- `buildSongPerformances` + `build()` propagate the page song's `title` / `slug` onto each performance row so the popover header has a title on single-song surfaces (was reading an empty title from the per-song composer, which doesn't join `songs`).
- `server-import-leak.test` extended to scan `~/lib` (helpers under `app/lib` that mix server + client value imports now fail this test) and to recognize `export function loader/action` declarations (prior false negatives).
- Routes + API loaders DRY'd via `createNoteworthyLoader` / `NoteworthyPerformancePage` / `createNoteworthyApiLoader` — `all-timers.tsx` and `jam-charts.tsx` (and their `/api/*` siblings) are now ~10 lines each.
- The `Tabs` primitive sets `cursor-pointer`.

## Test plan

- [ ] Visit `/songs` → click the new "Jam Charts" tab → loads `/songs/jam-charts` with ~1921 rows; click "All-Timers" → loads with ~1501 rows.
- [ ] On `/songs/jam-charts`: flame column is leftmost; click an orange flame on a row with a note → popover shows song title + note. Click an off-white flame (note-only row) → same popover.
- [ ] Reload at narrow viewport (~390px): flame column stays visible; Set column is hidden.
- [ ] Visit `/songs/triumph` (or any song with at least one noteworthy track) → "Jam Charts" tab appears between "All Performances" and "All-Timers". Click it → URL becomes `/songs/triumph/jam-charts`; back button returns; refresh keeps you on the tab.
- [ ] Same song, click "Graphs" tab → URL becomes `/songs/triumph/stats`. Click "All Performances" → URL becomes bare `/songs/triumph` (no `/performances` suffix).
- [ ] On `/songs/triumph/jam-charts` the "Jam Chart" filter chip is hidden; on `/songs/triumph/all-timers` both "Jam Chart" and "All-Timer" chips are hidden.
- [ ] Find a show with notes (e.g. `make db-query SQL="SELECT s.slug FROM shows s JOIN tracks t ON t.show_id=s.id WHERE t.note IS NOT NULL AND t.note <> '' LIMIT 5"`) → open `/shows/<slug>` → Show Highlights right rail is one list, set label printed once per group, flame left of song title, note text inline below.
- [ ] Setlist flow view on the same show: noteworthy tracks show flame next to the song title; tap the flame on mobile → popover.
- [ ] On `/songs/jam-charts` and `/songs/all-timers`, the "All-Timer" / "Jam Chart" filter chips are hidden per scope-implied rules.
- [ ] `make tc && bun run lint && bun run test` clean (1087 tests).

## Notes for the reviewer

- The composer keeps `note` (singular) in the schema and `Track` type, but `SongPagePerformance.notes` (plural) flows through cross-song surfaces. The shared `isNoteworthy` predicate accepts both keys so callers don't have to adapt at every call site.
- The empty-string `tracks.note <> ''` filter in `buildJamCharts` matters: the column historically allows `''` as "no note", and a plain `IS NOT NULL` check pulled in shows with no real annotations (caught during smoke testing).
- The `TrackRatingOverlay` click variant uses Radix Popover; the hover variant keeps Radix HoverCard. Same content in both, gated by the `trigger` prop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
