### PR TITLE
Mobile /songs: show Song + filter cols, align numeric cells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tmp/
 apps/web/.react-router/*
 .beads
 .gitattributes
+.playwright-mcp/*

--- a/apps/web/.react-router/types/app/routes/songs/+types/$slug.ts
+++ b/apps/web/.react-router/types/app/routes/songs/+types/$slug.ts
@@ -18,6 +18,15 @@ type Matches = [{
 }, {
   id: "routes/songs/$slug";
   module: typeof import("../$slug.js");
+}] | [{
+  id: "root";
+  module: typeof import("../../../root.js");
+}, {
+  id: "routes/songs/_layout";
+  module: typeof import("../_layout.js");
+}, {
+  id: "song-tab";
+  module: typeof import("../$slug.js");
 }];
 
 type Annotations = GetAnnotations<Info & { module: Module, matches: Matches }, false>;

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -27,6 +27,16 @@ If a route component references a runtime value from a `.ts` helper under `app/r
 - Feature components are organized by domain (e.g., `review/`, `setlist/`, `show/`)
 - Form components use React Hook Form with Zod validation
 
+## Keep components and CSS DRY
+
+Before writing markup, grep the className you're about to type. If it's already somewhere, you owe an extraction.
+
+- **Use existing primitives.** Bare `<input>`/`<textarea>` → [Input](app/components/ui/input.tsx)/[Textarea](app/components/ui/textarea.tsx). Hand-rolled selects → [GlassSelect](app/components/ui/glass-select.tsx) (finite options) or [SearchPicker](app/components/ui/search-picker.tsx) (async search). Don't inline `bg-*`/`hover:bg-*` on [Button](app/components/ui/button.tsx) when a `variant` covers the intent.
+- **2+ duplications → className constant** in [form-styles.ts](app/lib/form-styles.ts) (form chrome) or a domain module. See `formInputClass`, `formLabelClass`.
+- **2+ Button (or Badge / Card / …) className overrides → add a `variant`** to the existing CVA. See `variant="brand"`. Don't create `<MyButton>`.
+- **No thin wrappers to hide a className.** `<PremiumCard>` for `<Card className="card-premium">` is indirection, not abstraction. Use a constant or variant.
+- **Don't bake project styling into shadcn defaults.** Auth/search/etc. use the upstream primitive. Project looks → constant or variant.
+
 ## Package-Specific Commands
 
 ```bash

--- a/apps/web/app/components/author/author-columns.tsx
+++ b/apps/web/app/components/author/author-columns.tsx
@@ -24,7 +24,7 @@ type AuthorWithSongCount = Author & { songCount?: number };
 export const authorColumns: ColumnDef<AuthorWithSongCount>[] = [
   {
     accessorKey: "name",
-    meta: { width: "25%" },
+
     header: ({ column }) => {
       return (
         <Button
@@ -51,7 +51,7 @@ export const authorColumns: ColumnDef<AuthorWithSongCount>[] = [
   },
   {
     accessorKey: "songCount",
-    meta: { width: "25%" },
+
     header: ({ column }) => {
       return (
         <Button
@@ -71,7 +71,7 @@ export const authorColumns: ColumnDef<AuthorWithSongCount>[] = [
   },
   {
     accessorKey: "slug",
-    meta: { width: "25%" },
+
     header: ({ column }) => {
       return (
         <Button
@@ -90,7 +90,7 @@ export const authorColumns: ColumnDef<AuthorWithSongCount>[] = [
   },
   {
     accessorKey: "createdAt",
-    meta: { width: "25%" },
+
     header: ({ column }) => {
       return (
         <Button

--- a/apps/web/app/components/author/author-form.tsx
+++ b/apps/web/app/components/author/author-form.tsx
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { Button } from "~/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "~/components/ui/form";
 import { Input } from "~/components/ui/input";
+import { formInputClass } from "~/lib/form-styles";
 
 export const authorFormSchema = z.object({
   name: z.string().min(1, "Author name is required"),
@@ -48,11 +49,7 @@ export function AuthorForm({ defaultValues, submitLabel, cancelHref }: AuthorFor
             <FormItem>
               <FormLabel className="text-content-text-secondary">Author Name</FormLabel>
               <FormControl>
-                <Input
-                  placeholder="Enter author name"
-                  {...field}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
-                />
+                <Input placeholder="Enter author name" {...field} className={formInputClass} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -63,7 +60,7 @@ export function AuthorForm({ defaultValues, submitLabel, cancelHref }: AuthorFor
           <Button type="submit" onClick={form.handleSubmit(onSubmit)}>
             {submitLabel}
           </Button>
-          <Button type="button" variant="outline" onClick={() => navigate(cancelHref)}>
+          <Button type="button" variant="cancel" onClick={() => navigate(cancelHref)}>
             Cancel
           </Button>
         </div>

--- a/apps/web/app/components/author/author-search.test.tsx
+++ b/apps/web/app/components/author/author-search.test.tsx
@@ -1,0 +1,138 @@
+import { setup } from "@test/test-utils";
+import { screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { AuthorSearch } from "./author-search";
+
+describe("AuthorSearch", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // loadOnOpen contract: opening the popover with no query hits
+  // /api/authors?top=10 so the user sees the most-active authors before
+  // they type. Without this the list would start empty.
+  test("fetches /api/authors?top=10 when the popover opens with no query", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+
+    const { user } = await setup(<AuthorSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await waitFor(() => {
+      const urls = fetchMock.mock.calls.map((c) => c[0]);
+      expect(urls).toContain("/api/authors?top=10");
+    });
+  });
+
+  // 2+ char query switches to the scoped search endpoint with a higher
+  // limit. Below 2 chars stays on the top-10 endpoint (handled by the
+  // empty-query branch above).
+  test("fetches /api/authors?q=…&limit=20 with a 2+ char query", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+
+    const { user } = await setup(<AuthorSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search authors...");
+    await user.type(input, "tre");
+
+    await waitFor(
+      () => {
+        const urls = fetchMock.mock.calls.map((c) => c[0]);
+        expect(urls).toContain("/api/authors?q=tre&limit=20");
+      },
+      { timeout: 1500 },
+    );
+  });
+
+  // The clear-selection row is labeled "All Authors" (the noneLabel for
+  // this wrapper) so users can drop the current filter from inside the
+  // popover.
+  test("renders the 'All Authors' clear row", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [{ id: "a1", name: "Author One" }] });
+
+    const { user } = await setup(<AuthorSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    expect(await screen.findByText("All Authors")).toBeInTheDocument();
+  });
+
+  // With allowCreate=true, typing a non-matching name and clicking the
+  // "Create …" row POSTs to /api/admin/authors with the trimmed name,
+  // then selects the new author. The admin path is gated by allowCreate
+  // so non-admin consumers don't accidentally surface it.
+  test("allowCreate posts to /api/admin/authors and selects the new row", async () => {
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === "/api/admin/authors" && init?.method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ id: "new-1", name: "New Author" }),
+        } as Response);
+      }
+      // Every other call (top-10, debounced search) returns an empty list.
+      return Promise.resolve({ ok: true, json: async () => [] } as Response);
+    });
+    const onValueChange = vi.fn();
+
+    const { user } = await setup(<AuthorSearch onValueChange={onValueChange} allowCreate />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search authors...");
+    await user.type(input, "New Author");
+
+    const createRow = await screen.findByText('Create "New Author"', undefined, { timeout: 1500 });
+    await user.click(createRow);
+
+    await waitFor(() => {
+      const postCall = fetchMock.mock.calls.find((c) => c[0] === "/api/admin/authors");
+      expect(postCall).toBeDefined();
+      expect(postCall?.[1]?.method).toBe("POST");
+      expect(JSON.parse(postCall?.[1]?.body as string)).toEqual({ name: "New Author" });
+    });
+    await waitFor(() => expect(onValueChange).toHaveBeenCalledWith("new-1"));
+  });
+
+  // Without allowCreate, the create row never appears — even with a
+  // novel query.
+  test("does not show a create row when allowCreate is not set", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+
+    const { user } = await setup(<AuthorSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search authors...");
+    await user.type(input, "Novel Name");
+
+    // Wait for the debounced fetch to settle so any create row would have
+    // had a chance to render.
+    await waitFor(
+      () => {
+        const urls = fetchMock.mock.calls.map((c) => c[0]);
+        expect(urls).toContain("/api/authors?q=Novel%20Name&limit=20");
+      },
+      { timeout: 1500 },
+    );
+    expect(screen.queryByText(/Create "/)).not.toBeInTheDocument();
+  });
+
+  // Selecting "All Authors" fires onValueChange(null) — the parent
+  // (PerformanceFilterControls) maps null to "drop the author filter".
+  test("clicking 'All Authors' fires onValueChange(null)", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [{ id: "a1", name: "Author One" }] });
+    const onValueChange = vi.fn();
+
+    const { user } = await setup(<AuthorSearch value="a1" onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("All Authors"));
+
+    expect(onValueChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/web/app/components/author/author-search.tsx
+++ b/apps/web/app/components/author/author-search.tsx
@@ -1,10 +1,5 @@
 import type { Author } from "@bip/domain";
-import { Check, ChevronsUpDown, Plus } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
-import { Button } from "~/components/ui/button";
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "~/components/ui/command";
-import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
-import { cn } from "~/lib/utils";
+import { SearchPicker } from "~/components/ui/search-picker";
 
 interface AuthorSearchProps {
   value?: string | null;
@@ -14,6 +9,12 @@ interface AuthorSearchProps {
   allowCreate?: boolean;
 }
 
+/**
+ * Author picker for blog posts and admin tools. Loads a top-10 list as soon
+ * as the popover opens and switches to a query-scoped search at 2+ chars.
+ * Optionally exposes a "Create '<name>'" affordance for admins composing
+ * new posts when the author isn't on file yet.
+ */
 export function AuthorSearch({
   value,
   onValueChange,
@@ -21,175 +22,47 @@ export function AuthorSearch({
   className,
   allowCreate = false,
 }: AuthorSearchProps) {
-  const [open, setOpen] = useState(false);
-  const [authors, setAuthors] = useState<Author[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [currentAuthor, setCurrentAuthor] = useState<Author | null>(null);
-  const [creating, setCreating] = useState(false);
-  const [hasLoadedInitial, setHasLoadedInitial] = useState(false);
-
-  const selectedAuthor = authors.find((author) => author.id === value) || currentAuthor;
-
-  const searchAuthors = useCallback(async (query: string) => {
-    setLoading(true);
-    try {
-      const url =
-        query && query.length >= 2 ? `/api/authors?q=${encodeURIComponent(query)}&limit=20` : "/api/authors?top=10";
-
-      const response = await fetch(url);
-      if (response.ok) {
-        const data = await response.json();
-        setAuthors(data);
-      }
-    } catch (_error) {
-      // Swallow errors for now; UI remains unchanged on failure.
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  // Load current author when value changes
-  useEffect(() => {
-    const loadCurrentAuthor = async () => {
-      if (value && !authors.find((a) => a.id === value) && !currentAuthor) {
-        try {
-          const response = await fetch(`/api/authors/${value}`);
-          if (response.ok) {
-            const author = await response.json();
-            setCurrentAuthor(author);
-          }
-        } catch (_error) {
-          // Ignore errors when fetching the initial author; dropdown will just show placeholder.
-        }
-      } else if (!value) {
-        setCurrentAuthor(null);
-      }
-    };
-
-    loadCurrentAuthor();
-  }, [value, authors, currentAuthor]);
-
-  // Load top authors when dropdown opens
-  useEffect(() => {
-    if (open && !hasLoadedInitial) {
-      searchAuthors("");
-      setHasLoadedInitial(true);
-    }
-  }, [open, hasLoadedInitial, searchAuthors]);
-
-  useEffect(() => {
-    const delayedSearch = setTimeout(() => {
-      searchAuthors(searchQuery);
-    }, 300); // Debounce search
-
-    return () => clearTimeout(delayedSearch);
-  }, [searchQuery, searchAuthors]);
-
-  const handleCreateAuthor = async () => {
-    if (!allowCreate || !searchQuery.trim() || creating) return;
-
-    setCreating(true);
-    try {
-      const response = await fetch("/api/admin/authors", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: searchQuery.trim() }),
-      });
-
-      if (response.ok) {
-        const newAuthor = await response.json();
-        // Add to local state
-        setAuthors((prev) => [newAuthor, ...prev]);
-        // Select the newly created author
-        onValueChange(newAuthor.id);
-        setSearchQuery("");
-        setOpen(false);
-      }
-    } catch (_error) {
-      // Fail silently; the button remains available for another attempt.
-    } finally {
-      setCreating(false);
-    }
-  };
-
-  const showCreateOption =
-    allowCreate &&
-    searchQuery.trim().length >= 2 &&
-    !authors.some((a) => a.name.toLowerCase() === searchQuery.toLowerCase());
-
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          aria-expanded={open}
-          className={cn(
-            "justify-between bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20",
-            className,
-          )}
-        >
-          <span className="truncate">{selectedAuthor ? selectedAuthor.name : placeholder}</span>
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        className="p-0 bg-content-bg-primary/95 backdrop-blur-md border border-content-glass-border"
-        align="start"
-      >
-        <Command className="bg-transparent" shouldFilter={false}>
-          <CommandInput
-            placeholder="Search authors..."
-            value={searchQuery}
-            onValueChange={setSearchQuery}
-            className="text-white"
-          />
-          <CommandList className="max-h-[300px] overflow-auto">
-            <CommandEmpty>{loading ? "Loading..." : creating ? "Creating..." : "No authors found."}</CommandEmpty>
-            <CommandGroup>
-              {/* Option to clear selection */}
-              <CommandItem
-                value="none"
-                onSelect={() => {
-                  onValueChange(null);
-                  setOpen(false);
-                }}
-                className="text-white hover:bg-content-bg-secondary"
-              >
-                <Check className={cn("mr-2 h-4 w-4", !value ? "opacity-100" : "opacity-0")} />
-                All Authors
-              </CommandItem>
-
-              {/* Option to create new author */}
-              {showCreateOption && (
-                <CommandItem
-                  value={`create-${searchQuery}`}
-                  onSelect={handleCreateAuthor}
-                  className="text-brand-primary hover:bg-content-bg-secondary font-medium"
-                >
-                  <Plus className="mr-2 h-4 w-4" />
-                  Create "{searchQuery}"
-                </CommandItem>
-              )}
-
-              {authors.map((author) => (
-                <CommandItem
-                  key={author.id}
-                  value={author.id}
-                  onSelect={() => {
-                    onValueChange(author.id);
-                    setOpen(false);
-                  }}
-                  className="text-white hover:bg-content-bg-secondary"
-                >
-                  <Check className={cn("mr-2 h-4 w-4", value === author.id ? "opacity-100" : "opacity-0")} />
-                  {author.name}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+    <SearchPicker<Author>
+      value={value ?? null}
+      onValueChange={onValueChange}
+      className={className}
+      placeholder={placeholder}
+      searchPlaceholder="Search authors..."
+      emptyMessage="No authors found."
+      loadingMessage="Loading..."
+      loadOnOpen
+      itemId={(a) => a.id}
+      itemLabel={(a) => a.name}
+      noneLabel="All Authors"
+      fetchResults={async (query) => {
+        const url =
+          query && query.length >= 2 ? `/api/authors?q=${encodeURIComponent(query)}&limit=20` : "/api/authors?top=10";
+        const response = await fetch(url);
+        if (!response.ok) return [];
+        return (await response.json()) as Author[];
+      }}
+      fetchById={async (id) => {
+        const response = await fetch(`/api/authors/${id}`);
+        if (!response.ok) return null;
+        return (await response.json()) as Author;
+      }}
+      allowCreate={
+        allowCreate
+          ? {
+              label: (query) => `Create "${query}"`,
+              onCreate: async (name) => {
+                const response = await fetch("/api/admin/authors", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ name }),
+                });
+                if (!response.ok) return null;
+                return (await response.json()) as Author;
+              },
+            }
+          : undefined
+      }
+    />
   );
 }

--- a/apps/web/app/components/performance/date-venue-cell.test.tsx
+++ b/apps/web/app/components/performance/date-venue-cell.test.tsx
@@ -13,15 +13,17 @@ describe("DateVenueCell", () => {
     expect(screen.getByText("2024-06-15")).toBeInTheDocument();
   });
 
-  // The venue line is rendered, but only visible at sm+ breakpoints. We
-  // verify presence + the responsive class so mobile column overlap (the
-  // bug this component fixes) cannot regress silently.
-  test("renders venue line with hidden sm:block so it is hidden on mobile", async () => {
+  // The venue line is rendered, but only visible once the cell container
+  // is wide enough — a container query on the cell wrapper drives the
+  // toggle so the column collapses to date-only at narrow widths regardless
+  // of viewport. Verifies the CQ class is wired so the auto-collapse can't
+  // regress silently.
+  test("renders venue line with container-query gated visibility", async () => {
     await setup(<DateVenueCell date="2024-06-15" venue={{ name: "The Capitol Theatre", city: "Port Chester" }} />);
 
     const venueLine = screen.getByText(/The Capitol Theatre/);
     expect(venueLine.className).toContain("hidden");
-    expect(venueLine.className).toContain("sm:block");
+    expect(venueLine.className).toContain("@[10rem]/datecell:block");
   });
 
   // City and state are appended to the venue name when present so users
@@ -37,10 +39,10 @@ describe("DateVenueCell", () => {
   // When there is no venue, the venue line is omitted entirely (rather
   // than rendering an empty bullet) so the cell collapses to date-only.
   test("omits venue line when venue is undefined", async () => {
-    const { container } = await setup(<DateVenueCell date="2024-06-15" />);
+    await setup(<DateVenueCell date="2024-06-15" />);
 
     expect(screen.getByText("2024-06-15")).toBeInTheDocument();
-    // Only the date div should render — no second child line.
-    expect(container.querySelectorAll("div").length).toBeLessThanOrEqual(1);
+    // No venue text rendered — keeps the cell visually clean.
+    expect(screen.queryByText(",")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/components/performance/date-venue-cell.tsx
+++ b/apps/web/app/components/performance/date-venue-cell.tsx
@@ -13,17 +13,20 @@ interface DateVenueCellProps {
 
 /**
  * Combined Date + Venue cell for the performance tables (song-detail
- * "All Performances" and /songs/all-timers). The date renders on top; the
- * venue stacks beneath it at sm+ and is hidden on mobile so the column
- * collapses to a single-line date at narrow widths.
+ * "All Performances" and /songs/all-timers). The venue sublabel only
+ * shows at `sm` and above (mobile keeps the row tight to a single line),
+ * AND only when this cell's inline-size container has room — so the row
+ * still collapses cleanly when the column gets squeezed on desktop.
  */
 export function DateVenueCell({ date, venue }: DateVenueCellProps) {
   const venueLabel = venue?.name ? [venue.name, venue.city, venue.state].filter(Boolean).join(", ") : null;
 
   return (
-    <>
+    <div className="@container/datecell">
       <div className="font-medium">{date}</div>
-      {venueLabel && <div className="text-xs text-content-text-tertiary mt-0.5 hidden sm:block">{venueLabel}</div>}
-    </>
+      {venueLabel && (
+        <div className="text-xs text-content-text-tertiary mt-0.5 hidden sm:@[10rem]/datecell:block">{venueLabel}</div>
+      )}
+    </div>
   );
 }

--- a/apps/web/app/components/performance/performance-columns.test.tsx
+++ b/apps/web/app/components/performance/performance-columns.test.tsx
@@ -47,16 +47,16 @@ const defaultOptions = {
 };
 
 describe("createPerformanceColumns", () => {
-  // The default column set renders Date, Set, Song Before, Song After,
+  // The default column set renders Date, Song Before, Song After,
   // Notes, and Rating headers. Each side of the setlist context is its own
   // searchable column. Venue isn't a separate column — it's folded into
-  // the Date cell via DateVenueCell.
-  test("default columns include Date, Set, Song Before, Song After, Notes, Rating headers", async () => {
+  // the Date cell via DateVenueCell. Set was removed since the set number
+  // isn't meaningful when scanning a single song across many shows.
+  test("default columns include Date, Song Before, Song After, Notes, Rating headers", async () => {
     const columns = createPerformanceColumns(defaultOptions);
     await setupWithRouter(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
 
     expect(screen.getByText("Date")).toBeInTheDocument();
-    expect(screen.getByText("Set")).toBeInTheDocument();
     expect(screen.getByText("Song Before")).toBeInTheDocument();
     expect(screen.getByText("Song After")).toBeInTheDocument();
     expect(screen.getByText("Notes")).toBeInTheDocument();
@@ -84,18 +84,20 @@ describe("createPerformanceColumns", () => {
     expect(notesColumn?.meta?.hideOnMobile).toBe(true);
   });
 
-  // Song Before / Song After are context columns: useful when scanning but
-  // not primary signal. They always hide on mobile to keep narrow rows
-  // focused on Date, Set, and Rating regardless of which surface is hosting
-  // the table.
-  test("Song Before and Song After columns hide on mobile regardless of showSongColumn", () => {
+  // Song Before / Song After visibility depends on the surface:
+  // - Single-song view (/songs/:slug, `showSongColumn` false): visible
+  //   on mobile — segue context is the primary reason users scan the
+  //   per-song table.
+  // - Cross-song view (/songs/all-timers, /on-this-day, `showSongColumn`
+  //   true): hidden on mobile — too many columns to fit alongside Song.
+  test("Song Before / Song After hide on mobile only on cross-song surfaces", () => {
     const detailColumns = createPerformanceColumns(defaultOptions);
     const allTimerColumns = createPerformanceColumns({ ...defaultOptions, showSongColumn: true });
 
     const findColumn = (cols: typeof detailColumns, id: string) => cols.find((c) => "id" in c && c.id === id);
 
-    expect(findColumn(detailColumns, "songBefore")?.meta?.hideOnMobile).toBe(true);
-    expect(findColumn(detailColumns, "songAfter")?.meta?.hideOnMobile).toBe(true);
+    expect(findColumn(detailColumns, "songBefore")?.meta?.hideOnMobile).toBeFalsy();
+    expect(findColumn(detailColumns, "songAfter")?.meta?.hideOnMobile).toBeFalsy();
     expect(findColumn(allTimerColumns, "songBefore")?.meta?.hideOnMobile).toBe(true);
     expect(findColumn(allTimerColumns, "songAfter")?.meta?.hideOnMobile).toBe(true);
   });
@@ -317,17 +319,19 @@ describe("createPerformanceColumns", () => {
     expect(screen.queryByText("Song")).not.toBeInTheDocument();
   });
 
-  // The AllTimer flame column marks standout performances. Only shown on
-  // the "All Performances" tab of /songs/$slug, not on /songs/all-timers
-  // (where every row is already an all-timer by definition).
-  test("AllTimer flame column present when showAllTimerColumn is true", async () => {
+  // The AllTimer flame marks standout performances. Renders twice in the
+  // DOM per all-timer row: once in the standalone AllTimer column (hidden
+  // on mobile via CSS), once inline in the Set cell (visible only on
+  // mobile via CSS). jsdom doesn't apply media queries so both instances
+  // appear in this test — the count of 2 is the contract.
+  test("AllTimer flame renders in both the standalone column and inline in the Set cell", async () => {
     const performances = [makePerformance({ allTimer: true })];
     const columns = createPerformanceColumns({ ...defaultOptions, showAllTimerColumn: true });
     const { container } = await setupWithRouter(
       <DataTable columns={columns} data={performances} hideSearch hidePagination />,
     );
 
-    expect(container.querySelectorAll(".lucide-flame").length).toBe(1);
+    expect(container.querySelectorAll(".lucide-flame").length).toBe(2);
   });
 
   // TrackRatingCell receives initialRating from the performance's rating
@@ -377,8 +381,8 @@ describe("createPerformanceColumns", () => {
 
   // Sortable columns (Date, Rating, Song Before, Song After) show an
   // up/down arrow icon even when not actively sorted, so users can see
-  // at a glance which columns support sorting. Non-sortable columns
-  // (Set, Notes) render plain text headers with no icon.
+  // at a glance which columns support sorting. Notes is the only non-
+  // sortable header in the default set.
   test("sortable columns show sort indicator, non-sortable columns do not", async () => {
     const columns = createPerformanceColumns(defaultOptions);
     await setupWithRouter(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
@@ -388,9 +392,9 @@ describe("createPerformanceColumns", () => {
     expect(dateHeader).not.toBeNull();
     expect(dateHeader?.querySelector("svg")).not.toBeNull();
 
-    // Set is not sortable — plain text header
-    const setHeader = screen.getByText("Set").closest("th");
-    expect(setHeader?.querySelector("button")).toBeNull();
+    // Notes is not sortable — plain text header
+    const notesHeader = screen.getByText("Notes").closest("th");
+    expect(notesHeader?.querySelector("button")).toBeNull();
 
     const ratingHeader = screen.getByText("Rating").closest("button");
     expect(ratingHeader).not.toBeNull();
@@ -408,10 +412,10 @@ describe("createPerformanceColumns", () => {
 
   // Column order on the song-detail performances table reads as a
   // narrative: when did this happen (Date) → how rare was it (Gap) → when
-  // was the last time before that (Last Played) → which set was it (Set) →
-  // what came before / after (Song Before, Song After). Pinning the order
-  // so future column additions don't accidentally reshuffle this flow.
-  test("column order is Date, Gap, Last Played, Set, Song Before, Song After", async () => {
+  // was the last time before that (Last Played) → what came before /
+  // after (Song Before, Song After). Pinning the order so future column
+  // additions don't accidentally reshuffle this flow.
+  test("column order is Date, Gap, Last Played, Song Before, Song After", async () => {
     const columns = createPerformanceColumns(defaultOptions);
     await setupWithRouter(<DataTable columns={columns} data={[makePerformance()]} hideSearch hidePagination />);
 
@@ -421,14 +425,12 @@ describe("createPerformanceColumns", () => {
     const dateIdx = headers.findIndex((h) => h.startsWith("Date"));
     const gapIdx = headers.findIndex((h) => h.startsWith("Gap"));
     const lastPlayedIdx = headers.findIndex((h) => h.startsWith("Last Played"));
-    const setIdx = headers.findIndex((h) => h.startsWith("Set"));
     const songBeforeIdx = headers.findIndex((h) => h.startsWith("Song Before"));
     const songAfterIdx = headers.findIndex((h) => h.startsWith("Song After"));
     expect(dateIdx).toBeGreaterThan(-1);
     expect(gapIdx).toBeGreaterThan(dateIdx);
     expect(lastPlayedIdx).toBeGreaterThan(gapIdx);
-    expect(setIdx).toBeGreaterThan(lastPlayedIdx);
-    expect(songBeforeIdx).toBeGreaterThan(setIdx);
+    expect(songBeforeIdx).toBeGreaterThan(lastPlayedIdx);
     expect(songAfterIdx).toBeGreaterThan(songBeforeIdx);
   });
 
@@ -659,16 +661,13 @@ describe("gapSortingFn", () => {
 });
 
 describe("createPerformanceColumns extras", () => {
-  // Columns that need constrained widths (like the narrow allTimer flame
-  // icon and the Set label) set explicit meta.width. Other columns auto-size
-  // to avoid wasted space.
-  test("allTimer and Set columns have explicit meta.width", () => {
+  // Icon-only / ultra-narrow columns declare `fixedWidth` so they never
+  // grow or shrink with the table — they hold a single glyph or 1-2
+  // chars. Other columns flex via `weight` to fill the remainder.
+  test("allTimer column is fixed-width", () => {
     const columns = createPerformanceColumns({ ...defaultOptions, showAllTimerColumn: true });
 
     const allTimerColumn = columns.find((column) => "id" in column && column.id === "allTimer");
-    expect(allTimerColumn?.meta?.width).toBe("16px");
-
-    const setColumn = columns.find((column) => "accessorKey" in column && column.accessorKey === "set");
-    expect(setColumn?.meta?.width).toBe("48px");
+    expect(allTimerColumn?.meta?.fixedWidth).toBeTruthy();
   });
 });

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -133,7 +133,7 @@ function SortableHeader({
   return (
     <button
       type="button"
-      className="cursor-pointer select-none hover:text-content-text-primary w-full text-left flex items-start gap-1"
+      className="cursor-pointer select-none hover:text-content-text-primary w-full text-left flex flex-wrap items-start gap-x-1"
       onClick={() => column.toggleSorting()}
     >
       <span className={column.getIsSorted() ? "text-content-text-primary font-semibold" : ""}>{label}</span>
@@ -162,24 +162,21 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       columnHelper.accessor((row) => row.songTitle || "", {
         id: "song",
         header: ({ column }) => <SortableHeader column={column} label="Song" />,
+        // Cross-song surfaces (this column only renders there): the song
+        // title is the primary signal, so it claims a large share of the
+        // leftover space against the secondary date / context columns.
+        meta: { weight: 3 },
         enableSorting: true,
         sortingFn: "alphanumeric",
         cell: (info) => {
           const title = info.getValue() as string;
           const slug = info.row.original.songSlug;
-          // Title relies on column width + `[overflow-wrap:anywhere]` for
-          // sizing. Setting `min-w` on the inner element would let it stick
-          // out of the table-fixed cell and trigger a horizontal scrollbar
-          // on the wrapping div at narrow widths.
           return slug ? (
-            <a
-              href={`/songs/${slug}`}
-              className="text-base text-brand-primary hover:text-brand-secondary font-medium [overflow-wrap:anywhere]"
-            >
+            <a href={`/songs/${slug}`} className="text-base text-brand-primary hover:text-brand-secondary font-medium">
               {title}
             </a>
           ) : (
-            <span className="text-content-text-secondary [overflow-wrap:anywhere]">{title}</span>
+            <span className="text-content-text-secondary">{title}</span>
           );
         },
       }) as ColumnDef<SongPagePerformance, unknown>,
@@ -191,7 +188,9 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       columnHelper.accessor((row) => row.allTimer ?? false, {
         id: "allTimer",
         header: "",
-        meta: allTimerColumnMeta,
+        // Hidden on mobile here — the Set cell renders the flame inline
+        // on phones to recover the 16px this column would otherwise consume.
+        meta: { ...allTimerColumnMeta, hideOnMobile: true },
         enableSorting: false,
         cell: (info) => (info.getValue() ? <AllTimerCell /> : null),
       }) as ColumnDef<SongPagePerformance, unknown>,
@@ -201,7 +200,12 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
   columns.push(
     columnHelper.accessor("show.date", {
       id: "date",
-      meta: { width: "180px" },
+      // Desktop: weight 3 gives room for "MMM D, YYYY" + a venue line
+      // (DateVenueCell's @container/datecell drops the venue when the
+      // column gets squeezed). Mobile: fixed 5rem fits "M/D/YYYY" on one
+      // line and locks the column so the song-before / song-after flex
+      // columns can claim the rest.
+      meta: { weight: 3, mobileFixedWidth: "5rem" },
       header: ({ column }) => <SortableHeader column={column} label="Date" />,
       enableSorting: true,
       sortingFn: (a, b) => compareByShowDate(a.original, b.original),
@@ -209,13 +213,21 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
         const date = info.getValue();
         const showSlug = info.row.original.show.slug;
         const venue = info.row.original.venue;
+        const isAllTimer = info.row.original.allTimer;
         return (
-          <a href={`/shows/${showSlug}`} className="text-base text-brand-primary hover:text-brand-secondary block">
-            <DateVenueCell
-              date={<ShowDate date={date} />}
-              venue={{ name: venue?.name, city: venue?.city, state: venue?.state }}
-            />
-          </a>
+          <div className="flex flex-col gap-0.5">
+            <a href={`/shows/${showSlug}`} className="text-base text-brand-primary hover:text-brand-secondary block">
+              <DateVenueCell
+                date={<ShowDate date={date} />}
+                venue={{ name: venue?.name, city: venue?.city, state: venue?.state }}
+              />
+            </a>
+            {isAllTimer && !showSongColumn && (
+              <span className="sm:hidden">
+                <AllTimerCell align="start" />
+              </span>
+            )}
+          </div>
         );
       },
     }) as ColumnDef<SongPagePerformance, unknown>,
@@ -225,7 +237,7 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
     columns.push(
       columnHelper.accessor((row) => row.gap ?? Number.NEGATIVE_INFINITY, {
         id: "gap",
-        meta: { width: "64px" },
+        meta: { fixedWidth: "3.5rem", mobileFixedWidth: "2rem" },
         header: ({ column }) => <SortableHeader column={column} label="Gap" />,
         enableSorting: true,
         sortingFn: gapSortingFn,
@@ -242,15 +254,15 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       columns.push(
         columnHelper.accessor((row) => row.filteredGap ?? Number.NEGATIVE_INFINITY, {
           id: "filteredGap",
-          meta: { width: "72px" },
+          meta: { fixedWidth: "3.5rem", mobileFixedWidth: "2rem" },
           header: ({ column }) => (
             <SortableHeader
               column={column}
               label={
-                <span className="inline-flex items-center gap-1">
+                <span className="flex flex-col items-start leading-tight">
                   <Filter className="h-3 w-3" aria-hidden="true" />
                   <span className="sr-only">Filtered</span>
-                  Gap
+                  <span>Gap</span>
                 </span>
               }
             />
@@ -270,7 +282,7 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
     columns.push(
       columnHelper.accessor((row) => row.previousShow?.date ?? "", {
         id: "lastPlayed",
-        meta: { width: "110px", hideOnMobile: true },
+        meta: { fixedWidth: "5rem", hideOnMobile: true },
         header: ({ column }) => <SortableHeader column={column} label="Last Played" />,
         enableSorting: true,
         sortingFn: "alphanumeric",
@@ -279,33 +291,42 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
     );
   }
 
+  if (showSongColumn) {
+    // Cross-song surfaces (e.g. /songs/all-timers, /on-this-day) bring
+    // Set back as a column — when rows span many shows, the set label
+    // ("1", "E1") is the only on-row hint of where in the show this
+    // happened. On the single-song surfaces (/songs/:slug) Set was
+    // removed because every row's set is in the surrounding context.
+    columns.push(
+      columnHelper.accessor("set", {
+        id: "set",
+        header: "Set",
+        meta: { fixedWidth: "2.5rem" },
+        enableSorting: false,
+        cell: (info) => {
+          const set = info.getValue();
+          if (!set) return <span className="text-content-text-tertiary">—</span>;
+          return <span className="text-content-text-secondary">{formatSetLabel(set)}</span>;
+        },
+      }) as ColumnDef<SongPagePerformance, unknown>,
+    );
+  }
+
   columns.push(
-    columnHelper.accessor("set", {
-      header: "Set",
-      meta: { width: "48px" },
-      enableSorting: false,
-      cell: (info) => {
-        const set = info.getValue();
-        if (!set) return <span className="text-content-text-tertiary">—</span>;
-        // Cross-show table — we don't know the encore count of any one
-        // show, so single-encore collapse (E1 → E) is left off here.
-        return <span className="text-content-text-secondary">{formatSetLabel(set)}</span>;
-      },
-    }) as ColumnDef<SongPagePerformance, unknown>,
     columnHelper.accessor((row) => row.songBefore, {
       id: "songBefore",
       header: ({ column }) => <SortableHeader column={column} label="Song Before" />,
       enableSorting: true,
       sortingFn: songBeforeSortingFn,
-      meta: { hideOnMobile: true },
+      // Cross-song surfaces hide adjacency on mobile — too many columns
+      // to fit. Per-song surfaces keep them visible (user-requested).
+      meta: { weight: 1.6, hideOnMobile: showSongColumn },
       cell: (info) => {
         const before = info.getValue();
         if (!before?.songTitle) return null;
-        // Inline text rather than flex items so the title wraps mid-word
-        // instead of pushing past the arrow onto a new line. Arrow renders
-        // only on segues; its absence implicitly signals a non-segue.
+        // Arrow renders only on segues; its absence implicitly signals a non-segue.
         return (
-          <span className="[overflow-wrap:anywhere]">
+          <span>
             <a href={`/songs/${before.songSlug}`} className="text-content-text-secondary hover:text-brand-primary">
               {before.songTitle}
             </a>
@@ -319,13 +340,13 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       header: ({ column }) => <SortableHeader column={column} label="Song After" />,
       enableSorting: true,
       sortingFn: songAfterSortingFn,
-      meta: { hideOnMobile: true },
+      meta: { weight: 1.6, hideOnMobile: showSongColumn },
       cell: (info) => {
         const after = info.getValue();
         if (!after?.songTitle) return null;
         const outgoingSegue = info.row.original.segue;
         return (
-          <span className="[overflow-wrap:anywhere]">
+          <span>
             {outgoingSegue && <span className="text-content-text-tertiary">&gt; </span>}
             <a href={`/songs/${after.songSlug}`} className="text-content-text-secondary hover:text-brand-primary">
               {after.songTitle}
@@ -343,7 +364,7 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
         id: "notes",
         header: "Notes",
         enableSorting: false,
-        meta: { hideOnMobile: true },
+        meta: { weight: 2.8, hideOnMobile: true },
         cell: (info) => {
           const { annotations, notes } = info.getValue();
           const items = [];
@@ -371,7 +392,12 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       header: ({ column }) => <SortableHeader column={column} label="Rating" />,
       enableSorting: true,
       sortingFn: "basic",
-      meta: { hideOnMobile: true },
+      // Desktop 7.25rem (~116px) = badge width (~91px) + cell padding
+      // (24px), no extra. Mobile fits the compact badge at 6rem. The
+      // 5-star editor is no longer inline — it pops in a popover that
+      // overlays the badge — so the column doesn't need to hold the
+      // wider expanded state.
+      meta: { fixedWidth: "7.25rem", mobileFixedWidth: "6rem" },
       cell: (info) => {
         const rating = info.getValue();
         const ratingsCount = info.row.original.ratingsCount;

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -38,6 +38,27 @@ export const gapSortingFn = makeGapSortingFn("gap");
 export const filteredGapSortingFn = makeGapSortingFn("filteredGap");
 
 /**
+ * Adapt a SongPagePerformance row to the minimal Track-like shape the
+ * shared AllTimerCell + TrackRatingOverlay expect. The performance DTO
+ * uses `notes` (plural) for the note field and exposes the song title
+ * at the top level rather than under `song.title`; this normalizes both.
+ * Returns a structural subset of TrackLight — only the fields the
+ * overlay actually reads — since fabricating a full TrackLight with
+ * never-read defaults would be misleading.
+ */
+function trackFromPerformance(row: SongPagePerformance) {
+  return {
+    id: row.trackId,
+    allTimer: row.allTimer ?? null,
+    note: row.notes ?? null,
+    song: { title: row.songTitle ?? "", slug: row.songSlug ?? "" },
+    averageRating: row.rating ?? null,
+    ratingsCount: row.ratingsCount ?? null,
+    likesCount: 0,
+  };
+}
+
+/**
  * Sort comparator factory for the Song Before / Song After columns. The
  * primary axis is the adjacent song's title (case-insensitive). The
  * tiebreaker reads the relevant segue field — segue rows sort ahead of
@@ -107,6 +128,13 @@ interface PerformanceColumnOptions {
   showSongColumn?: boolean;
   showAllTimerColumn?: boolean;
   /**
+   * When true (and `showAllTimerColumn` is on), keep the flame column
+   * visible on mobile and instead hide the Set column there — the
+   * noteworthy marker is the critical signal on jam-charts surfaces,
+   * while the set number is secondary in that context.
+   */
+  mobileFlamePriority?: boolean;
+  /**
    * Gap + Last Played are per-song signals. On surfaces that mix songs
    * (all-timers, on-this-day), pass `false` to hide both. Defaults true.
    */
@@ -151,11 +179,39 @@ function SortableHeader({
 }
 
 export function createPerformanceColumns(options: PerformanceColumnOptions): ColumnDef<SongPagePerformance, unknown>[] {
-  const { showSongColumn, showAllTimerColumn, showGapColumns, hasNarrowingFilter, userRatingMap, isAuthenticated } =
-    options;
+  const {
+    showSongColumn,
+    showAllTimerColumn,
+    mobileFlamePriority,
+    showGapColumns,
+    hasNarrowingFilter,
+    userRatingMap,
+    isAuthenticated,
+  } = options;
   const includeGapColumns = showGapColumns !== false;
   const columnHelper = createColumnHelper<SongPagePerformance>();
   const columns: ColumnDef<SongPagePerformance, unknown>[] = [];
+
+  // AllTimer column comes first so the flame anchors the leftmost slot
+  // on the surfaces that show it (jam-charts, song-detail jam-charts +
+  // all-performances tabs) — the visual hierarchy reads "noteworthy
+  // marker → song/date → context columns" left to right.
+  if (showAllTimerColumn) {
+    columns.push(
+      columnHelper.accessor((row) => row.allTimer ?? false, {
+        id: "allTimer",
+        header: "",
+        // Hidden on mobile by default — the Set cell renders the flame
+        // inline on phones to recover the 16px this column would
+        // otherwise consume. `mobileFlamePriority` flips that on
+        // jam-charts surfaces where the marker is the critical signal
+        // and the Set column hides on mobile instead.
+        meta: { ...allTimerColumnMeta, hideOnMobile: !mobileFlamePriority },
+        enableSorting: false,
+        cell: (info) => <AllTimerCell track={trackFromPerformance(info.row.original)} />,
+      }) as ColumnDef<SongPagePerformance, unknown>,
+    );
+  }
 
   if (showSongColumn) {
     columns.push(
@@ -183,20 +239,6 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
     );
   }
 
-  if (showAllTimerColumn) {
-    columns.push(
-      columnHelper.accessor((row) => row.allTimer ?? false, {
-        id: "allTimer",
-        header: "",
-        // Hidden on mobile here — the Set cell renders the flame inline
-        // on phones to recover the 16px this column would otherwise consume.
-        meta: { ...allTimerColumnMeta, hideOnMobile: true },
-        enableSorting: false,
-        cell: (info) => (info.getValue() ? <AllTimerCell /> : null),
-      }) as ColumnDef<SongPagePerformance, unknown>,
-    );
-  }
-
   columns.push(
     columnHelper.accessor("show.date", {
       id: "date",
@@ -213,7 +255,7 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
         const date = info.getValue();
         const showSlug = info.row.original.show.slug;
         const venue = info.row.original.venue;
-        const isAllTimer = info.row.original.allTimer;
+        const track = trackFromPerformance(info.row.original);
         return (
           <div className="flex flex-col gap-0.5">
             <a href={`/shows/${showSlug}`} className="text-base text-brand-primary hover:text-brand-secondary block">
@@ -222,9 +264,9 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
                 venue={{ name: venue?.name, city: venue?.city, state: venue?.state }}
               />
             </a>
-            {isAllTimer && !showSongColumn && (
+            {!showSongColumn && (
               <span className="sm:hidden">
-                <AllTimerCell align="start" />
+                <AllTimerCell track={track} align="start" />
               </span>
             )}
           </div>
@@ -301,7 +343,7 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       columnHelper.accessor("set", {
         id: "set",
         header: "Set",
-        meta: { fixedWidth: "2.5rem" },
+        meta: { fixedWidth: "2.5rem", hideOnMobile: mobileFlamePriority },
         enableSorting: false,
         cell: (info) => {
           const set = info.getValue();

--- a/apps/web/app/components/performance/performance-filter-controls.test.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.test.tsx
@@ -184,14 +184,15 @@ describe("PerformanceFilterControls", () => {
     expect(handleUpdateFilter).not.toHaveBeenCalled();
   });
 
-  // On mobile the entire filter block is collapsed behind a "Filters"
-  // toggle button so it doesn't eat the viewport before any results show.
-  // The wrapper carries `hidden` until expanded; sm+ breakpoints keep it
-  // visible regardless via `sm:flex`/`sm:block`.
-  test("renders a mobile-only Filters toggle button (sm:hidden)", async () => {
+  // On mobile the entire filter block is collapsed behind a "Search & Filters"
+  // toggle button so it doesn't eat the viewport before any results show, and
+  // the label hints that the search box lives inside the expansion. The wrapper
+  // carries `hidden` until expanded; sm+ breakpoints keep it visible regardless
+  // via `sm:flex`/`sm:block`.
+  test("renders a mobile-only Search & Filters toggle button (sm:hidden)", async () => {
     await setup(<PerformanceFilterControls {...defaultProps} searchValue="" onSearchChange={() => {}} />);
 
-    const toggle = screen.getByRole("button", { name: /^Filters/ });
+    const toggle = screen.getByRole("button", { name: /^Search & Filters/ });
     expect(toggle.className).toContain("sm:hidden");
   });
 
@@ -207,7 +208,7 @@ describe("PerformanceFilterControls", () => {
     expect(wrapper.className).toContain("hidden");
     expect(wrapper.className).toContain("sm:block");
 
-    await user.click(screen.getByRole("button", { name: /^Filters/ }));
+    await user.click(screen.getByRole("button", { name: /^Search & Filters/ }));
 
     // After click, mobile-collapse should release.
     expect(wrapper.className).not.toMatch(/(^|\s)hidden(\s|$)/);
@@ -220,7 +221,7 @@ describe("PerformanceFilterControls", () => {
   test("Filters toggle carries short:!flex so it re-shows on phone landscape", async () => {
     await setup(<PerformanceFilterControls {...defaultProps} searchValue="" onSearchChange={() => {}} />);
 
-    const toggle = screen.getByRole("button", { name: /^Filters/ });
+    const toggle = screen.getByRole("button", { name: /^Search & Filters/ });
     expect(toggle.className).toContain("short:!flex");
   });
 
@@ -248,7 +249,7 @@ describe("PerformanceFilterControls", () => {
       />,
     );
 
-    const toggle = screen.getByRole("button", { name: /^Filters/ });
+    const toggle = screen.getByRole("button", { name: /^Search & Filters/ });
     // Badge is the count of active filters (timeRange + 2 toggles = 3).
     expect(toggle.textContent).toMatch(/3/);
   });

--- a/apps/web/app/components/performance/performance-filter-controls.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.tsx
@@ -9,8 +9,6 @@ import { cn } from "~/lib/utils";
 
 const ALL_TOGGLE_FILTERS = TOGGLE_FILTER_DEFINITIONS as unknown as Array<{ key: string; label: string }>;
 
-const TOGGLE_FILTERS_WITHOUT_ALL_TIMER = ALL_TOGGLE_FILTERS.filter((filter) => filter.key !== "allTimer");
-
 const labelClass =
   "text-xs font-medium text-content-text-secondary uppercase tracking-wide mb-1.5 h-[18px] flex items-center";
 
@@ -22,6 +20,14 @@ interface PerformanceFilterControlsProps {
   clearFilters: () => void;
   extraSelectFilters?: ReactNode;
   showAllTimerToggle?: boolean;
+  /**
+   * When false, hide the "Jam Chart" toggle chip. Set on the dedicated
+   * Jam Charts page (the whole result set is already jam-charts there)
+   * and on the All-Timers page (same reasoning as why "All-Timer" is
+   * hidden there) so toggle filters within those views express
+   * additional narrowing rather than redundant scope.
+   */
+  showJamChartToggle?: boolean;
   hideTimeRange?: boolean;
   coverFilter?: string;
   selectedAuthor?: string | null;
@@ -39,6 +45,7 @@ export function PerformanceFilterControls({
   clearFilters,
   extraSelectFilters,
   showAllTimerToggle = true,
+  showJamChartToggle = true,
   hideTimeRange = false,
   coverFilter,
   selectedAuthor,
@@ -47,7 +54,11 @@ export function PerformanceFilterControls({
   onSearchChange,
   hasActiveFilters = false,
 }: PerformanceFilterControlsProps) {
-  const toggleFilters = showAllTimerToggle ? ALL_TOGGLE_FILTERS : TOGGLE_FILTERS_WITHOUT_ALL_TIMER;
+  const toggleFilters = ALL_TOGGLE_FILTERS.filter((filter) => {
+    if (!showAllTimerToggle && filter.key === "allTimer") return false;
+    if (!showJamChartToggle && filter.key === "jamChart") return false;
+    return true;
+  });
   const showPlayedFilter =
     playedFilter !== undefined &&
     (hideTimeRange ||

--- a/apps/web/app/components/performance/performance-filter-controls.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.tsx
@@ -84,7 +84,7 @@ export function PerformanceFilterControls({
       >
         <span className="flex items-center gap-2">
           <Filter className="h-4 w-4" aria-hidden="true" />
-          Filters
+          Search &amp; Filters
           {activeFilterCount > 0 && (
             <span className="px-2 py-0.5 rounded-full bg-brand-primary/20 text-brand-primary text-xs">
               {activeFilterCount}

--- a/apps/web/app/components/performance/performance-table.tsx
+++ b/apps/web/app/components/performance/performance-table.tsx
@@ -13,6 +13,13 @@ interface PerformanceTableProps {
   performances: SongPagePerformance[];
   showSongColumn?: boolean;
   showAllTimerColumn?: boolean;
+  /**
+   * When true (and `showAllTimerColumn` is on), keep the flame column
+   * visible on mobile and hide the Set column there instead. Used on
+   * jam-charts surfaces where the noteworthy marker is the critical
+   * signal at narrow viewports.
+   */
+  mobileFlamePriority?: boolean;
   showGapColumns?: boolean;
   /**
    * When true, render the Filtered Gap column. Route is responsible for
@@ -34,6 +41,7 @@ export function PerformanceTable({
   performances,
   showSongColumn,
   showAllTimerColumn,
+  mobileFlamePriority,
   showGapColumns,
   hasNarrowingFilter,
   headerContent,
@@ -67,12 +75,21 @@ export function PerformanceTable({
       createPerformanceColumns({
         showSongColumn,
         showAllTimerColumn,
+        mobileFlamePriority,
         showGapColumns,
         hasNarrowingFilter,
         userRatingMap,
         isAuthenticated,
       }),
-    [showSongColumn, showAllTimerColumn, showGapColumns, hasNarrowingFilter, userRatingMap, isAuthenticated],
+    [
+      showSongColumn,
+      showAllTimerColumn,
+      mobileFlamePriority,
+      showGapColumns,
+      hasNarrowingFilter,
+      userRatingMap,
+      isAuthenticated,
+    ],
   );
 
   return (

--- a/apps/web/app/components/rating/rating-badge-button.tsx
+++ b/apps/web/app/components/rating/rating-badge-button.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { RatingComponent } from "~/components/rating/rating";
 import { LoginPromptPopover } from "~/components/ui/login-prompt-popover";
+import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
 import { StarRating } from "~/components/ui/star-rating";
 import { cn } from "~/lib/utils";
 
@@ -111,14 +112,14 @@ export function RatingBadgeButton({
     ? "bg-amber-500/10 border border-amber-500/50 shadow-[0_0_8px_rgba(245,158,11,0.2)]"
     : "glass-secondary border border-dashed border-glass-border hover:border-amber-500/30";
 
-  const ratingButton = (
+  // Badge is always the compact RatingComponent; tapping opens a Popover
+  // with the 5-star picker (overlay rather than inline expansion). Same
+  // behavior on desktop and mobile so the rating column never needs to
+  // hold the wider expanded state.
+  const compactButton = (
     <button
       type="button"
-      onClick={(e) => {
-        if (!isAuthenticated) return;
-        e.stopPropagation();
-        setIsExpanded((open) => !open);
-      }}
+      onClick={(e) => e.stopPropagation()}
       className={cn(
         layoutClass,
         paddingClass,
@@ -127,33 +128,78 @@ export function RatingBadgeButton({
         isAnimating && "animate-[avg-rating-update_0.5s_ease-out]",
       )}
     >
-      {isExpanded ? (
-        <StarRating
-          rateableId={rateableId}
-          rateableType={rateableType}
-          showSlug={showSlug}
-          initialRating={localUserRating}
-          onRatingChange={setLocalUserRating}
-          onAverageRatingChange={handleRatingChange}
-          skipRevalidation={skipRevalidation}
-        />
-      ) : (
-        <RatingComponent
-          rating={displayedRating || null}
-          ratingsCount={displayedCount || null}
-          userRating={localUserRating}
-        />
-      )}
+      <RatingComponent
+        rating={displayedRating || null}
+        ratingsCount={displayedCount || null}
+        userRating={localUserRating}
+      />
     </button>
   );
 
   if (!isAuthenticated) {
     return (
       <div className="w-auto">
-        <LoginPromptPopover message="Sign in to rate">{ratingButton}</LoginPromptPopover>
+        <LoginPromptPopover message="Sign in to rate">{compactButton}</LoginPromptPopover>
       </div>
     );
   }
 
-  return <div className="w-auto">{ratingButton}</div>;
+  return (
+    <div className="w-auto">
+      <Popover open={isExpanded} onOpenChange={setIsExpanded}>
+        <PopoverTrigger asChild>{compactButton}</PopoverTrigger>
+        {/*
+         * `side="top"` + negative sideOffset positions the popover so
+         * its bottom edge sits over the badge, visually replacing the
+         * collapsed star + count with the 5-star picker rather than
+         * floating in empty space below. Styling mirrors the desktop
+         * inline-expanded state — amber tint + border + soft glow when
+         * the user has rated, glass / dashed-border when they haven't —
+         * so opening the picker reads as the same component, just
+         * floated on mobile.
+         *
+         * The inline `background` style uses the raw `--popover` CSS
+         * variable directly because this Tailwind v4 theme registers
+         * `--color-*` tokens (used by Tailwind `bg-*` classes)
+         * separately from the older HSL-component `--popover` token
+         * shared with Radix — `bg-popover` / `bg-background` resolve to
+         * `transparent`. The amber tint layers on top via `bg-amber-500/10`.
+         */}
+        <PopoverContent
+          // Sized + colored to mirror the inline-expanded badge:
+          // same py-1 + px padding, same border + glow as the rated
+          // state. `min-h-8` + `sideOffset={-32}` makes the popover at
+          // least as tall as the underlying badge on desktop (~30px) so
+          // it fully covers the badge with `align="center"` + `side="top"`.
+          //
+          // Background is OPAQUE: rgb(33, 24, 11) = amber-500 (rgb 245,
+          // 158, 11) composited at 10% opacity over the dark page bg
+          // (--background ≈ rgb 9, 9, 11). Same visual color as the
+          // inline `bg-amber-500/10` reads against the row, without
+          // letting other cells show through.
+          className={cn(
+            "w-auto rounded-md flex items-center gap-1 min-h-8",
+            localHasRated ? "!p-1" : "!py-1 !px-2",
+            localHasRated
+              ? "border border-amber-500/50 shadow-[0_0_8px_rgba(245,158,11,0.2)]"
+              : "glass-secondary border border-dashed border-glass-border",
+          )}
+          style={localHasRated ? { backgroundColor: "rgb(33, 24, 11)" } : undefined}
+          align="center"
+          side="top"
+          sideOffset={-32}
+        >
+          <StarRating
+            rateableId={rateableId}
+            rateableType={rateableType}
+            showSlug={showSlug}
+            initialRating={localUserRating}
+            onRatingChange={setLocalUserRating}
+            onAverageRatingChange={handleRatingChange}
+            skipRevalidation={skipRevalidation}
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
 }

--- a/apps/web/app/components/search/global-search-drawer.tsx
+++ b/apps/web/app/components/search/global-search-drawer.tsx
@@ -5,7 +5,7 @@ import type {
   SegueRunMatchDetails,
   TrackMatchDetails,
 } from "@bip/domain";
-import { Loader2, Search, X } from "lucide-react";
+import { Loader2, MapPin, Music, Search, X } from "lucide-react";
 import { useCallback, useEffect } from "react";
 import { useNavigate } from "react-router";
 import { Input } from "~/components/ui/input";
@@ -35,6 +35,51 @@ function SearchResultItem({ result, onClose }: SearchResultItemProps) {
       onClose();
     }
   };
+
+  // Song-page result: link to /songs/<slug>, distinct icon and styling so
+  // users can tell at a glance it's a song page, not a specific performance.
+  if (result.entityType === "song") {
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        className="block w-full text-left p-3 hover:bg-purple-900/20 active:bg-purple-900/30 rounded-lg transition-colors group cursor-pointer"
+      >
+        <div className="flex items-center gap-3">
+          <Music className="h-4 w-4 text-purple-300 flex-shrink-0" />
+          <div className="flex-1 min-w-0">
+            <div className="text-base text-gray-200 font-medium">{result.songTitle || result.displayText}</div>
+            <div className="text-xs text-purple-400 mt-0.5">Song page</div>
+          </div>
+          {result.score && <span className="text-xs text-purple-400 font-medium">{result.score}%</span>}
+        </div>
+      </button>
+    );
+  }
+
+  // Venue-page result: link to /venues/<slug>, separate from individual shows
+  // at that venue.
+  if (result.entityType === "venue") {
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        className="block w-full text-left p-3 hover:bg-purple-900/20 active:bg-purple-900/30 rounded-lg transition-colors group cursor-pointer"
+      >
+        <div className="flex items-center gap-3">
+          <MapPin className="h-4 w-4 text-purple-300 flex-shrink-0" />
+          <div className="flex-1 min-w-0">
+            <div className="text-base text-gray-200 font-medium">
+              {result.venueName || result.displayText}
+              {result.venueLocation && <span className="text-gray-400 font-normal"> • {result.venueLocation}</span>}
+            </div>
+            <div className="text-xs text-purple-400 mt-0.5">Venue page</div>
+          </div>
+          {result.score && <span className="text-xs text-purple-400 font-medium">{result.score}%</span>}
+        </div>
+      </button>
+    );
+  }
 
   // Use displayText as fallback if individual fields aren't available
   const displayDate = result.date

--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -343,7 +343,9 @@ describe("SetlistCard", () => {
     // Average gap formats to one decimal place — terse, matches the rest
     // of the rarity stat presentation on the song-detail page.
     expect(screen.getByText(/Average \/ median song gap:\s*7\.5\s*\/\s*6\.0/)).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Last Played" })).toBeInTheDocument();
+    // Label is split into stacked <span>Last</span><span>Played</span>
+    // so the accessible name concatenates without whitespace.
+    expect(screen.getByRole("columnheader", { name: /LastPlayed/i })).toBeInTheDocument();
   });
 
   // The average gap summary lives BELOW the setlist text on the same row
@@ -383,7 +385,9 @@ describe("SetlistCard", () => {
     await user.click(screen.getByRole("button", { name: /gap chart/i }));
     // The card flipped views (table renders), but no callback was invoked
     // because none was passed — the only way list pages preserve local state.
-    expect(screen.getByRole("columnheader", { name: "Last Played" })).toBeInTheDocument();
+    // Label is split into stacked <span>Last</span><span>Played</span>
+    // so the accessible name concatenates without whitespace.
+    expect(screen.getByRole("columnheader", { name: /LastPlayed/i })).toBeInTheDocument();
     expect(onViewChange).not.toHaveBeenCalled();
   });
 

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -1,9 +1,10 @@
 import type { Attendance, Rating, Setlist, SetlistLight } from "@bip/domain";
-import { Check, Flame } from "lucide-react";
+import { Check } from "lucide-react";
 import { memo, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { RatingBadgeButton } from "~/components/rating/rating-badge-button";
 import { ShowDate } from "~/components/show-date";
+import { NoteworthyMarker } from "~/components/track/noteworthy-marker";
 import { Card, CardContent, CardHeader } from "~/components/ui/card";
 import { useSession } from "~/hooks/use-session";
 import { useAttendanceMutation } from "~/hooks/use-show-user-data";
@@ -351,9 +352,10 @@ function SetlistCardComponent({
                                   track.allTimer && "font-medium",
                                 )}
                               >
-                                {track.allTimer && (
-                                  <Flame className="h-3 w-3 md:h-4 md:w-4 inline-block mr-1 transform -translate-y-0.5 text-orange-500" />
-                                )}
+                                <NoteworthyMarker
+                                  track={track}
+                                  iconClassName="h-3 w-3 md:h-4 md:w-4 inline-block mr-1 transform -translate-y-0.5"
+                                />
                                 <Link to={`/songs/${track.song?.slug}`}>{track.song?.title}</Link>
                                 {trackAnnotationMap.has(track.id) && (
                                   <sup className="text-brand-secondary ml-0.5 font-medium text-xs">

--- a/apps/web/app/components/setlist/setlist-columns-personal.tsx
+++ b/apps/web/app/components/setlist/setlist-columns-personal.tsx
@@ -34,7 +34,7 @@ export function createPersonalSetlistColumns(
     createGapColumn<PersonalSetlistTableRow>({
       id: "yourGap",
       label: "Your Gap",
-      width: "60px",
+      weight: 0.8,
       state: (row) => row.personal.yourGap,
       debutLabel: "Your debut",
       thisShowLabel: "Earlier this show",
@@ -43,7 +43,7 @@ export function createPersonalSetlistColumns(
       id: "lastSeen",
       label: "Last Seen",
       accessor: (row) => row.personal.lastSeen,
-      width: "124px",
+      fixedWidth: "7.5rem",
       hideOnMobile: true,
     }),
     createSeenCountColumn(),
@@ -59,8 +59,21 @@ function createSeenCountColumn(): ColumnDef<PersonalSetlistTableRow, unknown> {
   const columnHelper = createColumnHelper<PersonalSetlistTableRow>();
   return columnHelper.accessor((row) => row.personal.totalTimesSeen, {
     id: "totalTimesSeen",
-    header: ({ column }) => <SortableHeader column={column} label="Seen Before" />,
-    meta: { width: "72px" },
+    header: ({ column }) => (
+      <SortableHeader
+        column={column}
+        label={
+          <span className="flex flex-col items-start leading-tight">
+            <span>Seen</span>
+            <span>Before</span>
+          </span>
+        }
+      />
+    ),
+    // Bounded content (1-3 digit count). Desktop fixedWidth holds the
+    // stacked "Seen / Before" header + sort arrow on its own line below
+    // without leaving any extra slack.
+    meta: { fixedWidth: "4.5rem", mobileFixedWidth: "3rem" },
     enableSorting: true,
     sortingFn: "basic",
     sortDescFirst: false,

--- a/apps/web/app/components/setlist/setlist-columns.test.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.test.tsx
@@ -176,7 +176,8 @@ describe("createSetlistColumns", () => {
         song: { id: "b", title: "Above the Waves", slug: "y" },
       }),
     ]);
-    await user.click(screen.getByRole("button", { name: /Last Played/i }));
+    // Label is split into stacked spans; accessible name is "LastPlayed".
+    await user.click(screen.getByRole("button", { name: /LastPlayed/i }));
     const songCells = screen.getAllByRole("cell").filter((_, i) => i % 7 === 3);
     expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
       "Basis for a Day",
@@ -378,12 +379,16 @@ describe("createSetlistColumns", () => {
     expect(link).toHaveAttribute("href", "/songs/confrontation");
   });
 
-  // Rating column hides on phones to keep the row legible — same pattern
-  // the "Last Seen" column uses on the personal table. Tablet+ shows it.
-  test("Rating column is marked hideOnMobile", () => {
+  // Rating stays visible on phones too — the rating button is the
+  // primary action on the setlist row and dropping it hides a core
+  // affordance. The column shrinks to a fixed `mobileFixedWidth` so it
+  // still fits alongside Song / Gap / Last Played.
+  test("Rating column declares mobileFixedWidth and is NOT hidden on mobile", () => {
     const columns = createSetlistColumns();
     const rating = columns.find((c) => c.id === "rating");
-    expect((rating?.meta as { hideOnMobile?: boolean } | undefined)?.hideOnMobile).toBe(true);
+    const meta = rating?.meta as { hideOnMobile?: boolean; mobileFixedWidth?: string } | undefined;
+    expect(meta?.hideOnMobile).toBeFalsy();
+    expect(meta?.mobileFixedWidth).toBeTruthy();
   });
 
   // Each row's Rating cell renders TrackRatingCell wired with the track's

--- a/apps/web/app/components/setlist/setlist-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.tsx
@@ -35,7 +35,7 @@ export function createSetlistColumns(ctx?: Partial<SetlistRatingContext>): Colum
     createGapColumn<SetlistTableRow>({
       id: "gap",
       label: "Gap",
-      width: "64px",
+      weight: 0.8,
       state: (row, allRows) => buildGapCellState({ isRepeat: isWithinShowRepeat(allRows, row), gap: row.gap }),
       debutLabel: "Debut",
       thisShowLabel: "This Show",
@@ -44,7 +44,7 @@ export function createSetlistColumns(ctx?: Partial<SetlistRatingContext>): Colum
       id: "lastPlayed",
       label: "Last Played",
       accessor: (row) => row.previousPerformanceShow,
-      width: "140px",
+      fixedWidth: "7.5rem",
     }),
     createRatingColumn<SetlistTableRow>(ratingCtx),
   ];

--- a/apps/web/app/components/setlist/setlist-common-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-common-columns.tsx
@@ -263,11 +263,9 @@ export function createSetlistCommonColumns<T extends TrackLight>(options?: {
             {!hideSetLabel && (
               <span className="text-content-text-secondary">{formatSetLabel(raw, { encoresInSet })}</span>
             )}
-            {row.allTimer && (
-              <span className="sm:hidden">
-                <AllTimerCell />
-              </span>
-            )}
+            <span className="sm:hidden">
+              <AllTimerCell track={row} />
+            </span>
           </div>
         );
       },
@@ -301,7 +299,7 @@ export function createSetlistCommonColumns<T extends TrackLight>(options?: {
       // inline on phones to recover the 16px this column would consume.
       meta: { ...allTimerColumnMeta, hideOnMobile: true },
       enableSorting: false,
-      cell: (info) => (info.row.original.allTimer ? <AllTimerCell /> : null),
+      cell: (info) => <AllTimerCell track={info.row.original} />,
     }) as ColumnDef<T, unknown>,
     columnHelper.accessor((row) => row.song?.title ?? "", {
       id: "song",

--- a/apps/web/app/components/setlist/setlist-common-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-common-columns.tsx
@@ -49,7 +49,13 @@ export function createRatingColumn<T extends TrackLight>(ctx: SetlistRatingConte
   return columnHelper.accessor((row) => row.averageRating ?? Number.NEGATIVE_INFINITY, {
     id: "rating",
     header: ({ column }) => <SortableHeader column={column} label="Rating" />,
-    meta: { width: "120px", hideOnMobile: true },
+    // Bounded content (star + "X.XX" + dot + count). The 5-star picker
+    // now floats in a popover instead of expanding the badge inline, so
+    // the column only needs to fit the compact badge. Desktop 7rem (~112px)
+    // gives ~96px content area (after 1rem horizontal padding) so the
+    // widest "★ 5.00 · 99" badge (~91px) sits with a few pixels of
+    // breathing room. Mobile 6rem fits the same compact rendering.
+    meta: { fixedWidth: "7rem", mobileFixedWidth: "6rem" },
     enableSorting: true,
     // Ties resolve to canonical set+position so "all unrated tracks" still
     // read top-to-bottom in the order they were played.
@@ -93,14 +99,41 @@ export function createShowDateLinkColumn<T extends TrackLight>(opts: {
   id: string;
   label: string;
   accessor: (row: T) => { date: string; slug: string | null } | null | undefined;
-  width: string;
+  /**
+   * Desktop column width. Date content is bounded ("MMM DD, YYYY" max
+   * ~100px), so callers should generally pass a fixedWidth here rather
+   * than relying on weight — flexing eats space the Song column wants.
+   */
+  fixedWidth: string;
   hideOnMobile?: boolean;
 }): ColumnDef<T, unknown> {
   const columnHelper = createColumnHelper<T>();
   return columnHelper.accessor((row) => opts.accessor(row)?.date ?? "", {
     id: opts.id,
-    header: ({ column }) => <SortableHeader column={column} label={opts.label} />,
-    meta: opts.hideOnMobile ? { width: opts.width, hideOnMobile: true } : { width: opts.width },
+    // Label words stack vertically so the header floor is the widest
+    // single word ("Played" / "Seen" ~ 50px) instead of the full phrase
+    // ("Last Played" ~ 76px). Combined with SortableHeader's flex-wrap,
+    // the sort arrow drops onto its own line below when the column is
+    // narrow, letting the date cells (~80px content) drive the column
+    // width instead of the header.
+    header: ({ column }) => (
+      <SortableHeader
+        column={column}
+        label={
+          <span className="flex flex-col leading-tight">
+            {opts.label.split(" ").map((word) => (
+              <span key={word}>{word}</span>
+            ))}
+          </span>
+        }
+      />
+    ),
+    // Mobile: 4.5rem locks the column to compact "M/D/YY" width — same
+    // pattern as the other date-only mobile cells — so the Rating column
+    // can sit alongside without crowding Song.
+    meta: opts.hideOnMobile
+      ? { fixedWidth: opts.fixedWidth, mobileFixedWidth: "4.5rem", hideOnMobile: true }
+      : { fixedWidth: opts.fixedWidth, mobileFixedWidth: "4.5rem" },
     enableSorting: true,
     // ISO YYYY-MM-DD strings sort lexicographically the same as
     // chronologically. Empty strings (no prior performance) sort first asc
@@ -126,7 +159,7 @@ export function createShowDateLinkColumn<T extends TrackLight>(opts: {
 export function createGapColumn<T extends TrackLight>(opts: {
   id: string;
   label: string;
-  width: string;
+  weight: number;
   /** Row-level state — must be stable per row so sort + cell agree. */
   state: (row: T, allRows: ReadonlyArray<T>) => GapCellState;
   debutLabel: string;
@@ -146,7 +179,10 @@ export function createGapColumn<T extends TrackLight>(opts: {
     {
       id: opts.id,
       header: ({ column }) => <SortableHeader column={column} label={opts.label} />,
-      meta: { width: opts.width },
+      // Gap content is bounded (debut icon, repeat icon, or up to 3
+      // digits) — fix both desktop (3rem) and mobile (2.5rem with the
+      // sort arrow wrapping onto its own line below the "Gap" label).
+      meta: { fixedWidth: "3rem", mobileFixedWidth: "2.5rem" },
       enableSorting: true,
       // Numeric compare with set+position tiebreaker — rows that share the
       // same gap value still read in canonical narrative order.
@@ -179,26 +215,61 @@ export function createSetlistCommonColumns<T extends TrackLight>(options?: {
   return [
     columnHelper.accessor((row) => row.set, {
       id: "set",
-      header: ({ column }) => <SortableHeader column={column} label="Set" />,
-      meta: { width: "36px" },
+      // "Set" label is sr-only on mobile — the column shrinks below the
+      // word's width, and "Set" + sort affordance are redundant when the
+      // cells themselves show "1", "2", "E1" right below.
+      header: ({ column }) => (
+        <SortableHeader
+          column={column}
+          label={
+            <span>
+              <span className="sr-only sm:not-sr-only">Set</span>
+            </span>
+          }
+        />
+      ),
+      // Set values max out at "E2" (2 chars). Bounded content → fixed
+      // 3rem on desktop. On mobile the column also doubles as the home
+      // for the all-timer flame icon (standalone AllTimer column is
+      // hidden on mobile to save space), so it's wide enough for either
+      // the flame or "E1" stacked vertically.
+      meta: {
+        fixedWidth: "2.5rem",
+        mobileFixedWidth: "1.25rem",
+        cellClassName: "!px-0 sm:!px-2",
+        headerClassName: "!px-0 sm:!px-2",
+      },
       enableSorting: true,
       sortingFn: (a, b) => compareBySetThenPosition(a.original, b.original),
       cell: (info) => {
         const raw = info.getValue() as string;
+        const row = info.row.original;
         const encoresInSet = countDistinctEncores(info.table.getCoreRowModel().rows.map((r) => r.original));
         // Show the set label only on the first row of a same-set run when
         // sorted by Set — keeps the grouping visually obvious. Other sorts
         // interleave sets, so every row keeps its label.
         const sorting = info.table.getState().sorting;
         const groupBySet = sorting.length > 0 && sorting[0].id === "set";
+        let hideSetLabel = false;
         if (groupBySet) {
           const sortedRows = info.table.getSortedRowModel().rows;
           const idx = sortedRows.findIndex((r) => r.id === info.row.id);
-          if (idx > 0 && sortedRows[idx - 1].original.set === info.row.original.set) {
-            return null;
+          if (idx > 0 && sortedRows[idx - 1].original.set === row.set) {
+            hideSetLabel = true;
           }
         }
-        return <span className="text-content-text-secondary">{formatSetLabel(raw, { encoresInSet })}</span>;
+        return (
+          <div className="flex flex-col items-center sm:items-start gap-0.5">
+            {!hideSetLabel && (
+              <span className="text-content-text-secondary">{formatSetLabel(raw, { encoresInSet })}</span>
+            )}
+            {row.allTimer && (
+              <span className="sm:hidden">
+                <AllTimerCell />
+              </span>
+            )}
+          </div>
+        );
       },
     }) as ColumnDef<T, unknown>,
     columnHelper.display({
@@ -206,7 +277,10 @@ export function createSetlistCommonColumns<T extends TrackLight>(options?: {
       header: ({ column }) => <SortableHeader column={column} label="Track" />,
       // Drops on narrow viewports — the Set column already orients the row,
       // and a tiny Track column would steal width from Song on mobile.
-      meta: { width: "42px", hideOnMobile: true },
+      // Track # (position within set) — bounded to 3 digits max. 3.5rem
+      // accommodates the "Track" header word + sort arrow + tighter
+      // padding on desktop.
+      meta: { fixedWidth: "3.5rem", hideOnMobile: true },
       enableSorting: true,
       // Track # = position-within-set, computed at render time from the
       // unsorted row model. The comparator falls through to the canonical
@@ -223,7 +297,9 @@ export function createSetlistCommonColumns<T extends TrackLight>(options?: {
     columnHelper.display({
       id: "allTimer",
       header: () => null,
-      meta: allTimerColumnMeta,
+      // Hidden on mobile here — the setlist Set cell renders the flame
+      // inline on phones to recover the 16px this column would consume.
+      meta: { ...allTimerColumnMeta, hideOnMobile: true },
       enableSorting: false,
       cell: (info) => (info.row.original.allTimer ? <AllTimerCell /> : null),
     }) as ColumnDef<T, unknown>,

--- a/apps/web/app/components/setlist/setlist-highlights.test.tsx
+++ b/apps/web/app/components/setlist/setlist-highlights.test.tsx
@@ -1,0 +1,285 @@
+import type { Setlist, Track } from "@bip/domain";
+import { setupWithRouter } from "@test/test-utils";
+import { screen, within } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { SetlistHighlights } from "./setlist-highlights";
+
+// Setlist-wide fixture defaults are stubbed where the component never
+// reads them — these tests focus on the tracks/sets the highlights panel
+// actually iterates over.
+function makeSetlist(sets: Array<{ label: string; tracks: Partial<Track>[] }>): Setlist {
+  return {
+    show: { id: "show-1", slug: "1995-10-21" } as Setlist["show"],
+    venue: { id: "venue-1", name: "The Wetlands" } as Setlist["venue"],
+    annotations: [],
+    averageSongGap: null,
+    medianSongGap: null,
+    debutCount: 0,
+    sets: sets.map((set, sortIdx) => ({
+      label: set.label,
+      sort: sortIdx,
+      tracks: set.tracks.map((t, i) => makeTrack({ set: set.label, position: i + 1, ...t })),
+    })),
+  };
+}
+
+function makeTrack(overrides: Partial<Track>): Track {
+  const song =
+    (overrides.song as Track["song"]) ??
+    ({
+      id: "song-default",
+      title: "Sound One",
+      slug: "sound-one",
+    } as unknown as Track["song"]);
+  return {
+    id: overrides.id ?? `track-${overrides.position ?? 0}-${song?.slug ?? "x"}`,
+    showId: "show-1",
+    songId: song?.id ?? "song-default",
+    set: overrides.set ?? "S1",
+    position: overrides.position ?? 1,
+    segue: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    likesCount: 0,
+    slug: null,
+    note: overrides.note ?? null,
+    allTimer: overrides.allTimer ?? false,
+    previousTrackId: null,
+    nextTrackId: null,
+    averageRating: 0,
+    ratingsCount: 0,
+    gap: null,
+    previousPerformanceShowId: null,
+    previousPerformanceShow: null,
+    song,
+    annotations: [],
+  } as unknown as Track;
+}
+
+describe("SetlistHighlights (compressed)", () => {
+  // When no track is an all-timer or has a note, there is nothing to
+  // highlight — the whole section is omitted so the right rail doesn't
+  // show an empty placeholder.
+  test("renders nothing when no tracks have allTimer or notes", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S1",
+        tracks: [{ song: { id: "a", title: "Above the Waves", slug: "above-the-waves" } as Track["song"] }],
+      },
+    ]);
+    const { container } = await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  // The compressed section is one list — not two subsections. Verifies
+  // we don't render separate "All-Timers" / "Track Notes" / "Jam Charts"
+  // sub-headers on the show page.
+  test("does not render separate All-Timers / Track Notes / Jam Charts subsection headers", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S1",
+        tracks: [
+          { allTimer: true, song: { id: "a", title: "Aceetobee", slug: "aceetobee" } as Track["song"] },
+          {
+            note: "Type II exploration.",
+            song: { id: "b", title: "Basis for a Day", slug: "basis-for-a-day" } as Track["song"],
+          },
+        ],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    expect(screen.queryByText("All-Timers")).not.toBeInTheDocument();
+    expect(screen.queryByText("Track Notes")).not.toBeInTheDocument();
+    expect(screen.queryByText("Jam Charts")).not.toBeInTheDocument();
+    // The single section heading does remain.
+    expect(screen.getByText("Show Highlights")).toBeInTheDocument();
+  });
+
+  // Both all-timers (no note) and noted-but-not-all-timer tracks land in
+  // the compressed list, with the song title as a link to /songs/{slug}.
+  test("lists both all-timer and noted tracks with song-page links", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S1",
+        tracks: [
+          { allTimer: true, song: { id: "a", title: "Aceetobee", slug: "aceetobee" } as Track["song"] },
+          {
+            note: "Glow-stick frenzy.",
+            song: { id: "b", title: "Basis for a Day", slug: "basis-for-a-day" } as Track["song"],
+          },
+        ],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    expect(screen.getByRole("link", { name: "Aceetobee" })).toHaveAttribute("href", "/songs/aceetobee");
+    expect(screen.getByRole("link", { name: "Basis for a Day" })).toHaveAttribute("href", "/songs/basis-for-a-day");
+  });
+
+  // The note text renders inline below the song name so users can read
+  // the curated commentary without a popover hop — the compressed section
+  // is the canonical place to scan notes.
+  test("renders note text below the song name", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S1",
+        tracks: [
+          {
+            note: "Type II Spaga, near 20 minutes.",
+            song: { id: "s", title: "Spaga", slug: "spaga" } as Track["song"],
+          },
+        ],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    expect(screen.getByText(/Type II Spaga, near 20 minutes/)).toBeInTheDocument();
+  });
+
+  // Set labels in the highlights panel match the rest of the app's
+  // formatting via `formatSetLabel` — "S1" → "1", and the encore drops
+  // its number when the show has exactly one encore.
+  test("formats set labels via formatSetLabel: S1 -> 1, single E1 -> E", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S1",
+        tracks: [{ allTimer: true, song: { id: "a", title: "Aceetobee", slug: "aceetobee" } as Track["song"] }],
+      },
+      {
+        label: "E1",
+        tracks: [{ allTimer: true, song: { id: "c", title: "Crickets", slug: "crickets" } as Track["song"] }],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    // "S1" never appears — only "1".
+    expect(screen.queryByText("S1")).not.toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    // Single encore collapses to "E", not "E1".
+    expect(screen.queryByText("E1")).not.toBeInTheDocument();
+    expect(screen.getByText("E")).toBeInTheDocument();
+  });
+
+  // With more than one encore in the show, the encore numerals stay so
+  // users can distinguish E1 from E2.
+  test("keeps the encore numeral when the show has multiple encores", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "E1",
+        tracks: [{ allTimer: true, song: { id: "x", title: "Aceetobee", slug: "aceetobee" } as Track["song"] }],
+      },
+      {
+        label: "E2",
+        tracks: [{ allTimer: true, song: { id: "y", title: "Crickets", slug: "crickets" } as Track["song"] }],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    expect(screen.getByText("E1")).toBeInTheDocument();
+    expect(screen.getByText("E2")).toBeInTheDocument();
+  });
+
+  // The flame icon sits to the LEFT of the song title — same reading
+  // order as the rest of the app, and visually anchors each row.
+  test("renders the flame icon to the left of the song title", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S1",
+        tracks: [{ allTimer: true, song: { id: "a", title: "Aceetobee", slug: "aceetobee" } as Track["song"] }],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    const row = screen.getByRole("link", { name: "Aceetobee" }).closest("li") as HTMLElement;
+    const flame = within(row).getByLabelText("All-timer");
+    const link = within(row).getByRole("link", { name: "Aceetobee" });
+    expect(flame.compareDocumentPosition(link) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  // The set label prints once per set-bucket transition; consecutive rows
+  // in the same set leave the slot blank so the reader's eye groups the
+  // rows under the single label. Matches how setlists are spoken aloud.
+  test("displays the set label only on the first row of each set group", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S1",
+        tracks: [
+          { allTimer: true, song: { id: "a", title: "Aceetobee", slug: "aceetobee" } as Track["song"] },
+          { allTimer: true, song: { id: "b", title: "Basis for a Day", slug: "basis-for-a-day" } as Track["song"] },
+          { note: "Slow ramp.", song: { id: "c", title: "Crickets", slug: "crickets" } as Track["song"] },
+        ],
+      },
+      {
+        label: "S2",
+        tracks: [{ allTimer: true, song: { id: "d", title: "Dribble", slug: "dribble" } as Track["song"] }],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    const rows = screen.getAllByRole("listitem");
+    expect(rows).toHaveLength(4);
+    // First row in S1 shows the label
+    expect(within(rows[0]).queryByText("1")).toBeInTheDocument();
+    // Subsequent S1 rows do not repeat the label
+    expect(within(rows[1]).queryByText("1")).not.toBeInTheDocument();
+    expect(within(rows[2]).queryByText("1")).not.toBeInTheDocument();
+    // First S2 row prints "2" since it's a new set
+    expect(within(rows[3]).queryByText("2")).toBeInTheDocument();
+  });
+
+  // Each row carries the corresponding flame icon. All-timer rows get the
+  // orange flame; jam-chart rows (note only) get the off-white flame so
+  // the two categories are visually distinct in the same list.
+  test("orange flame on all-timer rows, off-white flame on jam-chart rows", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S1",
+        tracks: [
+          { allTimer: true, song: { id: "a", title: "Aceetobee", slug: "aceetobee" } as Track["song"] },
+          { note: "Slow burn.", song: { id: "b", title: "Basis for a Day", slug: "basis-for-a-day" } as Track["song"] },
+        ],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    const aceeRow = screen.getByRole("link", { name: "Aceetobee" }).closest("li");
+    const basisRow = screen.getByRole("link", { name: "Basis for a Day" }).closest("li");
+    expect(aceeRow).not.toBeNull();
+    expect(basisRow).not.toBeNull();
+    const aceeFlame = within(aceeRow as HTMLElement).getByLabelText("All-timer");
+    const basisFlame = within(basisRow as HTMLElement).getByLabelText("Jam chart");
+    expect(aceeFlame.getAttribute("class") ?? "").toMatch(/text-orange-500/);
+    expect(basisFlame.getAttribute("class") ?? "").toMatch(/text-content-text-primary/);
+  });
+
+  // Tracks render in canonical show order (set bucket → position within
+  // set), not insertion order. Verifies the row sequence matches what a
+  // user expects when reading the show top to bottom.
+  test("orders rows by set then position", async () => {
+    const setlist = makeSetlist([
+      {
+        label: "S2",
+        tracks: [
+          { allTimer: true, position: 2, song: { id: "c", title: "Crickets", slug: "crickets" } as Track["song"] },
+        ],
+      },
+      {
+        label: "S1",
+        tracks: [
+          { allTimer: true, position: 3, song: { id: "a", title: "Aceetobee", slug: "aceetobee" } as Track["song"] },
+          {
+            allTimer: true,
+            position: 1,
+            song: { id: "b", title: "Basis for a Day", slug: "basis-for-a-day" } as Track["song"],
+          },
+        ],
+      },
+      {
+        label: "E1",
+        tracks: [
+          {
+            allTimer: true,
+            position: 1,
+            song: { id: "d", title: "Story of the World", slug: "story-of-the-world" } as Track["song"],
+          },
+        ],
+      },
+    ]);
+    await setupWithRouter(<SetlistHighlights setlist={setlist} />);
+    const links = screen.getAllByRole("link").map((el) => el.textContent);
+    expect(links).toEqual(["Basis for a Day", "Aceetobee", "Crickets", "Story of the World"]);
+  });
+});

--- a/apps/web/app/components/setlist/setlist-highlights.tsx
+++ b/apps/web/app/components/setlist/setlist-highlights.tsx
@@ -1,88 +1,64 @@
-import type { Setlist } from "@bip/domain";
-import { FileText, Flame } from "lucide-react";
-import { Link } from "react-router";
+import type { Setlist, TrackLight } from "@bip/domain";
+import { Link } from "react-router-dom";
+import { TrackIcon } from "~/components/track/track-icon";
+import { compareBySetThenPosition, countDistinctEncores, formatSetLabel } from "./set-label";
 
 interface SetlistHighlightsProps {
   setlist: Setlist;
 }
 
+/**
+ * Right-rail panel listing every track from the show that is either an
+ * all-timer or carries a curated jam-chart note, in canonical show order.
+ * Each row shows the position label (printed only on the first row of
+ * each set group), a flame (orange for all-timer, off-white for
+ * jam-chart), a song-page link, and the note text underneath when
+ * present. Hidden entirely when no track is noteworthy.
+ */
 export function SetlistHighlights({ setlist }: SetlistHighlightsProps) {
-  // Collect all tracks that are all-timers or have notes
-  const allTimerTracks = [];
-  const tracksWithNotes = [];
+  const highlights = setlist.sets.flatMap((set) => set.tracks).filter((track) => track.allTimer || hasNote(track));
+  if (highlights.length === 0) return null;
 
-  for (const set of setlist.sets) {
-    for (const track of set.tracks) {
-      if (track.allTimer) {
-        allTimerTracks.push({ ...track, set: set.label });
-      }
-
-      if (track.note && track.note.trim() !== "") {
-        tracksWithNotes.push({ ...track, set: set.label });
-      }
-    }
-  }
-
-  // If there are no highlights, don't render the component
-  if (allTimerTracks.length === 0 && tracksWithNotes.length === 0) {
-    return null;
-  }
+  const encoresInSet = countDistinctEncores(highlights);
+  const ordered = [...highlights].sort(compareBySetThenPosition);
 
   return (
     <div className="card-premium rounded-lg px-3 py-2 space-y-3">
       <h3 className="text-sm font-medium text-content-text-secondary">Show Highlights</h3>
-      {allTimerTracks.length > 0 && (
-        <div>
-          <h4 className="text-sm font-medium text-content-text-primary flex items-center gap-2 mb-1.5">
-            <Flame className="h-4 w-4 text-orange-500 shrink-0" />
-            <span>All-Timers</span>
-          </h4>
-          <ul className="space-y-0.5 pl-6">
-            {allTimerTracks.map((track) => (
-              <li key={track.id} className="text-content-text-secondary text-sm">
-                <div className="flex items-baseline gap-2">
-                  <span className="text-xs text-content-text-tertiary font-medium">{track.set}</span>
-                  <Link
-                    to={`/songs/${track.song?.slug}`}
-                    className="text-brand-tertiary hover:text-brand-primary hover:underline transition-colors"
-                  >
-                    {track.song?.title}
-                  </Link>
-                </div>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      {tracksWithNotes.length > 0 && (
-        <div>
-          <h4 className="text-sm font-medium text-content-text-primary flex items-center gap-2 mb-1.5">
-            <FileText className="h-4 w-4 text-info shrink-0" />
-            <span>Track Notes</span>
-          </h4>
-          <ul className="space-y-2 pl-6">
-            {tracksWithNotes.map((track) => (
-              <li key={track.id} className="text-content-text-secondary text-sm">
-                <div className="flex items-baseline gap-2">
-                  <span className="text-xs text-content-text-tertiary font-medium">{track.set}</span>
-                  <div className="flex-1">
+      <ul className="space-y-2">
+        {ordered.map((track, idx) => {
+          const showSetLabel = idx === 0 || ordered[idx - 1].set !== track.set;
+          return (
+            <li key={track.id} className="text-sm">
+              <div className="flex items-baseline gap-2">
+                <span className="text-xs text-content-text-tertiary font-medium w-5 shrink-0">
+                  {showSetLabel ? formatSetLabel(track.set, { encoresInSet }) : ""}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <span className="flex items-center gap-1.5">
+                    <TrackIcon track={track} iconClassName="h-3.5 w-3.5" />
                     <Link
                       to={`/songs/${track.song?.slug}`}
                       className="text-brand-primary hover:text-brand-secondary hover:underline transition-colors"
                     >
                       {track.song?.title}
                     </Link>
-                    <p className="text-xs text-content-text-tertiary mt-0.5 pl-2 border-l-2 border-glass-border">
-                      {track.note}
+                  </span>
+                  {hasNote(track) && (
+                    <p className="text-xs text-content-text-secondary mt-0.5 pl-2 border-l-2 border-glass-border">
+                      {track.note?.trim()}
                     </p>
-                  </div>
+                  )}
                 </div>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
+}
+
+function hasNote(track: Pick<TrackLight, "note">): boolean {
+  return !!track.note?.trim();
 }

--- a/apps/web/app/components/setlist/track-rating-overlay.test.tsx
+++ b/apps/web/app/components/setlist/track-rating-overlay.test.tsx
@@ -1,0 +1,78 @@
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+// Stub the session hook so the overlay can render without a data router.
+vi.mock("~/hooks/use-session", () => ({
+  useSession: () => ({ user: null, supabase: null }),
+}));
+
+import { TrackRatingOverlay, type TrackRatingOverlayTrack } from "./track-rating-overlay";
+
+function makeTrack(overrides: Partial<TrackRatingOverlayTrack> = {}): TrackRatingOverlayTrack {
+  return {
+    id: "track-1",
+    allTimer: false,
+    note: null,
+    song: { title: "Aceetobee" },
+    averageRating: 4.5,
+    ratingsCount: 10,
+    likesCount: 0,
+    ...overrides,
+  };
+}
+
+describe('TrackRatingOverlay trigger="click"', () => {
+  // The click variant uses Radix Popover so taps on touch devices
+  // surface the overlay — the hover-only variant is invisible on
+  // mobile. Verifies the trigger primitive is wired up to clicks.
+  test("opens the overlay on click and shows the note text", async () => {
+    const NOTE = "Type II Spaga, near 20 minutes.";
+    const { user } = await setup(
+      <TrackRatingOverlay track={makeTrack({ note: NOTE })} showRating={false} trigger="click">
+        <button type="button">flame</button>
+      </TrackRatingOverlay>,
+    );
+
+    expect(screen.queryByText(NOTE)).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "flame" }));
+    expect(await screen.findByText(NOTE)).toBeInTheDocument();
+  });
+
+  // `showRating={false}` is the variant used wherever the surrounding
+  // table already has a Rating column. The overlay should hide the
+  // rating UI even though the track carries averageRating data.
+  test("suppresses the rating display when showRating is false", async () => {
+    const { user } = await setup(
+      <TrackRatingOverlay
+        track={makeTrack({ note: "Big jam.", averageRating: 4.75, ratingsCount: 12 })}
+        showRating={false}
+        trigger="click"
+      >
+        <button type="button">flame</button>
+      </TrackRatingOverlay>,
+    );
+    await user.click(screen.getByRole("button", { name: "flame" }));
+    // Note still surfaces…
+    expect(await screen.findByText("Big jam.")).toBeInTheDocument();
+    // …but the rating number does not.
+    expect(screen.queryByText("4.75")).not.toBeInTheDocument();
+  });
+});
+
+describe("TrackRatingOverlay trigger default", () => {
+  // The default trigger is hover (Radix HoverCard). A click on the
+  // trigger should NOT open it — only hover does. Locks in the
+  // distinction so a regression won't silently turn every call site
+  // into click-only behavior on mobile.
+  test("does not open on click in hover mode", async () => {
+    const NOTE = "Should not appear on click.";
+    const { user } = await setup(
+      <TrackRatingOverlay track={makeTrack({ note: NOTE })}>
+        <button type="button">row</button>
+      </TrackRatingOverlay>,
+    );
+    await user.click(screen.getByRole("button", { name: "row" }));
+    expect(screen.queryByText(NOTE)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/setlist/track-rating-overlay.tsx
+++ b/apps/web/app/components/setlist/track-rating-overlay.tsx
@@ -1,14 +1,47 @@
-import type { Track, TrackLight } from "@bip/domain";
 import { useEffect, useRef, useState } from "react";
 import { RatingComponent } from "~/components/rating";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "~/components/ui/hover-card";
+import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
 import { Skeleton } from "~/components/ui/skeleton";
 import { StarRating } from "~/components/ui/star-rating";
 import { useSession } from "~/hooks/use-session";
 
+/**
+ * Minimal structural type for any track shape this overlay can read.
+ * Wider call sites pass a full `Track` / `TrackLight`; surfaces with
+ * their own track-like row shape (e.g. SongPagePerformance) adapt at
+ * the call site. Listed inline so consumers don't have to import the
+ * full domain types just to satisfy the prop.
+ */
+export interface TrackRatingOverlayTrack {
+  id: string;
+  allTimer?: boolean | null;
+  note?: string | null;
+  song?: { title?: string | null } | null;
+  averageRating?: number | null;
+  ratingsCount?: number | null;
+  likesCount?: number | null;
+}
+
 interface TrackRatingOverlayProps {
-  track: Track | TrackLight;
+  track: TrackRatingOverlayTrack;
   children: React.ReactNode;
+  /**
+   * When false, suppress the rating display, likes count, and user
+   * rating editor — and skip the /api/tracks/:id refetch. Use this
+   * variant when the surrounding view already shows rating in its own
+   * column (e.g. the gap-chart tables) so the overlay reduces to
+   * "song title + note" without redundant scoring data.
+   */
+  showRating?: boolean;
+  /**
+   * `"hover"` (default) wraps the trigger in a hover card — opens on
+   * pointer hover, works on desktop only. `"click"` uses a popover so
+   * the overlay also opens on tap on touch devices; use it on small
+   * targets like the standalone flame icon where mobile users have no
+   * other way to surface the note.
+   */
+  trigger?: "hover" | "click";
 }
 
 interface TrackDataResponse {
@@ -23,7 +56,7 @@ interface TrackDataResponse {
   userRating: number | null;
 }
 
-export function TrackRatingOverlay({ track, children }: TrackRatingOverlayProps) {
+export function TrackRatingOverlay({ track, children, showRating = true, trigger = "hover" }: TrackRatingOverlayProps) {
   const { user } = useSession();
   const [isOpen, setIsOpen] = useState(false);
   const [data, setData] = useState<TrackDataResponse | null>(null);
@@ -37,9 +70,12 @@ export function TrackRatingOverlay({ track, children }: TrackRatingOverlayProps)
     };
   }, []);
 
-  // Fetch fresh track data when hover card opens
+  // Fetch fresh track data when hover card opens. Skipped in note-only
+  // mode — the rating display is hidden anyway, and the note text on
+  // the row already comes from the same source.
   useEffect(() => {
     if (!isOpen) return;
+    if (!showRating) return;
 
     const fetchTrackData = async () => {
       setIsLoading(true);
@@ -62,80 +98,98 @@ export function TrackRatingOverlay({ track, children }: TrackRatingOverlayProps)
     };
 
     fetchTrackData();
-  }, [isOpen, track.id]);
+  }, [isOpen, track.id, showRating]);
 
   // Use fetched data if available, otherwise fall back to initial track data
   const displayRating = data?.track.averageRating ?? track.averageRating ?? 0;
   const ratingCount = data?.track.ratingsCount ?? track.ratingsCount ?? 0;
   const userRating = data?.userRating ?? null;
 
+  const content = (
+    <div className="space-y-3">
+      <div className="text-lg font-medium text-brand-primary">{track.song?.title}</div>
+
+      {showRating &&
+        (isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-6 w-32" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+        ) : (
+          <RatingComponent rating={displayRating} ratingsCount={ratingCount} userRating={userRating} />
+        ))}
+
+      {showRating && (data?.track.likesCount ?? track.likesCount ?? 0) > 0 && (
+        <div className="text-xs text-content-text-secondary">
+          {data?.track.likesCount ?? track.likesCount}{" "}
+          {(data?.track.likesCount ?? track.likesCount) === 1 ? "like" : "likes"}
+        </div>
+      )}
+
+      {(data?.track.note ?? track.note) && (
+        <div className="text-xs text-content-text-secondary border-t border-glass-border pt-2 mt-2">
+          {data?.track.note ?? track.note}
+        </div>
+      )}
+
+      {showRating && user && (
+        <div className="border-t border-glass-border pt-3 mt-3">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-content-text-secondary">Your Rating:</span>
+            <StarRating
+              rateableId={track.id}
+              rateableType="Track"
+              className="scale-110 [&_fieldset]:border-0"
+              initialRating={userRating}
+              onRatingChange={() => {
+                // Refetch track data after rating
+                setData(null);
+                setIsLoading(true);
+                fetch(`/api/tracks/${track.id}`, { credentials: "include" })
+                  .then((res) => res.json())
+                  .then((newData) => {
+                    if (isMountedRef.current) {
+                      setData(newData);
+                      setIsLoading(false);
+                    }
+                  })
+                  .catch(() => {
+                    if (isMountedRef.current) {
+                      setIsLoading(false);
+                    }
+                  });
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
+  // Shared content styling between the hover-card and popover variants
+  // so the panel looks identical regardless of trigger mode.
+  const contentClassName = "w-80 p-4 bg-black/90 backdrop-blur-md border-glass-border shadow-xl";
+
+  if (trigger === "click") {
+    return (
+      <Popover open={isOpen} onOpenChange={setIsOpen}>
+        <PopoverTrigger asChild className="cursor-pointer">
+          {children}
+        </PopoverTrigger>
+        <PopoverContent className={contentClassName} side="top" align="start">
+          {content}
+        </PopoverContent>
+      </Popover>
+    );
+  }
+
   return (
     <HoverCard openDelay={600} closeDelay={200} onOpenChange={setIsOpen}>
       <HoverCardTrigger asChild className="cursor-pointer">
         {children}
       </HoverCardTrigger>
-      <HoverCardContent
-        className="w-80 p-4 bg-black/90 backdrop-blur-md border-glass-border shadow-xl"
-        side="top"
-        align="start"
-      >
-        <div className="space-y-3">
-          <div className="text-lg font-medium text-brand-primary">{track.song?.title}</div>
-
-          {isLoading ? (
-            <div className="space-y-2">
-              <Skeleton className="h-6 w-32" />
-              <Skeleton className="h-4 w-20" />
-            </div>
-          ) : (
-            <RatingComponent rating={displayRating} ratingsCount={ratingCount} userRating={userRating} />
-          )}
-
-          {(data?.track.likesCount ?? track.likesCount) > 0 && (
-            <div className="text-xs text-content-text-secondary">
-              {data?.track.likesCount ?? track.likesCount}{" "}
-              {(data?.track.likesCount ?? track.likesCount) === 1 ? "like" : "likes"}
-            </div>
-          )}
-
-          {(data?.track.note ?? track.note) && (
-            <div className="text-xs text-content-text-secondary border-t border-glass-border pt-2 mt-2">
-              {data?.track.note ?? track.note}
-            </div>
-          )}
-
-          {user && (
-            <div className="border-t border-glass-border pt-3 mt-3">
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-content-text-secondary">Your Rating:</span>
-                <StarRating
-                  rateableId={track.id}
-                  rateableType="Track"
-                  className="scale-110 [&_fieldset]:border-0"
-                  initialRating={userRating}
-                  onRatingChange={() => {
-                    // Refetch track data after rating
-                    setData(null);
-                    setIsLoading(true);
-                    fetch(`/api/tracks/${track.id}`, { credentials: "include" })
-                      .then((res) => res.json())
-                      .then((newData) => {
-                        if (isMountedRef.current) {
-                          setData(newData);
-                          setIsLoading(false);
-                        }
-                      })
-                      .catch(() => {
-                        if (isMountedRef.current) {
-                          setIsLoading(false);
-                        }
-                      });
-                  }}
-                />
-              </div>
-            </div>
-          )}
-        </div>
+      <HoverCardContent className={contentClassName} side="top" align="start">
+        {content}
       </HoverCardContent>
     </HoverCard>
   );

--- a/apps/web/app/components/show-date-link.tsx
+++ b/apps/web/app/components/show-date-link.tsx
@@ -30,13 +30,16 @@ export function ShowDateLink({ show }: ShowDateLinkProps) {
   if (!show) return <span className="text-content-text-tertiary">—</span>;
   if (!show.slug) {
     return (
-      <span className="text-content-text-secondary">
+      <span className="@container/datecell text-content-text-secondary block">
         <ShowDate date={show.date} />
       </span>
     );
   }
   return (
-    <a href={`/shows/${show.slug}${suffix}`} className="text-base text-brand-primary hover:text-brand-secondary">
+    <a
+      href={`/shows/${show.slug}${suffix}`}
+      className="@container/datecell block text-base text-brand-primary hover:text-brand-secondary"
+    >
       <ShowDate date={show.date} />
     </a>
   );

--- a/apps/web/app/components/show-date.tsx
+++ b/apps/web/app/components/show-date.tsx
@@ -1,28 +1,25 @@
 import { formatDateShort, formatDateShortMobile } from "~/lib/utils";
 
-interface ShowDateProps {
-  date: string | Date;
-  /**
-   * Render the compact `M/D/YY` form at all viewport sizes instead of
-   * only on mobile. For dense surfaces where the four-digit year would
-   * wrap the cell.
-   */
-  compact?: boolean;
-}
-
 /**
- * Single rendering point for show dates across the app. Outputs `M/D/YYYY`
- * at sm+ and the compact `M/D/YY` on mobile so narrow tables (songs list,
- * performance tables) stay readable without overlap. Centralizing here keeps
- * date formatting consistent everywhere a show date is displayed — change
- * the format once and every callsite follows.
+ * Single rendering point for show dates across the app. Outputs both the
+ * full `M/D/YYYY` and compact `M/D/YY` forms; CSS picks which one to display
+ * based on the nearest ancestor labeled `@container/datecell`. When no such
+ * container exists (e.g. the SetlistCard header), the default — full form —
+ * shows and the compact span stays hidden. Cells that DO declare a
+ * `@container/datecell` (DateVenueCell variants, ShowDateLink) swap to the
+ * compact form once the cell tightens below ~6rem, so dense tables and
+ * narrow layouts collapse dates automatically.
+ *
+ * Implementation note: ShowDate must not establish the container itself —
+ * `container-type: inline-size` zeroes the element's intrinsic inline
+ * size, which collapses an inline-block to 0 width and breaks the date
+ * character-by-character. The container lives on a sized parent.
  */
-export function ShowDate({ date, compact }: ShowDateProps) {
-  if (compact) return <span>{formatDateShortMobile(date)}</span>;
+export function ShowDate({ date }: { date: string | Date }) {
   return (
     <>
-      <span className="hidden sm:inline">{formatDateShort(date)}</span>
-      <span className="sm:hidden">{formatDateShortMobile(date)}</span>
+      <span className="inline whitespace-nowrap @max-[6rem]/datecell:hidden">{formatDateShort(date)}</span>
+      <span className="hidden whitespace-nowrap @max-[6rem]/datecell:inline">{formatDateShortMobile(date)}</span>
     </>
   );
 }

--- a/apps/web/app/components/show/show-form.tsx
+++ b/apps/web/app/components/show/show-form.tsx
@@ -3,13 +3,16 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import type { ControllerRenderProps } from "react-hook-form";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
+import { ShowYoutubeManager } from "~/components/show/show-youtube-manager";
 import { Button } from "~/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "~/components/ui/form";
+import { GlassSelect } from "~/components/ui/glass-select";
 import { Input } from "~/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
 import { Switch } from "~/components/ui/switch";
 import { Textarea } from "~/components/ui/textarea";
 import { VenueSearch } from "~/components/venue/venue-search";
+import { formInputClass } from "~/lib/form-styles";
+import { cn } from "~/lib/utils";
 
 const showFormSchema = z.object({
   date: z.string().min(1, "Date is required"),
@@ -28,9 +31,10 @@ interface ShowFormProps {
   submitLabel?: string;
   cancelHref?: string;
   bands?: Band[];
+  showId?: string;
 }
 
-export function ShowForm({ defaultValues, onSubmit, submitLabel = "Submit", cancelHref }: ShowFormProps) {
+export function ShowForm({ defaultValues, onSubmit, submitLabel = "Submit", cancelHref, showId }: ShowFormProps) {
   const form = useForm<ShowFormValues>({
     resolver: zodResolver(showFormSchema),
     defaultValues: defaultValues || {
@@ -53,11 +57,7 @@ export function ShowForm({ defaultValues, onSubmit, submitLabel = "Submit", canc
             <FormItem>
               <FormLabel className="text-content-text-secondary">Date</FormLabel>
               <FormControl>
-                <Input
-                  type="date"
-                  {...field}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
-                />
+                <Input type="date" {...field} className={formInputClass} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -89,22 +89,18 @@ export function ShowForm({ defaultValues, onSubmit, submitLabel = "Submit", canc
           render={({ field }: { field: ControllerRenderProps<ShowFormValues, "bandId"> }) => (
             <FormItem>
               <FormLabel className="text-content-text-secondary">Band</FormLabel>
-              <Select onValueChange={field.onChange} value={field.value}>
-                <FormControl>
-                  <SelectTrigger className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary">
-                    <SelectValue placeholder="Select a band" />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent className="bg-content-bg-secondary border-content-bg-secondary">
-                  <SelectItem value="none">No band</SelectItem>
-                  <SelectItem
-                    value="db7f2c5d-2727-41fd-bd6f-e91c74164f09"
-                    className="text-content-text-primary hover:bg-content-bg-secondary"
-                  >
-                    The Disco Biscuits
-                  </SelectItem>
-                </SelectContent>
-              </Select>
+              <FormControl>
+                <GlassSelect
+                  value={field.value}
+                  onValueChange={field.onChange}
+                  placeholder="Select a band"
+                  className="w-full"
+                  options={[
+                    { value: "none", label: "No band" },
+                    { value: "db7f2c5d-2727-41fd-bd6f-e91c74164f09", label: "The Disco Biscuits" },
+                  ]}
+                />
+              </FormControl>
               <FormMessage />
             </FormItem>
           )}
@@ -117,16 +113,14 @@ export function ShowForm({ defaultValues, onSubmit, submitLabel = "Submit", canc
             <FormItem>
               <FormLabel className="text-content-text-secondary">Notes</FormLabel>
               <FormControl>
-                <Textarea
-                  placeholder="Enter show notes"
-                  {...field}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary min-h-[100px]"
-                />
+                <Textarea placeholder="Enter show notes" {...field} className={cn(formInputClass, "min-h-[100px]")} />
               </FormControl>
               <FormMessage />
             </FormItem>
           )}
         />
+
+        {showId && <ShowYoutubeManager showId={showId} />}
 
         <FormField
           control={form.control}
@@ -135,11 +129,7 @@ export function ShowForm({ defaultValues, onSubmit, submitLabel = "Submit", canc
             <FormItem>
               <FormLabel className="text-content-text-secondary">Relisten URL</FormLabel>
               <FormControl>
-                <Input
-                  placeholder="Enter Relisten URL"
-                  {...field}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
-                />
+                <Input placeholder="Enter Relisten URL" {...field} className={formInputClass} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -166,16 +156,11 @@ export function ShowForm({ defaultValues, onSubmit, submitLabel = "Submit", canc
         />
 
         <div className="flex gap-4 pt-2">
-          <Button type="submit" className="bg-brand-primary hover:bg-hover-accent text-content-text-primary">
+          <Button type="submit" variant="brand">
             {submitLabel}
           </Button>
           {cancelHref && (
-            <Button
-              type="button"
-              variant="outline"
-              asChild
-              className="border-content-bg-secondary text-content-text-secondary hover:bg-content-bg-secondary hover:text-content-text-primary"
-            >
+            <Button type="button" variant="cancel" asChild>
               <a href={cancelHref}>Cancel</a>
             </Button>
           )}

--- a/apps/web/app/components/show/show-youtube-manager.test.tsx
+++ b/apps/web/app/components/show/show-youtube-manager.test.tsx
@@ -1,0 +1,217 @@
+import { setup } from "@test/test-utils";
+import { screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { success: (...args: unknown[]) => toastSuccess(...args), error: (...args: unknown[]) => toastError(...args) },
+}));
+
+import { ShowYoutubeManager } from "./show-youtube-manager";
+
+describe("ShowYoutubeManager", () => {
+  beforeEach(() => {
+    toastSuccess.mockClear();
+    toastError.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // On mount, the component fetches the show's current videos so the admin
+  // sees what's already curated before adding/removing.
+  test("loads existing videos on mount and renders each URL as a link", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { id: "row-1", videoId: "abc12345678", url: "https://www.youtube.com/watch?v=abc12345678" },
+        { id: "row-2", videoId: "xyz12345678", url: "https://www.youtube.com/watch?v=xyz12345678" },
+      ],
+    });
+
+    await setup(<ShowYoutubeManager showId="show-1" />);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith("/api/show-youtubes?showId=show-1");
+    const first = await screen.findByText("https://www.youtube.com/watch?v=abc12345678");
+    expect(first).toBeInTheDocument();
+    expect(screen.getByText("https://www.youtube.com/watch?v=xyz12345678")).toBeInTheDocument();
+  });
+
+  // The "No videos yet" hint is the empty-state copy that should only appear
+  // when the GET returns zero rows. It's a visual signal that the editor
+  // loaded — not an error.
+  test("shows the empty-state hint when no videos exist", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({ ok: true, json: async () => [] });
+
+    await setup(<ShowYoutubeManager showId="show-1" />);
+
+    expect(await screen.findByPlaceholderText(/YouTube URL/i)).toBeInTheDocument();
+    // No <li> rows render in the empty state.
+    expect(screen.queryAllByRole("listitem")).toHaveLength(0);
+  });
+
+  // Add flow: typing input + clicking Add posts the raw input to the server
+  // (server is responsible for extracting the video id). On success, the new
+  // row is appended to the list optimistically using the server response.
+  test("clicking Add posts the input and appends the returned row", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "row-new",
+          videoId: "dQw4w9WgXcQ",
+          url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        }),
+      });
+    globalThis.fetch = fetchMock;
+
+    const { user } = await setup(<ShowYoutubeManager showId="show-1" />);
+
+    const input = await screen.findByPlaceholderText(/YouTube URL/i);
+    await user.type(input, "https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+    await user.click(screen.getByRole("button", { name: /add/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const [url, options] = fetchMock.mock.calls[1];
+    expect(url).toBe("/api/show-youtubes");
+    expect(options.method).toBe("POST");
+    expect(JSON.parse(options.body)).toEqual({
+      showId: "show-1",
+      input: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+
+    expect(await screen.findByText("https://www.youtube.com/watch?v=dQw4w9WgXcQ")).toBeInTheDocument();
+    expect(toastSuccess).toHaveBeenCalled();
+  });
+
+  // Pressing Enter inside the input fires the same add flow as clicking Add,
+  // so admins curating from the keyboard don't have to reach for the mouse.
+  test("pressing Enter in the input submits the add", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "row-new",
+          videoId: "newvideo123",
+          url: "https://www.youtube.com/watch?v=newvideo123",
+        }),
+      });
+    globalThis.fetch = fetchMock;
+
+    const { user } = await setup(<ShowYoutubeManager showId="show-1" />);
+
+    const input = await screen.findByPlaceholderText(/YouTube URL/i);
+    await user.type(input, "newvideo123{Enter}");
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(fetchMock.mock.calls[1][0]).toBe("/api/show-youtubes");
+    expect(fetchMock.mock.calls[1][1].method).toBe("POST");
+  });
+
+  // The Add button is disabled while the input is empty/whitespace so the
+  // admin can't fire a no-op POST.
+  test("Add button is disabled when the input is empty", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({ ok: true, json: async () => [] });
+
+    await setup(<ShowYoutubeManager showId="show-1" />);
+
+    expect(await screen.findByRole("button", { name: /add/i })).toBeDisabled();
+  });
+
+  // When the server rejects the input (e.g. couldn't extract a video id), the
+  // error message in the response body surfaces to the toast — the admin
+  // sees what went wrong, not a generic "failed".
+  test("surfaces the server error message via toast on a 400", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: "Could not extract a YouTube video id from that input." }),
+      });
+    globalThis.fetch = fetchMock;
+
+    const { user } = await setup(<ShowYoutubeManager showId="show-1" />);
+
+    const input = await screen.findByPlaceholderText(/YouTube URL/i);
+    await user.type(input, "garbage");
+    await user.click(screen.getByRole("button", { name: /add/i }));
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith("Could not extract a YouTube video id from that input."),
+    );
+  });
+
+  // Delete flow: clicking the trash button on a row sends DELETE with the
+  // row's id and removes it from the list on success.
+  test("clicking delete sends DELETE and removes the row", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ id: "row-1", videoId: "abc12345678", url: "https://www.youtube.com/watch?v=abc12345678" }],
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) });
+    globalThis.fetch = fetchMock;
+
+    const { user } = await setup(<ShowYoutubeManager showId="show-1" />);
+
+    await screen.findByText("https://www.youtube.com/watch?v=abc12345678");
+
+    // The list row has exactly one button (trash); pick it by its parent <li>.
+    const row = screen.getByText("https://www.youtube.com/watch?v=abc12345678").closest("li");
+    const deleteBtn = row?.querySelector("button");
+    if (!deleteBtn) throw new Error("delete button not found");
+    await user.click(deleteBtn);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const [url, options] = fetchMock.mock.calls[1];
+    expect(url).toBe("/api/show-youtubes");
+    expect(options.method).toBe("DELETE");
+    expect(JSON.parse(options.body)).toEqual({ id: "row-1" });
+
+    await waitFor(() =>
+      expect(screen.queryByText("https://www.youtube.com/watch?v=abc12345678")).not.toBeInTheDocument(),
+    );
+    expect(toastSuccess).toHaveBeenCalledWith("Video removed");
+  });
+
+  // Delete failure should surface the server's error message — same
+  // contract as the Add flow. Without this, a non-2xx delete would
+  // show a generic "Failed to remove video" even when the API returned
+  // a specific reason (e.g. "Video belongs to a different show").
+  test("surfaces the server error message via toast when delete returns non-ok", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ id: "row-1", videoId: "abc12345678", url: "https://www.youtube.com/watch?v=abc12345678" }],
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: "Video belongs to a different show." }),
+      });
+    globalThis.fetch = fetchMock;
+
+    const { user } = await setup(<ShowYoutubeManager showId="show-1" />);
+
+    await screen.findByText("https://www.youtube.com/watch?v=abc12345678");
+
+    const row = screen.getByText("https://www.youtube.com/watch?v=abc12345678").closest("li");
+    const deleteBtn = row?.querySelector("button");
+    if (!deleteBtn) throw new Error("delete button not found");
+    await user.click(deleteBtn);
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith("Video belongs to a different show."));
+    // Row stays on screen — failed delete shouldn't optimistically remove it.
+    expect(screen.getByText("https://www.youtube.com/watch?v=abc12345678")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/show/show-youtube-manager.tsx
+++ b/apps/web/app/components/show/show-youtube-manager.tsx
@@ -1,0 +1,140 @@
+import { Plus, Trash, Youtube } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { formInputClass, listRowClass } from "~/lib/form-styles";
+import { cn } from "~/lib/utils";
+
+interface ShowYoutubeEntry {
+  id: string;
+  videoId: string;
+  url: string;
+}
+
+interface ShowYoutubeManagerProps {
+  showId: string;
+}
+
+export function ShowYoutubeManager({ showId }: ShowYoutubeManagerProps) {
+  const [entries, setEntries] = useState<ShowYoutubeEntry[]>([]);
+  const [input, setInput] = useState("");
+  const [isAdding, setIsAdding] = useState(false);
+  const [isDeletingId, setIsDeletingId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const response = await fetch(`/api/show-youtubes?showId=${showId}`);
+      if (!response.ok) throw new Error("load failed");
+      const data = (await response.json()) as ShowYoutubeEntry[];
+      setEntries(data);
+    } catch {
+      toast.error("Failed to load YouTube videos");
+    }
+  }, [showId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleAdd = async () => {
+    if (!input.trim() || isAdding) return;
+    setIsAdding(true);
+    try {
+      const response = await fetch("/api/show-youtubes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ showId, input: input.trim() }),
+      });
+      if (!response.ok) {
+        const { error } = (await response.json().catch(() => ({}))) as { error?: string };
+        toast.error(error || "Failed to add video");
+        return;
+      }
+      const entry = (await response.json()) as ShowYoutubeEntry;
+      setEntries((prev) => [...prev, entry]);
+      setInput("");
+      toast.success("Video added");
+    } catch {
+      toast.error("Failed to add video");
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setIsDeletingId(id);
+    try {
+      const response = await fetch("/api/show-youtubes", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id }),
+      });
+      if (!response.ok) {
+        const { error } = (await response.json().catch(() => ({}))) as { error?: string };
+        toast.error(error || "Failed to remove video");
+        return;
+      }
+      setEntries((prev) => prev.filter((e) => e.id !== id));
+      toast.success("Video removed");
+    } catch {
+      toast.error("Failed to remove video");
+    } finally {
+      setIsDeletingId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 text-sm font-medium text-content-text-secondary">
+        <Youtube className="h-4 w-4 text-red-500" />
+        YouTube Videos
+      </div>
+
+      {entries.length > 0 && (
+        <ul className="space-y-2">
+          {entries.map((entry) => (
+            <li key={entry.id} className={cn(listRowClass, "flex items-center justify-between gap-3 p-2")}>
+              <a
+                href={entry.url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-sm text-content-text-primary hover:text-brand-primary underline truncate"
+              >
+                {entry.url}
+              </a>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => handleDelete(entry.id)}
+                disabled={isDeletingId === entry.id}
+                className="h-8 w-8 p-0 md:h-9 md:w-auto md:px-3 border-red-600 text-red-400 hover:bg-red-900/20 shrink-0"
+              >
+                <Trash className="h-3 w-3" />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex gap-2">
+        <Input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="YouTube URL or 11-char video ID"
+          className={formInputClass}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleAdd();
+            }
+          }}
+        />
+        <Button onClick={handleAdd} disabled={!input.trim() || isAdding} variant="brand" className="shrink-0">
+          <Plus className="h-4 w-4 mr-1" />
+          Add
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/components/song/song-form.tsx
+++ b/apps/web/app/components/song/song-form.tsx
@@ -9,6 +9,8 @@ import { Checkbox } from "~/components/ui/checkbox";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "~/components/ui/form";
 import { Input } from "~/components/ui/input";
 import { Textarea } from "~/components/ui/textarea";
+import { formInputClass } from "~/lib/form-styles";
+import { cn } from "~/lib/utils";
 
 // Create a schema for song form (omitting auto-generated fields)
 export const songFormSchema = z.object({
@@ -66,7 +68,7 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
 
   return (
     <Form {...form}>
-      <div className="space-y-6 max-w-2xl" onSubmit={form.handleSubmit(onSubmit)}>
+      <form className="space-y-6 max-w-2xl" onSubmit={form.handleSubmit(onSubmit)}>
         <FormField
           control={form.control}
           name="title"
@@ -74,11 +76,7 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
             <FormItem>
               <FormLabel className="text-content-text-secondary">Song Title</FormLabel>
               <FormControl>
-                <Input
-                  placeholder="Enter song title"
-                  {...field}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
-                />
+                <Input placeholder="Enter song title" {...field} className={formInputClass} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -117,7 +115,7 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
                   {...field}
                   value={field.value || ""}
                   onChange={(e) => field.onChange(e.target.value || null)}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary min-h-[200px]"
+                  className={cn(formInputClass, "min-h-[200px]")}
                 />
               </FormControl>
               <FormMessage />
@@ -137,7 +135,7 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
                   {...field}
                   value={field.value || ""}
                   onChange={(e) => field.onChange(e.target.value || null)}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary min-h-[200px] font-mono"
+                  className={cn(formInputClass, "min-h-[200px] font-mono")}
                 />
               </FormControl>
               <FormMessage />
@@ -157,7 +155,7 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
                   {...field}
                   value={field.value || ""}
                   onChange={(e) => field.onChange(e.target.value || null)}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
+                  className={formInputClass}
                 />
               </FormControl>
               <FormMessage />
@@ -177,7 +175,7 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
                   {...field}
                   value={field.value || ""}
                   onChange={(e) => field.onChange(e.target.value || null)}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
+                  className={formInputClass}
                 />
               </FormControl>
               <FormMessage />
@@ -197,7 +195,7 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
                   {...field}
                   value={field.value || ""}
                   onChange={(e) => field.onChange(e.target.value || null)}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
+                  className={formInputClass}
                 />
               </FormControl>
               <FormMessage />
@@ -217,7 +215,7 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
                   {...field}
                   value={field.value || ""}
                   onChange={(e) => field.onChange(e.target.value || null)}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
+                  className={formInputClass}
                 />
               </FormControl>
               <FormMessage />
@@ -244,23 +242,14 @@ export function SongForm({ defaultValues, submitLabel, cancelHref }: SongFormPro
         />
 
         <div className="flex gap-4 pt-2">
-          <Button
-            type="button"
-            onClick={form.handleSubmit(onSubmit)}
-            className="bg-brand-primary hover:bg-hover-accent text-content-text-primary"
-          >
+          <Button type="submit" variant="brand">
             {submitLabel}
           </Button>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => navigate(cancelHref)}
-            className="border-content-bg-secondary text-content-text-secondary hover:bg-content-bg-secondary hover:text-content-text-primary"
-          >
+          <Button type="button" variant="cancel" onClick={() => navigate(cancelHref)}>
             Cancel
           </Button>
         </div>
-      </div>
+      </form>
     </Form>
   );
 }

--- a/apps/web/app/components/song/song-search.test.tsx
+++ b/apps/web/app/components/song/song-search.test.tsx
@@ -1,0 +1,148 @@
+import type { Song } from "@bip/domain";
+import { setup } from "@test/test-utils";
+import { screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { SongSearch } from "./song-search";
+
+// SongSearch only reads `id` and `title`; the rest of the Song shape is
+// noise for these tests, so cast through `unknown`.
+function makeSong(id: string, title: string): Song {
+  return { id, title } as unknown as Song;
+}
+
+describe("SongSearch", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // The Disco Biscuits' song catalog is too big to load up front, so
+  // SongSearch requires 2+ chars before hitting the API. Below that, the
+  // user sees a "Type to search" hint and no network call fires.
+  test("does not call the search endpoint for queries shorter than 2 chars", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+
+    const { user } = await setup(<SongSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search songs...");
+    await user.type(input, "a");
+
+    // Give the debounce a chance to fire if it were going to.
+    await new Promise((r) => setTimeout(r, 400));
+    const apiCalls = fetchMock.mock.calls.filter((c) => String(c[0]).startsWith("/api/songs"));
+    expect(apiCalls).toHaveLength(0);
+  });
+
+  // 2+ chars triggers a debounced fetch to /api/songs?q=… with the query
+  // URL-encoded.
+  test("calls /api/songs?q=… for 2+ char queries", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+
+    const { user } = await setup(<SongSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search songs...");
+    await user.type(input, "wav");
+
+    await waitFor(
+      () => {
+        const urls = fetchMock.mock.calls.map((c) => c[0]);
+        expect(urls).toContain("/api/songs?q=wav");
+      },
+      { timeout: 1500 },
+    );
+  });
+
+  // initialSong renders on the trigger before the user opens the
+  // popover — important for the track-edit form, which lands with a
+  // pre-selected song.
+  test("renders the initialSong title on the trigger when value matches", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+    const initialSong = makeSong("s1", "Above the Waves");
+
+    await setup(<SongSearch value="s1" initialSong={initialSong} onValueChange={vi.fn()} />);
+
+    expect(screen.getByRole("combobox")).toHaveTextContent("Above the Waves");
+  });
+
+  // initialSong is kept in the results list even when the user's query
+  // doesn't match — so re-selecting the current value doesn't require
+  // clearing first. Critical for the track-edit form: opening the
+  // popover should always show the currently-selected song.
+  test("keeps initialSong in the results even when the API returns no matches", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+    const initialSong = makeSong("s1", "Above the Waves");
+
+    const { user } = await setup(<SongSearch value="s1" initialSong={initialSong} onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    // initial empty-query branch returns [initialSong] from the wrapper.
+    await screen.findAllByText("Above the Waves");
+  });
+
+  // Above the Waves should still appear when the query returns a list
+  // that doesn't include it (the wrapper prepends initialSong to results).
+  test("prepends initialSong to results when the API returns a non-matching list", async () => {
+    const initialSong = makeSong("s1", "Above the Waves");
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => [makeSong("s2", "Floes"), makeSong("s3", "Run Like Hell")],
+    });
+
+    const { user } = await setup(<SongSearch value="s1" initialSong={initialSong} onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search songs...");
+    await user.type(input, "flo");
+
+    // Wait for the debounced fetch to render its results — "Floes" only
+    // appears once that happens.
+    await screen.findByText("Floes", undefined, { timeout: 1500 });
+    // initialSong appears in the list (in addition to its presence on the
+    // trigger), so it shows up twice in the DOM.
+    expect(screen.getAllByText("Above the Waves").length).toBeGreaterThanOrEqual(2);
+  });
+
+  // The "No song" row is the clear affordance — selecting it should
+  // translate null back to "none" for the form state. The wrapper owns
+  // this translation so consumers using form fields don't have to.
+  test("clicking 'No song' fires onValueChange('none')", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+    const onValueChange = vi.fn();
+    const initialSong = makeSong("s1", "Above the Waves");
+
+    const { user } = await setup(<SongSearch value="s1" initialSong={initialSong} onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("No song"));
+
+    expect(onValueChange).toHaveBeenCalledWith("none");
+  });
+
+  // Selecting a song fires onValueChange with the song's id. Together
+  // with the "No song" test above, this verifies both legs of the
+  // form-state ↔ id translation.
+  test("clicking a song fires onValueChange with the song id", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [makeSong("s2", "Floes")] });
+    const onValueChange = vi.fn();
+
+    const { user } = await setup(<SongSearch onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search songs...");
+    await user.type(input, "flo");
+
+    const row = await screen.findByText("Floes", undefined, { timeout: 1500 });
+    await user.click(row);
+
+    expect(onValueChange).toHaveBeenCalledWith("s2");
+  });
+});

--- a/apps/web/app/components/song/song-search.tsx
+++ b/apps/web/app/components/song/song-search.tsx
@@ -1,10 +1,5 @@
 import type { Song } from "@bip/domain";
-import { Check, ChevronsUpDown } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
-import { Button } from "~/components/ui/button";
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "~/components/ui/command";
-import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
-import { cn } from "~/lib/utils";
+import { SearchPicker } from "~/components/ui/search-picker";
 
 interface SongSearchProps {
   value?: string;
@@ -14,6 +9,13 @@ interface SongSearchProps {
   initialSong?: Song;
 }
 
+/**
+ * Song picker used in the track-edit form. Requires 2+ chars of input
+ * before searching — there are too many songs in the catalog to load up
+ * front. The form layer uses the sentinel value "none" rather than null
+ * because it threads through react-hook-form as a plain string; the
+ * wrapper translates between "none" ↔ null at the boundary.
+ */
 export function SongSearch({
   value,
   onValueChange,
@@ -21,111 +23,32 @@ export function SongSearch({
   className,
   initialSong,
 }: SongSearchProps) {
-  const [open, setOpen] = useState(false);
-  const [songs, setSongs] = useState<Song[]>(initialSong ? [initialSong] : []);
-  const [loading, setLoading] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
-
-  const selectedSong = songs.find((song) => song.id === value) || initialSong;
-
-  const searchSongs = useCallback(
-    async (query: string) => {
-      if (!query || query.length < 2) {
-        setSongs(initialSong ? [initialSong] : []);
-        return;
-      }
-
-      setLoading(true);
-      try {
-        const response = await fetch(`/api/songs?q=${encodeURIComponent(query)}`);
-        if (response.ok) {
-          const data = await response.json();
-
-          // Ensure the initialSong is included if it's not in the search results
-          const songsToSet = [...data];
-          if (initialSong && !data.find((song: Song) => song.id === initialSong.id)) {
-            songsToSet.unshift(initialSong);
-          }
-
-          setSongs(songsToSet);
-        } else {
-        }
-      } catch (_error) {
-      } finally {
-        setLoading(false);
-      }
-    },
-    [initialSong],
-  );
-
-  useEffect(() => {
-    const delayedSearch = setTimeout(() => {
-      searchSongs(searchQuery);
-    }, 300); // Debounce search
-
-    return () => clearTimeout(delayedSearch);
-  }, [searchQuery, searchSongs]);
-
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          className={cn(
-            "justify-between bg-content-bg-secondary border-content-bg-secondary text-white hover:bg-gray-700",
-            className,
-          )}
-        >
-          {selectedSong ? selectedSong.title : placeholder}
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="p-0 bg-content-bg-secondary border-content-bg-secondary" align="start">
-        <Command className="bg-content-bg-secondary" shouldFilter={false}>
-          <CommandInput
-            placeholder="Search songs..."
-            value={searchQuery}
-            onValueChange={setSearchQuery}
-            className="text-white"
-          />
-          <CommandList>
-            <CommandEmpty>
-              {loading ? "Searching..." : searchQuery.length < 2 ? "Type to search songs" : "No songs found."}
-            </CommandEmpty>
-            <CommandGroup>
-              {/* Option to clear selection */}
-              <CommandItem
-                value="none"
-                onSelect={() => {
-                  onValueChange("none");
-                  setOpen(false);
-                }}
-                className="text-white hover:bg-gray-700"
-              >
-                <Check className={cn("mr-2 h-4 w-4", value === "none" ? "opacity-100" : "opacity-0")} />
-                No song
-              </CommandItem>
-
-              {songs.map((song) => (
-                <CommandItem
-                  key={song.id}
-                  value={song.id}
-                  onSelect={() => {
-                    onValueChange(song.id);
-                    setOpen(false);
-                  }}
-                  className="text-white hover:bg-gray-700"
-                >
-                  <Check className={cn("mr-2 h-4 w-4", value === song.id ? "opacity-100" : "opacity-0")} />
-                  {song.title}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+    <SearchPicker<Song>
+      value={value && value !== "none" ? value : null}
+      onValueChange={(v) => onValueChange(v ?? "none")}
+      className={className}
+      placeholder={placeholder}
+      searchPlaceholder="Search songs..."
+      emptyMessage={(q) => (q.length < 2 ? "Type to search songs" : "No songs found.")}
+      loadingMessage="Searching..."
+      itemId={(s) => s.id}
+      itemLabel={(s) => s.title}
+      noneLabel="No song"
+      initialItem={initialSong}
+      fetchResults={async (query) => {
+        if (!query || query.length < 2) return initialSong ? [initialSong] : [];
+        const response = await fetch(`/api/songs?q=${encodeURIComponent(query)}`);
+        if (!response.ok) return [];
+        const data = (await response.json()) as Song[];
+        // Keep the initial song visible in results even when it doesn't
+        // match the query, so the user can re-select the current value
+        // without clearing the field first.
+        if (initialSong && !data.find((song) => song.id === initialSong.id)) {
+          return [initialSong, ...data];
+        }
+        return data;
+      }}
+    />
   );
 }

--- a/apps/web/app/components/song/songs-columns.test.tsx
+++ b/apps/web/app/components/song/songs-columns.test.tsx
@@ -647,6 +647,67 @@ describe("getSongsColumns", () => {
     expect(avg?.meta?.hideOnMobile).toBe(true);
   });
 
+  // Dense filtered view on mobile drops the all-time date pair so the
+  // filtered date pair (which is the user's relevant signal under an
+  // active filter) has room. Desktop continues to show both pairs.
+  test("Last Played + First Played hide on mobile when showFilteredPlays is true", () => {
+    const columns = getSongsColumns({ showFilteredPlays: true });
+    const last = columns.find((c) => "accessorKey" in c && c.accessorKey === "dateLastPlayed");
+    const first = columns.find((c) => "accessorKey" in c && c.accessorKey === "dateFirstPlayed");
+    expect(last?.meta?.hideOnMobile).toBe(true);
+    expect(first?.meta?.hideOnMobile).toBe(true);
+  });
+
+  // Sparse view (no filter) keeps both date columns on mobile. They're
+  // the primary "when did this song happen?" signal when no filtered pair
+  // exists to take their place.
+  test("Last Played + First Played stay visible on mobile when showFilteredPlays is false", () => {
+    const columns = getSongsColumns({ showFilteredPlays: false });
+    const last = columns.find((c) => "accessorKey" in c && c.accessorKey === "dateLastPlayed");
+    const first = columns.find((c) => "accessorKey" in c && c.accessorKey === "dateFirstPlayed");
+    expect(last?.meta?.hideOnMobile).toBeFalsy();
+    expect(first?.meta?.hideOnMobile).toBeFalsy();
+  });
+
+  // Filtered Since First is the first filter column to drop on mobile
+  // because it's a derivable summary (filtered plays / shows in scope).
+  // The remaining 5 filter cols + Song fit; with Since First the row is
+  // too cramped.
+  test("Filtered Since First carries meta.hideOnMobile", () => {
+    const columns = getSongsColumns({ showFilteredPlays: true });
+    const col = columns.find((c) => "accessorKey" in c && c.accessorKey === "filteredPercentSinceDebut");
+    expect(col?.meta?.hideOnMobile).toBe(true);
+  });
+
+  // Filtered Avg Gap and Filtered Gap to End must NOT hide on mobile.
+  // They're part of the "Song + filter columns" mobile layout the user
+  // explicitly chose. Pinning so a future cleanup doesn't accidentally
+  // re-hide them along with their unconditionally-hidden all-time
+  // counterparts.
+  test("Filtered Avg Gap + Filtered Gap to End stay visible on mobile", () => {
+    const columns = getSongsColumns({ showFilteredPlays: true });
+    const avg = columns.find((c) => "accessorKey" in c && c.accessorKey === "filteredAverageGapShows");
+    const gap = columns.find((c) => "accessorKey" in c && c.accessorKey === "filteredShowsSinceLastPlayed");
+    expect(avg?.meta?.hideOnMobile).toBeFalsy();
+    expect(gap?.meta?.hideOnMobile).toBeFalsy();
+  });
+
+  // Numeric cells wrap their value in an inline-block sized with `ch`
+  // units, right-aligned, with tabular-nums so digit widths are uniform.
+  // The effect is that 1 / 10 / 100 stack with their ones digit aligned
+  // and larger numbers extend further left, without right-aligning the
+  // whole cell. Locks the alignment technique against silent regressions.
+  test("numeric cells render as right-aligned inline-block slots with tabular-nums", async () => {
+    await setupWithRouter(
+      <DataTable columns={baseColumns} data={[makeSong({ averageGapShows: 5.7 })]} hideSearch hidePagination />,
+    );
+    const slot = screen.getByText("5.7");
+    expect(slot.className).toContain("inline-block");
+    expect(slot.className).toContain("text-right");
+    expect(slot.className).toContain("tabular-nums");
+    expect(slot.style.minWidth).toBe("4ch");
+  });
+
   // Column ordering: Gap to Now sits immediately to the left of Last
   // Played so the "X shows ago" number reads naturally next to the date
   // it's measured against. % Since Debut and Avg Gap precede Gap to Now

--- a/apps/web/app/components/song/songs-columns.test.tsx
+++ b/apps/web/app/components/song/songs-columns.test.tsx
@@ -198,30 +198,6 @@ describe("getSongsColumns", () => {
     expect(screen.getByText("2.4")).toBeInTheDocument();
   });
 
-  // When showFilteredPlays is true, Last Played and First Played drop the
-  // venue sublabel and shrink — the row is wider with the extra filtered
-  // columns, so we trade venue-on-row for horizontal room.
-  test("showFilteredPlays=true: Last Played and First Played cells omit the venue sublabel", async () => {
-    await setupWithRouter(
-      <DataTable
-        columns={filteredColumns}
-        data={[
-          makeSong({
-            lastPlayedShow: makeShow(),
-            firstPlayedShow: makeShow({ slug: "1995-07-04-some-venue" }),
-          }),
-        ]}
-        hideSearch
-        hidePagination
-      />,
-    );
-
-    // Venue text would appear under the date in the no-filter baseline
-    // (see "Last Played venue" test below). Under filtered columns it
-    // must NOT render — neither for Last Played nor for First Played.
-    expect(screen.queryByText(/The Capitol Theatre/)).not.toBeInTheDocument();
-  });
-
   // When showFilteredPlays is true, the factory inserts a "Filtered Plays"
   // column next to Plays showing the count scoped to the active filter.
   test("showFilteredPlays=true: Filtered Plays column renders the scoped count", async () => {
@@ -345,6 +321,9 @@ describe("getSongsColumns", () => {
     ];
     const { user } = await setupWithRouter(<DataTable columns={baseColumns} data={songs} hideSearch hidePagination />);
 
+    // Header label is split into stacked <span>First</span><span>Played</span>
+    // (so it wraps to two lines at narrow widths); accessible name has no
+    // whitespace between the words.
     const sortHeader = screen.getByRole("button", { name: /^First Played/i });
     await user.click(sortHeader);
 
@@ -492,45 +471,46 @@ describe("getSongsColumns", () => {
     expect(titlesDesc.map((el) => el.textContent)).toEqual(["Crickets", "Plan B", "Home Again"]);
   });
 
-  // On mobile, the Last Played and First Played dates render in a compact
-  // M/D/YY format so the column fits without overlap. The long format
-  // ("Jun 15, 2024") is preserved at sm+ so desktop users see the full date.
-  // Both formats are present in the DOM, gated by responsive Tailwind classes.
-  test("Last Played cell renders both compact (mobile) and long (desktop) date formats", async () => {
+  // Both date formats are present in the DOM; the wrapping cell declares
+  // `@container/datecell` and ShowDate's spans use `@max-[6rem]/datecell:`
+  // to swap which one is visible. Wide column → full "Jun 15, 2024";
+  // tight column (many picks or narrow layout) → compact "6/15/24". One
+  // width for dense and sparse column sets, browser does the rest.
+  test("Last Played cell renders both compact and long date formats gated by container width", async () => {
     const song = makeSong({
       dateLastPlayed: new Date("2024-06-15"),
       lastPlayedShow: makeShow({ slug: "2024-06-15-the-cap" }),
     });
     await setupWithRouter(<DataTable columns={baseColumns} data={[song]} hideSearch hidePagination />);
 
-    // Long format visible at sm+ (hidden on mobile)
+    // Long format hidden once the cell tightens below 6rem
     const longFormat = screen.getByText(/6\/15\/2024/);
-    expect(longFormat.className).toContain("hidden");
-    expect(longFormat.className).toContain("sm:inline");
+    expect(longFormat.className).toContain("@max-[6rem]/datecell:hidden");
 
-    // Compact format visible on mobile (hidden at sm+)
+    // Compact format swaps in once the cell tightens below 6rem
     const compactFormat = screen.getByText("6/15/24");
-    expect(compactFormat.className).toContain("sm:hidden");
+    expect(compactFormat.className).toContain("hidden");
+    expect(compactFormat.className).toContain("@max-[6rem]/datecell:inline");
   });
 
   // Same dual-format treatment for First Played, mirroring Last Played so
-  // both date columns line up neatly at the same breakpoint.
-  test("First Played cell renders both compact (mobile) and long (desktop) date formats", async () => {
+  // both date columns collapse at the same threshold.
+  test("First Played cell renders both compact and long date formats gated by container width", async () => {
     const song = makeSong({
       dateFirstPlayed: new Date("1995-07-04"),
       firstPlayedShow: makeShow({ id: "show-first", slug: "1995-07-04-red-rocks" }),
     });
     await setupWithRouter(<DataTable columns={baseColumns} data={[song]} hideSearch hidePagination />);
 
-    expect(screen.getByText(/7\/4\/1995/).className).toContain("hidden");
-    expect(screen.getByText("7/4/95").className).toContain("sm:hidden");
+    expect(screen.getByText(/7\/4\/1995/).className).toContain("@max-[6rem]/datecell:hidden");
+    expect(screen.getByText("7/4/95").className).toContain("@max-[6rem]/datecell:inline");
   });
 
-  // The venue line beneath Last/First Played dates uses `hidden sm:block`
-  // so the cells collapse to date-only on mobile (matching the perf-table
-  // DateVenueCell pattern). Otherwise the wrapped venue text adds two
-  // extra lines per row on phones for marginal value.
-  test("Last Played venue line is hidden on mobile (hidden sm:block)", async () => {
+  // The venue line beneath Last/First Played dates is gated by the cell's
+  // @container/datecell — drops out once the column shrinks below ~10rem
+  // so dense tables collapse to date-only automatically (no viewport or
+  // filter-flag branching required).
+  test("Last Played venue line is gated by datecell container width", async () => {
     const song = makeSong({
       dateLastPlayed: new Date("2024-06-15"),
       lastPlayedShow: makeShow({ slug: "2024-06-15-the-cap" }),
@@ -539,10 +519,10 @@ describe("getSongsColumns", () => {
 
     const venueLine = screen.getByText(/The Capitol Theatre/);
     expect(venueLine.className).toContain("hidden");
-    expect(venueLine.className).toContain("sm:block");
+    expect(venueLine.className).toContain("@[8rem]/datecell:block");
   });
 
-  test("First Played venue line is hidden on mobile (hidden sm:block)", async () => {
+  test("First Played venue line is gated by datecell container width", async () => {
     const song = makeSong({
       dateFirstPlayed: new Date("1995-07-04"),
       firstPlayedShow: makeShow({
@@ -565,7 +545,7 @@ describe("getSongsColumns", () => {
 
     const venueLine = screen.getByText(/Red Rocks Amphitheatre/);
     expect(venueLine.className).toContain("hidden");
-    expect(venueLine.className).toContain("sm:block");
+    expect(venueLine.className).toContain("@[8rem]/datecell:block");
   });
 
   // Plays and Filtered Plays are short-but-prone-to-overlap headers on

--- a/apps/web/app/components/song/songs-columns.tsx
+++ b/apps/web/app/components/song/songs-columns.tsx
@@ -201,6 +201,24 @@ function dashOrSpan(content: ReactNode | null | undefined, className = "text-con
   return <span className={className}>{content}</span>;
 }
 
+/**
+ * Right-aligns digits inside an inline-block sized to the column's widest
+ * realistic value, so 1 / 10 / 100 stack with their ones digit aligned and
+ * larger numbers extend further left. The block itself sits flush-left in
+ * the cell (cells are left-aligned), so the whole column reads as
+ * "left-anchored numbers with right-aligned digits" rather than as a
+ * right-aligned column. `width` is the min-width of the slot in `ch`
+ * units; tabular-nums makes every digit the same `0`-glyph width so the
+ * digit columns actually align.
+ */
+function NumberCell({ width, className, children }: { width: string; className?: string; children: ReactNode }) {
+  return (
+    <span className={`inline-block text-right tabular-nums ${className ?? ""}`} style={{ minWidth: width }}>
+      {children}
+    </span>
+  );
+}
+
 interface GetSongsColumnsOptions {
   showFilteredPlays: boolean;
 }
@@ -215,17 +233,14 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const titleColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "title",
-    // Dense view (filtered + 4 date cols competing): Song needs a healthy
-    // share so single-word titles like "Shem-Rah Boo" fit on one line.
-    // Sparse view (2 date cols): Song should yield space to the date
-    // columns so their venue sublabels read on 1–2 lines instead of being
-    // squeezed to 3+.
+    // Dense view (filtered cols competing): Song needs a healthy share so
+    // single-word titles like "Shem-Rah Boo" fit on one line. Sparse view
+    // (2 date cols): Song should yield space to the date columns so their
+    // venue sublabels read on 1-2 lines instead of being squeezed to 3+.
     weight: showFilteredPlays ? 3 : 1.5,
-    // On dense-view mobile the 4-up date columns and Filtered Plays
-    // already exceed the viewport at their fixedWidths — give Song its
-    // own mobile fixedWidth so it can't collapse to 0 leftover and the
-    // body clips overflow on the right (matches the prod behavior).
-    mobileFixedWidth: showFilteredPlays ? "7rem" : undefined,
+    // No mobileFixedWidth: on dense mobile the all-time pair columns are
+    // hidden, so Song claims whatever leftover the 4 numeric + 2 date
+    // filter cols leave. Single-word titles fit one line; multi-word wrap.
     label: <HeaderLabel reserveIconRow={showFilteredPlays}>Song</HeaderLabel>,
     cell: (song) => (
       <Link to={`/songs/${song.slug}`} className="text-base text-brand-primary hover:text-brand-secondary font-medium">
@@ -244,7 +259,9 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     hideOnMobile: showFilteredPlays,
     cell: (song) =>
       song.timesPlayed > 0 ? (
-        <span className="text-content-text-primary font-semibold">{song.timesPlayed}</span>
+        <NumberCell width="3ch" className="text-content-text-primary font-semibold">
+          {song.timesPlayed}
+        </NumberCell>
       ) : (
         <span className="text-content-text-tertiary text-sm italic">Never performed</span>
       ),
@@ -254,9 +271,10 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     reservesIconRow: showFilteredPlays,
     accessorKey: "filteredTimesPlayed",
     fixedWidth: "4rem",
-    // Mobile shrinks — filtered counts on the all-timer view top out at
-    // ~36 plays, no need for the desktop 4rem.
-    mobileFixedWidth: "3rem",
+    // Mobile dense view fits 4 numeric filter cols + 2 date filter cols
+    // alongside Song. 2.5rem matches the other numeric filter cols so the
+    // row reads as a consistent block, and filtered counts top out at ~36.
+    mobileFixedWidth: "2.5rem",
     label: (
       <HeaderLabel filtered reserveIconRow>
         <span>Plays</span>
@@ -266,7 +284,9 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     cell: (song) => {
       const plays = song.filteredTimesPlayed ?? 0;
       return plays > 0 ? (
-        <span className="text-content-text-primary font-medium">{plays}</span>
+        <NumberCell width="3ch" className="text-content-text-primary font-medium">
+          {plays}
+        </NumberCell>
       ) : (
         <span className="text-content-text-tertiary text-sm">—</span>
       );
@@ -302,7 +322,7 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     cell: (song) =>
       dashOrSpan(
         song.percentSinceDebut !== null ? (
-          <span className="whitespace-nowrap">{sinceDebutFormatter.format(song.percentSinceDebut)}</span>
+          <NumberCell width="6ch">{sinceDebutFormatter.format(song.percentSinceDebut)}</NumberCell>
         ) : null,
       ),
     sortingFn: nullsLastNumericSort("percentSinceDebut"),
@@ -312,6 +332,10 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     reservesIconRow: showFilteredPlays,
     accessorKey: "filteredPercentSinceDebut",
     fixedWidth: "4rem",
+    // Hidden on mobile: the dense layout already crams Plays + Avg Gap
+    // + Gap to End + 2 date cols next to Song; this is the first filter
+    // col to drop because it's a derivable summary (plays / total shows).
+    hideOnMobile: true,
     label: (
       <HeaderLabel filtered reserveIconRow>
         <span>Since</span>
@@ -319,11 +343,10 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
       </HeaderLabel>
     ),
     title: "Filtered Since First",
-    hideOnMobile: true,
     cell: (song) =>
       dashOrSpan(
         song.filteredPercentSinceDebut != null ? (
-          <span className="whitespace-nowrap">{sinceDebutFormatter.format(song.filteredPercentSinceDebut)}</span>
+          <NumberCell width="5ch">{sinceDebutFormatter.format(song.filteredPercentSinceDebut)}</NumberCell>
         ) : null,
       ),
     sortingFn: nullsLastNumericSort("filteredPercentSinceDebut"),
@@ -340,7 +363,10 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
       </HeaderLabel>
     ),
     hideOnMobile: true,
-    cell: (song) => dashOrSpan(song.averageGapShows !== null ? song.averageGapShows.toFixed(1) : null),
+    cell: (song) =>
+      dashOrSpan(
+        song.averageGapShows !== null ? <NumberCell width="4ch">{song.averageGapShows.toFixed(1)}</NumberCell> : null,
+      ),
     sortingFn: nullsLastNumericSort("averageGapShows"),
   });
 
@@ -348,6 +374,7 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     reservesIconRow: showFilteredPlays,
     accessorKey: "filteredAverageGapShows",
     fixedWidth: "4rem",
+    mobileFixedWidth: "2.5rem",
     label: (
       <HeaderLabel filtered reserveIconRow>
         <span>Avg</span>
@@ -355,8 +382,12 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
       </HeaderLabel>
     ),
     title: "Filtered Avg Gap",
-    hideOnMobile: true,
-    cell: (song) => dashOrSpan(song.filteredAverageGapShows != null ? song.filteredAverageGapShows.toFixed(1) : null),
+    cell: (song) =>
+      dashOrSpan(
+        song.filteredAverageGapShows != null ? (
+          <NumberCell width="4ch">{song.filteredAverageGapShows.toFixed(1)}</NumberCell>
+        ) : null,
+      ),
     sortingFn: nullsLastNumericSort("filteredAverageGapShows"),
   });
 
@@ -371,7 +402,10 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     label: <HeaderLabel reserveIconRow={showFilteredPlays}>Gap to Now</HeaderLabel>,
     title: "Gap to Now",
     hideOnMobile: true,
-    cell: (song) => dashOrSpan(song.showsSinceLastPlayed),
+    cell: (song) =>
+      dashOrSpan(
+        song.showsSinceLastPlayed != null ? <NumberCell width="4ch">{song.showsSinceLastPlayed}</NumberCell> : null,
+      ),
     sortingFn: nullsLastNumericSort("showsSinceLastPlayed"),
   });
 
@@ -379,14 +413,19 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     reservesIconRow: showFilteredPlays,
     accessorKey: "filteredShowsSinceLastPlayed",
     fixedWidth: "4rem",
+    mobileFixedWidth: "2.5rem",
     label: (
       <HeaderLabel filtered reserveIconRow>
         <span>Gap to End</span>
       </HeaderLabel>
     ),
     title: "Filtered Gap to End",
-    hideOnMobile: true,
-    cell: (song) => dashOrSpan(song.filteredShowsSinceLastPlayed ?? null),
+    cell: (song) =>
+      dashOrSpan(
+        song.filteredShowsSinceLastPlayed != null ? (
+          <NumberCell width="3ch">{song.filteredShowsSinceLastPlayed}</NumberCell>
+        ) : null,
+      ),
     sortingFn: nullsLastNumericSort("filteredShowsSinceLastPlayed"),
   });
 
@@ -397,18 +436,23 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   // so the weight stays higher to keep each date legible.
   const dateColumnWeight = showFilteredPlays ? 1.4 : 1.0;
 
-  // Date columns on mobile lock to 4.5rem — wide enough for the compact
-  // "M/D/YY" rendered by ShowDate below its 6rem CQ threshold, no wider.
-  // Same width on sparse (2 dates) and dense (4 dates); on dense the
-  // table extends past the viewport and body's overflow-x:hidden clips
-  // the rightmost ("Filtered First") column — matches prod.
-  const dateColumnMobileWidth = "4.5rem";
+  // All-time date columns only render on mobile in the sparse view (no
+  // filters). 4.5rem comfortably fits the compact "M/D/YY" form ShowDate
+  // produces below its 6rem container-query threshold.
+  const allTimeDateMobileWidth = "4.5rem";
+
+  // Filtered date columns share mobile space with Song + 4 numeric filter
+  // cols, so they tighten to 4rem. Still above the compact-form CQ
+  // threshold; M/D/YY (max 8 chars) fits with text-xs and cell padding.
+  const filteredDateMobileWidth = "4rem";
 
   const lastPlayedColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "dateLastPlayed",
     weight: dateColumnWeight,
-    mobileFixedWidth: dateColumnMobileWidth,
+    mobileFixedWidth: allTimeDateMobileWidth,
+    // Hidden on mobile in dense view so the filtered date pair has room.
+    hideOnMobile: showFilteredPlays,
     label: <HeaderLabel reserveIconRow={showFilteredPlays}>Last Played</HeaderLabel>,
     cell: (song) => <DateVenueCell date={song.dateLastPlayed} show={song.lastPlayedShow} />,
   });
@@ -417,7 +461,7 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     reservesIconRow: showFilteredPlays,
     accessorKey: "dateLastFilteredPlayed",
     weight: dateColumnWeight,
-    mobileFixedWidth: dateColumnMobileWidth,
+    mobileFixedWidth: filteredDateMobileWidth,
     label: (
       <HeaderLabel filtered reserveIconRow>
         Last
@@ -431,7 +475,8 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     reservesIconRow: showFilteredPlays,
     accessorKey: "dateFirstPlayed",
     weight: dateColumnWeight,
-    mobileFixedWidth: dateColumnMobileWidth,
+    mobileFixedWidth: allTimeDateMobileWidth,
+    hideOnMobile: showFilteredPlays,
     label: <HeaderLabel reserveIconRow={showFilteredPlays}>First Played</HeaderLabel>,
     cell: (song) => <DateVenueCell date={song.dateFirstPlayed} show={song.firstPlayedShow} />,
   });
@@ -440,7 +485,7 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
     reservesIconRow: showFilteredPlays,
     accessorKey: "dateFirstFilteredPlayed",
     weight: dateColumnWeight,
-    mobileFixedWidth: dateColumnMobileWidth,
+    mobileFixedWidth: filteredDateMobileWidth,
     label: (
       <HeaderLabel filtered reserveIconRow>
         First

--- a/apps/web/app/components/song/songs-columns.tsx
+++ b/apps/web/app/components/song/songs-columns.tsx
@@ -99,7 +99,20 @@ interface SortableColumnOptions {
   label: ReactNode;
   /** Hover tooltip; used when the visible label needs disambiguation in prose. */
   title?: string;
-  width?: string;
+  /**
+   * Relative width share of *leftover* space under `table-layout: fixed`.
+   * Defaults to 1. Use > 1 for text columns; ignored when `fixedWidth` is
+   * set.
+   */
+  weight?: number;
+  /** Fixed column width (e.g. `"3rem"`) for short-content columns that
+   * shouldn't grow when the table widens. Wins over `weight`. */
+  fixedWidth?: string;
+  /** Mobile-specific fixed width — applied below the `sm` breakpoint.
+   * Use when a column's mobile rendering has a knowable max (e.g. dates
+   * without venue) and shouldn't gobble the leftover flex space that
+   * primary columns need. */
+  mobileFixedWidth?: string;
   hideOnMobile?: boolean;
   cell: (row: SongWithShows) => ReactNode;
   sortingFn?: SortingFn<SongWithShows>;
@@ -123,7 +136,12 @@ function makeSortableColumn(opts: SortableColumnOptions): ColumnDef<SongWithShow
   const sortIconWrapperClass = opts.reservesIconRow ? "sm:mt-3" : "";
   const def: ColumnDef<SongWithShows> = {
     accessorKey: opts.accessorKey,
-    meta: { width: opts.width, hideOnMobile: opts.hideOnMobile },
+    meta: {
+      weight: opts.weight,
+      fixedWidth: opts.fixedWidth,
+      mobileFixedWidth: opts.mobileFixedWidth,
+      hideOnMobile: opts.hideOnMobile,
+    },
     header: ({ column }) => (
       <Button
         variant="ghost"
@@ -143,38 +161,35 @@ function makeSortableColumn(opts: SortableColumnOptions): ColumnDef<SongWithShow
 
 /**
  * Renders a date with optional link to the show and a venue sublabel under
- * the date. Used by both Last Played and First Played columns — the only
- * difference between them is which date/show pair feeds in.
+ * the date. The cell is its own inline-size container, so the venue line
+ * drops out automatically when the column gets squeezed (many columns picked
+ * or a narrow layout) without callers passing a `hideVenue` flag. The date
+ * format collapses to compact via ShowDate's own container query.
  */
-function DateVenueCell({
-  date,
-  show,
-  hideVenue,
-  compact,
-}: {
-  date: Date | null;
-  show?: Show | null;
-  hideVenue?: boolean;
-  compact?: boolean;
-}): ReactNode {
+function DateVenueCell({ date, show }: { date: Date | null; show?: Show | null }): ReactNode {
   if (!date) return <span className="text-content-text-tertiary text-sm">—</span>;
-  const dateBlock = <ShowDate date={date} compact={compact} />;
-  const venueLine =
-    show?.venue && !hideVenue ? (
-      <div className="text-content-text-tertiary text-sm hidden sm:block">
-        {show.venue.name}, {show.venue.city} {show.venue.state}
-      </div>
-    ) : null;
+  const dateBlock = <ShowDate date={date} />;
+  // Venue only shows at `sm` and above (mobile keeps each row tight to
+  // a single date line), AND when the column is genuinely wide enough
+  // to hold it on desktop.
+  const venueLine = show?.venue ? (
+    <div className="text-content-text-tertiary text-sm hidden sm:@[8rem]/datecell:block">
+      {show.venue.name}, {show.venue.city} {show.venue.state}
+    </div>
+  ) : null;
   if (show?.slug) {
     return (
-      <Link to={`/shows/${show.slug}`} className="text-brand-primary hover:text-brand-secondary transition-colors">
+      <Link
+        to={`/shows/${show.slug}`}
+        className="@container/datecell block text-brand-primary hover:text-brand-secondary transition-colors"
+      >
         <div>{dateBlock}</div>
         {venueLine}
       </Link>
     );
   }
   return (
-    <div>
+    <div className="@container/datecell">
       <div className="text-content-text-secondary">{dateBlock}</div>
       {venueLine}
     </div>
@@ -200,13 +215,20 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const titleColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "title",
+    // Dense view (filtered + 4 date cols competing): Song needs a healthy
+    // share so single-word titles like "Shem-Rah Boo" fit on one line.
+    // Sparse view (2 date cols): Song should yield space to the date
+    // columns so their venue sublabels read on 1–2 lines instead of being
+    // squeezed to 3+.
+    weight: showFilteredPlays ? 3 : 1.5,
+    // On dense-view mobile the 4-up date columns and Filtered Plays
+    // already exceed the viewport at their fixedWidths — give Song its
+    // own mobile fixedWidth so it can't collapse to 0 leftover and the
+    // body clips overflow on the right (matches the prod behavior).
+    mobileFixedWidth: showFilteredPlays ? "7rem" : undefined,
     label: <HeaderLabel reserveIconRow={showFilteredPlays}>Song</HeaderLabel>,
-    width: showFilteredPlays ? "14%" : "26%",
     cell: (song) => (
-      <Link
-        to={`/songs/${song.slug}`}
-        className="inline-block min-w-[10ch] text-base text-brand-primary hover:text-brand-secondary font-medium [overflow-wrap:anywhere]"
-      >
+      <Link to={`/songs/${song.slug}`} className="text-base text-brand-primary hover:text-brand-secondary font-medium">
         {song.title}
       </Link>
     ),
@@ -215,10 +237,10 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const playsColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "timesPlayed",
+    fixedWidth: "4rem",
     label: <HeaderLabel reserveIconRow={showFilteredPlays}>Plays</HeaderLabel>,
-    width: showFilteredPlays ? "5%" : "8%",
-    // When Filtered Plays is also visible there isn't room for both count
-    // columns on mobile; the all-time count drops out at narrow widths.
+    // When Filtered Plays is also visible the all-time count is paired
+    // beside it; mobile-hide on the dense layout keeps both legible.
     hideOnMobile: showFilteredPlays,
     cell: (song) =>
       song.timesPlayed > 0 ? (
@@ -231,13 +253,16 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const filteredPlaysColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "filteredTimesPlayed",
+    fixedWidth: "4rem",
+    // Mobile shrinks — filtered counts on the all-timer view top out at
+    // ~36 plays, no need for the desktop 4rem.
+    mobileFixedWidth: "3rem",
     label: (
       <HeaderLabel filtered reserveIconRow>
         <span>Plays</span>
       </HeaderLabel>
     ),
     title: "Filtered Plays",
-    width: "5%",
     cell: (song) => {
       const plays = song.filteredTimesPlayed ?? 0;
       return plays > 0 ? (
@@ -265,6 +290,7 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const percentSinceDebutColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "percentSinceDebut",
+    fixedWidth: "4rem",
     label: (
       <HeaderLabel reserveIconRow={showFilteredPlays}>
         <span>Since</span>
@@ -272,7 +298,6 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
       </HeaderLabel>
     ),
     title: "% Since Debut",
-    width: showFilteredPlays ? "7%" : "6%",
     hideOnMobile: true,
     cell: (song) =>
       dashOrSpan(
@@ -286,6 +311,7 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const filteredPercentSinceDebutColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "filteredPercentSinceDebut",
+    fixedWidth: "4rem",
     label: (
       <HeaderLabel filtered reserveIconRow>
         <span>Since</span>
@@ -293,7 +319,6 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
       </HeaderLabel>
     ),
     title: "Filtered Since First",
-    width: "7%",
     hideOnMobile: true,
     cell: (song) =>
       dashOrSpan(
@@ -307,13 +332,13 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const avgGapColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "averageGapShows",
+    fixedWidth: "4rem",
     label: (
       <HeaderLabel reserveIconRow={showFilteredPlays}>
         <span>Avg</span>
         <span>Gap</span>
       </HeaderLabel>
     ),
-    width: "7%",
     hideOnMobile: true,
     cell: (song) => dashOrSpan(song.averageGapShows !== null ? song.averageGapShows.toFixed(1) : null),
     sortingFn: nullsLastNumericSort("averageGapShows"),
@@ -322,6 +347,7 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const filteredAvgGapColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "filteredAverageGapShows",
+    fixedWidth: "4rem",
     label: (
       <HeaderLabel filtered reserveIconRow>
         <span>Avg</span>
@@ -329,7 +355,6 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
       </HeaderLabel>
     ),
     title: "Filtered Avg Gap",
-    width: "7%",
     hideOnMobile: true,
     cell: (song) => dashOrSpan(song.filteredAverageGapShows != null ? song.filteredAverageGapShows.toFixed(1) : null),
     sortingFn: nullsLastNumericSort("filteredAverageGapShows"),
@@ -338,13 +363,13 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const currentGapColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "showsSinceLastPlayed",
+    fixedWidth: "4rem",
     // Spelled out vs. plain "Gap" so users can't confuse it with "Avg Gap"
     // on a quick scan. "to Now" anchors that this is the count up to today
     // (the filtered variant uses "to End" because its denominator stops
     // at the filter boundary).
     label: <HeaderLabel reserveIconRow={showFilteredPlays}>Gap to Now</HeaderLabel>,
     title: "Gap to Now",
-    width: "7%",
     hideOnMobile: true,
     cell: (song) => dashOrSpan(song.showsSinceLastPlayed),
     sortingFn: nullsLastNumericSort("showsSinceLastPlayed"),
@@ -353,85 +378,76 @@ export function getSongsColumns({ showFilteredPlays }: GetSongsColumnsOptions): 
   const filteredCurrentGapColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "filteredShowsSinceLastPlayed",
+    fixedWidth: "4rem",
     label: (
       <HeaderLabel filtered reserveIconRow>
         <span>Gap to End</span>
       </HeaderLabel>
     ),
     title: "Filtered Gap to End",
-    width: "7%",
     hideOnMobile: true,
     cell: (song) => dashOrSpan(song.filteredShowsSinceLastPlayed ?? null),
     sortingFn: nullsLastNumericSort("filteredShowsSinceLastPlayed"),
   });
 
-  // When filtered columns are active the row is wider; drop the venue
-  // sublabel and shrink the date columns to make room.
-  const dateColumnWidth = showFilteredPlays ? "8%" : "22%";
+  // Date columns flex — they share leftover space with the Song column.
+  // On the sparse view (2 date cols, no filtered siblings) the dates
+  // yield extra width to Song so the title column reads cleanly; on the
+  // dense filtered view they're already squeezed by their 4-up layout
+  // so the weight stays higher to keep each date legible.
+  const dateColumnWeight = showFilteredPlays ? 1.4 : 1.0;
+
+  // Date columns on mobile lock to 4.5rem — wide enough for the compact
+  // "M/D/YY" rendered by ShowDate below its 6rem CQ threshold, no wider.
+  // Same width on sparse (2 dates) and dense (4 dates); on dense the
+  // table extends past the viewport and body's overflow-x:hidden clips
+  // the rightmost ("Filtered First") column — matches prod.
+  const dateColumnMobileWidth = "4.5rem";
 
   const lastPlayedColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "dateLastPlayed",
+    weight: dateColumnWeight,
+    mobileFixedWidth: dateColumnMobileWidth,
     label: <HeaderLabel reserveIconRow={showFilteredPlays}>Last Played</HeaderLabel>,
-    width: dateColumnWidth,
-    cell: (song) => (
-      <DateVenueCell
-        date={song.dateLastPlayed}
-        show={song.lastPlayedShow}
-        hideVenue={showFilteredPlays}
-        compact={showFilteredPlays}
-      />
-    ),
+    cell: (song) => <DateVenueCell date={song.dateLastPlayed} show={song.lastPlayedShow} />,
   });
 
   const filteredLastPlayedColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "dateLastFilteredPlayed",
+    weight: dateColumnWeight,
+    mobileFixedWidth: dateColumnMobileWidth,
     label: (
       <HeaderLabel filtered reserveIconRow>
         Last
       </HeaderLabel>
     ),
     title: "Filtered Last Played",
-    width: dateColumnWidth,
-    cell: (song) => (
-      <DateVenueCell date={song.dateLastFilteredPlayed ?? null} show={song.lastFilteredPlayedShow} hideVenue compact />
-    ),
+    cell: (song) => <DateVenueCell date={song.dateLastFilteredPlayed ?? null} show={song.lastFilteredPlayedShow} />,
   });
 
   const firstPlayedColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "dateFirstPlayed",
+    weight: dateColumnWeight,
+    mobileFixedWidth: dateColumnMobileWidth,
     label: <HeaderLabel reserveIconRow={showFilteredPlays}>First Played</HeaderLabel>,
-    width: dateColumnWidth,
-    cell: (song) => (
-      <DateVenueCell
-        date={song.dateFirstPlayed}
-        show={song.firstPlayedShow}
-        hideVenue={showFilteredPlays}
-        compact={showFilteredPlays}
-      />
-    ),
+    cell: (song) => <DateVenueCell date={song.dateFirstPlayed} show={song.firstPlayedShow} />,
   });
 
   const filteredFirstPlayedColumn = makeSortableColumn({
     reservesIconRow: showFilteredPlays,
     accessorKey: "dateFirstFilteredPlayed",
+    weight: dateColumnWeight,
+    mobileFixedWidth: dateColumnMobileWidth,
     label: (
       <HeaderLabel filtered reserveIconRow>
         First
       </HeaderLabel>
     ),
     title: "Filtered First Played",
-    width: dateColumnWidth,
-    cell: (song) => (
-      <DateVenueCell
-        date={song.dateFirstFilteredPlayed ?? null}
-        show={song.firstFilteredPlayedShow}
-        hideVenue
-        compact
-      />
-    ),
+    cell: (song) => <DateVenueCell date={song.dateFirstFilteredPlayed ?? null} show={song.firstFilteredPlayedShow} />,
   });
 
   const columns: ColumnDef<SongWithShows>[] = [titleColumn, playsColumn];

--- a/apps/web/app/components/track/all-timer-cell.tsx
+++ b/apps/web/app/components/track/all-timer-cell.tsx
@@ -1,29 +1,64 @@
-import { Flame } from "lucide-react";
+import { TrackRatingOverlay, type TrackRatingOverlayTrack } from "~/components/setlist/track-rating-overlay";
+import { TrackIcon } from "./track-icon";
 
 /**
- * Table-cell renderer for the all-timer marker. The `h-6` wrapper matches
- * the default text-base line-height of adjacent cells so the 14px flame
- * sits on the same baseline as song-title text instead of floating high.
+ * Table-cell renderer for the noteworthy-track marker. The `h-6` wrapper
+ * matches the default text-base line-height of adjacent cells so the
+ * 14px flame sits on the same baseline as song-title text.
+ *
+ * Renders nothing when the track is neither an all-timer nor carries a
+ * note. When a note IS present, the flame is wrapped in the shared
+ * TrackRatingOverlay (rating-suppressed variant) so hovering it
+ * surfaces the song title + note text without duplicating the rating
+ * data that already lives in the row's Rating column.
  *
  * `align` controls horizontal placement: `"center"` (default) suits the
- * standalone narrow column; `"start"` is used when the flame is rendered
+ * standalone narrow column; `"start"` is used when the flame sits
  * inline beneath other content in a wider host cell (e.g. the perf-table
  * Date cell or the setlist Set cell on mobile).
  */
-export function AllTimerCell({ align = "center" }: { align?: "center" | "start" }) {
-  return (
+export function AllTimerCell({
+  track,
+  align = "center",
+}: {
+  /**
+   * Carries `allTimer`, `note`, and the minimal fields TrackRatingOverlay
+   * reads (id, song?.title, etc.). Wider call sites pass a full
+   * TrackLight; the perf-table cell adapts SongPagePerformance to the
+   * same shape with `trackFromPerformance`.
+   */
+  track: TrackRatingOverlayTrack;
+  align?: "center" | "start";
+}) {
+  const hasMarker = !!track.allTimer || !!track.note?.trim();
+  if (!hasMarker) return null;
+
+  const flame = (
     <div className={`flex h-6 items-center ${align === "center" ? "justify-center" : "justify-start"}`}>
-      <Flame className="h-3.5 w-3.5 text-orange-500" aria-label="All-timer" />
+      <TrackIcon track={track} iconClassName="h-3.5 w-3.5" />
     </div>
+  );
+
+  // No note → no information to surface in an overlay; the flame alone
+  // already says "all-timer". Avoid wrapping in the hover card to keep
+  // the cell inert.
+  if (!track.note?.trim()) return flame;
+
+  return (
+    <TrackRatingOverlay track={track} showRating={false} trigger="click">
+      {flame}
+    </TrackRatingOverlay>
   );
 }
 
 /**
  * Meta options for the all-timer column — narrowest viable slot with no
  * horizontal padding so it never steals width from neighboring columns.
- * Setlist views override `hideOnMobile: true` since they render the
- * flame inline in their Set cell on mobile; the perf table keeps it
- * visible since there's no equivalent host cell there.
+ * Mobile visibility is decided by the caller: setlist views and the
+ * perf table both default to hiding the column on mobile and rendering
+ * the flame inline in a neighboring cell instead; jam-charts surfaces
+ * keep the column visible on mobile (via the caller's
+ * `mobileFlamePriority`) so the marker stays at the leftmost slot.
  */
 export const allTimerColumnMeta = {
   fixedWidth: "1.5rem",

--- a/apps/web/app/components/track/all-timer-cell.tsx
+++ b/apps/web/app/components/track/all-timer-cell.tsx
@@ -4,10 +4,15 @@ import { Flame } from "lucide-react";
  * Table-cell renderer for the all-timer marker. The `h-6` wrapper matches
  * the default text-base line-height of adjacent cells so the 14px flame
  * sits on the same baseline as song-title text instead of floating high.
+ *
+ * `align` controls horizontal placement: `"center"` (default) suits the
+ * standalone narrow column; `"start"` is used when the flame is rendered
+ * inline beneath other content in a wider host cell (e.g. the perf-table
+ * Date cell or the setlist Set cell on mobile).
  */
-export function AllTimerCell() {
+export function AllTimerCell({ align = "center" }: { align?: "center" | "start" }) {
   return (
-    <div className="flex h-6 items-center justify-center">
+    <div className={`flex h-6 items-center ${align === "center" ? "justify-center" : "justify-start"}`}>
       <Flame className="h-3.5 w-3.5 text-orange-500" aria-label="All-timer" />
     </div>
   );
@@ -16,5 +21,12 @@ export function AllTimerCell() {
 /**
  * Meta options for the all-timer column — narrowest viable slot with no
  * horizontal padding so it never steals width from neighboring columns.
+ * Setlist views override `hideOnMobile: true` since they render the
+ * flame inline in their Set cell on mobile; the perf table keeps it
+ * visible since there's no equivalent host cell there.
  */
-export const allTimerColumnMeta = { width: "16px", cellClassName: "px-0 sm:px-0" } as const;
+export const allTimerColumnMeta = {
+  fixedWidth: "1.5rem",
+  mobileFixedWidth: "1rem",
+  cellClassName: "px-0 sm:px-0",
+} as const;

--- a/apps/web/app/components/track/noteworthy-marker.test.tsx
+++ b/apps/web/app/components/track/noteworthy-marker.test.tsx
@@ -1,0 +1,87 @@
+import { setup } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+// TrackRatingOverlay (used internally when a note exists) calls
+// useSession → useRouteLoaderData("root"); the test harness doesn't
+// run inside a data router, so stub the hook to return a logged-out
+// session.
+vi.mock("~/hooks/use-session", () => ({
+  useSession: () => ({ user: null, supabase: null }),
+}));
+
+import { isNoteworthy, NoteworthyMarker } from "./noteworthy-marker";
+
+describe("isNoteworthy", () => {
+  // A track with neither an all-timer flag nor a note has nothing to
+  // surface — every UI surface should treat it as a plain track.
+  test("returns false when both flags are absent", () => {
+    expect(isNoteworthy({ allTimer: false, note: null })).toBe(false);
+    expect(isNoteworthy({})).toBe(false);
+  });
+
+  // The all-timer flag alone qualifies a track as noteworthy — the
+  // orange flame stands on its own without a note.
+  test("returns true for all-timer-only tracks", () => {
+    expect(isNoteworthy({ allTimer: true })).toBe(true);
+    expect(isNoteworthy({ allTimer: true, note: null })).toBe(true);
+  });
+
+  // Empty-string and whitespace-only notes are how the data layer
+  // historically records "no note", so they must not pass the gate —
+  // matches the server's `tracks.note <> ''` SQL filter.
+  test("treats blank-string notes as absent", () => {
+    expect(isNoteworthy({ allTimer: false, note: "" })).toBe(false);
+    expect(isNoteworthy({ allTimer: false, note: "   " })).toBe(false);
+  });
+
+  // A non-empty curated note qualifies a track as noteworthy even
+  // when it's not an all-timer — drives the off-white "Jam Chart"
+  // flame variant.
+  test("returns true when note is present", () => {
+    expect(isNoteworthy({ allTimer: false, note: "Massive Spaga jam." })).toBe(true);
+  });
+
+  // SongPagePerformance carries the same data under `notes` (plural).
+  // The predicate accepts both shapes so cross-song surfaces don't have
+  // to adapt before calling.
+  test("accepts the SongPagePerformance shape with `notes` (plural)", () => {
+    expect(isNoteworthy({ allTimer: false, notes: "Type II exploration." })).toBe(true);
+    expect(isNoteworthy({ allTimer: false, notes: "" })).toBe(false);
+    expect(isNoteworthy({ allTimer: true, notes: null })).toBe(true);
+  });
+});
+
+describe("NoteworthyMarker", () => {
+  // Non-noteworthy tracks render nothing — callers don't need to gate
+  // on the flag pair before dropping the marker into a row.
+  test("renders nothing when track is neither all-timer nor noted", () => {
+    const { container } = render(<NoteworthyMarker track={{ id: "t1", allTimer: false, note: null }} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // All-timer without a note: bare flame (no click target). There's
+  // no popover-worthy content for this case.
+  test("renders the bare flame for all-timer without a note", async () => {
+    const { user } = await setup(<NoteworthyMarker track={{ id: "t1", allTimer: true, note: null }} />);
+    const flame = screen.getByLabelText("All-timer");
+    expect(flame).toBeInTheDocument();
+    // Clicking does not open a popover: there's no dialog/popover element
+    // because there's nothing to surface.
+    await user.click(flame);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  // When the track carries a note, clicking the flame opens the
+  // shared TrackRatingOverlay (rating-suppressed variant) so the note
+  // is reachable on touch devices too.
+  test("clicking the flame on a noted track opens a popover with the note text", async () => {
+    const NOTE = "Bombshell into Crickets is the rare full-band reprise.";
+    const { user } = await setup(
+      <NoteworthyMarker track={{ id: "t1", allTimer: false, note: NOTE, song: { title: "Bombshell" } }} />,
+    );
+    expect(screen.queryByText(NOTE)).not.toBeInTheDocument();
+    await user.click(screen.getByLabelText("Jam chart"));
+    expect(await screen.findByText(NOTE)).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/track/noteworthy-marker.tsx
+++ b/apps/web/app/components/track/noteworthy-marker.tsx
@@ -1,0 +1,48 @@
+import { TrackRatingOverlay, type TrackRatingOverlayTrack } from "~/components/setlist/track-rating-overlay";
+import { TrackIcon } from "./track-icon";
+
+/**
+ * "A track worth surfacing": all-timer OR a curated note. The single
+ * predicate used wherever the UI gates on noteworthy-ness, so the
+ * "marker exists" definition can't drift between call sites. Mirrors
+ * the server's SQL: `tracks.all_timer = true OR (tracks.note IS NOT
+ * NULL AND tracks.note <> '')` — keep them in sync.
+ *
+ * Accepts both `note` (Track / TrackLight shape) and `notes` (the
+ * SongPagePerformance projection) so cross-song surfaces don't have to
+ * adapt before calling.
+ */
+export function isNoteworthy(t: { allTimer?: boolean | null; note?: string | null; notes?: string | null }): boolean {
+  return !!t.allTimer || !!(t.note ?? t.notes)?.trim();
+}
+
+/**
+ * The standard noteworthy-track flame: renders nothing for plain
+ * tracks, the bare flame for all-timers without a note, and the flame
+ * wrapped in a click-triggered note popover when a note exists.
+ * Encapsulates the "is the track marker-worthy" + "does it carry a
+ * tap-target popover" decisions so call sites can just drop the
+ * component in without re-implementing either check.
+ *
+ * Use this on inline-flow surfaces (setlist flow view, song-title
+ * rows). Table cells with a fixed-height wrapper should use
+ * `AllTimerCell`, which composes this with the sized container.
+ */
+export function NoteworthyMarker({
+  track,
+  iconClassName,
+  className,
+}: {
+  track: TrackRatingOverlayTrack;
+  iconClassName?: string;
+  className?: string;
+}) {
+  if (!isNoteworthy(track)) return null;
+  const icon = <TrackIcon track={track} iconClassName={iconClassName} className={className} />;
+  if (!track.note?.trim()) return icon;
+  return (
+    <TrackRatingOverlay track={track} showRating={false} trigger="click">
+      <span className="cursor-pointer">{icon}</span>
+    </TrackRatingOverlay>
+  );
+}

--- a/apps/web/app/components/track/sortable-track-item.test.tsx
+++ b/apps/web/app/components/track/sortable-track-item.test.tsx
@@ -1,0 +1,232 @@
+import type { Track } from "@bip/domain";
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+// useSortable from @dnd-kit/sortable expects a SortableContext provider in
+// the tree. The tests don't exercise drag-and-drop behavior (that belongs
+// to TrackManager-level tests), so we stub the hook to return inert values
+// and let SortableTrackItem mount in isolation.
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => undefined,
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+import { SortableTrackItem } from "./sortable-track-item";
+
+// Minimal Track factory — the row only reads a handful of fields, so the
+// rest are stubbed with sensible defaults. Tests override what they care
+// about.
+function makeTrack(overrides: Partial<Track> = {}): Track {
+  return {
+    id: "track-1",
+    showId: "show-1",
+    songId: "song-1",
+    set: "S1",
+    position: 1,
+    segue: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    likesCount: 0,
+    slug: "story-of-the-world",
+    note: null,
+    allTimer: false,
+    previousTrackId: null,
+    nextTrackId: null,
+    averageRating: 0,
+    ratingsCount: 0,
+    gap: null,
+    previousPerformanceShowId: null,
+    previousPerformanceShow: null,
+    // Component only reads `song.title`; the rest of the Song shape is
+    // irrelevant for these tests, so cast through `unknown` to avoid
+    // tracking every field on the domain model.
+    song: { id: "song-1", title: "Story of the World" } as unknown as Track["song"],
+    annotations: [],
+    ...overrides,
+  };
+}
+
+describe("SortableTrackItem", () => {
+  // Baseline render: a minimal track shows position number + song title and
+  // none of the optional chrome (no flame, no segue, no note, no annotations).
+  test("renders position and song title for a minimal track", async () => {
+    await setup(<SortableTrackItem track={makeTrack()} onEdit={vi.fn()} onDelete={vi.fn()} />);
+
+    expect(screen.getByText("Story of the World")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  // Notes appear on their OWN line below the title (no parens). Earlier
+  // versions wrapped notes in `(...)` and put them inline with the title;
+  // the redesign moved them below to give long notes the full row width.
+  // This test guards against either regression.
+  test("renders the note on its own line below the title without parens", async () => {
+    await setup(
+      <SortableTrackItem
+        track={makeTrack({ note: "The jam emerges as minimal trance" })}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    const noteEl = screen.getByText("The jam emerges as minimal trance");
+    expect(noteEl).toBeInTheDocument();
+    expect(noteEl.tagName).toBe("P"); // own paragraph element, not inline span in title row
+    // No parens anywhere in the note text. Catches a future "wrap in (…)"
+    // change that would silently regress the display.
+    expect(screen.queryByText(/^\(.+\)$/)).not.toBeInTheDocument();
+  });
+
+  // When the track has no note, the note row is omitted entirely (not
+  // rendered as an empty <p>). Keeps the row compact for tracks without
+  // commentary.
+  test("does not render the note row when note is null", async () => {
+    const { container } = await setup(
+      <SortableTrackItem track={makeTrack({ note: null })} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+
+    // The note paragraph would have italic styling. No <p> with italic class.
+    expect(container.querySelector("p.italic")).toBeNull();
+  });
+
+  // All-timer flame icon renders inline next to the song title (not in a
+  // dedicated leading column). This was the mobile-fit change — the
+  // reserved column ate horizontal space and forced song titles to wrap.
+  test("renders the all-timer flame icon inline when allTimer is true", async () => {
+    const { container } = await setup(
+      <SortableTrackItem track={makeTrack({ allTimer: true })} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+
+    // Flame icon has text-orange-500. Assert one is present.
+    const flames = container.querySelectorAll("svg.text-orange-500");
+    expect(flames.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("does not render the flame icon when allTimer is false", async () => {
+    const { container } = await setup(
+      <SortableTrackItem track={makeTrack({ allTimer: false })} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+
+    expect(container.querySelector("svg.text-orange-500")).toBeNull();
+  });
+
+  // Segue marker (">") renders inline next to the title when present.
+  test("renders the segue marker when track.segue is set", async () => {
+    await setup(<SortableTrackItem track={makeTrack({ segue: ">" })} onEdit={vi.fn()} onDelete={vi.fn()} />);
+
+    expect(screen.getByText(">")).toBeInTheDocument();
+  });
+
+  // Annotations render below the note in their own section. Each annotation
+  // is its own row so multi-line annotations don't collapse together.
+  test("renders each annotation as its own row when annotations exist", async () => {
+    await setup(
+      <SortableTrackItem
+        track={makeTrack({
+          annotations: [
+            {
+              id: "ann-1",
+              trackId: "track-1",
+              desc: "inverted",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+            {
+              id: "ann-2",
+              trackId: "track-1",
+              desc: "with 'Floes' tease",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ],
+        })}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("inverted")).toBeInTheDocument();
+    expect(screen.getByText("with 'Floes' tease")).toBeInTheDocument();
+  });
+
+  // Annotations with empty desc are skipped — they'd render as visual noise
+  // (an empty bordered row). This is a defensive check against bad data.
+  test("skips annotations whose desc is null or empty", async () => {
+    const { container } = await setup(
+      <SortableTrackItem
+        track={makeTrack({
+          annotations: [
+            {
+              id: "ann-1",
+              trackId: "track-1",
+              desc: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+            {
+              id: "ann-2",
+              trackId: "track-1",
+              desc: "real annotation",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ],
+        })}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("real annotation")).toBeInTheDocument();
+    // Only one annotation row (the real one) renders.
+    const annotationRows = container.querySelectorAll("div.border-l-2");
+    expect(annotationRows.length).toBe(1);
+  });
+
+  // Edit button fires onEdit with the full track so the parent can hydrate
+  // an edit form without a re-fetch.
+  test("clicking the edit button fires onEdit with the track", async () => {
+    const onEdit = vi.fn();
+    const track = makeTrack();
+    const { user, container } = await setup(<SortableTrackItem track={track} onEdit={onEdit} onDelete={vi.fn()} />);
+
+    const editButton = container.querySelector('button[class*="border-gray-600"]');
+    if (!editButton) throw new Error("edit button not found");
+    await user.click(editButton);
+
+    expect(onEdit).toHaveBeenCalledWith(track);
+  });
+
+  // Delete button fires onDelete with the track id (not the full track) so
+  // the parent only needs the id for its DELETE request.
+  test("clicking the delete button fires onDelete with the track id", async () => {
+    const onDelete = vi.fn();
+    const { user, container } = await setup(
+      <SortableTrackItem track={makeTrack({ id: "track-xyz" })} onEdit={vi.fn()} onDelete={onDelete} />,
+    );
+
+    const deleteButton = container.querySelector('button[class*="border-red-600"]');
+    if (!deleteButton) throw new Error("delete button not found");
+    await user.click(deleteButton);
+
+    expect(onDelete).toHaveBeenCalledWith("track-xyz");
+  });
+
+  // Delete button disables while isDeleting=true so a slow API can't be
+  // triggered twice by a frustrated double-click.
+  test("delete button is disabled when isDeleting is true", async () => {
+    const { container } = await setup(
+      <SortableTrackItem track={makeTrack()} onEdit={vi.fn()} onDelete={vi.fn()} isDeleting />,
+    );
+
+    const deleteButton = container.querySelector('button[class*="border-red-600"]');
+    expect(deleteButton).toBeDisabled();
+  });
+});

--- a/apps/web/app/components/track/sortable-track-item.tsx
+++ b/apps/web/app/components/track/sortable-track-item.tsx
@@ -3,6 +3,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Edit2, Flame, GripVertical, Trash } from "lucide-react";
 import { Button } from "~/components/ui/button";
+import { listRowClass } from "~/lib/form-styles";
 import { cn } from "~/lib/utils";
 
 interface SortableTrackItemProps {
@@ -24,82 +25,72 @@ export function SortableTrackItem({ track, onEdit, onDelete, isDeleting }: Sorta
     <div
       ref={setNodeRef}
       style={style}
-      className={cn(
-        "p-3 bg-content-bg-secondary/50 rounded-lg border border-content-bg-secondary transition-all",
-        isDragging && "opacity-50 shadow-lg z-50",
-      )}
+      className={cn(listRowClass, "p-3 transition-all", isDragging && "opacity-50 shadow-lg z-50")}
     >
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex items-start space-x-4 flex-1">
-          {/* Drag Handle */}
-          <button
-            className="text-content-text-secondary hover:text-gray-300 cursor-grab active:cursor-grabbing p-1 mt-1"
-            {...attributes}
-            {...listeners}
-          >
-            <GripVertical className="h-4 w-4" />
-          </button>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between gap-2 md:gap-4">
+          <div className="flex items-center space-x-2 md:space-x-4 flex-1 min-w-0">
+            {/* Drag Handle */}
+            <button
+              className="text-content-text-secondary hover:text-gray-300 cursor-grab active:cursor-grabbing p-1 shrink-0"
+              {...attributes}
+              {...listeners}
+            >
+              <GripVertical className="h-4 w-4" />
+            </button>
 
-          {/* Position Number - now just for display */}
-          <span className="text-content-text-secondary font-mono text-sm w-8 mt-1">{track.position}</span>
+            {/* Position Number - now just for display */}
+            <span className="text-content-text-secondary font-mono text-sm w-6 md:w-8 shrink-0">{track.position}</span>
 
-          {/* All-timer indicator (reserved column to keep alignment) */}
-          <span className="w-5 mt-1 flex justify-center">
-            {track.allTimer && <Flame className="h-4 w-4 text-orange-500" />}
-          </span>
-
-          {/* Track Content */}
-          <div className="flex-1">
-            <div className="flex items-center gap-3 flex-wrap">
-              {/* Song Title */}
+            {/* Title + inline markers */}
+            <div className="flex items-center gap-2 md:gap-3 flex-wrap flex-1 min-w-0">
               <span className="text-white font-medium">{track.song?.title || "Unknown Song"}</span>
-
-              {/* Segue */}
+              {track.allTimer && <Flame className="h-4 w-4 text-orange-500 shrink-0" />}
               {track.segue && <span className="text-content-text-secondary text-sm">{track.segue}</span>}
-
-              {/* Notes */}
-              {track.note && <span className="text-content-text-secondary text-sm italic">({track.note})</span>}
             </div>
+          </div>
 
-            {/* Annotations */}
-            {track.annotations && track.annotations.length > 0 && (
-              <div className="mt-2 space-y-1">
-                {track.annotations.map(
-                  (annotation, index) =>
-                    annotation.desc && (
-                      <div
-                        key={annotation.id || index}
-                        className="text-content-text-accent text-sm pl-2 border-l-2 border-content-bg-secondary"
-                      >
-                        {annotation.desc}
-                      </div>
-                    ),
-                )}
-              </div>
-            )}
+          {/* Action Buttons */}
+          <div className="flex items-center gap-1 md:gap-2 shrink-0">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => onEdit(track)}
+              className="h-8 w-8 p-0 md:h-9 md:w-auto md:px-3 border-gray-600 text-gray-300 hover:bg-gray-700"
+            >
+              <Edit2 className="h-3 w-3" />
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => onDelete(track.id)}
+              disabled={isDeleting}
+              className="h-8 w-8 p-0 md:h-9 md:w-auto md:px-3 border-red-600 text-red-400 hover:bg-red-900/20"
+            >
+              <Trash className="h-3 w-3" />
+            </Button>
           </div>
         </div>
 
-        {/* Action Buttons */}
-        <div className="flex items-center gap-2">
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => onEdit(track)}
-            className="border-gray-600 text-gray-300 hover:bg-gray-700"
-          >
-            <Edit2 className="h-3 w-3" />
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => onDelete(track.id)}
-            disabled={isDeleting}
-            className="border-red-600 text-red-400 hover:bg-red-900/20"
-          >
-            <Trash className="h-3 w-3" />
-          </Button>
-        </div>
+        {/* Note (full-width, below title) */}
+        {track.note && <p className="text-content-text-secondary text-sm italic pl-8 md:pl-12">{track.note}</p>}
+
+        {/* Annotations (full-width, below note) */}
+        {track.annotations && track.annotations.length > 0 && (
+          <div className="space-y-1 pl-8 md:pl-12">
+            {track.annotations.map(
+              (annotation, index) =>
+                annotation.desc && (
+                  <div
+                    key={annotation.id || index}
+                    className="text-content-text-accent text-sm pl-2 border-l-2 border-content-bg-secondary"
+                  >
+                    {annotation.desc}
+                  </div>
+                ),
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/app/components/track/sortable-track-item.tsx
+++ b/apps/web/app/components/track/sortable-track-item.tsx
@@ -1,7 +1,8 @@
 import type { Track } from "@bip/domain";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { Edit2, Flame, GripVertical, Trash } from "lucide-react";
+import { Edit2, GripVertical, Trash } from "lucide-react";
+import { TrackIcon } from "~/components/track/track-icon";
 import { Button } from "~/components/ui/button";
 import { listRowClass } from "~/lib/form-styles";
 import { cn } from "~/lib/utils";
@@ -45,7 +46,7 @@ export function SortableTrackItem({ track, onEdit, onDelete, isDeleting }: Sorta
             {/* Title + inline markers */}
             <div className="flex items-center gap-2 md:gap-3 flex-wrap flex-1 min-w-0">
               <span className="text-white font-medium">{track.song?.title || "Unknown Song"}</span>
-              {track.allTimer && <Flame className="h-4 w-4 text-orange-500 shrink-0" />}
+              <TrackIcon track={track} iconClassName="h-4 w-4" />
               {track.segue && <span className="text-content-text-secondary text-sm">{track.segue}</span>}
             </div>
           </div>

--- a/apps/web/app/components/track/track-constants.test.ts
+++ b/apps/web/app/components/track/track-constants.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+
+import { compareSets, SEGUE_OPTIONS, SET_OPTIONS } from "./track-constants";
+
+describe("SET_OPTIONS", () => {
+  // The set dropdown lists S1-S3 then E1-E3. Order matters — it drives the
+  // visual order in the picker, which should match how the band's setlist
+  // pages render the same sets.
+  test("lists all six set values in S1→E3 order", () => {
+    expect(SET_OPTIONS.map((o) => o.value)).toEqual(["S1", "S2", "S3", "E1", "E2", "E3"]);
+  });
+
+  // Display labels expand the codes for humans: "Set 1" / "Encore 1" rather
+  // than the raw "S1" / "E1".
+  test("labels expand codes into 'Set N' / 'Encore N' display text", () => {
+    const byValue = Object.fromEntries(SET_OPTIONS.map((o) => [o.value, o.label]));
+    expect(byValue.S1).toBe("Set 1");
+    expect(byValue.S3).toBe("Set 3");
+    expect(byValue.E1).toBe("Encore 1");
+    expect(byValue.E3).toBe("Encore 3");
+  });
+});
+
+describe("SEGUE_OPTIONS", () => {
+  // Segue dropdown has two states: no segue (the form sentinel is "none")
+  // and ">" for the "song A > song B" continuous-play marker. The API
+  // boundary in track-manager.tsx translates "none" → null before saving.
+  test("offers a 'none' sentinel and the '>' marker", () => {
+    expect(SEGUE_OPTIONS).toEqual([
+      { value: "none", label: "No segue" },
+      { value: ">", label: ">" },
+    ]);
+  });
+});
+
+describe("compareSets", () => {
+  // Within the same type (set vs encore), order by numeric suffix —
+  // setlist views render sets in playback order.
+  test("orders sets numerically within the S group", () => {
+    expect(["S2", "S1", "S3"].sort(compareSets)).toEqual(["S1", "S2", "S3"]);
+  });
+
+  test("orders encores numerically within the E group", () => {
+    expect(["E3", "E1", "E2"].sort(compareSets)).toEqual(["E1", "E2", "E3"]);
+  });
+
+  // Encores always follow the regular sets, regardless of suffix. An
+  // encore is "after the show proper", so E1 > S3 even though 1 < 3.
+  test("places all encores after all sets", () => {
+    expect(["E1", "S3", "S1", "E2"].sort(compareSets)).toEqual(["S1", "S3", "E1", "E2"]);
+  });
+});

--- a/apps/web/app/components/track/track-constants.ts
+++ b/apps/web/app/components/track/track-constants.ts
@@ -1,0 +1,31 @@
+export const SET_OPTIONS = [
+  { value: "S1", label: "Set 1" },
+  { value: "S2", label: "Set 2" },
+  { value: "S3", label: "Set 3" },
+  { value: "E1", label: "Encore 1" },
+  { value: "E2", label: "Encore 2" },
+  { value: "E3", label: "Encore 3" },
+];
+
+export const SEGUE_OPTIONS = [
+  { value: "none", label: "No segue" },
+  { value: ">", label: ">" },
+];
+
+/**
+ * Orders set codes for the setlist UI: regular sets first (S1, S2, S3),
+ * then encores (E1, E2, E3). Within a group, sort numerically by suffix —
+ * an encore is "after the show", so E1 follows S3 even though 1 < 3.
+ */
+export function compareSets(a: string, b: string): number {
+  const setOrder = { S: 0, E: 1 };
+  const aType = a.charAt(0) as "S" | "E";
+  const bType = b.charAt(0) as "S" | "E";
+  const aNum = Number.parseInt(a.slice(1), 10);
+  const bNum = Number.parseInt(b.slice(1), 10);
+
+  if (aType !== bType) {
+    return setOrder[aType] - setOrder[bType];
+  }
+  return aNum - bNum;
+}

--- a/apps/web/app/components/track/track-edit-form.test.tsx
+++ b/apps/web/app/components/track/track-edit-form.test.tsx
@@ -1,0 +1,203 @@
+import { setup } from "@test/test-utils";
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { TrackEditForm } from "./track-edit-form";
+import type { TrackFormData } from "./use-track-api";
+
+const BASE_FORM: TrackFormData = {
+  songId: "none",
+  set: "S1",
+  position: 1,
+  segue: "none",
+  note: null,
+  annotationDesc: null,
+  allTimer: false,
+};
+
+describe("TrackEditForm", () => {
+  // The form is editing-aware: when `isEditing` is true it shows "Update";
+  // otherwise "Add". This drives which CTA the user sees in the same form.
+  test("renders the 'Add' CTA when isEditing is false", async () => {
+    await setup(
+      <TrackEditForm
+        formData={BASE_FORM}
+        onFormDataChange={vi.fn()}
+        isEditing={false}
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /add/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /update/i })).not.toBeInTheDocument();
+  });
+
+  test("renders the 'Update' CTA when isEditing is true", async () => {
+    await setup(
+      <TrackEditForm
+        formData={BASE_FORM}
+        onFormDataChange={vi.fn()}
+        isEditing
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /update/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^add/i })).not.toBeInTheDocument();
+  });
+
+  // While submitting, both CTAs disable so a slow API can't be triggered
+  // twice by a double-click.
+  test("disables the submit button while isSubmitting", async () => {
+    await setup(
+      <TrackEditForm
+        formData={BASE_FORM}
+        onFormDataChange={vi.fn()}
+        isEditing={false}
+        isSubmitting
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /add/i })).toBeDisabled();
+  });
+
+  // Note textarea is pre-populated from formData.note. Editing fires
+  // onFormDataChange with the new value. Empty string normalizes to null
+  // so the form state matches the DB column type.
+  test("seeds the Note textarea from formData.note", async () => {
+    await setup(
+      <TrackEditForm
+        formData={{ ...BASE_FORM, note: "The jam emerges as minimal trance" }}
+        onFormDataChange={vi.fn()}
+        isEditing
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText(/track notes/i)).toHaveValue("The jam emerges as minimal trance");
+  });
+
+  // We drive the change directly via fireEvent because the form is fully
+  // controlled — the parent owns formData and decides when to re-render.
+  // user.type can't progress past the first character on a controlled
+  // input that doesn't receive prop updates, so we synthesize the change
+  // event instead.
+  test("changing Note fires onFormDataChange whose updater sets the new value", async () => {
+    const onFormDataChange = vi.fn();
+    await setup(
+      <TrackEditForm
+        formData={BASE_FORM}
+        onFormDataChange={onFormDataChange}
+        isEditing={false}
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/track notes/i), {
+      target: { value: "The jam emerges" },
+    });
+
+    const updater = onFormDataChange.mock.calls.at(-1)?.[0] as (p: TrackFormData) => TrackFormData;
+    expect(updater(BASE_FORM).note).toBe("The jam emerges");
+  });
+
+  // Clearing the textarea sends null (not empty string) so the column
+  // type matches the DB.
+  test("clearing Note sends null via the updater, not an empty string", async () => {
+    const onFormDataChange = vi.fn();
+    await setup(
+      <TrackEditForm
+        formData={{ ...BASE_FORM, note: "x" }}
+        onFormDataChange={onFormDataChange}
+        isEditing
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/track notes/i), { target: { value: "" } });
+
+    const updater = onFormDataChange.mock.calls.at(-1)?.[0] as (p: TrackFormData) => TrackFormData;
+    expect(updater({ ...BASE_FORM, note: "x" }).note).toBeNull();
+  });
+
+  // Annotations textarea is shown alongside Notes — the "one per line"
+  // hint signals the field's expected format.
+  test("annotations field shows the 'one per line' hint", async () => {
+    await setup(
+      <TrackEditForm
+        formData={BASE_FORM}
+        onFormDataChange={vi.fn()}
+        isEditing
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/one per line/i)).toBeInTheDocument();
+  });
+
+  // All-timer checkbox is checked when formData.allTimer is true.
+  test("all-timer checkbox reflects formData.allTimer", async () => {
+    await setup(
+      <TrackEditForm
+        formData={{ ...BASE_FORM, allTimer: true }}
+        onFormDataChange={vi.fn()}
+        isEditing
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("checkbox", { name: /all-timer/i })).toBeChecked();
+  });
+
+  // Submit / Cancel fire the matching callbacks — the form doesn't own
+  // any submission logic itself.
+  test("clicking the submit CTA fires onSubmit", async () => {
+    const onSubmit = vi.fn();
+    const { user } = await setup(
+      <TrackEditForm
+        formData={BASE_FORM}
+        onFormDataChange={vi.fn()}
+        isEditing={false}
+        isSubmitting={false}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /add/i }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  test("clicking the cancel CTA fires onCancel", async () => {
+    const onCancel = vi.fn();
+    const { user } = await setup(
+      <TrackEditForm
+        formData={BASE_FORM}
+        onFormDataChange={vi.fn()}
+        isEditing={false}
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/app/components/track/track-edit-form.tsx
+++ b/apps/web/app/components/track/track-edit-form.tsx
@@ -1,0 +1,135 @@
+import { Check, X } from "lucide-react";
+import { SongSearch } from "~/components/song/song-search";
+import { Button } from "~/components/ui/button";
+import { Checkbox } from "~/components/ui/checkbox";
+import { GlassSelect } from "~/components/ui/glass-select";
+import { Textarea } from "~/components/ui/textarea";
+import { formInputClass, formLabelClass } from "~/lib/form-styles";
+import { SEGUE_OPTIONS, SET_OPTIONS } from "./track-constants";
+import type { TrackFormData } from "./use-track-api";
+
+interface TrackEditFormProps {
+  formData: TrackFormData;
+  onFormDataChange: (updater: (prev: TrackFormData) => TrackFormData) => void;
+  isEditing: boolean;
+  isSubmitting: boolean;
+  onSubmit: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * The inline form admins use to add or edit a track on a show. Pure
+ * presentational + controlled input — all state lives in the caller
+ * (`TrackManager`), which decides what `formData` to seed it with, when
+ * to flip between add/edit mode, and how to handle submission.
+ */
+export function TrackEditForm({
+  formData,
+  onFormDataChange,
+  isEditing,
+  isSubmitting,
+  onSubmit,
+  onCancel,
+}: TrackEditFormProps) {
+  return (
+    <div className="flex flex-col gap-4 p-4 bg-content-bg/50 rounded-lg border border-content-bg-secondary">
+      <div>
+        <label htmlFor="track-song" className={formLabelClass}>
+          Song
+        </label>
+        <SongSearch
+          value={formData.songId}
+          onValueChange={(value) => onFormDataChange((prev) => ({ ...prev, songId: value }))}
+          placeholder="Select a song..."
+          className="w-full"
+          initialSong={formData.song}
+        />
+      </div>
+
+      <div className="flex flex-wrap items-end gap-4">
+        <div className="w-28">
+          <label htmlFor="track-set" className={formLabelClass}>
+            Set
+          </label>
+          <GlassSelect
+            id="track-set"
+            value={formData.set}
+            onValueChange={(value) => onFormDataChange((prev) => ({ ...prev, set: value }))}
+            options={SET_OPTIONS}
+            className="w-full"
+          />
+        </div>
+
+        <div className="w-32">
+          <label htmlFor="track-segue" className={formLabelClass}>
+            Segue
+          </label>
+          <GlassSelect
+            id="track-segue"
+            value={formData.segue}
+            onValueChange={(value) => onFormDataChange((prev) => ({ ...prev, segue: value }))}
+            options={SEGUE_OPTIONS}
+            className="w-full"
+          />
+        </div>
+
+        <div className="flex items-center gap-2 h-10">
+          <Checkbox
+            id="track-all-timer"
+            checked={formData.allTimer}
+            onCheckedChange={(checked) => onFormDataChange((prev) => ({ ...prev, allTimer: checked === true }))}
+          />
+          <label htmlFor="track-all-timer" className="text-sm font-medium text-content-text-secondary cursor-pointer">
+            All-timer
+          </label>
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="track-note" className={formLabelClass}>
+          Track Notes
+        </label>
+        <Textarea
+          id="track-note"
+          value={formData.note || ""}
+          onChange={(e) => {
+            const value = e.target.value;
+            onFormDataChange((prev) => ({ ...prev, note: value || null }));
+          }}
+          placeholder="Add a note about this track..."
+          className={formInputClass}
+          rows={3}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="track-annotation" className={formLabelClass}>
+          Annotations
+          <span className="ml-2 text-xs text-content-text-tertiary">(one per line)</span>
+        </label>
+        <Textarea
+          id="track-annotation"
+          value={formData.annotationDesc || ""}
+          onChange={(e) => {
+            const value = e.target.value;
+            onFormDataChange((prev) => ({ ...prev, annotationDesc: value || null }));
+          }}
+          placeholder="Add annotations (one per line)..."
+          className={formInputClass}
+          rows={3}
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <Button onClick={onCancel} variant="cancel">
+          <X className="h-4 w-4 mr-1" />
+          Cancel
+        </Button>
+        <Button onClick={onSubmit} disabled={isSubmitting} variant="brand">
+          <Check className="h-4 w-4 mr-1" />
+          {isEditing ? "Update" : "Add"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/components/track/track-icon.test.tsx
+++ b/apps/web/app/components/track/track-icon.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { TrackIcon } from "./track-icon";
+
+describe("TrackIcon", () => {
+  // A track with neither flag set is not noteworthy, so the component
+  // renders nothing rather than leave an invisible marker.
+  test("renders nothing when neither allTimer nor note is set", () => {
+    const { container } = render(<TrackIcon track={{ allTimer: false, note: null }} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // Empty-string / whitespace-only notes carry no information; they
+  // should not flip the icon into the jam-chart variant.
+  test("treats blank-string notes as absent", () => {
+    const { container } = render(<TrackIcon track={{ allTimer: false, note: "   " }} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // All-timer (with or without a note) takes the orange flame — it's the
+  // stronger of the two signals and the user-facing color contract.
+  test("renders an orange flame when allTimer is true", () => {
+    render(<TrackIcon track={{ allTimer: true, note: null }} />);
+    const flame = screen.getByLabelText("All-timer");
+    expect(flame.getAttribute("class") ?? "").toMatch(/text-orange-500/);
+  });
+
+  // Jam-chart (note only) gets the off-white flame so it reads as a
+  // quieter signal next to the orange all-timer flame on the same list.
+  test("renders an off-white flame when only note is set", () => {
+    render(<TrackIcon track={{ allTimer: false, note: "Big Type II Spaga." }} />);
+    const flame = screen.getByLabelText("Jam chart");
+    expect(flame.getAttribute("class") ?? "").toMatch(/text-content-text-primary/);
+    expect(flame.getAttribute("class") ?? "").not.toMatch(/text-orange-500/);
+  });
+
+  // When both flags are set, orange (all-timer) wins — it's the stronger
+  // signal. Callers that want to surface the note do so via the
+  // surrounding hover overlay, not via this icon's color.
+  test("orange flame wins when both allTimer and note are set", () => {
+    render(<TrackIcon track={{ allTimer: true, note: "Story of the World > Crickets." }} />);
+    const flame = screen.getByLabelText("All-timer");
+    expect(flame.getAttribute("class") ?? "").toMatch(/text-orange-500/);
+  });
+
+  // Allow callers to pin a custom size — the same component is used in
+  // dense table cells (smaller) and standalone sections (larger).
+  test("iconClassName overrides the default size classes on the flame", () => {
+    render(<TrackIcon track={{ allTimer: true, note: null }} iconClassName="h-3 w-3" />);
+    const flame = screen.getByLabelText("All-timer");
+    expect(flame.getAttribute("class") ?? "").toMatch(/h-3/);
+    expect(flame.getAttribute("class") ?? "").toMatch(/w-3/);
+  });
+});

--- a/apps/web/app/components/track/track-icon.tsx
+++ b/apps/web/app/components/track/track-icon.tsx
@@ -1,0 +1,43 @@
+import { Flame } from "lucide-react";
+import { cn } from "~/lib/utils";
+
+interface TrackIconProps {
+  /**
+   * Track-like shape carrying the two flags the icon dispatches on.
+   * Accepts a narrow shape (not full `Track`) so call sites can pass
+   * partial projections without ceremony.
+   */
+  track: { allTimer?: boolean | null; note?: string | null };
+  /**
+   * Sizing/layout classes applied to the flame. Default `h-4 w-4` matches
+   * standalone-section sizing; dense table cells override to smaller.
+   */
+  iconClassName?: string;
+  /** Extra classes applied to the outer wrapper span. */
+  className?: string;
+}
+
+/**
+ * Visual marker for noteworthy tracks. Renders the orange flame when the
+ * track is an all-timer, the off-white flame when it carries a curated
+ * jam-chart note but isn't an all-timer, and nothing otherwise. The
+ * surrounding hover/click affordance for showing the note text is
+ * provided by the caller (e.g. AllTimerCell wraps the flame in a
+ * TrackRatingOverlay; the setlist flow view does the same for the whole
+ * row); this component is intentionally inert.
+ */
+export function TrackIcon({ track, iconClassName, className }: TrackIconProps) {
+  const allTimer = !!track.allTimer;
+  const note = !!track.note?.trim();
+
+  if (!allTimer && !note) return null;
+
+  const colorClass = allTimer ? "text-orange-500" : "text-content-text-primary";
+  const sizeClass = iconClassName ?? "h-4 w-4";
+  const label = allTimer ? "All-timer" : "Jam chart";
+  return (
+    <span className={cn("inline-flex items-center", className)}>
+      <Flame className={cn(sizeClass, "shrink-0", colorClass)} aria-label={label} />
+    </span>
+  );
+}

--- a/apps/web/app/components/track/track-manager.test.tsx
+++ b/apps/web/app/components/track/track-manager.test.tsx
@@ -1,0 +1,296 @@
+import type { Track } from "@bip/domain";
+import { setup } from "@test/test-utils";
+import { act, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// Stub the sortable row so we don't have to mount @dnd-kit/sortable
+// machinery — the row's render is covered by sortable-track-item.test.tsx.
+// We just need to know which tracks TrackManager handed it and capture
+// the onEdit / onDelete callbacks so we can invoke them directly.
+const capturedRowProps: Array<{
+  track: Track;
+  onEdit: (track: Track) => void;
+  onDelete: (id: string) => void;
+  isDeleting?: boolean;
+}> = [];
+vi.mock("./sortable-track-item", () => ({
+  SortableTrackItem: (props: {
+    track: Track;
+    onEdit: (track: Track) => void;
+    onDelete: (id: string) => void;
+    isDeleting?: boolean;
+  }) => {
+    capturedRowProps.push(props);
+    return (
+      <div data-testid={`row-${props.track.id}`}>
+        {props.track.song?.title ?? "unknown"}
+        <button type="button" onClick={() => props.onEdit(props.track)}>
+          edit-{props.track.id}
+        </button>
+        <button type="button" onClick={() => props.onDelete(props.track.id)}>
+          delete-{props.track.id}
+        </button>
+      </div>
+    );
+  },
+}));
+
+// DndContext stubbed so tests can capture the `onDragEnd` handler and
+// fire synthetic drag events without simulating real pointer drags in
+// jsdom. The captured ref is reset in `beforeEach`.
+let capturedOnDragEnd: ((event: { active: { id: string }; over: { id: string } | null }) => void) | undefined;
+vi.mock("@dnd-kit/core", async () => {
+  const actual = await vi.importActual<typeof import("@dnd-kit/core")>("@dnd-kit/core");
+  return {
+    ...actual,
+    DndContext: ({ onDragEnd, children }: { onDragEnd?: typeof capturedOnDragEnd; children: React.ReactNode }) => {
+      capturedOnDragEnd = onDragEnd;
+      return <>{children}</>;
+    },
+  };
+});
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { success: (...args: unknown[]) => toastSuccess(...args), error: (...args: unknown[]) => toastError(...args) },
+}));
+
+import { TrackManager } from "./track-manager";
+
+function makeTrack(overrides: Partial<Track> & { id: string }): Track {
+  return {
+    showId: "show-1",
+    songId: "song-1",
+    set: "S1",
+    position: 1,
+    segue: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    likesCount: 0,
+    slug: overrides.id,
+    note: null,
+    allTimer: false,
+    previousTrackId: null,
+    nextTrackId: null,
+    averageRating: 0,
+    ratingsCount: 0,
+    gap: null,
+    previousPerformanceShowId: null,
+    previousPerformanceShow: null,
+    annotations: [],
+    song: { id: "song-1", title: "Story of the World" } as unknown as Track["song"],
+    ...overrides,
+  } as Track;
+}
+
+describe("TrackManager", () => {
+  beforeEach(() => {
+    capturedRowProps.length = 0;
+    capturedOnDragEnd = undefined;
+    toastSuccess.mockClear();
+    toastError.mockClear();
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => [] }) as never;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // When initialTracks is supplied, TrackManager skips the on-mount load
+  // so the parent loader's data is the source of truth.
+  test("does not fetch /api/tracks on mount when initialTracks is provided", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+    globalThis.fetch = fetchMock as never;
+
+    await setup(<TrackManager showId="show-1" initialTracks={[makeTrack({ id: "t-1" })]} />);
+
+    // Wait for any micro-tasks the mount effect would schedule.
+    await new Promise((r) => setTimeout(r, 0));
+    const tracksFetches = fetchMock.mock.calls.filter((c) => String(c[0]).startsWith("/api/tracks"));
+    expect(tracksFetches).toHaveLength(0);
+  });
+
+  // With no initialTracks, the on-mount effect kicks off the GET so the
+  // component can render its current state without needing the parent to
+  // pass data down.
+  test("fetches /api/tracks?showId=… on mount when initialTracks is empty", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+    globalThis.fetch = fetchMock as never;
+
+    await setup(<TrackManager showId="show-1" />);
+
+    await waitFor(() => {
+      const urls = fetchMock.mock.calls.map((c) => c[0]);
+      expect(urls).toContain("/api/tracks?showId=show-1");
+    });
+  });
+
+  // Initial tracks render grouped by set with section headers, in the
+  // order S1, S2, S3, E1, E2, E3 (encore-after-sets).
+  test("groups tracks by set with section headers in S→E order", async () => {
+    await setup(
+      <TrackManager
+        showId="show-1"
+        initialTracks={[
+          makeTrack({ id: "t-e1", set: "E1", position: 1 }),
+          makeTrack({ id: "t-s2", set: "S2", position: 1 }),
+          makeTrack({ id: "t-s1", set: "S1", position: 1 }),
+        ]}
+      />,
+    );
+
+    const headings = screen.getAllByRole("heading", { level: 3 }).map((h) => h.textContent);
+    expect(headings).toEqual(["Set 1", "Set 2", "Encore 1"]);
+  });
+
+  // The "Add Track" button shows the form when clicked. The form itself
+  // is the TrackEditForm component — recognized by its "Add" CTA inside
+  // the section.
+  test("clicking 'Add Track' opens the edit form with an 'Add' CTA", async () => {
+    const { user } = await setup(<TrackManager showId="show-1" initialTracks={[makeTrack({ id: "t-1" })]} />);
+
+    expect(screen.queryByLabelText(/track notes/i)).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /add track/i }));
+
+    expect(screen.getByLabelText(/track notes/i)).toBeInTheDocument();
+    // Add CTA inside the form (distinct from the "Add Track" header button).
+    expect(screen.getAllByRole("button", { name: /^add$/i }).length).toBeGreaterThanOrEqual(1);
+  });
+
+  // Cancel closes the form, returning the component to its list-only
+  // state. Add Track button becomes clickable again.
+  test("cancel closes the open edit form", async () => {
+    const { user } = await setup(<TrackManager showId="show-1" initialTracks={[makeTrack({ id: "t-1" })]} />);
+
+    await user.click(screen.getByRole("button", { name: /add track/i }));
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(screen.queryByLabelText(/track notes/i)).not.toBeInTheDocument();
+  });
+
+  // While the form is open, the "Add Track" header button is disabled so
+  // a user can't open a second form on top of the current one.
+  test("Add Track button disables while the form is open", async () => {
+    const { user } = await setup(<TrackManager showId="show-1" initialTracks={[makeTrack({ id: "t-1" })]} />);
+
+    await user.click(screen.getByRole("button", { name: /add track/i }));
+    expect(screen.getByRole("button", { name: /add track/i })).toBeDisabled();
+  });
+
+  // Clicking the edit pencil on a row opens the form pre-populated with
+  // that row's data. The CTA flips to "Update" so the user knows they're
+  // editing rather than adding.
+  test("clicking edit on a row opens the form with the row's data and an 'Update' CTA", async () => {
+    const { user } = await setup(
+      <TrackManager
+        showId="show-1"
+        initialTracks={[makeTrack({ id: "t-1", note: "The jam emerges as minimal trance" })]}
+      />,
+    );
+
+    // The stub above renders an edit button labeled "edit-<id>".
+    await user.click(screen.getByText("edit-t-1"));
+
+    expect(screen.getByLabelText(/track notes/i)).toHaveValue("The jam emerges as minimal trance");
+    expect(screen.getByRole("button", { name: /update/i })).toBeInTheDocument();
+  });
+
+  describe("drag-and-drop reorder", () => {
+    // Same-set reorder: drop t-2 onto t-1's position. The component should
+    // PUT /api/tracks/reorder with the new index-based positions for the
+    // affected set, and apply the new positions optimistically to local
+    // state (read off the captured row props passed on re-render).
+    test("dropping within the same set PUTs reorder updates and updates positions locally", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { id: "t-1", position: 2 },
+          { id: "t-2", position: 1 },
+        ],
+      });
+      globalThis.fetch = fetchMock as never;
+
+      await setup(
+        <TrackManager
+          showId="show-1"
+          initialTracks={[
+            makeTrack({ id: "t-1", set: "S1", position: 1 }),
+            makeTrack({ id: "t-2", set: "S1", position: 2 }),
+          ]}
+        />,
+      );
+
+      // Fire the drag-end as if the user dropped t-2 on t-1's slot.
+      await act(async () => {
+        capturedOnDragEnd?.({ active: { id: "t-2" }, over: { id: "t-1" } });
+      });
+
+      await waitFor(() => {
+        const reorderCalls = fetchMock.mock.calls.filter((c) => c[0] === "/api/tracks/reorder");
+        expect(reorderCalls).toHaveLength(1);
+        const body = JSON.parse(reorderCalls[0][1].body);
+        expect(body.updates).toEqual([
+          { id: "t-2", position: 1, set: "S1" },
+          { id: "t-1", position: 2, set: "S1" },
+        ]);
+      });
+    });
+
+    // Cross-set drag is rejected: the reorder endpoint expects a single
+    // set per call. The component shows an error toast and skips the PUT.
+    test("dropping across sets shows an error toast and skips the PUT", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+      globalThis.fetch = fetchMock as never;
+
+      await setup(
+        <TrackManager
+          showId="show-1"
+          initialTracks={[
+            makeTrack({ id: "t-s1", set: "S1", position: 1 }),
+            makeTrack({ id: "t-s2", set: "S2", position: 1 }),
+          ]}
+        />,
+      );
+
+      await act(async () => {
+        capturedOnDragEnd?.({ active: { id: "t-s1" }, over: { id: "t-s2" } });
+      });
+
+      expect(toastError).toHaveBeenCalledWith(expect.stringMatching(/between different sets/i));
+      const reorderCalls = fetchMock.mock.calls.filter((c) => c[0] === "/api/tracks/reorder");
+      expect(reorderCalls).toHaveLength(0);
+    });
+
+    // Drop-on-self / drop-outside-target: dnd-kit fires onDragEnd with
+    // active.id === over.id (drop on same slot) or over === null
+    // (released outside any droppable). Both are no-ops — no PUT, no toast.
+    test("dropping on the same row is a no-op (no PUT, no toast)", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+      globalThis.fetch = fetchMock as never;
+
+      await setup(<TrackManager showId="show-1" initialTracks={[makeTrack({ id: "t-1" })]} />);
+
+      await act(async () => {
+        capturedOnDragEnd?.({ active: { id: "t-1" }, over: { id: "t-1" } });
+      });
+
+      expect(fetchMock.mock.calls.filter((c) => c[0] === "/api/tracks/reorder")).toHaveLength(0);
+      expect(toastError).not.toHaveBeenCalled();
+    });
+
+    test("dropping outside any droppable (over=null) is a no-op", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+      globalThis.fetch = fetchMock as never;
+
+      await setup(<TrackManager showId="show-1" initialTracks={[makeTrack({ id: "t-1" })]} />);
+
+      await act(async () => {
+        capturedOnDragEnd?.({ active: { id: "t-1" }, over: null });
+      });
+
+      expect(fetchMock.mock.calls.filter((c) => c[0] === "/api/tracks/reorder")).toHaveLength(0);
+      expect(toastError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/app/components/track/track-manager.tsx
+++ b/apps/web/app/components/track/track-manager.tsx
@@ -10,10 +10,9 @@ import {
 } from "@dnd-kit/core";
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { arrayMove, SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
-import { Check, Plus, X } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { Plus } from "lucide-react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { SongSearch } from "~/components/song/song-search";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -26,242 +25,57 @@ import {
 } from "~/components/ui/alert-dialog";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
-import { Checkbox } from "~/components/ui/checkbox";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
 import { SortableTrackItem } from "./sortable-track-item";
+import { compareSets, SET_OPTIONS } from "./track-constants";
+import { TrackEditForm } from "./track-edit-form";
+import { type TrackFormData, useTrackApi } from "./use-track-api";
 
 interface TrackManagerProps {
   showId: string;
   initialTracks?: Track[];
 }
 
-interface TrackFormData {
-  id?: string;
-  songId: string;
-  set: string;
-  position: number;
-  segue: string;
-  note: string | null;
-  song?: Track["song"];
-  annotationDesc?: string | null;
-  allTimer: boolean;
-}
+const INITIAL_FORM: TrackFormData = {
+  songId: "none",
+  set: "S1",
+  position: 1,
+  segue: "none",
+  note: null,
+  annotationDesc: null,
+  allTimer: false,
+};
 
-const SET_OPTIONS = [
-  { value: "S1", label: "Set 1" },
-  { value: "S2", label: "Set 2" },
-  { value: "S3", label: "Set 3" },
-  { value: "E1", label: "Encore 1" },
-  { value: "E2", label: "Encore 2" },
-  { value: "E3", label: "Encore 3" },
-];
-
-const SEGUE_OPTIONS = [
-  { value: "none", label: "No segue" },
-  { value: ">", label: ">" },
-];
-
+/**
+ * The Track List section on the show edit page. Owns the local tracks
+ * state + the form-open / editing-row UI lifecycle, and delegates network
+ * calls to `useTrackApi` and form rendering to `TrackEditForm`. Drag-and-
+ * drop reorder is handled inline because it needs access to the live
+ * tracks list to compute optimistic position updates.
+ */
 export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) {
   const [tracks, setTracks] = useState<Track[]>(initialTracks);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [isAddingNew, setIsAddingNew] = useState(false);
   const [deleteTrackId, setDeleteTrackId] = useState<string | null>(null);
-  const [isCreating, setIsCreating] = useState(false);
-  const [isUpdating, setIsUpdating] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [formData, setFormData] = useState<TrackFormData>({
-    songId: "none",
-    set: "S1",
-    position: 1,
-    segue: "none",
-    note: null,
-    annotationDesc: null,
-    allTimer: false,
-  });
+  const [formData, setFormData] = useState<TrackFormData>(INITIAL_FORM);
 
-  // Set up drag and drop sensors
   const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor));
+  const api = useTrackApi(showId, setTracks);
 
-  const loadTracks = useCallback(async () => {
-    try {
-      const response = await fetch(`/api/tracks?showId=${showId}`);
-      if (response.ok) {
-        const data = await response.json();
-        setTracks(data);
-      }
-    } catch (_error) {
-      toast.error("Failed to load tracks");
-    }
-  }, [showId]);
-
-  // Load tracks when component mounts
+  // Fetch when the parent didn't seed us — keeps the component usable
+  // standalone (e.g. on routes that haven't been migrated to loader
+  // prefetching yet).
   useEffect(() => {
     if (initialTracks.length === 0) {
-      loadTracks();
+      api.loadTracks();
     }
-  }, [initialTracks.length, loadTracks]);
+    // We only want to load once on mount when initialTracks is empty.
+  }, [initialTracks.length, api.loadTracks]);
 
-  // Helper function to sort sets properly (S1, S2, S3, E1, E2, E3)
-  const sortSets = (a: string, b: string) => {
-    const setOrder = { S: 0, E: 1 };
-    const aType = a.charAt(0) as "S" | "E";
-    const bType = b.charAt(0) as "S" | "E";
-    const aNum = Number.parseInt(a.slice(1), 10);
-    const bNum = Number.parseInt(b.slice(1), 10);
-
-    if (aType !== bType) {
-      return setOrder[aType] - setOrder[bType];
-    }
-    return aNum - bNum;
-  };
-
-  // Create track
-  const createTrack = async (data: TrackFormData) => {
-    setIsCreating(true);
-    try {
-      const response = await fetch("/api/tracks", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          ...data,
-          showId,
-          songId: data.songId === "none" ? undefined : data.songId,
-          segue: data.segue === "none" ? null : data.segue,
-          annotationDesc: data.annotationDesc,
-        }),
-      });
-      if (!response.ok) throw new Error("Failed to create track");
-      const newTrack = await response.json();
-
-      // Fetch song information for the newly created track
-      let trackWithSong = newTrack;
-      if (newTrack.songId && !newTrack.song) {
-        try {
-          const songResponse = await fetch(`/api/songs/${newTrack.songId}`);
-          if (songResponse.ok) {
-            const song = await songResponse.json();
-            trackWithSong = { ...newTrack, song };
-          }
-        } catch (_error) {}
-      }
-
-      setTracks((prev) =>
-        [...prev, trackWithSong].sort((a, b) => {
-          if (a.set !== b.set) return sortSets(a.set, b.set);
-          return a.position - b.position;
-        }),
-      );
-      setIsAddingNew(false);
-      resetForm();
-      toast.success("Track added successfully");
-    } catch {
-      toast.error("Failed to add track");
-    } finally {
-      setIsCreating(false);
-    }
-  };
-
-  // Update track
-  const updateTrack = async ({ id, ...data }: TrackFormData & { id: string }) => {
-    setIsUpdating(true);
-    try {
-      const response = await fetch(`/api/tracks/${id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          ...data,
-          songId: data.songId === "none" ? undefined : data.songId,
-          segue: data.segue === "none" ? null : data.segue,
-          annotationDesc: data.annotationDesc,
-        }),
-      });
-      if (!response.ok) throw new Error("Failed to update track");
-      const updatedTrack = await response.json();
-
-      setTracks((prev) =>
-        prev
-          .map((track) => (track.id === updatedTrack.id ? updatedTrack : track))
-          .sort((a, b) => {
-            if (a.set !== b.set) return sortSets(a.set, b.set);
-            return a.position - b.position;
-          }),
-      );
-      setEditingId(null);
-      resetForm();
-      toast.success("Track updated successfully");
-    } catch {
-      toast.error("Failed to update track");
-    } finally {
-      setIsUpdating(false);
-    }
-  };
-
-  // Delete track
-  const deleteTrack = async (id: string) => {
-    setIsDeleting(true);
-    try {
-      const response = await fetch(`/api/tracks/${id}`, {
-        method: "DELETE",
-      });
-      if (!response.ok) throw new Error("Failed to delete track");
-      setTracks((prev) => prev.filter((track) => track.id !== id));
-      toast.success("Track deleted successfully");
-    } catch {
-      toast.error("Failed to delete track");
-    } finally {
-      setIsDeleting(false);
-    }
-  };
-
-  // Reorder tracks
-  const reorderTracks = async (updates: { id: string; position: number; set: string }[]) => {
-    try {
-      const response = await fetch("/api/tracks/reorder", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ updates }),
-      });
-      if (!response.ok) throw new Error("Failed to reorder tracks");
-      const updatedTracks = await response.json();
-
-      // Update local state with new positions, preserving song data
-      setTracks((prev) =>
-        prev.map((track) => {
-          const updated = updatedTracks.find((t: Track) => t.id === track.id);
-          if (updated) {
-            // Merge updated track data with original track's song data
-            return { ...track, ...updated };
-          }
-          return track;
-        }),
-      );
-      toast.success("Track order updated");
-    } catch {
-      toast.error("Failed to reorder tracks");
-    }
-  };
-
-  const resetForm = () => {
-    setFormData({
-      songId: "none",
-      set: "S1",
-      position: 1,
-      segue: "none",
-      note: null,
-      annotationDesc: null,
-      allTimer: false,
-    });
-  };
+  const resetForm = () => setFormData(INITIAL_FORM);
 
   const startEditing = (track: Track) => {
     setEditingId(track.id);
-    // Join all annotations with line breaks for editing
-    const annotationsText =
-      track.annotations
-        ?.map((annotation) => annotation.desc)
-        .filter((desc) => desc)
-        .join("\n") || null;
-
     setFormData({
       id: track.id,
       songId: track.songId,
@@ -270,7 +84,13 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
       segue: track.segue || "none",
       note: track.note,
       song: track.song,
-      annotationDesc: annotationsText,
+      // Editor displays annotations as a multi-line textarea — one
+      // annotation per line.
+      annotationDesc:
+        track.annotations
+          ?.map((annotation) => annotation.desc)
+          .filter((desc) => desc)
+          .join("\n") || null,
       allTimer: track.allTimer ?? false,
     });
   };
@@ -281,50 +101,50 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
     resetForm();
   };
 
-  const handleSubmit = (position?: number) => {
+  const handleSubmit = async () => {
     if (formData.songId === "none") {
       toast.error("Please select a song");
       return;
     }
 
-    const submitData = {
-      ...formData,
-      position: position || formData.position,
-    };
+    // For a new track, drop it at the end of its target set; for an
+    // edit, keep whatever position the track already has.
+    const nextPosition = editingId
+      ? formData.position
+      : Math.max(0, ...tracks.filter((t) => t.set === formData.set).map((t) => t.position)) + 1;
+    const submitData = { ...formData, position: nextPosition };
 
-    if (editingId) {
-      updateTrack({ ...submitData, id: editingId });
-    } else {
-      createTrack(submitData);
+    const result = editingId
+      ? await api.updateTrack({ ...submitData, id: editingId })
+      : await api.createTrack(submitData);
+
+    if (result) {
+      setEditingId(null);
+      setIsAddingNew(false);
+      resetForm();
     }
   };
 
-  const handleDelete = (id: string) => {
-    setDeleteTrackId(id);
-  };
+  const handleDelete = (id: string) => setDeleteTrackId(id);
 
-  const confirmDelete = () => {
+  const confirmDelete = async () => {
     if (deleteTrackId) {
-      deleteTrack(deleteTrackId);
+      await api.deleteTrack(deleteTrackId);
       setDeleteTrackId(null);
     }
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
-
-    if (!over || active.id === over.id) {
-      return;
-    }
+    if (!over || active.id === over.id) return;
 
     const activeTrack = tracks.find((track) => track.id === active.id);
     const overTrack = tracks.find((track) => track.id === over.id);
+    if (!activeTrack || !overTrack) return;
 
-    if (!activeTrack || !overTrack) {
-      return;
-    }
-
-    // Only allow reordering within the same set for now
+    // Cross-set drag is intentionally rejected — the server reorder
+    // endpoint expects a single set at a time. A toast tells the admin
+    // why nothing happened.
     if (activeTrack.set !== overTrack.set) {
       toast.error("Cannot move tracks between different sets yet");
       return;
@@ -333,32 +153,26 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
     const currentSetTracks = tracks.filter((track) => track.set === activeTrack.set);
     const oldIndex = currentSetTracks.findIndex((track) => track.id === active.id);
     const newIndex = currentSetTracks.findIndex((track) => track.id === over.id);
+    if (oldIndex === newIndex) return;
 
-    if (oldIndex !== newIndex) {
-      // Reorder tracks within the set
-      const reorderedSetTracks = arrayMove(currentSetTracks, oldIndex, newIndex);
+    const reorderedSetTracks = arrayMove(currentSetTracks, oldIndex, newIndex);
+    const updates = reorderedSetTracks.map((track, index) => ({
+      id: track.id,
+      position: index + 1,
+      set: track.set,
+    }));
 
-      // Update positions
-      const updates = reorderedSetTracks.map((track, index) => ({
-        id: track.id,
-        position: index + 1,
-        set: track.set,
-      }));
-
-      // Optimistically update local state
-      const updatedTracks = tracks.map((track) => {
+    // Apply the new positions locally before the server confirms so the
+    // row visibly snaps to its new spot — the server PUT just validates.
+    setTracks((prev) =>
+      prev.map((track) => {
         const update = updates.find((u) => u.id === track.id);
         return update ? { ...track, position: update.position } : track;
-      });
-
-      setTracks(updatedTracks);
-
-      // Send updates to server
-      reorderTracks(updates);
-    }
+      }),
+    );
+    api.reorderTracks(updates);
   };
 
-  // Group tracks by set
   const tracksBySet = tracks.reduce(
     (acc, track) => {
       if (!acc[track.set]) acc[track.set] = [];
@@ -368,126 +182,14 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
     {} as Record<string, Track[]>,
   );
 
-  const renderTrackForm = () => {
-    // Auto-calculate position for new tracks
-    const nextPosition = editingId
-      ? formData.position
-      : Math.max(0, ...tracks.filter((t) => t.set === formData.set).map((t) => t.position)) + 1;
-
-    return (
-      <div className="grid grid-cols-1 md:grid-cols-7 gap-4 p-4 bg-content-bg/50 rounded-lg border border-content-bg-secondary">
-        <div className="md:col-span-2">
-          <label htmlFor="track-song" className="block text-sm font-medium text-content-text-secondary mb-1">
-            Song
-          </label>
-          <SongSearch
-            value={formData.songId}
-            onValueChange={(value) => setFormData((prev) => ({ ...prev, songId: value }))}
-            placeholder="Select a song..."
-            className="w-full"
-            initialSong={formData.song}
-          />
-        </div>
-
-        <div>
-          <label htmlFor="track-set" className="block text-sm font-medium text-content-text-secondary mb-1">
-            Set
-          </label>
-          <Select value={formData.set} onValueChange={(value) => setFormData((prev) => ({ ...prev, set: value }))}>
-            <SelectTrigger
-              id="track-set"
-              className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
-            >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent className="bg-content-bg-secondary border-content-bg-secondary">
-              {SET_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value} className="text-content-text-primary">
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div>
-          <label htmlFor="track-segue" className="block text-sm font-medium text-content-text-secondary mb-1">
-            Segue
-          </label>
-          <Select value={formData.segue} onValueChange={(value) => setFormData((prev) => ({ ...prev, segue: value }))}>
-            <SelectTrigger
-              id="track-segue"
-              className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
-            >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent className="bg-content-bg-secondary border-content-bg-secondary">
-              {SEGUE_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value} className="text-content-text-primary">
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div className="md:col-span-2">
-          <label htmlFor="track-annotation" className="block text-sm font-medium text-content-text-secondary mb-1">
-            Annotations
-            <span className="ml-2 text-xs text-content-text-tertiary">(one per line)</span>
-          </label>
-          <textarea
-            id="track-annotation"
-            value={formData.annotationDesc || ""}
-            onChange={(e) => setFormData((prev) => ({ ...prev, annotationDesc: e.target.value || null }))}
-            placeholder="Add annotations (one per line)..."
-            className="w-full px-3 py-2 bg-content-bg-secondary border border-content-bg-secondary text-content-text-primary rounded-md focus:outline-none focus:ring-2 focus:ring-brand-primary"
-            rows={3}
-          />
-        </div>
-
-        <div className="flex items-end gap-2">
-          <Button
-            onClick={() => handleSubmit(nextPosition)}
-            disabled={isCreating || isUpdating}
-            className="bg-brand-primary hover:bg-hover-accent"
-          >
-            <Check className="h-4 w-4 mr-1" />
-            {editingId ? "Update" : "Add"}
-          </Button>
-          <Button
-            onClick={cancelEditing}
-            variant="outline"
-            className="border-content-bg-secondary text-content-text-secondary"
-          >
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
-
-        <div className="md:col-span-7 flex items-center gap-2">
-          <Checkbox
-            id="track-all-timer"
-            checked={formData.allTimer}
-            onCheckedChange={(checked) => setFormData((prev) => ({ ...prev, allTimer: checked === true }))}
-          />
-          <label htmlFor="track-all-timer" className="text-sm font-medium text-content-text-secondary cursor-pointer">
-            All-timer
-          </label>
-        </div>
-      </div>
-    );
-  };
+  const isFormOpen = isAddingNew || editingId !== null;
 
   return (
-    <Card className="border-content-bg-secondary bg-content-bg/50">
+    <Card className="card-premium">
       <CardHeader>
         <div className="flex justify-between items-center">
           <CardTitle className="text-content-text-primary">Track List</CardTitle>
-          <Button
-            onClick={() => setIsAddingNew(true)}
-            disabled={isAddingNew || editingId !== null}
-            className="bg-brand-primary hover:bg-hover-accent"
-          >
+          <Button onClick={() => setIsAddingNew(true)} disabled={isFormOpen} variant="brand">
             <Plus className="h-4 w-4 mr-1" />
             Add Track
           </Button>
@@ -495,7 +197,16 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
       </CardHeader>
 
       <CardContent className="space-y-4">
-        {isAddingNew && renderTrackForm()}
+        {isAddingNew && (
+          <TrackEditForm
+            formData={formData}
+            onFormDataChange={setFormData}
+            isEditing={false}
+            isSubmitting={api.isCreating}
+            onSubmit={handleSubmit}
+            onCancel={cancelEditing}
+          />
+        )}
 
         {Object.keys(tracksBySet).length === 0 ? (
           <div className="text-center py-8 text-content-text-tertiary">
@@ -509,7 +220,7 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
             modifiers={[restrictToVerticalAxis]}
           >
             {Object.entries(tracksBySet)
-              .sort(([a], [b]) => sortSets(a, b))
+              .sort(([a], [b]) => compareSets(a, b))
               .map(([setName, setTracks]) => {
                 const sortedTracks = setTracks.sort((a, b) => a.position - b.position);
                 const trackIds = sortedTracks.map((track) => track.id);
@@ -522,20 +233,27 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
 
                     <SortableContext items={trackIds} strategy={verticalListSortingStrategy}>
                       <div className="space-y-2">
-                        {sortedTracks.map((track) => (
-                          <div key={track.id}>
-                            {editingId === track.id ? (
-                              renderTrackForm()
-                            ) : (
-                              <SortableTrackItem
-                                track={track}
-                                onEdit={startEditing}
-                                onDelete={handleDelete}
-                                isDeleting={isDeleting}
-                              />
-                            )}
-                          </div>
-                        ))}
+                        {sortedTracks.map((track) =>
+                          editingId === track.id ? (
+                            <TrackEditForm
+                              key={track.id}
+                              formData={formData}
+                              onFormDataChange={setFormData}
+                              isEditing
+                              isSubmitting={api.isUpdating}
+                              onSubmit={handleSubmit}
+                              onCancel={cancelEditing}
+                            />
+                          ) : (
+                            <SortableTrackItem
+                              key={track.id}
+                              track={track}
+                              onEdit={startEditing}
+                              onDelete={handleDelete}
+                              isDeleting={api.isDeleting}
+                            />
+                          ),
+                        )}
                       </div>
                     </SortableContext>
                   </div>

--- a/apps/web/app/components/track/use-track-api.test.tsx
+++ b/apps/web/app/components/track/use-track-api.test.tsx
@@ -1,0 +1,297 @@
+import type { Track } from "@bip/domain";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { success: (...args: unknown[]) => toastSuccess(...args), error: (...args: unknown[]) => toastError(...args) },
+}));
+
+import { useTrackApi } from "./use-track-api";
+
+// Track factory — the hook only cares about a few fields, the rest are
+// stubbed to keep the tests readable.
+function makeTrack(overrides: Partial<Track> & { id: string }): Track {
+  return {
+    showId: "show-1",
+    songId: "song-1",
+    set: "S1",
+    position: 1,
+    segue: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    likesCount: 0,
+    slug: overrides.id,
+    note: null,
+    allTimer: false,
+    previousTrackId: null,
+    nextTrackId: null,
+    averageRating: 0,
+    ratingsCount: 0,
+    gap: null,
+    previousPerformanceShowId: null,
+    previousPerformanceShow: null,
+    annotations: [],
+    ...overrides,
+  } as Track;
+}
+
+const BASE_FORM = {
+  songId: "song-1",
+  set: "S1" as const,
+  position: 1,
+  segue: "none" as const,
+  note: null,
+  annotationDesc: null,
+  allTimer: false,
+};
+
+function setupHook(initialTracks: Track[] = []) {
+  // The hook is driven by an external `tracks` array. We mimic that with
+  // a local closure so the test can assert post-hook state.
+  let tracks = [...initialTracks];
+  const setTracks = vi.fn((updater: (prev: Track[]) => Track[]) => {
+    tracks = updater(tracks);
+  });
+  const hook = renderHook(() => useTrackApi("show-1", setTracks as never));
+  return { hook, getTracks: () => tracks, setTracks };
+}
+
+describe("useTrackApi", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    toastSuccess.mockClear();
+    toastError.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("createTrack", () => {
+    // The POST body translates the "none" form sentinel to undefined for
+    // songId (so it's omitted) and null for segue (the API treats null
+    // and missing differently). showId is injected from the hook arg.
+    test("POSTs to /api/tracks with translated form sentinels and the showId", async () => {
+      // Include a `song` in the mock so the hook doesn't trigger its
+      // hydration fallback — that's covered by the dedicated test below.
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ...makeTrack({ id: "new-1", songId: "song-1", set: "S2", position: 3 }),
+          song: { id: "song-1", title: "Floes" },
+        }),
+      });
+      const { hook } = setupHook();
+
+      await act(async () => {
+        await hook.result.current.createTrack({
+          ...BASE_FORM,
+          songId: "none",
+          set: "S2",
+          position: 3,
+          segue: "none",
+        });
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, options] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/tracks");
+      expect(options.method).toBe("POST");
+      const body = JSON.parse(options.body);
+      expect(body.showId).toBe("show-1");
+      expect(body.songId).toBeUndefined();
+      expect(body.segue).toBeNull();
+      expect(body.set).toBe("S2");
+    });
+
+    // The newly-created track is appended to the local list and re-sorted
+    // so it lands in its set's correct position.
+    test("appends the created track and keeps tracks sorted by set + position", async () => {
+      const existing = [
+        makeTrack({ id: "t-s1-1", set: "S1", position: 1 }),
+        makeTrack({ id: "t-s2-1", set: "S2", position: 1 }),
+      ];
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeTrack({ id: "t-s1-2", set: "S1", position: 2 }),
+      });
+      const { hook, getTracks } = setupHook(existing);
+
+      await act(async () => {
+        await hook.result.current.createTrack({ ...BASE_FORM, set: "S1", position: 2 });
+      });
+
+      const ids = getTracks().map((t) => t.id);
+      expect(ids).toEqual(["t-s1-1", "t-s1-2", "t-s2-1"]);
+    });
+
+    // When the server omits the song relation, the hook hydrates it via
+    // /api/songs/:id so the row label renders without a follow-up reload.
+    test("hydrates song data via /api/songs/:id when missing from the response", async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ ...makeTrack({ id: "new-1" }), songId: "song-99", song: null }),
+        })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "song-99", title: "Floes" }) });
+      const { hook, getTracks } = setupHook();
+
+      await act(async () => {
+        await hook.result.current.createTrack({ ...BASE_FORM, songId: "song-99" });
+      });
+
+      expect(fetchMock.mock.calls[1][0]).toBe("/api/songs/song-99");
+      const created = getTracks().find((t) => t.id === "new-1");
+      expect(created?.song).toEqual({ id: "song-99", title: "Floes" });
+    });
+
+    // POST failures surface a toast and don't touch local state.
+    test("fires an error toast and leaves state unchanged on non-ok response", async () => {
+      fetchMock.mockResolvedValueOnce({ ok: false, status: 500 });
+      const existing = [makeTrack({ id: "t-1" })];
+      const { hook, getTracks } = setupHook(existing);
+
+      await act(async () => {
+        await hook.result.current.createTrack(BASE_FORM);
+      });
+
+      expect(toastError).toHaveBeenCalled();
+      expect(getTracks().map((t) => t.id)).toEqual(["t-1"]);
+    });
+
+    // isCreating flips true during the request and back to false when the
+    // request completes — used by the form to disable the submit button.
+    test("toggles isCreating during the request lifecycle", async () => {
+      let resolveCreate: ((value: unknown) => void) | undefined;
+      const pendingResponse = new Promise((resolve) => {
+        resolveCreate = resolve;
+      });
+      fetchMock.mockReturnValueOnce(pendingResponse);
+      const { hook } = setupHook();
+
+      expect(hook.result.current.isCreating).toBe(false);
+      let createPromise: Promise<unknown>;
+      act(() => {
+        createPromise = hook.result.current.createTrack(BASE_FORM);
+      });
+      await waitFor(() => expect(hook.result.current.isCreating).toBe(true));
+
+      await act(async () => {
+        resolveCreate?.({ ok: true, json: async () => makeTrack({ id: "new-1" }) });
+        await createPromise;
+      });
+      expect(hook.result.current.isCreating).toBe(false);
+    });
+  });
+
+  describe("updateTrack", () => {
+    // PUT /api/tracks/:id with the same form-sentinel translation as POST.
+    test("PUTs to /api/tracks/:id with translated form sentinels", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeTrack({ id: "t-1", segue: ">" }),
+      });
+      const { hook } = setupHook([makeTrack({ id: "t-1" })]);
+
+      await act(async () => {
+        await hook.result.current.updateTrack({ ...BASE_FORM, id: "t-1", segue: ">" });
+      });
+
+      const [url, options] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/tracks/t-1");
+      expect(options.method).toBe("PUT");
+      const body = JSON.parse(options.body);
+      expect(body.segue).toBe(">");
+    });
+
+    // The returned track replaces the existing entry in the local list,
+    // and the list is re-sorted so a set/position change moves the row.
+    test("replaces the matching track and re-sorts the list", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeTrack({ id: "t-1", set: "S2", position: 5 }),
+      });
+      const { hook, getTracks } = setupHook([
+        makeTrack({ id: "t-1", set: "S1", position: 1 }),
+        makeTrack({ id: "t-2", set: "S2", position: 4 }),
+      ]);
+
+      await act(async () => {
+        await hook.result.current.updateTrack({ ...BASE_FORM, id: "t-1", set: "S2", position: 5 });
+      });
+
+      expect(getTracks().map((t) => t.id)).toEqual(["t-2", "t-1"]);
+    });
+  });
+
+  describe("deleteTrack", () => {
+    // DELETE removes the row from local state on success and fires a toast.
+    test("DELETEs /api/tracks/:id and removes the row from state", async () => {
+      fetchMock.mockResolvedValueOnce({ ok: true });
+      const { hook, getTracks } = setupHook([makeTrack({ id: "t-1" }), makeTrack({ id: "t-2" })]);
+
+      await act(async () => {
+        await hook.result.current.deleteTrack("t-1");
+      });
+
+      expect(fetchMock.mock.calls[0][0]).toBe("/api/tracks/t-1");
+      expect(fetchMock.mock.calls[0][1].method).toBe("DELETE");
+      expect(getTracks().map((t) => t.id)).toEqual(["t-2"]);
+    });
+  });
+
+  describe("reorderTracks", () => {
+    // The reorder endpoint takes a list of {id, position, set} updates.
+    // The hook merges the server's response (full track records) into
+    // local state, preserving any client-only fields like `song`.
+    test("PUTs reorder updates and merges the response into local state", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: "t-1", position: 2 },
+          { id: "t-2", position: 1 },
+        ],
+      });
+      const { hook, getTracks } = setupHook([
+        makeTrack({ id: "t-1", position: 1, song: { title: "Floes" } as never }),
+        makeTrack({ id: "t-2", position: 2, song: { title: "Waves" } as never }),
+      ]);
+
+      await act(async () => {
+        await hook.result.current.reorderTracks([
+          { id: "t-1", position: 2, set: "S1" },
+          { id: "t-2", position: 1, set: "S1" },
+        ]);
+      });
+
+      const tracks = getTracks();
+      expect(tracks.find((t) => t.id === "t-1")?.position).toBe(2);
+      // Original song data preserved — the server response only includes
+      // position/set, not the full nested relation.
+      expect((tracks.find((t) => t.id === "t-1")?.song as { title: string } | undefined)?.title).toBe("Floes");
+    });
+  });
+
+  describe("loadTracks", () => {
+    // Initial-load helper: hits /api/tracks?showId=…, fills local state,
+    // and swallows errors with a toast so the form doesn't blow up if the
+    // load fails on mount.
+    test("fetches /api/tracks?showId=… and replaces local state with the response", async () => {
+      const tracks = [makeTrack({ id: "t-loaded-1" }), makeTrack({ id: "t-loaded-2" })];
+      fetchMock.mockResolvedValueOnce({ ok: true, json: async () => tracks });
+      const { hook, getTracks } = setupHook();
+
+      await act(async () => {
+        await hook.result.current.loadTracks();
+      });
+
+      expect(fetchMock.mock.calls[0][0]).toBe("/api/tracks?showId=show-1");
+      expect(getTracks().map((t) => t.id)).toEqual(["t-loaded-1", "t-loaded-2"]);
+    });
+  });
+});

--- a/apps/web/app/components/track/use-track-api.ts
+++ b/apps/web/app/components/track/use-track-api.ts
@@ -1,0 +1,184 @@
+import type { Track } from "@bip/domain";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { compareSets } from "./track-constants";
+
+export interface TrackFormData {
+  id?: string;
+  songId: string;
+  set: string;
+  position: number;
+  segue: string;
+  note: string | null;
+  song?: Track["song"];
+  annotationDesc?: string | null;
+  allTimer: boolean;
+}
+
+type SetTracks = (updater: (prev: Track[]) => Track[]) => void;
+
+function sortTracks(tracks: Track[]): Track[] {
+  return [...tracks].sort((a, b) => {
+    if (a.set !== b.set) return compareSets(a.set, b.set);
+    return a.position - b.position;
+  });
+}
+
+// Translates the form's "none" sentinels to the shape the API expects.
+// "none" songId → undefined (omitted), "none" segue → null (explicitly cleared).
+function buildSavePayload(data: TrackFormData) {
+  return {
+    ...data,
+    songId: data.songId === "none" ? undefined : data.songId,
+    segue: data.segue === "none" ? null : data.segue,
+    annotationDesc: data.annotationDesc,
+  };
+}
+
+/**
+ * Owns the four track-mutation network calls (create / update / delete /
+ * reorder) plus the initial load. Each call updates the parent's tracks
+ * state via the supplied `setTracks` updater and fires a toast on
+ * success/failure. UI state transitions (closing the form, resetting
+ * fields, etc.) stay with the caller.
+ */
+export function useTrackApi(showId: string, setTracks: SetTracks) {
+  const [isCreating, setIsCreating] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const loadTracks = useCallback(async () => {
+    try {
+      const response = await fetch(`/api/tracks?showId=${showId}`);
+      if (response.ok) {
+        const data = (await response.json()) as Track[];
+        setTracks(() => data);
+      }
+    } catch {
+      toast.error("Failed to load tracks");
+    }
+  }, [showId, setTracks]);
+
+  const createTrack = useCallback(
+    async (data: TrackFormData): Promise<Track | null> => {
+      setIsCreating(true);
+      try {
+        const response = await fetch("/api/tracks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...buildSavePayload(data), showId }),
+        });
+        if (!response.ok) throw new Error("Failed to create track");
+        const newTrack = (await response.json()) as Track;
+
+        // Hydrate the song relation if the server didn't include it — keeps
+        // the row label correct without forcing a full reload.
+        let trackWithSong = newTrack;
+        if (newTrack.songId && !newTrack.song) {
+          try {
+            const songResponse = await fetch(`/api/songs/${newTrack.songId}`);
+            if (songResponse.ok) {
+              const song = await songResponse.json();
+              trackWithSong = { ...newTrack, song };
+            }
+          } catch {
+            // Non-fatal — the row still renders, just with whatever the
+            // create endpoint returned.
+          }
+        }
+
+        setTracks((prev) => sortTracks([...prev, trackWithSong]));
+        toast.success("Track added successfully");
+        return trackWithSong;
+      } catch {
+        toast.error("Failed to add track");
+        return null;
+      } finally {
+        setIsCreating(false);
+      }
+    },
+    [showId, setTracks],
+  );
+
+  const updateTrack = useCallback(
+    async ({ id, ...data }: TrackFormData & { id: string }): Promise<Track | null> => {
+      setIsUpdating(true);
+      try {
+        const response = await fetch(`/api/tracks/${id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(buildSavePayload(data)),
+        });
+        if (!response.ok) throw new Error("Failed to update track");
+        const updatedTrack = (await response.json()) as Track;
+
+        setTracks((prev) => sortTracks(prev.map((track) => (track.id === updatedTrack.id ? updatedTrack : track))));
+        toast.success("Track updated successfully");
+        return updatedTrack;
+      } catch {
+        toast.error("Failed to update track");
+        return null;
+      } finally {
+        setIsUpdating(false);
+      }
+    },
+    [setTracks],
+  );
+
+  const deleteTrack = useCallback(
+    async (id: string): Promise<boolean> => {
+      setIsDeleting(true);
+      try {
+        const response = await fetch(`/api/tracks/${id}`, { method: "DELETE" });
+        if (!response.ok) throw new Error("Failed to delete track");
+        setTracks((prev) => prev.filter((track) => track.id !== id));
+        toast.success("Track deleted successfully");
+        return true;
+      } catch {
+        toast.error("Failed to delete track");
+        return false;
+      } finally {
+        setIsDeleting(false);
+      }
+    },
+    [setTracks],
+  );
+
+  const reorderTracks = useCallback(
+    async (updates: { id: string; position: number; set: string }[]): Promise<void> => {
+      try {
+        const response = await fetch("/api/tracks/reorder", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ updates }),
+        });
+        if (!response.ok) throw new Error("Failed to reorder tracks");
+        const updatedTracks = (await response.json()) as Partial<Track>[];
+
+        // Merge server-confirmed positions back into local state while
+        // preserving any client-only relation data the server didn't echo.
+        setTracks((prev) =>
+          prev.map((track) => {
+            const updated = updatedTracks.find((t) => t.id === track.id);
+            return updated ? { ...track, ...updated } : track;
+          }),
+        );
+        toast.success("Track order updated");
+      } catch {
+        toast.error("Failed to reorder tracks");
+      }
+    },
+    [setTracks],
+  );
+
+  return {
+    loadTracks,
+    createTrack,
+    updateTrack,
+    deleteTrack,
+    reorderTracks,
+    isCreating,
+    isUpdating,
+    isDeleting,
+  };
+}

--- a/apps/web/app/components/ui/button.test.tsx
+++ b/apps/web/app/components/ui/button.test.tsx
@@ -1,0 +1,40 @@
+import { setup } from "@test/test-utils";
+import { describe, expect, test } from "vitest";
+
+import { Button } from "./button";
+
+describe("Button variants", () => {
+  // The "brand" variant is the project's primary CTA — the purple
+  // bg-brand-primary + bg-hover-accent on hover. Centralizing the styling
+  // in the Button's variant system lets every primary submit/Add button
+  // declare `variant="brand"` instead of repeating the className string.
+  test("variant='brand' applies the brand primary styling", async () => {
+    const { container } = await setup(<Button variant="brand">Submit</Button>);
+    const btn = container.querySelector("button") as HTMLButtonElement;
+    expect(btn.className).toContain("bg-brand-primary");
+    expect(btn.className).toContain("hover:bg-hover-accent");
+  });
+
+  // Picking variant="brand" should NOT pick up the shadcn default variant
+  // classes — variants are mutually exclusive.
+  test("variant='brand' does not include the default variant's bg-primary", async () => {
+    const { container } = await setup(<Button variant="brand">Submit</Button>);
+    const btn = container.querySelector("button") as HTMLButtonElement;
+    // The default variant uses `bg-primary` (semantic shadcn token); brand
+    // uses `bg-brand-primary`. Match-by-word to avoid `bg-brand-primary`
+    // false-positive matching `bg-primary`.
+    expect(btn.className).not.toMatch(/(^|\s)bg-primary(\s|$)/);
+  });
+
+  // The "cancel" variant is the project's secondary "back / dismiss"
+  // button — outlined with the dark-theme border, secondary text color,
+  // and a fill-on-hover transition that signals the affordance.
+  test("variant='cancel' applies the outlined cancel styling with hover state", async () => {
+    const { container } = await setup(<Button variant="cancel">Cancel</Button>);
+    const btn = container.querySelector("button") as HTMLButtonElement;
+    expect(btn.className).toContain("border-content-bg-secondary");
+    expect(btn.className).toContain("text-content-text-secondary");
+    expect(btn.className).toContain("hover:bg-content-bg-secondary");
+    expect(btn.className).toContain("hover:text-content-text-primary");
+  });
+});

--- a/apps/web/app/components/ui/button.tsx
+++ b/apps/web/app/components/ui/button.tsx
@@ -10,6 +10,15 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        // The project's primary CTA — purple brand bg with the darker
+        // `hover-accent` token on hover. Used for "Save", "Update",
+        // "Add Track", etc. across the admin forms.
+        brand: "bg-brand-primary text-content-text-primary hover:bg-hover-accent",
+        // Secondary "Cancel / back / dismiss" CTA — outlined dark-theme
+        // border with a fill-on-hover transition. Paired with `variant="brand"`
+        // submits across the admin forms.
+        cancel:
+          "border border-content-bg-secondary bg-transparent text-content-text-secondary hover:bg-content-bg-secondary hover:text-content-text-primary",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",

--- a/apps/web/app/components/ui/data-table.test.tsx
+++ b/apps/web/app/components/ui/data-table.test.tsx
@@ -2,7 +2,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { setup } from "@test/test-utils";
 import { screen } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
-import { DataTable } from "./data-table";
+import { computeColumnWidths, DataTable } from "./data-table";
 
 type Row = { id: string; name: string; count: number };
 
@@ -208,11 +208,16 @@ describe("DataTable", () => {
     expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
   });
 
-  // Columns marked `meta.hideOnMobile` get `hidden sm:table-cell` on both
-  // the header and body cells so they disappear at narrow viewports without
-  // needing a separate mobile column set. Used for the perf-table Notes
-  // column and other long-text columns that crowd phones.
-  test("hideOnMobile meta adds hidden sm:table-cell to header and body cells", async () => {
+  // Columns marked `meta.hideOnMobile` are dropped from rendering below the
+  // `sm` breakpoint — driven through TanStack's `columnVisibility` (not CSS
+  // `hidden sm:table-cell`) so the `<colgroup>` indices stay aligned with
+  // the actually-rendered TDs.
+  //
+  // jsdom doesn't fire ResizeObserver, so wrapperWidth stays 0 here. The
+  // gating treats unmeasured (wrapperWidth=0) as desktop — preferring a
+  // full render over preemptive hiding. So in this test the hideOnMobile
+  // column should still render.
+  test("hideOnMobile meta column renders by default (wrapper unmeasured)", async () => {
     const columnsWithHidden: ColumnDef<Row>[] = [
       { accessorKey: "name", header: "Name" },
       { accessorKey: "count", header: "Count", meta: { hideOnMobile: true } },
@@ -220,47 +225,83 @@ describe("DataTable", () => {
 
     await setup(<DataTable columns={columnsWithHidden} data={rows} hideSearch />);
 
-    const countHeader = screen.getByText("Count").closest("th");
-    expect(countHeader?.className).toContain("hidden");
-    expect(countHeader?.className).toContain("sm:table-cell");
-
-    const nameHeader = screen.getByText("Name").closest("th");
-    expect(nameHeader?.className ?? "").not.toContain("hidden");
-
-    const countCell = screen.getByText("3").closest("td");
-    expect(countCell?.className).toContain("hidden");
-    expect(countCell?.className).toContain("sm:table-cell");
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Count")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
   });
 
-  // The table uses `table-auto` on mobile (lets columns size to content,
-  // avoiding header overlap) and `table-fixed` at sm+ (keeps the
-  // percentage-width sizing predictable on desktop).
-  test("table element uses table-auto on mobile and sm:table-fixed at sm+", async () => {
-    const { container } = await setup(<DataTable columns={basicColumns} data={rows} hideSearch />);
-
-    const tableEl = container.querySelector("table");
-    expect(tableEl?.className).toContain("table-auto");
-    expect(tableEl?.className).toContain("sm:table-fixed");
-  });
-
-  // `meta.width` is exposed as a CSS custom property and only takes effect
-  // at sm+ via a Tailwind class — on mobile the column sizes to content.
-  // Without this gating, desktop-tuned widths would starve other columns
-  // at phone widths (the bug observed on /songs/all-timers and /on-this-day).
-  test("honors meta.width via --col-w + sm:w-[var(--col-w)] on column defs", async () => {
-    const columnsWithWidths: ColumnDef<Row>[] = [
-      { accessorKey: "name", header: "Name", meta: { width: "60%" } },
-      { accessorKey: "count", header: "Count", meta: { width: "40%" } },
+  // Column widths come from a <colgroup>. Each column uses either a
+  // `fixedWidth` (CSS length, applied verbatim) or a `weight` (share of
+  // pixel space left after fixed-width columns claim theirs). The wrapper
+  // width is measured at runtime via ResizeObserver; on first paint
+  // (before measurement) widths fall back to relative percentages.
+  test("first-paint render uses percentage widths for flex columns", async () => {
+    const columnsWithWeights: ColumnDef<Row>[] = [
+      { accessorKey: "name", header: "Name", meta: { weight: 3 } },
+      { accessorKey: "count", header: "Count" /* default weight 1 */ },
     ];
 
-    await setup(<DataTable columns={columnsWithWidths} data={rows} hideSearch />);
+    const { container } = await setup(<DataTable columns={columnsWithWeights} data={rows} hideSearch />);
 
-    const nameHeader = screen.getByText("Name").closest("th");
-    const countHeader = screen.getByText("Count").closest("th");
+    const cols = container.querySelectorAll("colgroup col");
+    expect(cols).toHaveLength(2);
+    // 3 of 4 total weight = 75%; 1 of 4 = 25%. (jsdom doesn't fire
+    // ResizeObserver, so we stay on the percentage fallback path.)
+    expect((cols[0] as HTMLElement).style.width).toBe("75%");
+    expect((cols[1] as HTMLElement).style.width).toBe("25%");
+  });
 
-    expect(nameHeader?.style.getPropertyValue("--col-w")).toBe("60%");
-    expect(countHeader?.style.getPropertyValue("--col-w")).toBe("40%");
-    expect(nameHeader?.className).toContain("sm:w-[var(--col-w)]");
-    expect(countHeader?.className).toContain("sm:w-[var(--col-w)]");
+  // Fixed-width columns get their declared length verbatim regardless of
+  // measurement state — flex columns share whatever's left.
+  test("fixedWidth columns get their length verbatim", async () => {
+    const columns: ColumnDef<Row>[] = [
+      { accessorKey: "name", header: "Name" /* flex weight 1 */ },
+      { accessorKey: "count", header: "Count", meta: { fixedWidth: "3rem" } },
+    ];
+
+    const { container } = await setup(<DataTable columns={columns} data={rows} hideSearch />);
+
+    const cols = container.querySelectorAll("colgroup col");
+    expect((cols[0] as HTMLElement).style.width).toBe("100%");
+    expect((cols[1] as HTMLElement).style.width).toBe("3rem");
+  });
+});
+
+describe("computeColumnWidths", () => {
+  // The DOM render path is exercised in the DataTable tests above but
+  // only on the pre-measurement (percentage) branch — jsdom doesn't fire
+  // ResizeObserver. Drive the post-measurement branch directly so we
+  // catch regressions in the pixel math: fixedWidth columns get their
+  // declared length, the rest split the remainder by weight.
+  type R = { id: string };
+  const c = (
+    id: string,
+    meta?: { weight?: number; fixedWidth?: string },
+  ): { id: string; columnDef: ColumnDef<R, unknown> } => ({
+    id,
+    columnDef: { id, meta } as ColumnDef<R, unknown>,
+  });
+
+  test("with a measured wrapper, flex columns split leftover pixels by weight", () => {
+    const cols = [c("song", { weight: 3 }), c("date", { weight: 1 })];
+    const widths = computeColumnWidths<R, unknown>(cols, /* wrapperWidth */ 1000, /* rootFontSize */ 16);
+    // 100% goes to flex; song gets 3/4 = 750px, date gets 250px.
+    expect(widths).toEqual(["750px", "250px"]);
+  });
+
+  test("fixedWidth columns subtract from leftover; flex columns share the rest", () => {
+    const cols = [c("song", { weight: 3 }), c("plays", { fixedWidth: "4rem" }), c("date", { weight: 1 })];
+    // 4rem = 64px at 16px root; leftover = 1000-64 = 936; song gets 3/4 = 702, date 234.
+    const widths = computeColumnWidths<R, unknown>(cols, 1000, 16);
+    expect(widths).toEqual(["702px", "4rem", "234px"]);
+  });
+
+  test("wrapperWidth=0 (SSR / first paint) falls back to percentage shares for flex columns", () => {
+    const cols = [c("song", { weight: 3 }), c("plays", { fixedWidth: "4rem" }), c("date", { weight: 1 })];
+    const widths = computeColumnWidths<R, unknown>(cols, 0, 16);
+    // Pixel math is suppressed; flex shares fall back to percentages of the full container.
+    // Fixed col still applied. The shares ignore the fixedWidth and may sum > 100% for
+    // a single frame before measurement takes over — intentional, documented in the helper.
+    expect(widths).toEqual(["75%", "4rem", "25%"]);
   });
 });

--- a/apps/web/app/components/ui/data-table.tsx
+++ b/apps/web/app/components/ui/data-table.tsx
@@ -15,18 +15,114 @@ import {
 declare module "@tanstack/react-table" {
   // biome-ignore lint/correctness/noUnusedVariables: required by TanStack's module augmentation pattern
   interface ColumnMeta<TData extends RowData, TValue> {
-    width?: string;
+    /**
+     * Fixed width for this column under `table-layout: fixed` — typically
+     * a `rem` value sized to the column's expected content (e.g. `"3rem"`
+     * for short numbers like "378", `"1.5rem"` for an icon-only column).
+     * Fixed columns never grow or shrink with the table. Leftover space
+     * is divided among the remaining (flex) columns by `weight`.
+     */
+    fixedWidth?: string;
+    /**
+     * Optional mobile override for `fixedWidth`. Applied below the `sm`
+     * breakpoint when the column would otherwise crowd siblings — e.g.
+     * the Rating column wants 8rem on desktop to give the rating-count
+     * button breathing room, but 5rem on phones so Song Before / After
+     * can still hold a word per line.
+     */
+    mobileFixedWidth?: string;
+    /**
+     * Relative share of *leftover* horizontal space — what's left after
+     * fixed-width columns claim theirs. Defaults to 1. Use > 1 for columns
+     * holding long free text (titles, notes); < 1 to bias against. Ignored
+     * when `fixedWidth` is set.
+     */
+    weight?: number;
     cellClassName?: string;
+    /**
+     * Optional extra classes for the header `<th>`. Use when the column
+     * needs to override the default padding so the declared
+     * `fixedWidth` / `mobileFixedWidth` actually controls the cell box
+     * (e.g. icon-only columns with `cellClassName: "!px-0"` want the
+     * matching `headerClassName: "!px-0"`).
+     */
+    headerClassName?: string;
     hideOnMobile?: boolean;
   }
 }
 
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 
 import { Input } from "~/components/ui/input";
 import { PaginationControls } from "~/components/ui/pagination-controls";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/ui/table";
 import { cn } from "~/lib/utils";
+
+/**
+ * Convert a CSS length value (currently `rem` or `px`) to pixels. `rem`
+ * resolves against the root font-size; `px` returns the number as-is.
+ * Only the units actually used by `meta.fixedWidth` callers in this
+ * codebase are supported on purpose — adding more units (`em`, `%`,
+ * viewport units) would invite calling code to depend on context that
+ * isn't reliably available at column-width compute time.
+ */
+function cssLengthToPx(value: string, rootFontSize: number): number {
+  const trimmed = value.trim();
+  if (trimmed.endsWith("rem")) return parseFloat(trimmed) * rootFontSize;
+  if (trimmed.endsWith("px")) return parseFloat(trimmed);
+  return parseFloat(trimmed) || 0;
+}
+
+/**
+ * Tailwind's `sm` breakpoint. Columns with `meta.hideOnMobile` are
+ * dropped from rendering entirely below this width via TanStack's
+ * `columnVisibility` — driving it through TanStack (rather than CSS
+ * `hidden sm:table-cell`) keeps `<colgroup>` indices aligned with the
+ * actually-rendered TDs, so `<col>` widths land on the right columns.
+ */
+const SM_BREAKPOINT_PX = 640;
+
+/**
+ * Compute the `width` style for each visible leaf column. Columns with
+ * `meta.fixedWidth` get their declared length verbatim; remaining columns
+ * share `wrapperWidth - sum(fixedWidth)` by `meta.weight` (default 1).
+ *
+ * Callers pass `table.getVisibleLeafColumns()`, which already filters
+ * out columns hidden via `columnVisibility` (e.g. `hideOnMobile` at
+ * narrow widths). The math here just trusts that visibility decision.
+ *
+ * `wrapperWidth === 0` happens on SSR and on the first client render
+ * before the ResizeObserver fires; in that window we fall back to plain
+ * percentages so the table still renders. The percentages there can sum
+ * to more than 100% if any column is also fixed-width (the percentage
+ * ignores the fixed columns), but the misalignment lasts one paint
+ * before pixel measurement takes over.
+ */
+export function computeColumnWidths<TData, TValue>(
+  cols: readonly { id: string; columnDef: ColumnDef<TData, TValue> }[],
+  wrapperWidth: number,
+  rootFontSize: number,
+): string[] {
+  const isMobile = wrapperWidth > 0 && wrapperWidth < SM_BREAKPOINT_PX;
+  const fixedFor = (c: (typeof cols)[number]): string | undefined =>
+    (isMobile && c.columnDef.meta?.mobileFixedWidth) || c.columnDef.meta?.fixedWidth;
+
+  const fixedSum = cols.reduce((s, c) => {
+    const fw = fixedFor(c);
+    return fw ? s + cssLengthToPx(fw, rootFontSize) : s;
+  }, 0);
+  const totalWeight = cols.reduce((sum, c) => (fixedFor(c) ? sum : sum + (c.columnDef.meta?.weight ?? 1)), 0);
+  const leftoverPx = Math.max(0, wrapperWidth - fixedSum);
+  const usePixels = wrapperWidth > 0;
+
+  return cols.map((column) => {
+    const fixed = fixedFor(column);
+    if (fixed) return fixed;
+    const weight = column.columnDef.meta?.weight ?? 1;
+    const share = totalWeight > 0 ? weight / totalWeight : 0;
+    return usePixels ? `${share * leftoverPx}px` : `${share * 100}%`;
+  });
+}
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -66,6 +162,44 @@ export function DataTable<TData, TValue>({
   const [sorting, setSorting] = useState<SortingState>(initialSorting ?? []);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+
+  // Measure the table wrapper so col widths can be computed in pixels.
+  // Chrome's `table-layout: fixed` algorithm distributes leftover space
+  // equally across flex `<col>`s when their widths are declared as
+  // `calc()` expressions mixing % and rem — declared `weight` ratios are
+  // ignored. Computing widths in pixels (resolved against the measured
+  // wrapper) sidesteps that algorithm path so weights actually apply.
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [wrapperWidth, setWrapperWidth] = useState<number>(0);
+  useEffect(() => {
+    const el = wrapperRef.current;
+    if (!el) return;
+    setWrapperWidth(el.clientWidth);
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) setWrapperWidth(entry.contentRect.width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Drop `hideOnMobile` columns below the `sm` breakpoint via TanStack's
+  // columnVisibility (not CSS) so `<colgroup>` indices stay aligned with
+  // the rendered TDs — CSS-hiding leaves phantom column slots in the
+  // colgroup that Chrome's table-fixed layout mis-allocates space to.
+  const hideOnMobileColumnIds = columns
+    .map((c) => (c.meta?.hideOnMobile ? (c as { id?: string; accessorKey?: string }) : null))
+    .filter((c): c is { id?: string; accessorKey?: string } => Boolean(c))
+    .map((c) => c.id ?? (c.accessorKey as string))
+    .filter(Boolean) as string[];
+  const isMobile = wrapperWidth > 0 && wrapperWidth < SM_BREAKPOINT_PX;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: hideOnMobileColumnIds is derived from columns and stable across renders for a given table.
+  useEffect(() => {
+    setColumnVisibility((prev) => {
+      const next: VisibilityState = { ...prev };
+      for (const id of hideOnMobileColumnIds) next[id] = !isMobile;
+      return next;
+    });
+  }, [isMobile, hideOnMobileColumnIds.join(",")]);
 
   const table = useReactTable({
     data,
@@ -131,33 +265,36 @@ export function DataTable<TData, TValue>({
 
       {!hidePagination && paginationBlock}
 
-      <div className="overflow-x-auto w-full min-w-0">
-        <Table className="w-full table-auto sm:table-fixed">
+      <div ref={wrapperRef} className="@container/datatable w-full min-w-0">
+        <Table className="w-full">
+          <colgroup>
+            {(() => {
+              const cols = table.getVisibleLeafColumns();
+              const rootFontSize =
+                typeof window === "undefined"
+                  ? 16
+                  : parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+              const widths = computeColumnWidths(cols, wrapperWidth, rootFontSize);
+              return cols.map((column, i) => <col key={column.id} style={{ width: widths[i] }} />);
+            })()}
+          </colgroup>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id} className="text-left text-sm text-content-text-secondary">
-                {headerGroup.headers.map((header) => {
-                  const hideOnMobile = header.column.columnDef.meta?.hideOnMobile;
-                  // Width hint applies only at sm+ — on mobile we let
-                  // table-auto size columns to content. Without this,
-                  // desktop-tuned widths (e.g. 180px for the perf-table
-                  // Date column) would starve other columns on phones.
-                  const width = header.column.columnDef.meta?.width;
-                  const widthStyle = width ? ({ "--col-w": width } as React.CSSProperties) : undefined;
-                  return (
-                    <TableHead
-                      key={header.id}
-                      className={cn(
-                        "px-1.5 py-2 sm:p-3 text-sm text-content-text-secondary align-top",
-                        hideOnMobile && "hidden sm:table-cell",
-                        width && "sm:w-[var(--col-w)]",
-                      )}
-                      style={widthStyle}
-                    >
-                      {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
-                    </TableHead>
-                  );
-                })}
+                {headerGroup.headers.map((header) => (
+                  <TableHead
+                    key={header.id}
+                    // text-xs on mobile keeps multi-word headers ("Last
+                    // Played", "Avg Gap") from forcing fixed-width columns
+                    // wider than their numeric content actually needs.
+                    className={cn(
+                      "px-1.5 py-2 sm:px-2 sm:py-2.5 text-xs sm:text-sm text-content-text-secondary align-top",
+                      header.column.columnDef.meta?.headerClassName,
+                    )}
+                  >
+                    {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
               </TableRow>
             ))}
           </TableHeader>
@@ -184,8 +321,7 @@ export function DataTable<TData, TValue>({
                     <TableCell
                       key={cell.id}
                       className={cn(
-                        "px-1.5 py-2 sm:p-3 align-top break-words",
-                        cell.column.columnDef.meta?.hideOnMobile && "hidden sm:table-cell",
+                        "px-1.5 py-2 sm:px-2 sm:py-2.5 align-top break-words",
                         cell.column.columnDef.meta?.cellClassName,
                       )}
                     >

--- a/apps/web/app/components/ui/filters/select-filter.tsx
+++ b/apps/web/app/components/ui/filters/select-filter.tsx
@@ -1,3 +1,4 @@
+import { glassSelectContentClass, glassSelectItemClass, glassSelectTriggerClass } from "~/components/ui/glass-select";
 import {
   Select,
   SelectContent,
@@ -8,10 +9,6 @@ import {
   SelectValue,
 } from "~/components/ui/select";
 
-const selectTriggerClass =
-  "h-[34px] text-sm bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20";
-const selectContentClass = "bg-glass-bg border-glass-border backdrop-blur-md";
-const selectItemClass = "text-content-text-primary hover:bg-hover-glass";
 const labelClass =
   "text-xs font-medium text-content-text-secondary uppercase tracking-wide mb-1.5 h-[18px] flex items-center";
 const groupLabelClass = "text-xs uppercase text-content-text-tertiary tracking-wide py-1";
@@ -48,12 +45,12 @@ export function SelectFilter({
         {label}
       </label>
       <Select value={value} onValueChange={onValueChange}>
-        <SelectTrigger id={id} className={`${width ?? ""} ${selectTriggerClass}`}>
+        <SelectTrigger id={id} className={`${width ?? ""} ${glassSelectTriggerClass}`}>
           <SelectValue placeholder={placeholder} />
         </SelectTrigger>
-        <SelectContent className={selectContentClass}>
+        <SelectContent className={glassSelectContentClass}>
           {options?.map((option) => (
-            <SelectItem key={option.value} value={option.value} className={selectItemClass}>
+            <SelectItem key={option.value} value={option.value} className={glassSelectItemClass}>
               {option.label}
             </SelectItem>
           ))}
@@ -61,7 +58,7 @@ export function SelectFilter({
             <SelectGroup key={group.label}>
               <SelectLabel className={groupLabelClass}>{group.label}</SelectLabel>
               {group.options.map((option) => (
-                <SelectItem key={option.value} value={option.value} className={selectItemClass}>
+                <SelectItem key={option.value} value={option.value} className={glassSelectItemClass}>
                   {option.label}
                 </SelectItem>
               ))}

--- a/apps/web/app/components/ui/glass-select.test.tsx
+++ b/apps/web/app/components/ui/glass-select.test.tsx
@@ -1,0 +1,62 @@
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { GlassSelect, glassSelectContentClass, glassSelectTriggerClass } from "./glass-select";
+
+const OPTIONS = [
+  { value: "S1", label: "Set 1" },
+  { value: "S2", label: "Set 2" },
+];
+
+describe("GlassSelect", () => {
+  // The trigger button shows the label of the currently-selected option
+  // — verified by rendering with `value` matching an option.
+  test("renders the selected option's label on the trigger", async () => {
+    await setup(<GlassSelect value="S2" onValueChange={vi.fn()} options={OPTIONS} />);
+    expect(screen.getByRole("combobox")).toHaveTextContent("Set 2");
+  });
+
+  // No selection + a placeholder renders the placeholder on the trigger.
+  test("renders the placeholder when no value matches", async () => {
+    await setup(<GlassSelect value="" onValueChange={vi.fn()} options={OPTIONS} placeholder="Pick a set" />);
+    expect(screen.getByRole("combobox")).toHaveTextContent("Pick a set");
+  });
+
+  // Selecting an option fires onValueChange with the option's value (not
+  // its label) so the caller can store the canonical key.
+  test("selecting an option fires onValueChange with the value (not the label)", async () => {
+    const onValueChange = vi.fn();
+    const { user } = await setup(<GlassSelect value="S1" onValueChange={onValueChange} options={OPTIONS} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("Set 2"));
+    expect(onValueChange).toHaveBeenCalledWith("S2");
+  });
+
+  // The trigger applies the project's glass styling so it visually
+  // matches the /songs filter dropdowns and other GlassSelect consumers.
+  test("applies the glass trigger styling", async () => {
+    await setup(<GlassSelect value="S1" onValueChange={vi.fn()} options={OPTIONS} />);
+    const trigger = screen.getByRole("combobox");
+    expect(trigger.className).toContain("bg-glass-bg");
+    expect(trigger.className).toContain("border-glass-border");
+  });
+
+  // The shared className constants are exported so other components
+  // (notably SelectFilter, used on /songs) can reuse them and stay in
+  // visual lockstep with GlassSelect.
+  test("exposes shared class-name constants for sibling components", () => {
+    expect(glassSelectTriggerClass).toContain("bg-glass-bg");
+    expect(glassSelectContentClass).toContain("bg-glass-bg");
+  });
+
+  // Caller-supplied className stacks with the glass classes so layouts
+  // can specify width / sizing without losing the visual treatment.
+  test("merges caller-supplied className with the trigger's glass classes", async () => {
+    await setup(<GlassSelect value="S1" onValueChange={vi.fn()} options={OPTIONS} className="w-40" />);
+    const trigger = screen.getByRole("combobox");
+    expect(trigger.className).toContain("w-40");
+    expect(trigger.className).toContain("bg-glass-bg");
+  });
+});

--- a/apps/web/app/components/ui/glass-select.tsx
+++ b/apps/web/app/components/ui/glass-select.tsx
@@ -1,0 +1,53 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
+import { cn } from "~/lib/utils";
+
+export const glassSelectTriggerClass =
+  "h-[34px] text-sm bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20";
+export const glassSelectContentClass = "bg-glass-bg border-glass-border backdrop-blur-md";
+export const glassSelectItemClass = "text-content-text-primary hover:bg-hover-glass";
+
+export interface GlassSelectOption {
+  value: string;
+  label: string;
+}
+
+interface GlassSelectProps {
+  id?: string;
+  value: string;
+  onValueChange: (value: string) => void;
+  options: GlassSelectOption[];
+  placeholder?: string;
+  className?: string;
+  ariaLabel?: string;
+}
+
+/**
+ * Standard select dropdown with the project's "glass" styling — same trigger
+ * and popover treatment as the filter dropdowns on /songs (Time Range, Cover,
+ * Author). Use this anywhere a finite-option select is needed so dropdowns
+ * stay visually consistent across pages.
+ */
+export function GlassSelect({
+  id,
+  value,
+  onValueChange,
+  options,
+  placeholder,
+  className,
+  ariaLabel,
+}: GlassSelectProps) {
+  return (
+    <Select value={value} onValueChange={onValueChange}>
+      <SelectTrigger id={id} aria-label={ariaLabel} className={cn(glassSelectTriggerClass, className)}>
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent className={glassSelectContentClass}>
+        {options.map((option) => (
+          <SelectItem key={option.value} value={option.value} className={glassSelectItemClass}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/web/app/components/ui/search-picker.test.tsx
+++ b/apps/web/app/components/ui/search-picker.test.tsx
@@ -1,0 +1,232 @@
+import { setup } from "@test/test-utils";
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { SearchPicker } from "./search-picker";
+
+interface Item {
+  id: string;
+  name: string;
+}
+
+const ITEMS: Item[] = [
+  { id: "1", name: "Apple" },
+  { id: "2", name: "Banana" },
+  { id: "3", name: "Cherry" },
+];
+
+// Default props shared across happy-path tests. Individual tests override
+// only the props they need so each test reads as a delta from the baseline.
+function baseProps(overrides: Partial<React.ComponentProps<typeof SearchPicker<Item>>> = {}) {
+  return {
+    value: null,
+    onValueChange: vi.fn(),
+    fetchResults: vi.fn().mockResolvedValue([]),
+    itemId: (item: Item) => item.id,
+    itemLabel: (item: Item) => item.name,
+    placeholder: "Pick one…",
+    ...overrides,
+  };
+}
+
+describe("SearchPicker", () => {
+  // Renders the placeholder when no value is selected and no initial item
+  // is provided. This is the cold-start state for most pickers.
+  test("renders the placeholder when value is null and no initial item", async () => {
+    await setup(<SearchPicker<Item> {...baseProps({ placeholder: "Pick a fruit" })} />);
+    expect(screen.getByRole("combobox")).toHaveTextContent("Pick a fruit");
+  });
+
+  // When an initial item is provided (the caller already has the record),
+  // the trigger shows its label without waiting for the user to interact.
+  test("renders the initial item's label on the trigger", async () => {
+    await setup(<SearchPicker<Item> {...baseProps({ value: "1", initialItem: { id: "1", name: "Apple" } })} />);
+    expect(screen.getByRole("combobox")).toHaveTextContent("Apple");
+  });
+
+  // When only `fetchById` is provided (no initialItem), the trigger seeds
+  // its label asynchronously. Useful for forms that only know the id.
+  test("seeds the trigger label by calling fetchById", async () => {
+    const fetchById = vi.fn().mockResolvedValue({ id: "2", name: "Banana" });
+
+    await setup(<SearchPicker<Item> {...baseProps({ value: "2", fetchById })} />);
+
+    await waitFor(() => expect(fetchById).toHaveBeenCalledWith("2"));
+    await waitFor(() => expect(screen.getByRole("combobox")).toHaveTextContent("Banana"));
+  });
+
+  // Debounce contract: fetchResults fires after a 300ms quiet period, not
+  // on every keystroke. We assert via the call count after waiting past
+  // the debounce window. Real timers keep this aligned with production
+  // behavior — fake timers + cmdk's internal scheduling fight each other.
+  test("debounces fetchResults so a burst of input collapses to one call", async () => {
+    const fetchResults = vi.fn().mockResolvedValue(ITEMS);
+
+    const { user } = await setup(<SearchPicker<Item> {...baseProps({ fetchResults })} />);
+
+    // Mount fires the initial empty-query fetch via the debounced effect.
+    await waitFor(() => expect(fetchResults).toHaveBeenCalledWith(""));
+    fetchResults.mockClear();
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search…");
+    await user.type(input, "app");
+
+    await waitFor(() => expect(fetchResults).toHaveBeenCalledWith("app"), { timeout: 1500 });
+    // The intermediate "a" and "ap" debounced away — at most one call for
+    // the final query (a small amount of slop is fine because user.type
+    // delays between keystrokes).
+    const appCalls = fetchResults.mock.calls.filter((args) => args[0] === "app");
+    expect(appCalls.length).toBe(1);
+  });
+
+  // Clicking an item reports its id via onValueChange and closes the
+  // popover. This is the core selection path the wrappers depend on.
+  test("clicking a result fires onValueChange with the item id and closes the popover", async () => {
+    const onValueChange = vi.fn();
+    const fetchResults = vi.fn().mockResolvedValue(ITEMS);
+
+    const { user } = await setup(<SearchPicker<Item> {...baseProps({ onValueChange, fetchResults })} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const cherry = await screen.findByText("Cherry");
+    await user.click(cherry);
+
+    expect(onValueChange).toHaveBeenCalledWith("3");
+    await waitFor(() => expect(screen.queryByPlaceholderText("Search…")).not.toBeInTheDocument());
+  });
+
+  // When `noneLabel` is set, an extra clear-selection row appears at the
+  // top of the list. Selecting it fires onValueChange(null) so callers
+  // can drop the current selection.
+  test("noneLabel renders a clear-selection row that reports null", async () => {
+    const onValueChange = vi.fn();
+    const fetchResults = vi.fn().mockResolvedValue(ITEMS);
+
+    const { user } = await setup(
+      <SearchPicker<Item> {...baseProps({ value: "1", onValueChange, fetchResults, noneLabel: "Clear" })} />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("Clear"));
+
+    expect(onValueChange).toHaveBeenCalledWith(null);
+  });
+
+  // Without `noneLabel`, the clear row is suppressed entirely. Pickers
+  // that require a selection use this to prevent accidental clearing.
+  test("noneLabel undefined suppresses the clear-selection row", async () => {
+    const fetchResults = vi.fn().mockResolvedValue(ITEMS);
+
+    const { user } = await setup(<SearchPicker<Item> {...baseProps({ fetchResults })} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await screen.findByText("Apple");
+    expect(screen.queryByText("Clear")).not.toBeInTheDocument();
+    expect(screen.queryByText(/^No /)).not.toBeInTheDocument();
+  });
+
+  // `loadOnOpen` triggers an immediate fetch when the popover opens —
+  // bypassing the debounce delay — so wrappers like AuthorSearch can
+  // populate a top-N list before the user types anything.
+  test("loadOnOpen fires fetchResults('') immediately on open", async () => {
+    const fetchResults = vi.fn().mockResolvedValue(ITEMS);
+
+    const { user } = await setup(<SearchPicker<Item> {...baseProps({ fetchResults, loadOnOpen: true })} />);
+
+    // Drain the initial mount fetch so we don't conflate it with the open.
+    await waitFor(() => expect(fetchResults).toHaveBeenCalled());
+    fetchResults.mockClear();
+
+    await user.click(screen.getByRole("combobox"));
+    await waitFor(() => expect(fetchResults).toHaveBeenCalledWith(""));
+  });
+
+  // `emptyMessage` accepts a function of the current query so wrappers
+  // can show "Type to search…" until the query is long enough, then
+  // "No results." when it is.
+  test("emptyMessage function receives the current query", async () => {
+    const fetchResults = vi.fn().mockResolvedValue([]);
+
+    const { user } = await setup(
+      <SearchPicker<Item>
+        {...baseProps({
+          fetchResults,
+          emptyMessage: (q) => (q.length < 2 ? "Type more" : "No matches"),
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    expect(await screen.findByText("Type more")).toBeInTheDocument();
+
+    const input = screen.getByPlaceholderText("Search…");
+    await user.type(input, "xyz");
+    expect(await screen.findByText("No matches", undefined, { timeout: 1500 })).toBeInTheDocument();
+  });
+
+  // `allowCreate` exposes a "Create …" row at the top of the list. Default
+  // shouldShow requires 2+ trimmed chars and no exact-match in items.
+  test("allowCreate shows a create row at 2+ chars when no exact match exists", async () => {
+    const fetchResults = vi.fn().mockResolvedValue([]);
+    const onCreate = vi.fn().mockResolvedValue({ id: "9", name: "Durian" });
+    const onValueChange = vi.fn();
+
+    const { user } = await setup(
+      <SearchPicker<Item>
+        {...baseProps({
+          fetchResults,
+          onValueChange,
+          allowCreate: { label: (q) => `Create "${q}"`, onCreate },
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search…");
+    await user.type(input, "Du");
+
+    const createRow = await screen.findByText('Create "Du"', undefined, { timeout: 1500 });
+    await user.click(createRow);
+
+    await waitFor(() => expect(onCreate).toHaveBeenCalledWith("Du"));
+    await waitFor(() => expect(onValueChange).toHaveBeenCalledWith("9"));
+  });
+
+  // Default shouldShow hides the create row when the query matches an
+  // existing item exactly (case-insensitive). Prevents duplicate creation
+  // when the user typed something already in the catalog.
+  test("allowCreate hides the create row when an exact match already exists", async () => {
+    const fetchResults = vi.fn().mockResolvedValue([{ id: "1", name: "Apple" }]);
+
+    const { user } = await setup(
+      <SearchPicker<Item>
+        {...baseProps({
+          fetchResults,
+          allowCreate: { label: (q) => `Create "${q}"`, onCreate: vi.fn() },
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search…");
+    await user.type(input, "apple");
+
+    // Give the debounce + fetch a chance to settle; the existing item is
+    // already in items so the create row should never appear.
+    await screen.findByText("Apple");
+    expect(screen.queryByText(/Create "/)).not.toBeInTheDocument();
+  });
+
+  // fetchResults rejecting (e.g. server 500) is handled gracefully: items
+  // clear and the configured emptyMessage shows. Prevents a transient
+  // network error from corrupting the local items list.
+  test("fetchResults rejecting clears the list without surfacing the error", async () => {
+    const fetchResults = vi.fn().mockRejectedValue(new Error("network down"));
+
+    const { user } = await setup(<SearchPicker<Item> {...baseProps({ fetchResults, emptyMessage: "no results" })} />);
+
+    await user.click(screen.getByRole("combobox"));
+    expect(await screen.findByText("no results")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/ui/search-picker.tsx
+++ b/apps/web/app/components/ui/search-picker.tsx
@@ -1,0 +1,270 @@
+import { Check, ChevronsUpDown, Plus } from "lucide-react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
+import { Button } from "~/components/ui/button";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "~/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
+import { cn } from "~/lib/utils";
+
+export interface SearchPickerCreateOption<T> {
+  // Built from the current query — e.g. `Create "Foo"`.
+  label: (query: string) => string;
+  // Called when the user clicks the create option. Returns the new item, or
+  // null if creation failed. On success, the new item is selected and the
+  // popover closes.
+  onCreate: (query: string) => Promise<T | null>;
+  // Optional predicate to decide whether the create option should show.
+  // Default: query has at least 2 trimmed chars AND no existing item
+  // already matches the query exactly via itemLabel comparison.
+  shouldShow?: (query: string, items: T[]) => boolean;
+}
+
+interface SearchPickerProps<T> {
+  // The selected item's id, or null when nothing is selected.
+  value: string | null;
+  onValueChange: (value: string | null) => void;
+
+  // Returns items matching the current query. Wrappers decide what "empty
+  // query" means — return [] to suppress the list, or return top-N items.
+  fetchResults: (query: string) => Promise<T[]>;
+  // Optional: fetch by id so the trigger label can render before the user
+  // opens the popover. Use this OR `initialItem`.
+  fetchById?: (id: string) => Promise<T | null>;
+  // Pre-seeded initial item — alternative to `fetchById` when the caller
+  // already has the full record (e.g. from a parent loader).
+  initialItem?: T | null;
+
+  itemId: (item: T) => string;
+  itemLabel: (item: T) => ReactNode;
+
+  // Optional clear-selection row at the top of the list. When set, a row
+  // with this label is rendered first; selecting it fires onValueChange(null).
+  noneLabel?: string;
+
+  // Optional create-from-query affordance (AuthorSearch's feature). When
+  // provided, a "Create …" row appears at the top of the list whenever
+  // `shouldShow` returns true.
+  allowCreate?: SearchPickerCreateOption<T>;
+
+  // If true, fires fetchResults("") as soon as the popover opens — used
+  // when the wrapper wants to seed a top-N list before the user types.
+  loadOnOpen?: boolean;
+
+  placeholder?: string;
+  searchPlaceholder?: string;
+  // Static message OR function of the current query. The function form
+  // lets wrappers say things like "Type to search…" until the query is
+  // long enough, then "No results."
+  emptyMessage?: string | ((query: string) => string);
+  loadingMessage?: string;
+
+  className?: string;
+}
+
+/**
+ * Generic popover-combobox for picking a single item from an async search.
+ * Powers AuthorSearch, SongSearch, VenueSearch (and any future "pick a thing
+ * by typing to search" UI). The wrapper supplies the domain-specific bits
+ * (API endpoint, item shape, copy); this component owns the popover shell,
+ * debounced search, selection state, and "glass" styling so all three look
+ * and feel the same.
+ */
+export function SearchPicker<T>({
+  value,
+  onValueChange,
+  fetchResults,
+  fetchById,
+  initialItem,
+  itemId,
+  itemLabel,
+  noneLabel,
+  allowCreate,
+  loadOnOpen = false,
+  placeholder = "Search…",
+  searchPlaceholder = "Search…",
+  emptyMessage = "No results found.",
+  loadingMessage = "Searching…",
+  className,
+}: SearchPickerProps<T>) {
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState<T[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [currentItem, setCurrentItem] = useState<T | null>(initialItem ?? null);
+  const [hasLoadedInitial, setHasLoadedInitial] = useState(false);
+
+  // Pick the matching item from the latest results, falling back to the
+  // pre-seeded `currentItem` (initialItem or fetched-by-id).
+  const selectedItem = (value != null && items.find((it) => itemId(it) === value)) || currentItem;
+
+  // Seed the trigger label by fetching the selected item by id when it
+  // isn't in `items` and no `initialItem` was provided. Re-runs whenever
+  // `value` changes so route navigations / form resets stay in sync.
+  useEffect(() => {
+    if (!fetchById) return;
+    if (value == null) {
+      setCurrentItem(initialItem ?? null);
+      return;
+    }
+    if (currentItem && itemId(currentItem) === value) return;
+    if (items.find((it) => itemId(it) === value)) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const fetched = await fetchById(value);
+        if (!cancelled && fetched) setCurrentItem(fetched);
+      } catch {
+        // Trigger keeps placeholder if the fetch fails — non-fatal.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [value, fetchById, currentItem, items, itemId, initialItem]);
+
+  const runSearch = useCallback(
+    async (query: string) => {
+      setLoading(true);
+      try {
+        const next = await fetchResults(query);
+        setItems(next);
+      } catch {
+        // Empty results on failure; UI shows the configured empty message.
+        setItems([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [fetchResults],
+  );
+
+  // Debounce the search so we don't spam the API on every keystroke.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      runSearch(searchQuery);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery, runSearch]);
+
+  // Optional load-on-open: triggers the first fetch immediately (without
+  // waiting for the debounce) so the user sees a populated list before
+  // they start typing.
+  useEffect(() => {
+    if (open && loadOnOpen && !hasLoadedInitial) {
+      setHasLoadedInitial(true);
+      runSearch("");
+    }
+  }, [open, loadOnOpen, hasLoadedInitial, runSearch]);
+
+  const defaultShouldShowCreate = (query: string, currentItems: T[]) => {
+    const trimmed = query.trim();
+    if (trimmed.length < 2) return false;
+    return !currentItems.some((item) => {
+      const label = itemLabel(item);
+      return typeof label === "string" && label.toLowerCase() === trimmed.toLowerCase();
+    });
+  };
+
+  const showCreate = allowCreate != null && (allowCreate.shouldShow ?? defaultShouldShowCreate)(searchQuery, items);
+
+  const handleCreate = async () => {
+    if (!allowCreate || !searchQuery.trim() || creating) return;
+    setCreating(true);
+    try {
+      const created = await allowCreate.onCreate(searchQuery.trim());
+      if (created) {
+        setItems((prev) => [created, ...prev]);
+        onValueChange(itemId(created));
+        setCurrentItem(created);
+        setSearchQuery("");
+        setOpen(false);
+      }
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const resolveEmptyMessage = () => {
+    if (creating) return "Creating…";
+    if (loading) return loadingMessage;
+    return typeof emptyMessage === "function" ? emptyMessage(searchQuery) : emptyMessage;
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className={cn(
+            "justify-between bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20",
+            className,
+          )}
+        >
+          <span className="truncate">{selectedItem ? itemLabel(selectedItem) : placeholder}</span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="p-0 bg-glass-bg backdrop-blur-md border border-glass-border" align="start">
+        <Command className="bg-transparent" shouldFilter={false}>
+          <CommandInput
+            placeholder={searchPlaceholder}
+            value={searchQuery}
+            onValueChange={setSearchQuery}
+            className="text-white"
+          />
+          <CommandList className="max-h-[300px] overflow-auto">
+            <CommandEmpty>{resolveEmptyMessage()}</CommandEmpty>
+            <CommandGroup>
+              {noneLabel != null && (
+                <CommandItem
+                  value="__none__"
+                  onSelect={() => {
+                    onValueChange(null);
+                    setOpen(false);
+                  }}
+                  className="text-content-text-primary hover:bg-hover-glass"
+                >
+                  <Check className={cn("mr-2 h-4 w-4", value == null ? "opacity-100" : "opacity-0")} />
+                  {noneLabel}
+                </CommandItem>
+              )}
+
+              {showCreate && allowCreate && (
+                <CommandItem
+                  value={`__create__:${searchQuery}`}
+                  onSelect={handleCreate}
+                  className="text-brand-primary hover:bg-hover-glass font-medium"
+                >
+                  <Plus className="mr-2 h-4 w-4" />
+                  {allowCreate.label(searchQuery)}
+                </CommandItem>
+              )}
+
+              {items.map((item) => {
+                const id = itemId(item);
+                return (
+                  <CommandItem
+                    key={id}
+                    value={id}
+                    onSelect={() => {
+                      onValueChange(id);
+                      setCurrentItem(item);
+                      setOpen(false);
+                    }}
+                    className="text-content-text-primary hover:bg-hover-glass"
+                  >
+                    <Check className={cn("mr-2 h-4 w-4", value === id ? "opacity-100" : "opacity-0")} />
+                    {itemLabel(item)}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/app/components/ui/sortable-header.tsx
+++ b/apps/web/app/components/ui/sortable-header.tsx
@@ -1,5 +1,6 @@
 import type { Column } from "@tanstack/react-table";
 import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon } from "lucide-react";
+import type { ReactNode } from "react";
 
 /**
  * Header cell that toggles its column's sort direction on click. Renders
@@ -8,22 +9,25 @@ import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon } from "lucide-react";
  * as plain text so callers can use this for every header without branching.
  * Generic over the row shape — works for any TanStack `Column<T>`.
  */
-export function SortableHeader<T>({ column, label }: { column: Column<T, unknown>; label: string }) {
+export function SortableHeader<T>({ column, label }: { column: Column<T, unknown>; label: ReactNode }) {
   if (!column.getCanSort()) return <span>{label}</span>;
   return (
     <button
       type="button"
-      className="cursor-pointer select-none hover:text-content-text-primary text-left"
+      // `flex flex-wrap` so the sort arrow drops onto its own line when
+      // the column gets too narrow to hold both label + arrow inline
+      // (lets narrow columns like Set squeeze to 1.5rem on mobile).
+      className="cursor-pointer select-none hover:text-content-text-primary text-left flex flex-wrap items-start gap-x-1"
       onClick={() => column.toggleSorting()}
     >
       <span className={column.getIsSorted() ? "text-content-text-primary font-semibold" : ""}>{label}</span>
-      <span className={column.getIsSorted() ? "text-brand-primary ml-1" : "ml-1"}>
+      <span className={column.getIsSorted() ? "text-brand-primary" : ""}>
         {column.getIsSorted() === "asc" ? (
-          <ArrowUpIcon className="h-4 w-4 inline" />
+          <ArrowUpIcon className="h-3 w-3 sm:h-4 sm:w-4 inline" />
         ) : column.getIsSorted() === "desc" ? (
-          <ArrowDownIcon className="h-4 w-4 inline" />
+          <ArrowDownIcon className="h-3 w-3 sm:h-4 sm:w-4 inline" />
         ) : (
-          <ArrowUpDown className="h-4 w-4 inline" />
+          <ArrowUpDown className="h-3 w-3 sm:h-4 sm:w-4 inline" />
         )}
       </span>
     </button>

--- a/apps/web/app/components/ui/star-rating.tsx
+++ b/apps/web/app/components/ui/star-rating.tsx
@@ -346,7 +346,7 @@ const StarIcon = ({
   <div className="relative">
     {/* Empty star (background) */}
     <svg
-      className={cn("w-4 h-4 ms-1", filled || half ? "text-content-text-tertiary" : "text-content-text-tertiary")}
+      className={cn("w-4 h-4", filled || half ? "text-content-text-tertiary" : "text-content-text-tertiary")}
       aria-hidden="true"
       xmlns="http://www.w3.org/2000/svg"
       fill="currentColor"
@@ -366,7 +366,7 @@ const StarIcon = ({
         style={{ animationDelay: delay ? `${delay}ms` : undefined }}
       >
         <svg
-          className={cn("w-4 h-4 ms-1", isAnimating && "animate-star-glow")}
+          className={cn("w-4 h-4", isAnimating && "animate-star-glow")}
           style={{
             animationDelay: delay ? `${delay}ms` : undefined,
             color: "hsl(var(--rating-gold))",

--- a/apps/web/app/components/ui/tabs.tsx
+++ b/apps/web/app/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      "inline-flex cursor-pointer items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
       className,
     )}
     {...props}

--- a/apps/web/app/components/venue/venue-form.test.tsx
+++ b/apps/web/app/components/venue/venue-form.test.tsx
@@ -1,0 +1,154 @@
+import { setupWithRouter } from "@test/test-utils";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { VenueForm } from "./venue-form";
+
+describe("VenueForm", () => {
+  // Default-country branch: with "United States" as the country, the
+  // state field renders as the state-picker dropdown labeled "State"
+  // (not "State/Province"), because we know which list applies.
+  test("renders state as a 'State' dropdown when country is the United States", async () => {
+    await setupWithRouter(<VenueForm onSubmit={vi.fn()} submitLabel="Save" cancelHref="/venues" />);
+
+    // The visible label is exactly "State" + the required marker "*".
+    // It's a <label> with `for=...`; querying via the form-item role
+    // group keeps us off Radix's hidden native `<select>` element.
+    const labels = screen.getAllByText(
+      (_, el) => el?.tagName === "LABEL" && /^State\s*\*?$/.test(el.textContent ?? ""),
+    );
+    expect(labels.length).toBeGreaterThan(0);
+  });
+
+  // Switching to Canada flips the label to "Province" — the wording
+  // matches what Canadian admins expect.
+  test("flips the state field to 'Province' when country becomes Canada", async () => {
+    const { user } = await setupWithRouter(<VenueForm onSubmit={vi.fn()} submitLabel="Save" cancelHref="/venues" />);
+
+    const comboboxes = screen.getAllByRole("combobox");
+    const countryCombobox = comboboxes.find((c) => c.textContent?.includes("United States"));
+    if (!countryCombobox) throw new Error("country combobox not found");
+    await user.click(countryCombobox);
+    // The Radix popover renders options with role="option"; the hidden
+    // native `<option>` Radix injects for accessibility is NOT in the
+    // popover's role tree, so this picks the interactive one.
+    await user.click(await screen.findByRole("option", { name: "Canada" }));
+
+    await waitFor(() => {
+      const provinceLabels = screen.getAllByText(
+        (_, el) => el?.tagName === "LABEL" && /^Province\s*\*?$/.test(el.textContent ?? ""),
+      );
+      expect(provinceLabels.length).toBeGreaterThan(0);
+    });
+  });
+
+  // Any country that isn't US or Canada renders state as a free-text
+  // input labeled "State/Province" — there's no canonical list for
+  // those countries, so the form falls back to manual entry.
+  test("renders state as a free-text input for non-US/Canada countries", async () => {
+    const { user } = await setupWithRouter(<VenueForm onSubmit={vi.fn()} submitLabel="Save" cancelHref="/venues" />);
+
+    const comboboxes = screen.getAllByRole("combobox");
+    const countryCombobox = comboboxes.find((c) => c.textContent?.includes("United States"));
+    if (!countryCombobox) throw new Error("country combobox not found");
+    await user.click(countryCombobox);
+    await user.click(await screen.findByRole("option", { name: "United Kingdom" }));
+
+    await waitFor(() => expect(screen.getByPlaceholderText(/state or province/i)).toBeInTheDocument());
+  });
+
+  // Default values seed the form for the edit flow — the parent route
+  // passes the existing venue and the form renders it pre-populated.
+  test("seeds inputs from defaultValues for the edit flow", async () => {
+    await setupWithRouter(
+      <VenueForm
+        defaultValues={{ name: "Wetlands", city: "New York", state: "NY", country: "United States" }}
+        onSubmit={vi.fn()}
+        submitLabel="Update"
+        cancelHref="/venues"
+      />,
+    );
+
+    expect(screen.getByPlaceholderText(/venue name/i)).toHaveValue("Wetlands");
+    expect(screen.getByPlaceholderText(/enter city/i)).toHaveValue("New York");
+  });
+
+  // Submitting with valid data calls onSubmit with the form values.
+  test("submits the form values via onSubmit when fields are valid", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const { user } = await setupWithRouter(<VenueForm onSubmit={onSubmit} submitLabel="Save" cancelHref="/venues" />);
+
+    // Fill name / city via fireEvent.change (the inputs are controlled
+    // through react-hook-form, which can handle synthetic change events
+    // even when the visible value briefly desyncs).
+    fireEvent.change(screen.getByPlaceholderText(/venue name/i), {
+      target: { value: "Red Rocks" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/enter city/i), {
+      target: { value: "Morrison" },
+    });
+
+    // Pick a state from the dropdown.
+    const comboboxes = screen.getAllByRole("combobox");
+    const stateCombobox = comboboxes.find((c) => c.textContent?.includes("Select state"));
+    if (!stateCombobox) throw new Error("state combobox not found");
+    await user.click(stateCombobox);
+    await user.click(await screen.findByRole("option", { name: "CO" }));
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled();
+      const submitted = onSubmit.mock.calls[0][0];
+      expect(submitted.name).toBe("Red Rocks");
+      expect(submitted.city).toBe("Morrison");
+      expect(submitted.state).toBe("CO");
+      expect(submitted.country).toBe("United States");
+    });
+  });
+
+  // Cities with commas fail Zod validation — the error message bubbles
+  // through FormMessage and the form refuses to call onSubmit.
+  test("rejects cities containing a comma and does not call onSubmit", async () => {
+    const onSubmit = vi.fn();
+    const { user } = await setupWithRouter(<VenueForm onSubmit={onSubmit} submitLabel="Save" cancelHref="/venues" />);
+
+    fireEvent.change(screen.getByPlaceholderText(/venue name/i), {
+      target: { value: "Some Venue" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/enter city/i), {
+      target: { value: "Brooklyn, NY" },
+    });
+
+    const comboboxes = screen.getAllByRole("combobox");
+    const stateCombobox = comboboxes.find((c) => c.textContent?.includes("Select state"));
+    if (!stateCombobox) throw new Error("state combobox not found");
+    await user.click(stateCombobox);
+    await user.click(await screen.findByRole("option", { name: "NY" }));
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(screen.getByText(/should not contain commas/i)).toBeInTheDocument());
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  // US / Canada require a state; if the admin leaves it blank the form
+  // surfaces the schema-level error and refuses to submit.
+  test("requires a state when country is US or Canada", async () => {
+    const onSubmit = vi.fn();
+    const { user } = await setupWithRouter(<VenueForm onSubmit={onSubmit} submitLabel="Save" cancelHref="/venues" />);
+
+    fireEvent.change(screen.getByPlaceholderText(/venue name/i), {
+      target: { value: "Some Venue" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/enter city/i), {
+      target: { value: "Anywhere" },
+    });
+
+    // Don't touch the state combobox. Submit.
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(screen.getByText(/state\/province is required/i)).toBeInTheDocument());
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/components/venue/venue-form.tsx
+++ b/apps/web/app/components/venue/venue-form.tsx
@@ -7,8 +7,9 @@ import { useNavigate } from "react-router-dom";
 import { z } from "zod";
 import { Button } from "~/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "~/components/ui/form";
+import { GlassSelect } from "~/components/ui/glass-select";
 import { Input } from "~/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
+import { formInputClass } from "~/lib/form-styles";
 
 // Create a schema for venue form (omitting auto-generated fields)
 export const venueFormSchema = z
@@ -100,11 +101,7 @@ export function VenueForm({ defaultValues, onSubmit, submitLabel, cancelHref }: 
                 Venue Name <span className="text-error">*</span>
               </FormLabel>
               <FormControl>
-                <Input
-                  placeholder="Enter venue name"
-                  {...field}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
-                />
+                <Input placeholder="Enter venue name" {...field} className={formInputClass} />
               </FormControl>
               <FormMessage className="text-error" />
             </FormItem>
@@ -120,11 +117,7 @@ export function VenueForm({ defaultValues, onSubmit, submitLabel, cancelHref }: 
                 City <span className="text-error">*</span>
               </FormLabel>
               <FormControl>
-                <Input
-                  placeholder="Enter city"
-                  {...field}
-                  className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
-                />
+                <Input placeholder="Enter city" {...field} className={formInputClass} />
               </FormControl>
               <FormMessage className="text-error" />
             </FormItem>
@@ -151,30 +144,20 @@ export function VenueForm({ defaultValues, onSubmit, submitLabel, cancelHref }: 
                 </FormLabel>
                 <FormControl>
                   {isUSOrCanada ? (
-                    <Select
-                      onValueChange={field.onChange}
-                      value={field.value && stateOptions.includes(field.value) ? field.value : ""}
+                    <GlassSelect
                       key={selectedCountry}
-                    >
-                      <SelectTrigger className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary">
-                        <SelectValue
-                          placeholder={`Select ${selectedCountry === "United States" ? "state" : "province"}`}
-                        />
-                      </SelectTrigger>
-                      <SelectContent className="max-h-[200px] overflow-y-auto bg-dropdown border border-border">
-                        {stateOptions.map((option) => (
-                          <SelectItem key={option} value={option} className="text-dropdown hover:bg-dropdown-hover">
-                            {option}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                      value={field.value && stateOptions.includes(field.value) ? field.value : ""}
+                      onValueChange={field.onChange}
+                      options={stateOptions.map((option) => ({ value: option, label: option }))}
+                      placeholder={`Select ${selectedCountry === "United States" ? "state" : "province"}`}
+                      className="w-full"
+                    />
                   ) : (
                     <Input
                       placeholder="Enter state or province (optional)"
                       {...field}
                       value={field.value || ""}
-                      className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary"
+                      className={formInputClass}
                     />
                   )}
                 </FormControl>
@@ -192,35 +175,25 @@ export function VenueForm({ defaultValues, onSubmit, submitLabel, cancelHref }: 
               <FormLabel className="text-content-text-primary">
                 Country <span className="text-error">*</span>
               </FormLabel>
-              <Select onValueChange={field.onChange} value={field.value}>
-                <FormControl>
-                  <SelectTrigger className="bg-content-bg-secondary border-content-bg-secondary text-content-text-primary">
-                    <SelectValue placeholder="Select a country" />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent className="max-h-[200px] overflow-y-auto bg-dropdown border border-border">
-                  {COUNTRIES.map((country) => (
-                    <SelectItem key={country} value={country} className="text-dropdown hover:bg-dropdown-hover">
-                      {country}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <FormControl>
+                <GlassSelect
+                  value={field.value}
+                  onValueChange={field.onChange}
+                  options={COUNTRIES.map((country) => ({ value: country, label: country }))}
+                  placeholder="Select a country"
+                  className="w-full"
+                />
+              </FormControl>
               <FormMessage className="text-error" />
             </FormItem>
           )}
         />
 
         <div className="flex gap-4 pt-2">
-          <Button type="submit" className="bg-brand-primary hover:bg-hover-accent text-content-text-primary">
+          <Button type="submit" variant="brand">
             {submitLabel}
           </Button>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => navigate(cancelHref)}
-            className="border-border text-foreground hover:bg-accent hover:text-accent-foreground"
-          >
+          <Button type="button" variant="cancel" onClick={() => navigate(cancelHref)}>
             Cancel
           </Button>
         </div>

--- a/apps/web/app/components/venue/venue-search.test.tsx
+++ b/apps/web/app/components/venue/venue-search.test.tsx
@@ -1,0 +1,161 @@
+import type { Venue } from "@bip/domain";
+import { setup } from "@test/test-utils";
+import { screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { VenueSearch } from "./venue-search";
+
+// VenueSearch only reads name/city/state for label formatting; the rest
+// of the Venue shape is irrelevant, so cast through `unknown`.
+function makeVenue(overrides: Partial<Venue> & { id: string; name: string }): Venue {
+  return overrides as unknown as Venue;
+}
+
+describe("VenueSearch", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Same min-query rule as SongSearch: <2 chars never hits the catalog
+  // search endpoint. Below 2 the user sees a "Type to search venues" hint.
+  test("does not call /api/venues for queries shorter than 2 chars", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+
+    const { user } = await setup(<VenueSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search venues...");
+    await user.type(input, "w");
+
+    await new Promise((r) => setTimeout(r, 400));
+    const apiCalls = fetchMock.mock.calls.filter(
+      (c) => String(c[0]).startsWith("/api/venues") && !String(c[0]).match(/\/api\/venues\/[^?]+$/),
+    );
+    expect(apiCalls).toHaveLength(0);
+  });
+
+  // 2+ chars triggers a debounced fetch to /api/venues?q=…
+  test("calls /api/venues?q=… for 2+ char queries", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [] });
+
+    const { user } = await setup(<VenueSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search venues...");
+    await user.type(input, "wet");
+
+    await waitFor(
+      () => {
+        const urls = fetchMock.mock.calls.map((c) => c[0]);
+        expect(urls).toContain("/api/venues?q=wet");
+      },
+      { timeout: 1500 },
+    );
+  });
+
+  // The trigger seeds itself by fetching the selected venue by id so a
+  // pre-existing selection (e.g. from a show edit loader) renders
+  // immediately without opening the popover.
+  test("fetches /api/venues/:id to seed the trigger when value is set", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url === "/api/venues/v1") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeVenue({ id: "v1", name: "Wetlands Preserve", city: "New York", state: "NY" }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => [] } as Response);
+    });
+
+    await setup(<VenueSearch value="v1" onValueChange={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByRole("combobox")).toHaveTextContent("Wetlands Preserve (New York, NY)"));
+  });
+
+  // formatVenueLabel: when city + state are present, the label reads
+  // "Name (City, State)" so visually similar venues in different
+  // locations are distinguishable.
+  test("formats venue label as 'Name (City, State)' when location is present", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => [makeVenue({ id: "v1", name: "Red Rocks", city: "Morrison", state: "CO" })],
+    });
+
+    const { user } = await setup(<VenueSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search venues...");
+    await user.type(input, "red");
+
+    expect(await screen.findByText("Red Rocks (Morrison, CO)", undefined, { timeout: 1500 })).toBeInTheDocument();
+  });
+
+  // formatVenueLabel: when both city and state are missing, the label is
+  // just the venue name — no empty parens.
+  test("formats venue label as just 'Name' when city and state are both missing", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => [makeVenue({ id: "v1", name: "Mystery Venue", city: undefined, state: undefined })],
+    });
+
+    const { user } = await setup(<VenueSearch onValueChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search venues...");
+    await user.type(input, "mys");
+
+    expect(await screen.findByText("Mystery Venue", undefined, { timeout: 1500 })).toBeInTheDocument();
+    // No empty "()" should render.
+    expect(screen.queryByText(/Mystery Venue \(\)/)).not.toBeInTheDocument();
+  });
+
+  // Clear path: "No venue" translates null back to "none" for form-state
+  // compatibility.
+  test("clicking 'No venue' fires onValueChange('none')", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url === "/api/venues/v1") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeVenue({ id: "v1", name: "Wetlands", city: "NYC", state: "NY" }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => [] } as Response);
+    });
+    const onValueChange = vi.fn();
+
+    const { user } = await setup(<VenueSearch value="v1" onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("No venue"));
+
+    expect(onValueChange).toHaveBeenCalledWith("none");
+  });
+
+  // Selecting a venue fires onValueChange with the venue's id (the other
+  // half of the form-state ↔ id translation contract).
+  test("clicking a venue fires onValueChange with the venue id", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => [makeVenue({ id: "v2", name: "Red Rocks", city: "Morrison", state: "CO" })],
+    });
+    const onValueChange = vi.fn();
+
+    const { user } = await setup(<VenueSearch onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const input = await screen.findByPlaceholderText("Search venues...");
+    await user.type(input, "red");
+
+    const row = await screen.findByText("Red Rocks (Morrison, CO)", undefined, { timeout: 1500 });
+    await user.click(row);
+
+    expect(onValueChange).toHaveBeenCalledWith("v2");
+  });
+});

--- a/apps/web/app/components/venue/venue-search.tsx
+++ b/apps/web/app/components/venue/venue-search.tsx
@@ -1,10 +1,5 @@
 import type { Venue } from "@bip/domain";
-import { Check, ChevronsUpDown } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
-import { Button } from "~/components/ui/button";
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "~/components/ui/command";
-import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
-import { cn } from "~/lib/utils";
+import { SearchPicker } from "~/components/ui/search-picker";
 
 interface VenueSearchProps {
   value?: string;
@@ -13,129 +8,42 @@ interface VenueSearchProps {
   className?: string;
 }
 
+function formatVenueLabel(venue: Venue) {
+  const location = [venue.city, venue.state].filter(Boolean).join(", ");
+  return location ? `${venue.name} (${location})` : venue.name;
+}
+
+/**
+ * Venue picker for the show edit form. Requires 2+ chars before
+ * searching the catalog; the trigger seeds itself by fetching the
+ * current venue by id so the show's existing venue renders without
+ * needing to open the popover first. Form state uses "none" instead
+ * of null for compatibility with the surrounding form layer.
+ */
 export function VenueSearch({ value, onValueChange, placeholder = "Search venues...", className }: VenueSearchProps) {
-  const [open, setOpen] = useState(false);
-  const [venues, setVenues] = useState<Venue[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [currentVenue, setCurrentVenue] = useState<Venue | null>(null);
-
-  const selectedVenue = venues.find((venue) => venue.id === value) || currentVenue;
-
-  const searchVenues = useCallback(async (query: string) => {
-    if (!query || query.length < 2) {
-      setVenues([]);
-      return;
-    }
-
-    setLoading(true);
-    try {
-      const response = await fetch(`/api/venues?q=${encodeURIComponent(query)}`);
-      if (response.ok) {
-        const data = await response.json();
-        setVenues(data);
-      } else {
-      }
-    } catch (_error) {
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  // Load current venue when value changes
-  useEffect(() => {
-    const loadCurrentVenue = async () => {
-      if (value && value !== "none" && !venues.find((v) => v.id === value) && !currentVenue) {
-        try {
-          const response = await fetch(`/api/venues/${value}`);
-          if (response.ok) {
-            const venue = await response.json();
-            setCurrentVenue(venue);
-          }
-        } catch (_error) {}
-      } else if (!value || value === "none") {
-        setCurrentVenue(null);
-      }
-    };
-
-    loadCurrentVenue();
-  }, [value, venues, currentVenue]);
-
-  useEffect(() => {
-    const delayedSearch = setTimeout(() => {
-      searchVenues(searchQuery);
-    }, 300); // Debounce search
-
-    return () => clearTimeout(delayedSearch);
-  }, [searchQuery, searchVenues]);
-
-  const formatVenueLabel = (venue: Venue) => {
-    const location = [venue.city, venue.state].filter(Boolean).join(", ");
-    return location ? `${venue.name} (${location})` : venue.name;
-  };
-
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          aria-expanded={open}
-          className={cn(
-            "justify-between bg-content-bg border-content-bg-secondary text-white hover:bg-content-bg-secondary",
-            className,
-          )}
-        >
-          {selectedVenue ? formatVenueLabel(selectedVenue) : placeholder}
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        className="p-0 bg-content-bg-primary/95 backdrop-blur-md border border-content-glass-border"
-        align="start"
-      >
-        <Command className="bg-transparent" shouldFilter={false}>
-          <CommandInput
-            placeholder="Search venues..."
-            value={searchQuery}
-            onValueChange={setSearchQuery}
-            className="text-white"
-          />
-          <CommandList>
-            <CommandEmpty>
-              {loading ? "Searching..." : searchQuery.length < 2 ? "Type to search venues" : "No venues found."}
-            </CommandEmpty>
-            <CommandGroup>
-              {/* Option to clear selection */}
-              <CommandItem
-                value="none"
-                onSelect={() => {
-                  onValueChange("none");
-                  setOpen(false);
-                }}
-                className="text-white hover:bg-content-bg-secondary"
-              >
-                <Check className={cn("mr-2 h-4 w-4", value === "none" ? "opacity-100" : "opacity-0")} />
-                No venue
-              </CommandItem>
-
-              {venues.map((venue) => (
-                <CommandItem
-                  key={venue.id}
-                  value={venue.id}
-                  onSelect={() => {
-                    onValueChange(venue.id);
-                    setOpen(false);
-                  }}
-                  className="text-white hover:bg-content-bg-secondary"
-                >
-                  <Check className={cn("mr-2 h-4 w-4", value === venue.id ? "opacity-100" : "opacity-0")} />
-                  {formatVenueLabel(venue)}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+    <SearchPicker<Venue>
+      value={value && value !== "none" ? value : null}
+      onValueChange={(v) => onValueChange(v ?? "none")}
+      className={className}
+      placeholder={placeholder}
+      searchPlaceholder="Search venues..."
+      emptyMessage={(q) => (q.length < 2 ? "Type to search venues" : "No venues found.")}
+      loadingMessage="Searching..."
+      itemId={(v) => v.id}
+      itemLabel={formatVenueLabel}
+      noneLabel="No venue"
+      fetchResults={async (query) => {
+        if (!query || query.length < 2) return [];
+        const response = await fetch(`/api/venues?q=${encodeURIComponent(query)}`);
+        if (!response.ok) return [];
+        return (await response.json()) as Venue[];
+      }}
+      fetchById={async (id) => {
+        const response = await fetch(`/api/venues/${id}`);
+        if (!response.ok) return null;
+        return (await response.json()) as Venue;
+      }}
+    />
   );
 }

--- a/apps/web/app/lib/form-styles.ts
+++ b/apps/web/app/lib/form-styles.ts
@@ -1,0 +1,27 @@
+/**
+ * Dark-theme styling for form Input / Textarea controls used in admin
+ * and edit forms across the app. Centralized here so a token change
+ * (e.g. swapping `--content-bg-secondary` for a different surface)
+ * propagates to every form at once instead of needing 17+ edits.
+ *
+ * Auth forms (login / register / forgot-password) and search inputs use
+ * a different visual treatment and should NOT use this constant.
+ */
+export const formInputClass = "bg-content-bg-secondary border-content-bg-secondary text-content-text-primary";
+
+/**
+ * Block-level label style for native `<label>` elements in forms that
+ * don't run through react-hook-form's `<FormLabel>` (which has its own
+ * styling layer). Sits above the input on its own line with a tight
+ * margin, in the dark-theme secondary-text color.
+ */
+export const formLabelClass = "block text-sm font-medium text-content-text-secondary mb-1";
+
+/**
+ * Surface treatment shared by list rows across the app (track rows,
+ * curated-video rows, etc.): a faint dark fill, rounded corners, and a
+ * subtle border in the project's secondary-border tone. Padding stays
+ * with the caller so denser lists can use `p-2` and content-heavier rows
+ * can use `p-3` without forking the shared treatment.
+ */
+export const listRowClass = "rounded-lg border border-content-bg-secondary bg-content-bg-secondary/50";

--- a/apps/web/app/lib/noteworthy-performance-api.ts
+++ b/apps/web/app/lib/noteworthy-performance-api.ts
@@ -1,0 +1,32 @@
+import type { PerformanceFilterOptions } from "@bip/core/page-composers/song-page-composer";
+import type { AllTimersPageView } from "@bip/domain";
+import { publicLoader } from "~/lib/base-loaders";
+import { buildFilteredCacheKey, parsePerformanceFilters } from "~/lib/performance-filter-params";
+import { services } from "~/server/services";
+
+/**
+ * Shared API loader for the cross-song noteworthy-performance endpoints
+ * (`/api/all-timers`, `/api/jam-charts`). Parses URL filters, derives a
+ * filter-aware cache key, and delegates to the route-specific `build`
+ * function (which carries the base WHERE condition). Returns just the
+ * performances array — the routes are consumed by client-side refetch,
+ * not by SSR loaders that also need a dehydrated query client.
+ */
+export function createNoteworthyApiLoader({
+  cacheSuffix,
+  build,
+}: {
+  /** Cache-key suffix passed through `buildFilteredCacheKey` — e.g. `"all-timers"` or `"jam-charts"`. */
+  cacheSuffix: string;
+  build: (filters: PerformanceFilterOptions) => Promise<AllTimersPageView>;
+}) {
+  return publicLoader(async ({ request, context }) => {
+    const url = new URL(request.url);
+    const filters = await parsePerformanceFilters(url, context);
+    const cacheKey = buildFilteredCacheKey(url, cacheSuffix, filters.attendedUserId);
+
+    const result = await services.cache.getOrSet(cacheKey, async () => build(filters), { ttl: 3600 });
+
+    return result.performances;
+  });
+}

--- a/apps/web/app/lib/noteworthy-performance-loader.ts
+++ b/apps/web/app/lib/noteworthy-performance-loader.ts
@@ -1,0 +1,51 @@
+import type { AllTimersPageView } from "@bip/domain";
+import { type DehydratedState, dehydrate } from "@tanstack/react-query";
+import { type PublicContext, publicLoader } from "~/lib/base-loaders";
+import { showUserDataQueryKey, trackUserRatingsQueryKey } from "~/lib/query-keys";
+import { createPrefetchClient } from "~/lib/query-prefetch";
+import { services } from "~/server/services";
+import { computeShowUserData } from "~/server/show-user-data";
+import { computeTrackUserRatings } from "~/server/track-user-ratings";
+
+export type NoteworthyLoaderData = AllTimersPageView & { dehydratedState: DehydratedState };
+
+/**
+ * Server-only loader factory for the cross-song noteworthy-performance
+ * pages (`/songs/all-timers`, `/songs/jam-charts`). Caches the composer
+ * result and prefetches per-track rating + per-show attendance data so
+ * the first frame paints with hydrated chrome.
+ *
+ * Kept in its own file (no JSX, no client imports) because route
+ * components reference `NoteworthyPerformancePage` as a runtime value;
+ * if the loader factory and the component lived in the same module,
+ * Vite would pull `~/server/*` into the client bundle through the
+ * component import and break `<Link>` navigation (see PR #58 +
+ * apps/web/CLAUDE.md).
+ */
+export function createNoteworthyLoader({
+  cacheKey,
+  build,
+}: {
+  cacheKey: string;
+  build: () => Promise<AllTimersPageView>;
+}) {
+  return publicLoader(async ({ context }: { context: PublicContext }): Promise<NoteworthyLoaderData> => {
+    const view = await services.cache.getOrSet(cacheKey, build, { ttl: 3600 });
+
+    const trackIds = view.performances.map((p) => p.trackId);
+    const showIds = [...new Set(view.performances.map((p) => p.show.id))];
+    const queryClient = createPrefetchClient();
+    await Promise.all([
+      queryClient.prefetchQuery({
+        queryKey: trackUserRatingsQueryKey(trackIds),
+        queryFn: () => computeTrackUserRatings(context, trackIds),
+      }),
+      queryClient.prefetchQuery({
+        queryKey: showUserDataQueryKey(showIds),
+        queryFn: () => computeShowUserData(context, showIds),
+      }),
+    ]);
+
+    return { ...view, dehydratedState: dehydrate(queryClient) };
+  });
+}

--- a/apps/web/app/lib/noteworthy-performance-page.tsx
+++ b/apps/web/app/lib/noteworthy-performance-page.tsx
@@ -1,0 +1,77 @@
+import { PerformanceTable } from "~/components/performance";
+import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
+import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
+import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
+import type { NoteworthyLoaderData } from "~/lib/noteworthy-performance-loader";
+
+/**
+ * Shared page body for the cross-song noteworthy-performance pages
+ * (`/songs/all-timers`, `/songs/jam-charts`). The two routes differ
+ * only in (a) the API endpoint they refetch from when filters change
+ * and (b) which toggle chip is hidden because it matches the page's
+ * base condition (All-Timer chip on all-timers, Jam Chart chip on
+ * jam-charts).
+ *
+ * Kept in its own client-safe module — the loader factory lives in
+ * `noteworthy-performance-loader.ts` so route components can render
+ * this component without dragging server imports into the client
+ * bundle (see PR #58 + apps/web/CLAUDE.md).
+ */
+export function NoteworthyPerformancePage({
+  apiUrl,
+  hideAllTimerToggle = false,
+  hideJamChartToggle = false,
+}: {
+  apiUrl: string;
+  hideAllTimerToggle?: boolean;
+  hideJamChartToggle?: boolean;
+}) {
+  const { performances: allPerformances } = useSerializedLoaderData<NoteworthyLoaderData>();
+  const {
+    filteredData: filteredPerformances,
+    isLoading,
+    selectedTimeRange,
+    coverFilter,
+    selectedAuthor,
+    activeToggleSet,
+    hasActiveFilters,
+    searchText,
+    setSearchText,
+    updateFilter,
+    toggleFilter,
+    clearFilters,
+  } = usePerformancePageFilters({
+    initialData: allPerformances,
+    apiUrl,
+    searchFilter: searchPerformance,
+  });
+
+  return (
+    <div>
+      <PerformanceTable
+        performances={filteredPerformances}
+        isLoading={isLoading}
+        showSongColumn
+        showAllTimerColumn
+        mobileFlamePriority
+        showGapColumns={false}
+        headerContent={
+          <PerformanceFilterControls
+            selectedTimeRange={selectedTimeRange}
+            activeToggleSet={activeToggleSet}
+            updateFilter={updateFilter}
+            toggleFilter={toggleFilter}
+            clearFilters={clearFilters}
+            coverFilter={coverFilter}
+            selectedAuthor={selectedAuthor}
+            showAllTimerToggle={!hideAllTimerToggle}
+            showJamChartToggle={!hideJamChartToggle}
+            searchValue={searchText}
+            onSearchChange={setSearchText}
+            hasActiveFilters={hasActiveFilters}
+          />
+        }
+      />
+    </div>
+  );
+}

--- a/apps/web/app/lib/performance-filter-params.ts
+++ b/apps/web/app/lib/performance-filter-params.ts
@@ -15,6 +15,7 @@ const VALID_FILTER_KEYS = new Set([
   "standalone",
   "inverted",
   "dyslexic",
+  "jamChart",
   "allTimer",
 ]);
 

--- a/apps/web/app/lib/server-import-leak.test.ts
+++ b/apps/web/app/lib/server-import-leak.test.ts
@@ -93,20 +93,31 @@ function valueImports(sourceFile: ts.SourceFile): ValueImport[] {
 
 /**
  * Build a set of spans (start/end offsets) that belong to server-only exports
- * — the code inside `export const loader = ...` and friends. A reference to
- * an imported identifier inside these spans is stripped from the client
- * bundle by React Router's vite plugin and is therefore safe.
+ * — the code inside `export const loader = ...`, `export async function
+ * action(...)`, and friends. A reference to an imported identifier inside
+ * these spans is stripped from the client bundle by React Router's vite
+ * plugin and is therefore safe.
+ *
+ * Recognizes both export forms because route authors mix them freely: the
+ * variable form (`export const loader = publicLoader(...)`) and the
+ * function-declaration form (`export async function action(args) {...}`).
  */
 function serverOnlySpans(sourceFile: ts.SourceFile): Array<[number, number]> {
   const spans: Array<[number, number]> = [];
   for (const statement of sourceFile.statements) {
-    if (!ts.isVariableStatement(statement)) continue;
-    const hasExport = statement.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+    const modifiers = ts.canHaveModifiers(statement) ? ts.getModifiers(statement) : undefined;
+    const hasExport = modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
     if (!hasExport) continue;
-    for (const decl of statement.declarationList.declarations) {
-      if (!ts.isIdentifier(decl.name)) continue;
-      if (!SERVER_ONLY_EXPORT_NAMES.has(decl.name.text)) continue;
-      if (decl.initializer) spans.push([decl.initializer.getStart(sourceFile), decl.initializer.getEnd()]);
+
+    if (ts.isVariableStatement(statement)) {
+      for (const decl of statement.declarationList.declarations) {
+        if (!ts.isIdentifier(decl.name)) continue;
+        if (!SERVER_ONLY_EXPORT_NAMES.has(decl.name.text)) continue;
+        if (decl.initializer) spans.push([decl.initializer.getStart(sourceFile), decl.initializer.getEnd()]);
+      }
+    } else if (ts.isFunctionDeclaration(statement) && statement.name && statement.body) {
+      if (!SERVER_ONLY_EXPORT_NAMES.has(statement.name.text)) continue;
+      spans.push([statement.body.getStart(sourceFile), statement.body.getEnd()]);
     }
   }
   return spans;
@@ -144,10 +155,13 @@ describe("loader helper modules must not leak server code into the client bundle
   // References inside the default component or at module top level trigger a
   // violation — those would pull the helper into the client bundle.
   test("route .tsx files reference server-helper imports only in server-only exports", async () => {
-    const helperFiles = await fg("**/*.ts", {
-      cwd: ROUTES_ROOT,
+    // Scan helpers under both `app/routes/` (per the original PR #58
+    // failure mode) and `app/lib/` — both are common places to put
+    // loader plumbing that route components import.
+    const helperFiles = await fg(["routes/**/*.{ts,tsx}", "lib/**/*.{ts,tsx}"], {
+      cwd: APP_ROOT,
       absolute: true,
-      ignore: ["**/*.test.ts"],
+      ignore: ["**/*.test.ts", "**/*.test.tsx"],
     });
     const serverHelpers = new Set(helperFiles.filter((f) => directlyImportsServerCode(parse(f))));
 

--- a/apps/web/app/lib/song-filters.ts
+++ b/apps/web/app/lib/song-filters.ts
@@ -84,6 +84,7 @@ export const TOGGLE_FILTER_DEFINITIONS = [
   { key: "standalone", label: "Standalone" },
   { key: "inverted", label: "Inverted" },
   { key: "dyslexic", label: "Dyslexic" },
+  { key: "jamChart", label: "Jam Chart" },
   { key: "allTimer", label: "All-Timer" },
   { key: "attended", label: "Attended" },
 ] as const;

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -92,11 +92,17 @@ export default [
     ...prefix("songs", [
       index("routes/songs/_index.tsx"),
       route("all-timers", "routes/songs/all-timers.tsx"),
+      route("jam-charts", "routes/songs/jam-charts.tsx"),
       route("histories", "routes/songs/histories.tsx"),
       route("recent", "routes/songs/recent.tsx"),
       route("this-year", "routes/songs/this-year.tsx"),
       route("new", "routes/songs/new.tsx"),
       route(":slug", "routes/songs/$slug.tsx"),
+      // Same file backs `/songs/:slug/:tab` (jam-charts, all-timers,
+      // stats, history, lyrics, guitar-tabs) so the in-song tabs are
+      // shareable URLs. A unique `id` is required because RR v7 keys
+      // routes by module path.
+      route(":slug/:tab", "routes/songs/$slug.tsx", { id: "song-tab" }),
       route(":slug/edit", "routes/songs/$slug.edit.tsx"),
     ]),
   ]),
@@ -115,6 +121,7 @@ export default [
     route("venues", "routes/api/venues.tsx"),
     route("venues/:id", "routes/api/venues/$id.tsx"),
     route("all-timers", "routes/api/all-timers.tsx"),
+    route("jam-charts", "routes/api/jam-charts.tsx"),
     route("songs", "routes/api/songs.tsx"),
     route("songs/performances", "routes/api/songs/performances.tsx"),
     route("songs/:id", "routes/api/songs/$id.tsx"),

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -109,6 +109,7 @@ export default [
     route("attendances", "routes/api/attendances.tsx"),
     route("shows/user-data", "routes/api/shows/user-data.tsx"),
     route("shows/reorder", "routes/api/shows/reorder.tsx"),
+    route("show-youtubes", "routes/api/show-youtubes.tsx"),
     route("authors", "routes/api/authors.tsx"),
     route("authors/:id", "routes/api/authors/$id.tsx"),
     route("venues", "routes/api/venues.tsx"),

--- a/apps/web/app/routes/api/jam-charts.tsx
+++ b/apps/web/app/routes/api/jam-charts.tsx
@@ -2,6 +2,6 @@ import { createNoteworthyApiLoader } from "~/lib/noteworthy-performance-api";
 import { services } from "~/server/services";
 
 export const loader = createNoteworthyApiLoader({
-  cacheSuffix: "all-timers",
-  build: (filters) => services.songPageComposer.buildAllTimers(filters),
+  cacheSuffix: "jam-charts",
+  build: (filters) => services.songPageComposer.buildJamCharts(filters),
 });

--- a/apps/web/app/routes/api/show-youtubes.test.ts
+++ b/apps/web/app/routes/api/show-youtubes.test.ts
@@ -1,0 +1,241 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router-dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// adminAction / publicLoader normally wrap with auth and base loader chrome.
+// For route-level unit tests we bypass them and exercise the inner function
+// directly so we can isolate body parsing, validation, and service delegation.
+vi.mock("~/lib/base-loaders", () => ({
+  adminAction: <T>(fn: (args: ActionFunctionArgs) => Promise<T>) => fn,
+  publicLoader: <T>(fn: (args: LoaderFunctionArgs) => Promise<T>) => fn,
+}));
+
+const listEntriesForShow = vi.fn();
+const createForShow = vi.fn();
+const deleteEntry = vi.fn();
+
+vi.mock("~/server/services", () => ({
+  services: {
+    youtube: {
+      listEntriesForShow: (...args: unknown[]) => listEntriesForShow(...args),
+      createForShow: (...args: unknown[]) => createForShow(...args),
+      deleteEntry: (...args: unknown[]) => deleteEntry(...args),
+    },
+  },
+}));
+
+vi.mock("~/lib/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn() },
+}));
+
+// Imported after mocks so the route picks up our pass-through wrappers.
+const { loader, action } = await import("./show-youtubes");
+
+function makeLoaderRequest(url: string): LoaderFunctionArgs {
+  return {
+    request: new Request(url),
+    params: {},
+    context: {},
+  } as unknown as LoaderFunctionArgs;
+}
+
+function makeActionRequest(body: unknown, method = "POST"): ActionFunctionArgs {
+  const init: RequestInit = { method, headers: { "Content-Type": "application/json" } };
+  if (method !== "GET" && method !== "HEAD") {
+    init.body = JSON.stringify(body);
+  }
+  return {
+    request: new Request("http://localhost/api/show-youtubes", init),
+    params: {},
+    context: {},
+  } as unknown as ActionFunctionArgs;
+}
+
+async function readJson(response: unknown): Promise<{ status: number; body: unknown }> {
+  const res = response as Response;
+  return { status: res.status, body: await res.json() };
+}
+
+describe("GET /api/show-youtubes", () => {
+  beforeEach(() => {
+    listEntriesForShow.mockReset();
+  });
+
+  // Happy path: the loader passes showId through to YoutubeService and
+  // returns whatever the service hands back. Keeps the route a thin shell.
+  test("returns the entry list for a showId", async () => {
+    const entries = [{ id: "row-1", videoId: "abc12345678", url: "https://www.youtube.com/watch?v=abc12345678" }];
+    listEntriesForShow.mockResolvedValue(entries);
+
+    const result = await loader(makeLoaderRequest("http://localhost/api/show-youtubes?showId=show-1"));
+
+    expect(listEntriesForShow).toHaveBeenCalledWith("show-1");
+    expect(result).toEqual(entries);
+  });
+
+  // Without showId, the loader returns a 400 Response — never reaches the
+  // service. (badRequest() returns rather than throws, so we inspect the
+  // returned Response.)
+  test("returns 400 when showId is missing", async () => {
+    const result = await loader(makeLoaderRequest("http://localhost/api/show-youtubes"));
+
+    expect(listEntriesForShow).not.toHaveBeenCalled();
+    expect((result as Response).status).toBe(400);
+  });
+});
+
+describe("POST /api/show-youtubes", () => {
+  beforeEach(() => {
+    createForShow.mockReset();
+  });
+
+  // Happy path: a full youtube.com URL has its video id extracted by the
+  // route and passed to the service. Returning the created row lets the
+  // client append optimistically without a follow-up GET.
+  test("extracts the video id from a full youtube.com URL and creates the row", async () => {
+    createForShow.mockResolvedValue({
+      id: "row-new",
+      videoId: "dQw4w9WgXcQ",
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+
+    const result = await action(
+      makeActionRequest({ showId: "show-1", input: "https://www.youtube.com/watch?v=dQw4w9WgXcQ" }),
+    );
+
+    expect(createForShow).toHaveBeenCalledWith("show-1", "dQw4w9WgXcQ");
+    expect(result).toEqual({
+      id: "row-new",
+      videoId: "dQw4w9WgXcQ",
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+  });
+
+  // youtu.be short-links carry the id in the pathname. They're the format
+  // YouTube's share UI defaults to, so they're a common paste target.
+  test("extracts the video id from a youtu.be short link", async () => {
+    createForShow.mockResolvedValue({ id: "row-x", videoId: "abc12345678", url: "" });
+
+    await action(makeActionRequest({ showId: "show-1", input: "https://youtu.be/abc12345678" }));
+
+    expect(createForShow).toHaveBeenCalledWith("show-1", "abc12345678");
+  });
+
+  // /embed/<id> URLs come from share dialogs and from copying iframe srcs.
+  test("extracts the video id from an /embed/ URL", async () => {
+    createForShow.mockResolvedValue({ id: "row-x", videoId: "embed123456", url: "" });
+
+    await action(makeActionRequest({ showId: "show-1", input: "https://www.youtube.com/embed/embed123456" }));
+
+    expect(createForShow).toHaveBeenCalledWith("show-1", "embed123456");
+  });
+
+  // Power users sometimes paste just the 11-character id rather than a URL.
+  // We accept that directly without re-parsing.
+  test("accepts a raw 11-character video id", async () => {
+    createForShow.mockResolvedValue({ id: "row-x", videoId: "AbCdEfGhIjK", url: "" });
+
+    await action(makeActionRequest({ showId: "show-1", input: "AbCdEfGhIjK" }));
+
+    expect(createForShow).toHaveBeenCalledWith("show-1", "AbCdEfGhIjK");
+  });
+
+  // Input that doesn't look like a video id or a recognizable URL is
+  // rejected with 400 + a human-readable error — the UI surfaces this
+  // straight to the admin.
+  test("rejects garbage input with 400 and an error message", async () => {
+    const result = await action(makeActionRequest({ showId: "show-1", input: "not a url" }));
+
+    expect(createForShow).not.toHaveBeenCalled();
+    const { status, body } = await readJson(result);
+    expect(status).toBe(400);
+    expect(body).toEqual({ error: "Could not extract a YouTube video id from that input." });
+  });
+
+  // A non-youtube URL is also rejected — same path as garbage input. The
+  // route shouldn't try to "make it work" for arbitrary URLs.
+  test("rejects URLs from non-youtube hosts with 400", async () => {
+    const result = await action(makeActionRequest({ showId: "show-1", input: "https://vimeo.com/123" }));
+
+    expect(createForShow).not.toHaveBeenCalled();
+    expect((result as Response).status).toBe(400);
+  });
+
+  // Missing showId or input is rejected before we ever try to extract or
+  // create anything. Catches malformed client calls early.
+  test("returns 400 when showId or input is missing", async () => {
+    const noShowId = await action(makeActionRequest({ input: "AbCdEfGhIjK" }));
+    expect((noShowId as Response).status).toBe(400);
+
+    const noInput = await action(makeActionRequest({ showId: "show-1" }));
+    expect((noInput as Response).status).toBe(400);
+
+    expect(createForShow).not.toHaveBeenCalled();
+  });
+
+  // If the service blows up (db error, etc.), the route returns 500 with a
+  // generic message — the underlying error is logged but not surfaced to
+  // the client (could leak internals).
+  test("returns 500 with a generic message when the service throws", async () => {
+    createForShow.mockRejectedValue(new Error("db is down"));
+
+    const result = await action(makeActionRequest({ showId: "show-1", input: "AbCdEfGhIjK" }));
+
+    const { status, body } = await readJson(result);
+    expect(status).toBe(500);
+    expect(body).toEqual({ error: "Failed to add video." });
+  });
+});
+
+describe("DELETE /api/show-youtubes", () => {
+  beforeEach(() => {
+    deleteEntry.mockReset();
+  });
+
+  // Happy path: pass through the row id and return success. The UI uses
+  // this to remove the row from local state.
+  test("delegates a valid body to YoutubeService.deleteEntry", async () => {
+    deleteEntry.mockResolvedValue(undefined);
+
+    const result = await action(makeActionRequest({ id: "row-1" }, "DELETE"));
+
+    expect(deleteEntry).toHaveBeenCalledWith("row-1");
+    expect(result).toEqual({ success: true });
+  });
+
+  // Missing id is rejected before reaching the service.
+  test("returns 400 when id is missing", async () => {
+    const result = await action(makeActionRequest({}, "DELETE"));
+
+    expect(deleteEntry).not.toHaveBeenCalled();
+    expect((result as Response).status).toBe(400);
+  });
+
+  // Service-level errors become a generic 500 with a logged underlying
+  // error, same shape as POST.
+  test("returns 500 when the service throws", async () => {
+    deleteEntry.mockRejectedValue(new Error("db is down"));
+
+    const result = await action(makeActionRequest({ id: "row-1" }, "DELETE"));
+
+    const { status, body } = await readJson(result);
+    expect(status).toBe(500);
+    expect(body).toEqual({ error: "Failed to delete video." });
+  });
+});
+
+describe("/api/show-youtubes method guards", () => {
+  beforeEach(() => {
+    createForShow.mockReset();
+    deleteEntry.mockReset();
+  });
+
+  // Anything other than POST or DELETE returns 405 without touching the
+  // services.
+  test("rejects unsupported methods with 405", async () => {
+    const result = await action(makeActionRequest({}, "PUT"));
+
+    expect(createForShow).not.toHaveBeenCalled();
+    expect(deleteEntry).not.toHaveBeenCalled();
+    expect((result as Response).status).toBe(405);
+  });
+});

--- a/apps/web/app/routes/api/show-youtubes.tsx
+++ b/apps/web/app/routes/api/show-youtubes.tsx
@@ -1,0 +1,78 @@
+import { adminAction, publicLoader } from "~/lib/base-loaders";
+import { badRequest, methodNotAllowed } from "~/lib/errors";
+import { logger } from "~/lib/logger";
+import { services } from "~/server/services";
+
+// Accept a raw 11-char YouTube video ID, a full youtube.com/watch?v=…
+// URL, or a youtu.be/… short link. Returns null when no id can be extracted.
+function extractVideoId(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  if (/^[A-Za-z0-9_-]{11}$/.test(trimmed)) return trimmed;
+  try {
+    const url = new URL(trimmed);
+    if (url.hostname.endsWith("youtu.be")) {
+      const id = url.pathname.replace(/^\//, "");
+      return /^[A-Za-z0-9_-]{11}$/.test(id) ? id : null;
+    }
+    if (url.hostname.endsWith("youtube.com") || url.hostname.endsWith("youtube-nocookie.com")) {
+      const v = url.searchParams.get("v");
+      if (v && /^[A-Za-z0-9_-]{11}$/.test(v)) return v;
+      const embedMatch = url.pathname.match(/^\/embed\/([A-Za-z0-9_-]{11})/);
+      if (embedMatch) return embedMatch[1];
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+// GET /api/show-youtubes?showId=xxx — list curated videos for a show
+export const loader = publicLoader(async ({ request }) => {
+  const url = new URL(request.url);
+  const showId = url.searchParams.get("showId");
+  if (!showId) return badRequest();
+  const entries = await services.youtube.listEntriesForShow(showId);
+  return entries;
+});
+
+export const action = adminAction(async ({ request }) => {
+  if (request.method === "POST") {
+    const { showId, input } = (await request.json()) as { showId?: string; input?: string };
+    if (!showId || !input) return badRequest();
+    const videoId = extractVideoId(input);
+    if (!videoId) {
+      return new Response(JSON.stringify({ error: "Could not extract a YouTube video id from that input." }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    try {
+      const entry = await services.youtube.createForShow(showId, videoId);
+      return entry;
+    } catch (error) {
+      logger.error("Failed to add show youtube", { error });
+      return new Response(JSON.stringify({ error: "Failed to add video." }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+  }
+
+  if (request.method === "DELETE") {
+    const { id } = (await request.json()) as { id?: string };
+    if (!id) return badRequest();
+    try {
+      await services.youtube.deleteEntry(id);
+      return { success: true };
+    } catch (error) {
+      logger.error("Failed to delete show youtube", { error });
+      return new Response(JSON.stringify({ error: "Failed to delete video." }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+  }
+
+  return methodNotAllowed();
+});

--- a/apps/web/app/routes/mcp/index.tsx
+++ b/apps/web/app/routes/mcp/index.tsx
@@ -483,6 +483,15 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
         try {
           const setlist = await services.setlists.findByShowSlug(slug);
           if (setlist) {
+            // Annotation rows carry `trackId`; group them so each track in
+            // the response can carry its own annotation strings. Sync's
+            // diffTrackAnnotations replaces local-by-trackId on every run.
+            const annotationsByTrackId = new Map<string, string[]>();
+            for (const ann of setlist.annotations) {
+              const list = annotationsByTrackId.get(ann.trackId) ?? [];
+              list.push(ann.desc ?? "");
+              annotationsByTrackId.set(ann.trackId, list);
+            }
             setlists.push({
               showSlug: setlist.show.slug,
               showDate: setlist.show.date,
@@ -494,6 +503,12 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
                   songTitle: t.song?.title || "",
                   songSlug: t.song?.slug || "",
                   segue: t.segue,
+                  // Admin-curated; sync-missing-shows reads these from the
+                  // payload to populate Track.note / Track.allTimer on insert
+                  // and to drift-update existing rows.
+                  note: t.note,
+                  allTimer: t.allTimer ?? false,
+                  annotations: annotationsByTrackId.get(t.id) ?? [],
                 })),
               })),
             });
@@ -527,6 +542,11 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
               ratingsCount: show.ratingsCount,
               notes: show.notes,
               relistenUrl: show.relistenUrl,
+              // Admin-curated stat flags; gate every downstream aggregate
+              // (countForStats → STATS_SHOWS_WHERE) and same-day ordering
+              // (dayOrder). Sync mirrors them on insert + drift-update.
+              countForStats: show.countForStats,
+              dayOrder: show.dayOrder,
             });
           } else {
             errors.push({ slug, error: "Not found" });
@@ -556,6 +576,16 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
               timesPlayed: song.timesPlayed,
               dateFirstPlayed: song.dateFirstPlayed,
               dateLastPlayed: song.dateLastPlayed,
+              // Curated admin fields the lyrics/info page surfaces. Sync
+              // mirrors them on insert + drift-update (see
+              // buildSongDriftUpdate).
+              cover: song.cover,
+              legacyAuthor: song.legacyAuthor,
+              featuredLyric: song.featuredLyric,
+              tabs: song.tabs,
+              notes: song.notes,
+              history: song.history,
+              guitarTabsUrl: song.guitarTabsUrl,
             });
           } else {
             errors.push({ slug, error: "Not found" });
@@ -584,6 +614,14 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
               state: venue.state,
               country: venue.country,
               timesPlayed: venue.timesPlayed,
+              // Contact + geocode columns. Sync mirrors them on insert +
+              // drift-update (see buildVenueDriftUpdate).
+              street: venue.street,
+              postalCode: venue.postalCode,
+              phone: venue.phone,
+              website: venue.website,
+              latitude: venue.latitude,
+              longitude: venue.longitude,
             });
           } else {
             errors.push({ slug, error: "Not found" });

--- a/apps/web/app/routes/shows/$slug.edit.tsx
+++ b/apps/web/app/routes/shows/$slug.edit.tsx
@@ -147,6 +147,7 @@ export default function EditShow() {
               submitLabel="Update Show"
               cancelHref={`/shows/${show.slug}`}
               bands={bands}
+              showId={show.id}
             />
           </CardContent>
         </Card>

--- a/apps/web/app/routes/songs/$slug.test.tsx
+++ b/apps/web/app/routes/songs/$slug.test.tsx
@@ -4,6 +4,20 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
+// Mock `useNavigate` + `useParams` to drive the URL-syncing tab logic
+// without needing a Routes definition. Other react-router exports
+// (MemoryRouter, Link, etc.) keep their real implementations.
+const mockNavigate = vi.fn();
+const mockParams: { slug?: string; tab?: string } = { slug: "basis-for-a-day" };
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => mockParams,
+  };
+});
+
 // Mock server-side modules
 vi.mock("~/server/services", () => ({ services: {} }));
 vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
@@ -91,6 +105,51 @@ function renderSongPage() {
 describe("SongPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset URL params to the default (no :tab) between tests so each
+    // test starts on the "All Performances" tab.
+    mockParams.slug = "basis-for-a-day";
+    mockParams.tab = undefined;
+  });
+
+  // The :tab URL segment is the source of truth for the active tab —
+  // back/forward and shareable links should land on the right pane.
+  test("activates the tab specified by the URL :tab segment", () => {
+    mockParams.tab = "stats";
+    renderSongPage();
+
+    const statsTab = screen.getByRole("tab", { name: /graphs/i });
+    expect(statsTab).toHaveAttribute("data-state", "active");
+  });
+
+  // A typo'd or unknown :tab segment falls back to "All Performances"
+  // instead of rendering nothing — guards against broken inbound links.
+  test("falls back to the All Performances tab when :tab is unknown", () => {
+    mockParams.tab = "definitely-not-a-tab";
+    renderSongPage();
+
+    const performancesTab = screen.getByRole("tab", { name: /all performances/i });
+    expect(performancesTab).toHaveAttribute("data-state", "active");
+  });
+
+  // Clicking a non-default tab navigates to the nested URL so the new
+  // URL can be bookmarked / shared / used by the back button.
+  test("clicking a tab navigates to /songs/:slug/:tab", async () => {
+    const user = userEvent.setup();
+    renderSongPage();
+
+    await user.click(screen.getByRole("tab", { name: /graphs/i }));
+    expect(mockNavigate).toHaveBeenCalledWith("/songs/basis-for-a-day/stats");
+  });
+
+  // The default ("performances") tab navigates back to the bare song
+  // URL so there's no redundant `/performances` suffix in the URL.
+  test("clicking the All Performances tab navigates to bare /songs/:slug", async () => {
+    mockParams.tab = "stats";
+    const user = userEvent.setup();
+    renderSongPage();
+
+    await user.click(screen.getByRole("tab", { name: /all performances/i }));
+    expect(mockNavigate).toHaveBeenCalledWith("/songs/basis-for-a-day");
   });
 
   // The All-Timers tab visibility should be based on the unfiltered data,

--- a/apps/web/app/routes/songs/$slug.test.tsx
+++ b/apps/web/app/routes/songs/$slug.test.tsx
@@ -164,18 +164,21 @@ describe("SongPage", () => {
 
   // The TabsList on song-detail clips at narrow widths because there can be
   // up to 6 tabs (All Performances, All-Timers, Stats, History, Lyrics,
-  // Guitar Tabs). Mobile gets a single <select> dropdown instead while sm+
-  // continues to use the horizontal tab strip.
-  test("song tabs render as a select on mobile (sm:hidden) and tab strip on sm+", () => {
+  // Guitar Tabs). Mobile gets a Radix Select instead — a native <select> was
+  // used before, but its OS-styling didn't look like a dropdown to users, so
+  // they didn't realize it was tappable. The Radix trigger renders as a
+  // styled button (role="combobox") with a visible chevron.
+  test("song tabs render as a Radix Select on mobile (sm:hidden) and tab strip on sm+", () => {
     renderSongPage();
 
     const tabList = screen.getByRole("tablist");
     expect(tabList.className).toContain("hidden");
     expect(tabList.className).toContain("sm:flex");
 
-    const select = screen.getByLabelText(/song view/i);
-    const wrapper = select.closest("div");
-    expect(wrapper?.className).toContain("sm:hidden");
+    const trigger = screen.getByRole("combobox", { name: /song view/i });
+    expect(trigger.textContent).toMatch(/All Performances/);
+    const wrapper = screen.getByTestId("mobile-song-view");
+    expect(wrapper.className).toContain("sm:hidden");
   });
 
   // The "last show" sublabel marks the song as having been played at the

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -3,13 +3,14 @@ import { type DehydratedState, dehydrate } from "@tanstack/react-query";
 import { ArrowLeft, BarChart3, FileTextIcon, Flame, GuitarIcon, History, ListMusic, Pencil } from "lucide-react";
 import { type ReactNode, useMemo, useState } from "react";
 import type { LoaderFunctionArgs } from "react-router";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { AdminOnly } from "~/components/admin/admin-only";
 import { PerformanceTable } from "~/components/performance";
 import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
 import { RatingComponent } from "~/components/rating";
 import { ShowDate } from "~/components/show-date";
 import { YearlyPlayChart } from "~/components/song/yearly-play-chart";
+import { isNoteworthy } from "~/components/track/noteworthy-marker";
 import { Button } from "~/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
@@ -185,13 +186,21 @@ function formatAvgMedianGap(avg: number | null | undefined, median: number | nul
   return `${fmt(avg)} / ${fmt(median)}`;
 }
 
+// Allowlist used to validate the `:tab` URL segment so a typo'd path
+// like /songs/triumph/foo falls back to the default tab instead of
+// rendering nothing. Order is informational only.
+const VALID_TABS = ["performances", "jam-charts", "all-timers", "stats", "history", "lyrics", "guitar-tabs"] as const;
+type TabValue = (typeof VALID_TABS)[number];
+
 export default function SongPage() {
   const { song, performances: allPerformances, showsByYear } = useSerializedLoaderData<LoaderData>();
-  const [searchParams] = useSearchParams();
-  const tabParam = searchParams.get("tab");
-  const validTabs = ["performances", "all-timers", "stats", "history", "lyrics", "guitar-tabs"];
-  const defaultTab = tabParam && validTabs.includes(tabParam) ? tabParam : "performances";
-  const [activeTab, setActiveTab] = useState(defaultTab);
+  const params = useParams<{ tab?: string }>();
+  const navigate = useNavigate();
+  // The :tab segment is the source of truth — Tabs renders whatever
+  // the URL says, and clicking a tab navigates so back/forward and
+  // shareable links work.
+  const activeTab: TabValue =
+    params.tab && (VALID_TABS as readonly string[]).includes(params.tab) ? (params.tab as TabValue) : "performances";
   const {
     filteredData: filteredPerformances,
     isLoading,
@@ -209,14 +218,31 @@ export default function SongPage() {
     extraParams: useMemo(() => ({ slug: song.slug }), [song.slug]),
     searchFilter: searchPerformance,
   });
+  const handleTabChange = (value: string) => {
+    clearFilters();
+    // "performances" is the default; navigate to bare /songs/:slug so
+    // the URL doesn't carry a redundant /performances suffix.
+    navigate(value === "performances" ? `/songs/${song.slug}` : `/songs/${song.slug}/${value}`);
+  };
 
   const hasAllTimers = useMemo(() => allPerformances.some((p) => p.allTimer), [allPerformances]);
   const filteredAllTimers = useMemo(() => filteredPerformances.filter((p) => p.allTimer), [filteredPerformances]);
+  // Jam Charts: all-timer OR any track with a curated note (non-empty).
+  // Superset of all-timers; the tab only appears when the song has at
+  // least one such performance.
+  const hasJamCharts = useMemo(() => allPerformances.some(isNoteworthy), [allPerformances]);
+  const filteredJamCharts = useMemo(() => filteredPerformances.filter(isNoteworthy), [filteredPerformances]);
   // Server-narrowing filter active = any UI filter that affects the
   // performance set the server returned. Excludes `searchText` (client-only).
   // Used to render the Filtered Gap column in the performances table.
   const hasServerNarrowingFilter = selectedTimeRange !== "all" || activeToggleSet.size > 0;
-  const filterContent = (
+  // Tab-specific noteworthy-toggle suppression: when the active tab is
+  // already scoped to "all-timers" or "jam-charts", the matching chip
+  // (and the chip that strictly subsets it) shouldn't reappear in the
+  // filter row because toggling it would either be a no-op or
+  // contradict the tab's scope. Mirrors how the global pages hide
+  // those chips on their own routes.
+  const renderFilterContent = (overrides?: { hideAllTimerToggle?: boolean; hideJamChartToggle?: boolean }) => (
     <PerformanceFilterControls
       selectedTimeRange={selectedTimeRange}
       activeToggleSet={activeToggleSet}
@@ -226,6 +252,8 @@ export default function SongPage() {
       searchValue={searchText}
       onSearchChange={setSearchText}
       hasActiveFilters={hasActiveFilters}
+      showAllTimerToggle={!overrides?.hideAllTimerToggle}
+      showJamChartToggle={!overrides?.hideJamChartToggle}
     />
   );
 
@@ -356,22 +384,9 @@ export default function SongPage() {
         </div>
       )}
 
-      <Tabs
-        value={activeTab}
-        className="w-full"
-        onValueChange={(value) => {
-          setActiveTab(value);
-          clearFilters();
-        }}
-      >
+      <Tabs value={activeTab} className="w-full" onValueChange={handleTabChange}>
         <div className="sm:hidden mb-4" data-testid="mobile-song-view">
-          <Select
-            value={activeTab}
-            onValueChange={(value) => {
-              setActiveTab(value);
-              clearFilters();
-            }}
-          >
+          <Select value={activeTab} onValueChange={handleTabChange}>
             <SelectTrigger
               aria-label="Song view"
               className="w-full h-11 bg-glass-bg border border-glass-border text-content-text-primary hover:bg-glass-bg/80 focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20"
@@ -380,6 +395,7 @@ export default function SongPage() {
             </SelectTrigger>
             <SelectContent className="bg-glass-bg border-glass-border backdrop-blur-md">
               <SelectItem value="performances">All Performances</SelectItem>
+              {hasJamCharts && <SelectItem value="jam-charts">Jam Charts</SelectItem>}
               {hasAllTimers && <SelectItem value="all-timers">All-Timers</SelectItem>}
               <SelectItem value="stats">Stats</SelectItem>
               {song.history && <SelectItem value="history">History</SelectItem>}
@@ -400,6 +416,19 @@ export default function SongPage() {
             <ListMusic className="h-4 w-4" />
             All Performances
           </TabsTrigger>
+          {hasJamCharts && (
+            <TabsTrigger
+              value="jam-charts"
+              className={cn(
+                "flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-none data-[state=active]:shadow-none",
+                "data-[state=active]:border-b-2 data-[state=active]:border-brand-primary data-[state=active]:bg-transparent",
+                "data-[state=inactive]:bg-transparent data-[state=inactive]:text-content-text-tertiary",
+              )}
+            >
+              <Flame className="h-4 w-4" />
+              Jam Charts
+            </TabsTrigger>
+          )}
           {hasAllTimers && (
             <TabsTrigger
               value="all-timers"
@@ -465,6 +494,18 @@ export default function SongPage() {
           )}
         </TabsList>
 
+        {hasJamCharts && (
+          <TabsContent value="jam-charts" className="mt-6">
+            <PerformanceTable
+              performances={filteredJamCharts}
+              isLoading={isLoading}
+              showAllTimerColumn
+              hasNarrowingFilter={hasServerNarrowingFilter}
+              headerContent={renderFilterContent({ hideJamChartToggle: true })}
+            />
+          </TabsContent>
+        )}
+
         {hasAllTimers && (
           <TabsContent value="all-timers" className="mt-6 space-y-8">
             {/* Featured cards for performances with notes */}
@@ -504,7 +545,7 @@ export default function SongPage() {
               performances={filteredAllTimers}
               isLoading={isLoading}
               hasNarrowingFilter={hasServerNarrowingFilter}
-              headerContent={filterContent}
+              headerContent={renderFilterContent({ hideAllTimerToggle: true, hideJamChartToggle: true })}
             />
           </TabsContent>
         )}
@@ -515,7 +556,7 @@ export default function SongPage() {
             showAllTimerColumn
             isLoading={isLoading}
             hasNarrowingFilter={hasServerNarrowingFilter}
-            headerContent={filterContent}
+            headerContent={renderFilterContent()}
           />
         </TabsContent>
 

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -11,6 +11,7 @@ import { RatingComponent } from "~/components/rating";
 import { ShowDate } from "~/components/show-date";
 import { YearlyPlayChart } from "~/components/song/yearly-play-chart";
 import { Button } from "~/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
@@ -363,26 +364,29 @@ export default function SongPage() {
           clearFilters();
         }}
       >
-        <div className="sm:hidden mb-4">
-          <label htmlFor="song-view-select" className="sr-only">
-            Song view
-          </label>
-          <select
-            id="song-view-select"
+        <div className="sm:hidden mb-4" data-testid="mobile-song-view">
+          <Select
             value={activeTab}
-            onChange={(event) => {
-              setActiveTab(event.target.value);
+            onValueChange={(value) => {
+              setActiveTab(value);
               clearFilters();
             }}
-            className="w-full h-11 px-3 rounded-md bg-glass-bg border border-glass-border text-content-text-primary focus:outline-none focus:ring-1 focus:ring-ring/20"
           >
-            <option value="performances">All Performances</option>
-            {hasAllTimers && <option value="all-timers">All-Timers</option>}
-            <option value="stats">Stats</option>
-            {song.history && <option value="history">History</option>}
-            {song.lyrics && <option value="lyrics">Lyrics</option>}
-            {(song.tabs || song.guitarTabsUrl) && <option value="guitar-tabs">Guitar Tabs</option>}
-          </select>
+            <SelectTrigger
+              aria-label="Song view"
+              className="w-full h-11 bg-glass-bg border border-glass-border text-content-text-primary hover:bg-glass-bg/80 focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="bg-glass-bg border-glass-border backdrop-blur-md">
+              <SelectItem value="performances">All Performances</SelectItem>
+              {hasAllTimers && <SelectItem value="all-timers">All-Timers</SelectItem>}
+              <SelectItem value="stats">Stats</SelectItem>
+              {song.history && <SelectItem value="history">History</SelectItem>}
+              {song.lyrics && <SelectItem value="lyrics">Lyrics</SelectItem>}
+              {(song.tabs || song.guitarTabsUrl) && <SelectItem value="guitar-tabs">Guitar Tabs</SelectItem>}
+            </SelectContent>
+          </Select>
         </div>
         <TabsList className="w-full hidden sm:flex justify-start border-b border-glass-border/30 rounded-none bg-transparent p-0">
           <TabsTrigger

--- a/apps/web/app/routes/songs/_layout.tsx
+++ b/apps/web/app/routes/songs/_layout.tsx
@@ -16,6 +16,7 @@ const TABS: Tab[] = [
   { label: "All Songs", path: "/songs", icon: ListMusic },
   { label: "Last 10 Shows", path: "/songs/recent", icon: Clock },
   { label: "This Year", path: "/songs/this-year", icon: Calendar },
+  { label: "Jam Charts", path: "/songs/jam-charts", icon: Flame },
   { label: "All-Timers", path: "/songs/all-timers", icon: Flame, iconClassName: "text-orange-500" },
   { label: "Histories", path: "/songs/histories", icon: History },
 ];

--- a/apps/web/app/routes/songs/all-timers.test.tsx
+++ b/apps/web/app/routes/songs/all-timers.test.tsx
@@ -6,7 +6,16 @@ import { describe, expect, test, vi } from "vitest";
 // Mock server-side modules
 vi.mock("~/server/services", () => ({ services: {} }));
 vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
-vi.mock("@bip/domain", () => ({}));
+vi.mock("@bip/domain", () => ({
+  // Loader imports CacheKeys.songs.allTimers() at module top level.
+  CacheKeys: { songs: { allTimers: () => "test-key" } },
+}));
+vi.mock("~/lib/noteworthy-performance-loader", () => ({
+  createNoteworthyLoader: vi.fn(),
+}));
+vi.mock("~/lib/noteworthy-performance-page", () => ({
+  NoteworthyPerformancePage: (props: object) => mockShallowComponent("NoteworthyPerformancePage", props),
+}));
 
 // Mock hooks
 vi.mock("~/hooks/use-serialized-loader-data", () => ({
@@ -64,12 +73,17 @@ describe("AllTimersPage", () => {
     expect(screen.queryByRole("link", { name: /back to songs/i })).not.toBeInTheDocument();
   });
 
-  // The PerformanceTable should still render as the main content.
-  test("renders the PerformanceTable with showSongColumn", () => {
+  // The page delegates to NoteworthyPerformancePage with the
+  // all-timers-specific endpoint and both noteworthy toggle chips
+  // hidden (All-Timer because the whole page is all-timers, Jam Chart
+  // for the same scope-redundancy reason).
+  test("renders NoteworthyPerformancePage with the all-timers API url and both toggles hidden", () => {
     renderAllTimers();
 
-    const table = screen.getByTestId("PerformanceTable");
-    expect(table).toBeInTheDocument();
-    expect(table.textContent).toContain('"showSongColumn":true');
+    const page = screen.getByTestId("NoteworthyPerformancePage");
+    expect(page).toBeInTheDocument();
+    expect(page.textContent).toContain('"apiUrl":"/api/all-timers"');
+    expect(page.textContent).toContain('"hideAllTimerToggle":true');
+    expect(page.textContent).toContain('"hideJamChartToggle":true');
   });
 });

--- a/apps/web/app/routes/songs/all-timers.tsx
+++ b/apps/web/app/routes/songs/all-timers.tsx
@@ -1,43 +1,11 @@
-import { type AllTimersPageView, CacheKeys } from "@bip/domain";
-import { type DehydratedState, dehydrate } from "@tanstack/react-query";
-import { PerformanceTable } from "~/components/performance";
-import { PerformanceFilterControls } from "~/components/performance/performance-filter-controls";
-import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
-import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
-import { publicLoader } from "~/lib/base-loaders";
-import { showUserDataQueryKey, trackUserRatingsQueryKey } from "~/lib/query-keys";
-import { createPrefetchClient } from "~/lib/query-prefetch";
+import { CacheKeys } from "@bip/domain";
+import { createNoteworthyLoader } from "~/lib/noteworthy-performance-loader";
+import { NoteworthyPerformancePage } from "~/lib/noteworthy-performance-page";
 import { services } from "~/server/services";
-import { computeShowUserData } from "~/server/show-user-data";
-import { computeTrackUserRatings } from "~/server/track-user-ratings";
 
-type LoaderData = AllTimersPageView & { dehydratedState: DehydratedState };
-
-export const loader = publicLoader(async ({ context }): Promise<LoaderData> => {
-  const cacheKey = CacheKeys.songs.allTimers();
-  const cacheOptions = { ttl: 3600 };
-
-  const view = await services.cache.getOrSet(
-    cacheKey,
-    async () => services.songPageComposer.buildAllTimers(),
-    cacheOptions,
-  );
-
-  const trackIds = view.performances.map((p) => p.trackId);
-  const showIds = [...new Set(view.performances.map((p) => p.show.id))];
-  const queryClient = createPrefetchClient();
-  await Promise.all([
-    queryClient.prefetchQuery({
-      queryKey: trackUserRatingsQueryKey(trackIds),
-      queryFn: () => computeTrackUserRatings(context, trackIds),
-    }),
-    queryClient.prefetchQuery({
-      queryKey: showUserDataQueryKey(showIds),
-      queryFn: () => computeShowUserData(context, showIds),
-    }),
-  ]);
-
-  return { ...view, dehydratedState: dehydrate(queryClient) };
+export const loader = createNoteworthyLoader({
+  cacheKey: CacheKeys.songs.allTimers(),
+  build: () => services.songPageComposer.buildAllTimers(),
 });
 
 export function meta() {
@@ -45,49 +13,5 @@ export function meta() {
 }
 
 export default function AllTimersPage() {
-  const { performances: allPerformances } = useSerializedLoaderData<LoaderData>();
-  const {
-    filteredData: filteredPerformances,
-    isLoading,
-    selectedTimeRange,
-    coverFilter,
-    selectedAuthor,
-    activeToggleSet,
-    hasActiveFilters,
-    searchText,
-    setSearchText,
-    updateFilter,
-    toggleFilter,
-    clearFilters,
-  } = usePerformancePageFilters({
-    initialData: allPerformances,
-    apiUrl: "/api/all-timers",
-    searchFilter: searchPerformance,
-  });
-
-  return (
-    <div>
-      <PerformanceTable
-        performances={filteredPerformances}
-        isLoading={isLoading}
-        showSongColumn
-        showGapColumns={false}
-        headerContent={
-          <PerformanceFilterControls
-            selectedTimeRange={selectedTimeRange}
-            activeToggleSet={activeToggleSet}
-            updateFilter={updateFilter}
-            toggleFilter={toggleFilter}
-            clearFilters={clearFilters}
-            coverFilter={coverFilter}
-            selectedAuthor={selectedAuthor}
-            showAllTimerToggle={false}
-            searchValue={searchText}
-            onSearchChange={setSearchText}
-            hasActiveFilters={hasActiveFilters}
-          />
-        }
-      />
-    </div>
-  );
+  return <NoteworthyPerformancePage apiUrl="/api/all-timers" hideAllTimerToggle hideJamChartToggle />;
 }

--- a/apps/web/app/routes/songs/histories.tsx
+++ b/apps/web/app/routes/songs/histories.tsx
@@ -108,7 +108,7 @@ function HistoryPreview({ text }: { text: string }) {
 const historiesColumns: ColumnDef<HistorySong>[] = [
   {
     accessorKey: "title",
-    meta: { width: "25%", cellClassName: "align-top" },
+    meta: { weight: 1, cellClassName: "align-top" },
     header: "Song",
     cell: ({ row }) => (
       <Link
@@ -121,7 +121,7 @@ const historiesColumns: ColumnDef<HistorySong>[] = [
   },
   {
     accessorKey: "history",
-    meta: { width: "75%", cellClassName: "align-top" },
+    meta: { weight: 3, cellClassName: "align-top" },
     header: "Preview",
     cell: ({ row }) => <HistoryPreview text={normalizeHistoryText(row.original.history)} />,
   },

--- a/apps/web/app/routes/songs/jam-charts.test.tsx
+++ b/apps/web/app/routes/songs/jam-charts.test.tsx
@@ -1,0 +1,37 @@
+import { mockShallowComponent } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("~/server/services", () => ({ services: {} }));
+vi.mock("@bip/domain", () => ({
+  CacheKeys: { songs: { jamCharts: () => "test-key" } },
+}));
+vi.mock("~/lib/noteworthy-performance-loader", () => ({
+  createNoteworthyLoader: vi.fn(),
+}));
+vi.mock("~/lib/noteworthy-performance-page", () => ({
+  NoteworthyPerformancePage: (props: object) => mockShallowComponent("NoteworthyPerformancePage", props),
+}));
+
+import JamChartsPage from "./jam-charts";
+
+describe("JamChartsPage", () => {
+  // The page delegates to NoteworthyPerformancePage with the
+  // jam-charts API endpoint. Only the Jam Chart toggle chip is hidden
+  // — the All-Timer chip stays visible because jam-charts is a
+  // superset of all-timers and users may want to narrow further.
+  test("renders NoteworthyPerformancePage with the jam-charts API url and only the Jam Chart toggle hidden", () => {
+    render(
+      <MemoryRouter initialEntries={["/songs/jam-charts"]}>
+        <JamChartsPage />
+      </MemoryRouter>,
+    );
+
+    const page = screen.getByTestId("NoteworthyPerformancePage");
+    expect(page).toBeInTheDocument();
+    expect(page.textContent).toContain('"apiUrl":"/api/jam-charts"');
+    expect(page.textContent).toContain('"hideJamChartToggle":true');
+    expect(page.textContent).not.toContain('"hideAllTimerToggle":true');
+  });
+});

--- a/apps/web/app/routes/songs/jam-charts.tsx
+++ b/apps/web/app/routes/songs/jam-charts.tsx
@@ -1,0 +1,20 @@
+import { CacheKeys } from "@bip/domain";
+import { createNoteworthyLoader } from "~/lib/noteworthy-performance-loader";
+import { NoteworthyPerformancePage } from "~/lib/noteworthy-performance-page";
+import { services } from "~/server/services";
+
+export const loader = createNoteworthyLoader({
+  cacheKey: CacheKeys.songs.jamCharts(),
+  build: () => services.songPageComposer.buildJamCharts(),
+});
+
+export function meta() {
+  return [
+    { title: "Jam Charts | Songs" },
+    { name: "description", content: "Noteworthy performances: all-timers and curated jam-chart picks" },
+  ];
+}
+
+export default function JamChartsPage() {
+  return <NoteworthyPerformancePage apiUrl="/api/jam-charts" hideJamChartToggle />;
+}

--- a/apps/web/app/styles.css
+++ b/apps/web/app/styles.css
@@ -58,6 +58,18 @@
   --color-rating-gold: hsl(38 95% 62%);
 }
 
+/* Radix Popover/Select sets `body[data-scroll-locked]` and adds a
+   margin-right matching the scrollbar width on open. In this app the
+   scroll lives on <html> rather than <body>, so that compensation
+   visually narrows the body and every page-width container (most
+   noticeably the show edit Card) snaps inward when a dropdown opens.
+   Force margin-right to 0 to keep layout stable. The `html` prefix is
+   load-bearing — it raises specificity above Radix's runtime-injected
+   `body[data-scroll-locked] { margin-right: 15px !important }` rule. */
+html body[data-scroll-locked] {
+  margin-right: 0 !important;
+}
+
 @layer base {
   /* Design Token System - Premium Purple & Vibrant Green Palette */
   :root {

--- a/packages/core/scripts/sync-missing-shows.test.ts
+++ b/packages/core/scripts/sync-missing-shows.test.ts
@@ -3,6 +3,10 @@ import {
   buildShowCreateInput,
   buildSongCreateInput,
   buildTrackCreateInputs,
+  buildTrackDriftUpdates,
+  diffTrackAnnotations,
+  buildSongDriftUpdate,
+  buildVenueDriftUpdate,
   buildShowDriftUpdate,
   buildVenueCreateInput,
   collectSongSlugs,
@@ -11,6 +15,7 @@ import {
   matchVenue,
   parseYearsArg,
   showNeedsUpdate,
+  type LocalTrackForDrift,
   type McpSearchVenueResult,
   type McpSetlist,
   type McpShow,
@@ -164,6 +169,8 @@ describe("buildShowCreateInput", () => {
       ratingsCount: 22,
       notes: "Festival opener",
       relistenUrl: "https://relisten.example/xyz",
+      countForStats: true,
+      dayOrder: null,
       venueId: null,
       bandId: null,
       createdAt: now,
@@ -212,6 +219,55 @@ describe("buildShowCreateInput", () => {
     );
     expect(input.venueId).toBe("venue-uc-uuid");
     expect(input.bandId).toBe("band-biscuits-uuid");
+  });
+
+  // countForStats and dayOrder are admin-controlled on prod and gate every
+  // downstream stat (countForStats → STATS_SHOWS_WHERE → gaps/timesPlayed;
+  // dayOrder → same-day tiebreak). They must mirror verbatim — local default
+  // of `countForStats=true`/`dayOrder=null` would mis-classify soundchecks
+  // and mis-order same-day pairs.
+  test("mirrors countForStats and dayOrder from MCP into the insert", () => {
+    const now = new Date("2026-04-23T12:00:00Z");
+    const input = buildShowCreateInput(
+      {
+        slug: "2026-02-06-miami-beach-bandshell-miami-beach-fl",
+        date: "2026-02-06",
+        venueName: "Miami Beach Bandshell",
+        venueCity: "Miami Beach",
+        averageRating: null,
+        ratingsCount: 0,
+        notes: null,
+        relistenUrl: null,
+        countForStats: false,
+        dayOrder: 2,
+      },
+      now,
+    );
+    expect(input.countForStats).toBe(false);
+    expect(input.dayOrder).toBe(2);
+  });
+
+  // Older MCP responses (pre-deploy) won't include countForStats/dayOrder. The
+  // builder must tolerate undefined and fall back to schema defaults
+  // (countForStats=true, dayOrder=null) — otherwise the next sync would
+  // overwrite real values with `undefined` once the new fields ship.
+  test("defaults countForStats=true and dayOrder=null when MCP omits them", () => {
+    const now = new Date("2026-04-23T12:00:00Z");
+    const input = buildShowCreateInput(
+      {
+        slug: "2026-04-18-the-uc-theatre-berkeley-ca",
+        date: "2026-04-18",
+        venueName: "The UC Theatre",
+        venueCity: "Berkeley",
+        averageRating: null,
+        ratingsCount: 0,
+        notes: null,
+        relistenUrl: null,
+      },
+      now,
+    );
+    expect(input.countForStats).toBe(true);
+    expect(input.dayOrder).toBeNull();
   });
 });
 
@@ -303,6 +359,43 @@ describe("showNeedsUpdate", () => {
       showNeedsUpdate(
         { averageRating: 4.2, ratingsCount: 19, notes: null, relistenUrl: null },
         remoteWithNulls,
+      ),
+    ).toBe(false);
+  });
+
+  // countForStats drift is the headline reason for this whole change: admins
+  // flip soundcheck/radio shows to `false` on prod and the local copy stays
+  // `true` forever, inflating play counts and shrinking gaps. Must trip drift.
+  test("returns true when countForStats drifts", () => {
+    const remoteWithFlag: McpShow = { ...remote, countForStats: false };
+    expect(
+      showNeedsUpdate(
+        { averageRating: 4.2, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr", countForStats: true, dayOrder: null },
+        remoteWithFlag,
+      ),
+    ).toBe(true);
+  });
+
+  // dayOrder drift is rarer but real — a same-day pair gets re-ordered on
+  // prod and local stays stale. Must trip drift.
+  test("returns true when dayOrder drifts", () => {
+    const remoteWithOrder: McpShow = { ...remote, dayOrder: 2 };
+    expect(
+      showNeedsUpdate(
+        { averageRating: 4.2, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr", countForStats: true, dayOrder: 1 },
+        remoteWithOrder,
+      ),
+    ).toBe(true);
+  });
+
+  // Pre-deploy MCP responses omit the new fields entirely. When MCP doesn't
+  // report a value, drift detection must NOT compare against `undefined` and
+  // claim drift on every show. Treats missing remote field as "no opinion".
+  test("ignores countForStats/dayOrder when remote omits them", () => {
+    expect(
+      showNeedsUpdate(
+        { averageRating: 4.2, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr", countForStats: false, dayOrder: 3 },
+        remote,
       ),
     ).toBe(false);
   });
@@ -511,6 +604,42 @@ describe("buildShowDriftUpdate", () => {
       relistenUrl: null,
     });
   });
+
+  // countForStats flip on an existing show is the primary stats divergence
+  // fix: prod reclassifies a show as a soundcheck, local mirrors the change,
+  // and the caller (orchestrator) feeds the show's date into the post-batch
+  // rebuild. The patch itself just contains the flipped flag.
+  test("emits countForStats when it drifts", () => {
+    const remoteWithFlag: McpShow = { ...remote, countForStats: false };
+    const localWithFlag = { ...localInSync, countForStats: true, dayOrder: null };
+    const patch = buildShowDriftUpdate(localWithFlag, remoteWithFlag, "venue-brooklyn-steel-uuid");
+    expect(patch).toEqual({ countForStats: false });
+  });
+
+  // dayOrder drift — patch carries only the changed field, doesn't churn the
+  // aggregate block.
+  test("emits dayOrder when it drifts", () => {
+    const remoteWithOrder: McpShow = { ...remote, dayOrder: 2 };
+    const localWithOrder = { ...localInSync, countForStats: true, dayOrder: 1 };
+    const patch = buildShowDriftUpdate(localWithOrder, remoteWithOrder, "venue-brooklyn-steel-uuid");
+    expect(patch).toEqual({ dayOrder: 2 });
+  });
+
+  // Combined drift: aggregate + flag + dayOrder all in one patch. Caller does
+  // a single UPDATE, not three.
+  test("combines aggregate, countForStats, and dayOrder drift into one patch", () => {
+    const remoteWith: McpShow = { ...remote, ratingsCount: 13, countForStats: false, dayOrder: 2 };
+    const localWith = { ...localInSync, ratingsCount: 12, countForStats: true, dayOrder: 1 };
+    const patch = buildShowDriftUpdate(localWith, remoteWith, "venue-brooklyn-steel-uuid");
+    expect(patch).toEqual({
+      averageRating: 3.7,
+      ratingsCount: 13,
+      notes: null,
+      relistenUrl: null,
+      countForStats: false,
+      dayOrder: 2,
+    });
+  });
 });
 
 // buildVenueCreateInput maps an MCP venue record to a Prisma Venue insert.
@@ -537,9 +666,122 @@ describe("buildVenueCreateInput", () => {
       state: "CA",
       country: "US",
       timesPlayed: 3,
+      street: null,
+      postalCode: null,
+      phone: null,
+      website: null,
+      latitude: null,
+      longitude: null,
       createdAt: now,
       updatedAt: now,
     });
+  });
+
+  // Contact + geocode fields land on insert when MCP supplies them. Previously
+  // these were never written, so Venue pages on local sat blank even though
+  // prod had street/phone/website populated.
+  test("mirrors street/phone/website/lat-long/postalCode when MCP supplies them", () => {
+    const now = new Date("2026-04-23T12:00:00Z");
+    const input = buildVenueCreateInput(
+      {
+        slug: "red-rocks-amphitheatre",
+        name: "Red Rocks Amphitheatre",
+        city: "Morrison",
+        state: "CO",
+        country: "US",
+        timesPlayed: 7,
+        street: "18300 W Alameda Pkwy",
+        postalCode: "80465",
+        phone: "+1-720-865-2494",
+        website: "https://redrocksonline.com",
+        latitude: 39.6654,
+        longitude: -105.2057,
+      },
+      now,
+    );
+    expect(input).toMatchObject({
+      street: "18300 W Alameda Pkwy",
+      postalCode: "80465",
+      phone: "+1-720-865-2494",
+      website: "https://redrocksonline.com",
+      latitude: 39.6654,
+      longitude: -105.2057,
+    });
+  });
+});
+
+// buildVenueDriftUpdate mirrors prod's curated venue fields onto an existing
+// local row. Identity is the venue slug; diff covers every column except
+// `timesPlayed` (derived from Show count, not curated) and the search/legacy
+// columns. Returns null when nothing drifted.
+describe("buildVenueDriftUpdate", () => {
+  const local = {
+    name: "Red Rocks Amphitheatre",
+    city: "Morrison",
+    state: "CO",
+    country: "US",
+    street: "18300 W Alameda Pkwy",
+    postalCode: "80465",
+    phone: "+1-720-865-2494",
+    website: "https://redrocksonline.com",
+    latitude: 39.6654,
+    longitude: -105.2057,
+  };
+
+  // Identical local + remote: skip the UPDATE. Re-runs idempotent.
+  test("returns null when every mirrored field matches", () => {
+    expect(
+      buildVenueDriftUpdate(local, {
+        slug: "red-rocks-amphitheatre",
+        name: "Red Rocks Amphitheatre",
+        city: "Morrison",
+        state: "CO",
+        country: "US",
+        timesPlayed: 7,
+        street: "18300 W Alameda Pkwy",
+        postalCode: "80465",
+        phone: "+1-720-865-2494",
+        website: "https://redrocksonline.com",
+        latitude: 39.6654,
+        longitude: -105.2057,
+      }),
+    ).toBeNull();
+  });
+
+  // Website edit on prod — only `website` flows through.
+  test("emits only the drifted field", () => {
+    expect(
+      buildVenueDriftUpdate(local, {
+        slug: "red-rocks-amphitheatre",
+        name: "Red Rocks Amphitheatre",
+        city: "Morrison",
+        state: "CO",
+        country: "US",
+        timesPlayed: 7,
+        street: "18300 W Alameda Pkwy",
+        postalCode: "80465",
+        phone: "+1-720-865-2494",
+        website: "https://redrocksonline.com/new-path",
+        latitude: 39.6654,
+        longitude: -105.2057,
+      }),
+    ).toEqual({ website: "https://redrocksonline.com/new-path" });
+  });
+
+  // Pre-deploy MCP omits contact + geocode columns. Sparse remote must not
+  // claim drift on those fields — otherwise every existing venue would have
+  // its phone/website/lat-long clobbered to null on the next sync.
+  test("ignores contact and geocode fields when remote omits them", () => {
+    expect(
+      buildVenueDriftUpdate(local, {
+        slug: "red-rocks-amphitheatre",
+        name: "Red Rocks Amphitheatre",
+        city: "Morrison",
+        state: "CO",
+        country: "US",
+        timesPlayed: 7,
+      }),
+    ).toBeNull();
   });
 });
 
@@ -570,8 +812,52 @@ describe("buildSongCreateInput", () => {
       timesPlayed: 412,
       dateFirstPlayed: new Date("1998-07-04"),
       dateLastPlayed: new Date("2026-02-06"),
+      cover: null,
+      legacyAuthor: null,
+      featuredLyric: null,
+      tabs: null,
+      notes: null,
+      history: null,
+      guitarTabsUrl: null,
       createdAt: now,
       updatedAt: now,
+    });
+  });
+
+  // Curated text fields (lyrics, tabs, notes, history, featuredLyric,
+  // guitarTabsUrl) and the `cover`/`legacyAuthor` admin flags must mirror
+  // verbatim on insert. These are the prod-curated columns the sync didn't
+  // previously write — leaving them null on first insert meant Song pages
+  // looked empty on local even though prod had content.
+  test("mirrors curated admin fields when MCP supplies them", () => {
+    const now = new Date("2026-04-23T12:00:00Z");
+    const input = buildSongCreateInput(
+      {
+        slug: "crystal-ball",
+        title: "Crystal Ball",
+        author: "Disco Biscuits",
+        lyrics: "And the sky lights up...",
+        timesPlayed: 188,
+        dateFirstPlayed: "2002-12-31",
+        dateLastPlayed: "2025-07-04",
+        cover: false,
+        legacyAuthor: "Disco Biscuits",
+        featuredLyric: "And the sky lights up",
+        tabs: "https://example/tabs",
+        notes: "Type II launches frequent",
+        history: "Debuted NYE 2002",
+        guitarTabsUrl: "https://example/guitar",
+      },
+      now,
+    );
+    expect(input).toMatchObject({
+      cover: false,
+      legacyAuthor: "Disco Biscuits",
+      featuredLyric: "And the sky lights up",
+      tabs: "https://example/tabs",
+      notes: "Type II launches frequent",
+      history: "Debuted NYE 2002",
+      guitarTabsUrl: "https://example/guitar",
     });
   });
 
@@ -625,9 +911,40 @@ describe("buildTrackCreateInputs", () => {
     ]);
     const tracks = buildTrackCreateInputs(setlist, "show-miami-uuid", songSlugToId);
     expect(tracks).toEqual([
-      { showId: "show-miami-uuid", songId: "song-basis-uuid", set: "S1", position: 1, segue: ">" },
-      { showId: "show-miami-uuid", songId: "song-aceetobee-uuid", set: "S1", position: 2, segue: null },
+      { showId: "show-miami-uuid", songId: "song-basis-uuid", set: "S1", position: 1, segue: ">", note: null, allTimer: false },
+      { showId: "show-miami-uuid", songId: "song-aceetobee-uuid", set: "S1", position: 2, segue: null, note: null, allTimer: false },
     ]);
+  });
+
+  // allTimer and note are admin-curated on prod (admins toggle the all-timer
+  // flag from track pages, and inline track annotations carry the `note`
+  // string). New MCP payloads include both per track; the builder must
+  // mirror them into the insert. Defaults: allTimer=false, note=null when MCP
+  // omits — keeps pre-deploy MCP responses parsing.
+  test("mirrors allTimer and note from MCP tracks into the insert", () => {
+    const setlist: McpSetlist = {
+      showSlug: "2025-07-04-red-rocks-morrison-co",
+      showDate: "2025-07-04",
+      venue: { name: "Red Rocks", city: "Morrison", state: "CO" },
+      sets: [
+        {
+          label: "S2",
+          tracks: [
+            // Curated all-timer with an inline note — a typical Red Rocks moment.
+            { position: 1, songTitle: "Crystal Ball", songSlug: "crystal-ball", segue: ">", allTimer: true, note: "Glow-stick war peak" },
+            // Vanilla track, defaults apply.
+            { position: 2, songTitle: "Helicopters", songSlug: "helicopters", segue: null },
+          ],
+        },
+      ],
+    };
+    const songSlugToId = new Map([
+      ["crystal-ball", "song-crystal-uuid"],
+      ["helicopters", "song-helicopters-uuid"],
+    ]);
+    const tracks = buildTrackCreateInputs(setlist, "show-rr-uuid", songSlugToId);
+    expect(tracks[0]).toMatchObject({ allTimer: true, note: "Glow-stick war peak" });
+    expect(tracks[1]).toMatchObject({ allTimer: false, note: null });
   });
 
   // If a song slug is missing from the map (upstream skipped or errored), we
@@ -652,5 +969,282 @@ describe("buildTrackCreateInputs", () => {
     const tracks = buildTrackCreateInputs(setlist, "show-uuid", songSlugToId);
     expect(tracks).toHaveLength(1);
     expect(tracks[0]?.songId).toBe("song-shem-uuid");
+  });
+});
+
+// buildTrackDriftUpdates computes per-track patches for existing local tracks
+// in a single show. The key is (showId, position) — within one show, position
+// is unique. Drift fields: segue, note, allTimer. Returns a list of {trackId,
+// patch} so the caller can issue scoped UPDATE statements without re-fetching.
+// Empty array means "nothing changed".
+describe("buildTrackDriftUpdates", () => {
+  // Canonical drift: prod marked track 3 (Crystal Ball) as an all-timer and
+  // added a note. Local row catches up on next sync. Other tracks unchanged
+  // → not in the result.
+  test("emits a patch only for the track whose fields drifted", () => {
+    const local: LocalTrackForDrift[] = [
+      { id: "track-1-uuid", position: 1, segue: ">", note: null, allTimer: false },
+      { id: "track-2-uuid", position: 2, segue: null, note: null, allTimer: false },
+      { id: "track-3-uuid", position: 3, segue: ">", note: null, allTimer: false },
+    ];
+    const remote: McpSetlist = {
+      showSlug: "2025-07-04-red-rocks-morrison-co",
+      showDate: "2025-07-04",
+      venue: { name: "Red Rocks", city: "Morrison", state: "CO" },
+      sets: [
+        {
+          label: "S2",
+          tracks: [
+            { position: 1, songTitle: "Helicopters", songSlug: "helicopters", segue: ">" },
+            { position: 2, songTitle: "Munchkin Invasion", songSlug: "munchkin-invasion", segue: null },
+            { position: 3, songTitle: "Crystal Ball", songSlug: "crystal-ball", segue: ">", allTimer: true, note: "Glow-stick war peak" },
+          ],
+        },
+      ],
+    };
+    const patches = buildTrackDriftUpdates(local, remote);
+    expect(patches).toEqual([
+      { trackId: "track-3-uuid", patch: { allTimer: true, note: "Glow-stick war peak" } },
+    ]);
+  });
+
+  // Idempotency: when local already matches remote on every field, no patches.
+  // This is the no-op re-run path — the orchestrator must skip the UPDATE
+  // entirely so updatedAt doesn't churn.
+  test("returns an empty list when nothing drifted", () => {
+    const local: LocalTrackForDrift[] = [
+      { id: "track-1-uuid", position: 1, segue: ">", note: null, allTimer: false },
+    ];
+    const remote: McpSetlist = {
+      showSlug: "2026-02-06-miami-beach-bandshell-miami-beach-fl",
+      showDate: "2026-02-06",
+      venue: { name: "Miami Beach Bandshell", city: "Miami Beach", state: "FL" },
+      sets: [
+        { label: "S1", tracks: [{ position: 1, songTitle: "Basis for a Day", songSlug: "basis-for-a-day", segue: ">", allTimer: false, note: null }] },
+      ],
+    };
+    expect(buildTrackDriftUpdates(local, remote)).toEqual([]);
+  });
+
+  // Segue edits land too — sometimes prod fixes a `>` to `,` after the fact.
+  // (Tracks can drift segue independently of admin flags.)
+  test("emits a patch when segue drifts", () => {
+    const local: LocalTrackForDrift[] = [
+      { id: "track-1-uuid", position: 1, segue: ">", note: null, allTimer: false },
+    ];
+    const remote: McpSetlist = {
+      showSlug: "2026-02-06-miami-beach-bandshell-miami-beach-fl",
+      showDate: "2026-02-06",
+      venue: { name: "Miami Beach Bandshell", city: "Miami Beach", state: "FL" },
+      sets: [
+        { label: "S1", tracks: [{ position: 1, songTitle: "Basis for a Day", songSlug: "basis-for-a-day", segue: "," }] },
+      ],
+    };
+    expect(buildTrackDriftUpdates(local, remote)).toEqual([
+      { trackId: "track-1-uuid", patch: { segue: "," } },
+    ]);
+  });
+
+  // Pre-deploy MCP responses omit allTimer / note. Treat omission as "no
+  // opinion" — don't claim drift just because the remote payload is sparse,
+  // or every existing track would get its admin fields clobbered to defaults
+  // on the next sync.
+  test("ignores allTimer / note when remote omits them", () => {
+    const local: LocalTrackForDrift[] = [
+      { id: "track-1-uuid", position: 1, segue: null, note: "kept locally", allTimer: true },
+    ];
+    const remote: McpSetlist = {
+      showSlug: "2026-02-06-miami-beach-bandshell-miami-beach-fl",
+      showDate: "2026-02-06",
+      venue: { name: "Miami Beach Bandshell", city: "Miami Beach", state: "FL" },
+      sets: [
+        // No allTimer / note keys at all — pre-deploy MCP shape.
+        { label: "S1", tracks: [{ position: 1, songTitle: "Basis for a Day", songSlug: "basis-for-a-day", segue: null }] },
+      ],
+    };
+    expect(buildTrackDriftUpdates(local, remote)).toEqual([]);
+  });
+
+  // Position is the only stable key within a show — a track that appears in
+  // local but not in the remote setlist (e.g. removed upstream) gets skipped,
+  // not patched. Deletion is intentionally not handled by drift; it's a
+  // separate cleanup concern.
+  test("skips local tracks whose position is absent from the remote setlist", () => {
+    const local: LocalTrackForDrift[] = [
+      { id: "track-1-uuid", position: 1, segue: null, note: null, allTimer: false },
+      { id: "track-99-uuid", position: 99, segue: null, note: null, allTimer: true },
+    ];
+    const remote: McpSetlist = {
+      showSlug: "2026-02-06-miami-beach-bandshell-miami-beach-fl",
+      showDate: "2026-02-06",
+      venue: { name: "Miami Beach Bandshell", city: "Miami Beach", state: "FL" },
+      sets: [
+        { label: "S1", tracks: [{ position: 1, songTitle: "Basis for a Day", songSlug: "basis-for-a-day", segue: null }] },
+      ],
+    };
+    expect(buildTrackDriftUpdates(local, remote)).toEqual([]);
+  });
+});
+
+// diffTrackAnnotations replaces the local Annotation set for one track with
+// whatever prod's MCP reports. Sync semantics are replace-not-merge: an
+// annotation removed on prod must disappear locally on the next run.
+// Identity is by `desc` text (the only content column) so a desc edit shows
+// up as one delete + one create — the helper doesn't try to be clever about
+// updates because Annotation has no other mutable content.
+describe("diffTrackAnnotations", () => {
+  // Canonical case: prod has [a, b], local has [a, c]. Keep a, delete c,
+  // create b. The id of `c` is what the caller needs for the DELETE statement.
+  test("returns the create/delete delta to reach the remote set", () => {
+    const local = [
+      { id: "ann-a-uuid", desc: "patches on patches" },
+      { id: "ann-c-uuid", desc: "outdated annotation" },
+    ];
+    const remote = ["patches on patches", "tribal opener"];
+    expect(diffTrackAnnotations(local, remote)).toEqual({
+      toCreateDescs: ["tribal opener"],
+      toDeleteIds: ["ann-c-uuid"],
+    });
+  });
+
+  // No drift: identical sets in any order. No writes, no deletes — keeps
+  // re-runs free of updatedAt churn on the parent track row.
+  test("returns empty deltas when local and remote match (order-insensitive)", () => {
+    const local = [
+      { id: "ann-a-uuid", desc: "patches on patches" },
+      { id: "ann-b-uuid", desc: "tribal opener" },
+    ];
+    const remote = ["tribal opener", "patches on patches"];
+    expect(diffTrackAnnotations(local, remote)).toEqual({ toCreateDescs: [], toDeleteIds: [] });
+  });
+
+  // Pre-deploy MCP omits annotations entirely. `undefined` must mean "no
+  // opinion" — never wipe out the local set. (Versus an explicit empty
+  // array, which DOES mean "prod has zero annotations now; delete local".)
+  test("returns empty deltas when remote annotations are undefined", () => {
+    const local = [{ id: "ann-a-uuid", desc: "patches on patches" }];
+    expect(diffTrackAnnotations(local, undefined)).toEqual({ toCreateDescs: [], toDeleteIds: [] });
+  });
+
+  // Explicit empty array means "prod has zero" — local must be wiped.
+  test("deletes all local annotations when remote is explicitly empty", () => {
+    const local = [
+      { id: "ann-a-uuid", desc: "patches on patches" },
+      { id: "ann-b-uuid", desc: "tribal opener" },
+    ];
+    expect(diffTrackAnnotations(local, [])).toEqual({
+      toCreateDescs: [],
+      toDeleteIds: ["ann-a-uuid", "ann-b-uuid"],
+    });
+  });
+});
+
+// buildSongDriftUpdate diffs an existing local Song row against the latest
+// MCP response and returns a patch — only the curated admin fields (title,
+// lyrics, cover, legacyAuthor, featuredLyric, tabs, notes, history,
+// guitarTabsUrl). It intentionally does NOT touch the derived stats columns
+// (timesPlayed, dateFirstPlayed, dateLastPlayed, yearlyPlayData) — those are
+// owned by the post-sync rebuild and would otherwise race against it.
+describe("buildSongDriftUpdate", () => {
+  const localBase = {
+    title: "Crystal Ball",
+    lyrics: "And the sky lights up...",
+    cover: false,
+    legacyAuthor: "Disco Biscuits",
+    featuredLyric: "And the sky lights up",
+    tabs: null,
+    notes: null,
+    history: null,
+    guitarTabsUrl: null,
+  };
+
+  // No drift across every mirrored field: skip the UPDATE. Re-runs stay
+  // idempotent — updatedAt doesn't churn on unchanged songs.
+  test("returns null when every curated field matches", () => {
+    expect(
+      buildSongDriftUpdate(localBase, {
+        slug: "crystal-ball",
+        title: "Crystal Ball",
+        author: "Disco Biscuits",
+        lyrics: "And the sky lights up...",
+        timesPlayed: 188,
+        dateFirstPlayed: null,
+        dateLastPlayed: null,
+        cover: false,
+        legacyAuthor: "Disco Biscuits",
+        featuredLyric: "And the sky lights up",
+      }),
+    ).toBeNull();
+  });
+
+  // Lyrics edit on prod (typo fix or expansion) mirrors locally. Patch
+  // contains only the lyrics field — no churn on the rest of the row.
+  test("emits only the lyrics field when lyrics drifts", () => {
+    const patch = buildSongDriftUpdate(localBase, {
+      slug: "crystal-ball",
+      title: "Crystal Ball",
+      author: "Disco Biscuits",
+      lyrics: "And the sky lights up (extended)",
+      timesPlayed: 188,
+      dateFirstPlayed: null,
+      dateLastPlayed: null,
+    });
+    expect(patch).toEqual({ lyrics: "And the sky lights up (extended)" });
+  });
+
+  // Multi-field drift: title rename + new featuredLyric + cover flag flip
+  // bundle into one patch — one UPDATE round-trip instead of three.
+  test("combines multiple drifted fields into one patch", () => {
+    const patch = buildSongDriftUpdate(localBase, {
+      slug: "crystal-ball",
+      title: "Crystal Ball (Reprise)",
+      author: "Disco Biscuits",
+      lyrics: "And the sky lights up...",
+      timesPlayed: 188,
+      dateFirstPlayed: null,
+      dateLastPlayed: null,
+      cover: true,
+      featuredLyric: "Glow stick crescendo",
+    });
+    expect(patch).toEqual({
+      title: "Crystal Ball (Reprise)",
+      cover: true,
+      featuredLyric: "Glow stick crescendo",
+    });
+  });
+
+  // Pre-deploy MCP omits the new curated fields. Sparse remote payload must
+  // never claim drift on `cover` / `legacyAuthor` / `featuredLyric` / `tabs`
+  // / `notes` / `history` / `guitarTabsUrl` — otherwise every existing song
+  // would have those fields clobbered to null on the next sync.
+  test("ignores curated fields when remote omits them", () => {
+    expect(
+      buildSongDriftUpdate(localBase, {
+        slug: "crystal-ball",
+        title: "Crystal Ball",
+        author: "Disco Biscuits",
+        lyrics: "And the sky lights up...",
+        timesPlayed: 188,
+        dateFirstPlayed: null,
+        dateLastPlayed: null,
+      }),
+    ).toBeNull();
+  });
+
+  // Patch never touches the derived stats columns even when the MCP payload
+  // includes new play data. Stats are owned by the post-sync rebuild.
+  test("never emits derived stats columns even when remote reports new values", () => {
+    const patch = buildSongDriftUpdate(localBase, {
+      slug: "crystal-ball",
+      title: "Crystal Ball",
+      author: "Disco Biscuits",
+      lyrics: "Lyrics edit",
+      timesPlayed: 999,
+      dateFirstPlayed: "1999-01-01",
+      dateLastPlayed: "2026-05-22",
+    });
+    expect(patch).not.toHaveProperty("timesPlayed");
+    expect(patch).not.toHaveProperty("dateFirstPlayed");
+    expect(patch).not.toHaveProperty("dateLastPlayed");
   });
 });

--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -40,7 +40,10 @@ export interface McpShowSummary {
 
 // Richer shape returned by the `get_shows` tool (vs the summary from
 // `get_shows_by_year`). Carries the aggregate fields we mirror: ratingsCount,
-// notes, relistenUrl.
+// notes, relistenUrl, and the admin-controlled stat flags countForStats /
+// dayOrder. The flags are optional so older MCP deploys (pre-this-change)
+// keep parsing cleanly — see showNeedsUpdate for the "omit means no opinion"
+// drift semantics.
 export interface McpShow {
   slug: string;
   date: string;
@@ -50,6 +53,8 @@ export interface McpShow {
   ratingsCount: number;
   notes: string | null;
   relistenUrl: string | null;
+  countForStats?: boolean;
+  dayOrder?: number | null;
 }
 
 export interface McpSetlistTrack {
@@ -57,6 +62,13 @@ export interface McpSetlistTrack {
   songTitle: string;
   songSlug: string;
   segue: string | null;
+  // Admin-curated; optional on the wire so older MCP responses parse cleanly.
+  allTimer?: boolean | null;
+  note?: string | null;
+  // Per-track annotations from the Annotation table. `undefined` means
+  // "no opinion" (pre-deploy MCP); an explicit empty array means "prod has
+  // zero". Replace-not-merge semantics on sync — see diffTrackAnnotations.
+  annotations?: string[];
 }
 
 export interface McpSetlistSet {
@@ -80,6 +92,17 @@ export interface McpSong {
   // MCP serializes these as ISO strings (JSON.stringify of Date); tolerate both.
   dateFirstPlayed: string | Date | null;
   dateLastPlayed: string | Date | null;
+  // Curated admin fields. Optional on the wire so pre-deploy MCP responses
+  // parse, and treated as "no opinion" in drift detection — see
+  // buildSongDriftUpdate. `null` is distinct from `undefined` here: explicit
+  // null means "prod has cleared the value" and DOES drift.
+  cover?: boolean | null;
+  legacyAuthor?: string | null;
+  featuredLyric?: string | null;
+  tabs?: string | null;
+  notes?: string | null;
+  history?: string | null;
+  guitarTabsUrl?: string | null;
 }
 
 export interface McpVenue {
@@ -89,6 +112,14 @@ export interface McpVenue {
   state: string | null;
   country: string | null;
   timesPlayed: number;
+  // Contact + geocode columns. Optional on the wire so pre-deploy MCP parses;
+  // `undefined` = "no opinion" in drift detection.
+  street?: string | null;
+  postalCode?: string | null;
+  phone?: string | null;
+  website?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
 }
 
 export interface McpSearchVenueResult {
@@ -190,6 +221,13 @@ export function buildShowCreateInput(
     ratingsCount: show.ratingsCount,
     notes: show.notes,
     relistenUrl: show.relistenUrl,
+    // Fall back to schema defaults when MCP omits the flags. `??` is critical:
+    // a pre-deploy MCP returns `undefined`, which Prisma would otherwise pass
+    // through as "no opinion" (fine on insert) but the explicit default makes
+    // the contract obvious in tests and avoids surprises if Prisma's behavior
+    // ever shifts.
+    countForStats: show.countForStats ?? true,
+    dayOrder: show.dayOrder ?? null,
     venueId: opts.venueId ?? null,
     bandId: opts.bandId ?? null,
     createdAt: now,
@@ -204,6 +242,8 @@ export interface LocalShowAggregates {
   ratingsCount: number;
   notes: string | null;
   relistenUrl: string | null;
+  countForStats?: boolean;
+  dayOrder?: number | null;
 }
 
 const AVERAGE_RATING_TOLERANCE = 1e-6;
@@ -212,6 +252,12 @@ export function showNeedsUpdate(local: LocalShowAggregates, remote: McpShow): bo
   if (local.ratingsCount !== remote.ratingsCount) return true;
   if (local.notes !== remote.notes) return true;
   if (local.relistenUrl !== remote.relistenUrl) return true;
+  // countForStats / dayOrder: only compare when remote actually reports them.
+  // A pre-deploy MCP omits these, and treating `undefined` as a drift would
+  // claim every show needs an update — flapping `countForStats` to its default
+  // and clobbering admin-set values.
+  if (remote.countForStats !== undefined && (local.countForStats ?? true) !== remote.countForStats) return true;
+  if (remote.dayOrder !== undefined && (local.dayOrder ?? null) !== remote.dayOrder) return true;
   const la = local.averageRating;
   const ra = remote.averageRating;
   if (la === null || ra === null) return la !== ra;
@@ -235,23 +281,37 @@ export interface ShowDriftUpdate {
   notes?: string | null;
   relistenUrl?: string | null;
   venueId?: string | null;
+  countForStats?: boolean;
+  dayOrder?: number | null;
 }
 
 /**
- * Compute the patch to apply to an already-local show row. Two independent
- * triggers: aggregate drift (rating/notes/relistenUrl/ratingsCount) and venue
- * back-fill (local venueId is null but the venue is now resolvable). Returns
- * null when nothing changed so callers can skip the UPDATE entirely and keep
- * re-runs idempotent.
+ * Compute the patch to apply to an already-local show row. Independent
+ * triggers: aggregate drift (rating/notes/relistenUrl/ratingsCount), the
+ * admin-controlled flags (countForStats, dayOrder), and venue back-fill (local
+ * venueId is null but the venue is now resolvable). Returns null when nothing
+ * changed so callers can skip the UPDATE entirely and keep re-runs idempotent.
+ *
+ * countForStats and dayOrder are emitted independently from the aggregate
+ * block — flipping the flag shouldn't churn updatedAt with an identical
+ * rating payload, and vice versa.
  */
 export function buildShowDriftUpdate(
   local: LocalShowForDrift,
   remote: McpShow,
   resolvedVenueId: string | null,
 ): ShowDriftUpdate | null {
-  const aggregatesDrift = showNeedsUpdate(local, remote);
+  const aggregatesDrift =
+    local.ratingsCount !== remote.ratingsCount ||
+    local.notes !== remote.notes ||
+    local.relistenUrl !== remote.relistenUrl ||
+    averageRatingDrift(local.averageRating, remote.averageRating);
+  const countForStatsDrift =
+    remote.countForStats !== undefined && (local.countForStats ?? true) !== remote.countForStats;
+  const dayOrderDrift =
+    remote.dayOrder !== undefined && (local.dayOrder ?? null) !== remote.dayOrder;
   const venueDrift = local.venueId === null && resolvedVenueId !== null;
-  if (!aggregatesDrift && !venueDrift) return null;
+  if (!aggregatesDrift && !countForStatsDrift && !dayOrderDrift && !venueDrift) return null;
   const update: ShowDriftUpdate = {};
   if (aggregatesDrift) {
     update.averageRating = remote.averageRating;
@@ -259,8 +319,15 @@ export function buildShowDriftUpdate(
     update.notes = remote.notes;
     update.relistenUrl = remote.relistenUrl;
   }
+  if (countForStatsDrift) update.countForStats = remote.countForStats;
+  if (dayOrderDrift) update.dayOrder = remote.dayOrder ?? null;
   if (venueDrift) update.venueId = resolvedVenueId;
   return update;
+}
+
+function averageRatingDrift(local: number | null, remote: number | null): boolean {
+  if (local === null || remote === null) return local !== remote;
+  return Math.abs(local - remote) > AVERAGE_RATING_TOLERANCE;
 }
 
 export function buildSongCreateInput(song: McpSong, now: Date): Prisma.SongUncheckedCreateInput {
@@ -271,9 +338,76 @@ export function buildSongCreateInput(song: McpSong, now: Date): Prisma.SongUnche
     timesPlayed: song.timesPlayed,
     dateFirstPlayed: song.dateFirstPlayed ? new Date(song.dateFirstPlayed) : null,
     dateLastPlayed: song.dateLastPlayed ? new Date(song.dateLastPlayed) : null,
+    // Optional curated fields — `?? null` collapses `undefined` (older MCP)
+    // to a stable explicit value, matching the existing buildShowCreateInput
+    // pattern.
+    cover: song.cover ?? null,
+    legacyAuthor: song.legacyAuthor ?? null,
+    featuredLyric: song.featuredLyric ?? null,
+    tabs: song.tabs ?? null,
+    notes: song.notes ?? null,
+    history: song.history ?? null,
+    guitarTabsUrl: song.guitarTabsUrl ?? null,
     createdAt: now,
     updatedAt: now,
   };
+}
+
+// Shape-minimal view of a local Song row for drift detection. Mirrors the
+// curated fields buildSongDriftUpdate compares; derived stats columns are
+// intentionally omitted (the post-sync rebuild owns them).
+export interface LocalSongCurated {
+  title: string;
+  lyrics: string | null;
+  cover: boolean | null;
+  legacyAuthor: string | null;
+  featuredLyric: string | null;
+  tabs: string | null;
+  notes: string | null;
+  history: string | null;
+  guitarTabsUrl: string | null;
+}
+
+export interface SongDriftUpdate {
+  title?: string;
+  lyrics?: string | null;
+  cover?: boolean | null;
+  legacyAuthor?: string | null;
+  featuredLyric?: string | null;
+  tabs?: string | null;
+  notes?: string | null;
+  history?: string | null;
+  guitarTabsUrl?: string | null;
+}
+
+/**
+ * Compute the patch to mirror prod's curated Song fields onto an existing
+ * local row. Returns null when nothing changed. Derived stats columns
+ * (timesPlayed, dateFirstPlayed/LastPlayed, yearlyPlayData) are owned by
+ * `rebuildGapsAndSongStatsSince` and intentionally never appear in the patch.
+ *
+ * Fields whose remote value is `undefined` are treated as "no opinion" — a
+ * pre-deploy MCP that doesn't return `cover` shouldn't clobber a locally set
+ * value. Explicit `null` from MCP IS drift (prod cleared the field).
+ */
+export function buildSongDriftUpdate(local: LocalSongCurated, remote: McpSong): SongDriftUpdate | null {
+  const patch: SongDriftUpdate = {};
+  if (local.title !== remote.title) patch.title = remote.title;
+  if (local.lyrics !== remote.lyrics) patch.lyrics = remote.lyrics;
+  if (remote.cover !== undefined && local.cover !== remote.cover) patch.cover = remote.cover;
+  if (remote.legacyAuthor !== undefined && local.legacyAuthor !== remote.legacyAuthor) {
+    patch.legacyAuthor = remote.legacyAuthor;
+  }
+  if (remote.featuredLyric !== undefined && local.featuredLyric !== remote.featuredLyric) {
+    patch.featuredLyric = remote.featuredLyric;
+  }
+  if (remote.tabs !== undefined && local.tabs !== remote.tabs) patch.tabs = remote.tabs;
+  if (remote.notes !== undefined && local.notes !== remote.notes) patch.notes = remote.notes;
+  if (remote.history !== undefined && local.history !== remote.history) patch.history = remote.history;
+  if (remote.guitarTabsUrl !== undefined && local.guitarTabsUrl !== remote.guitarTabsUrl) {
+    patch.guitarTabsUrl = remote.guitarTabsUrl;
+  }
+  return Object.keys(patch).length === 0 ? null : patch;
 }
 
 export function buildVenueCreateInput(venue: McpVenue, now: Date): Prisma.VenueUncheckedCreateInput {
@@ -284,9 +418,70 @@ export function buildVenueCreateInput(venue: McpVenue, now: Date): Prisma.VenueU
     state: venue.state,
     country: venue.country,
     timesPlayed: venue.timesPlayed,
+    street: venue.street ?? null,
+    postalCode: venue.postalCode ?? null,
+    phone: venue.phone ?? null,
+    website: venue.website ?? null,
+    latitude: venue.latitude ?? null,
+    longitude: venue.longitude ?? null,
     createdAt: now,
     updatedAt: now,
   };
+}
+
+// Shape-minimal local Venue row used by buildVenueDriftUpdate. Excludes
+// timesPlayed (derived, not curated) and the search/legacy columns.
+export interface LocalVenueCurated {
+  name: string | null;
+  city: string | null;
+  state: string | null;
+  country: string | null;
+  street: string | null;
+  postalCode: string | null;
+  phone: string | null;
+  website: string | null;
+  latitude: number | null;
+  longitude: number | null;
+}
+
+export interface VenueDriftUpdate {
+  name?: string | null;
+  city?: string | null;
+  state?: string | null;
+  country?: string | null;
+  street?: string | null;
+  postalCode?: string | null;
+  phone?: string | null;
+  website?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+}
+
+/**
+ * Diff a local Venue row against the latest MCP venue payload and return a
+ * patch of the drifted curated fields, or null when nothing changed.
+ *
+ * timesPlayed is intentionally excluded — it's a derived count of shows at
+ * the venue, not a curated value, and the search/legacy columns are likewise
+ * out of scope. Fields whose remote value is `undefined` (older MCP that
+ * doesn't return contact/geocode columns) are treated as "no opinion" so a
+ * sparse upstream can't clobber locally populated columns.
+ */
+export function buildVenueDriftUpdate(local: LocalVenueCurated, remote: McpVenue): VenueDriftUpdate | null {
+  const patch: VenueDriftUpdate = {};
+  // name / city / state / country come from the base MCP shape and are
+  // compared unconditionally (they were always synced on insert).
+  if (local.name !== remote.name) patch.name = remote.name;
+  if (local.city !== remote.city) patch.city = remote.city;
+  if (local.state !== remote.state) patch.state = remote.state;
+  if (local.country !== remote.country) patch.country = remote.country;
+  if (remote.street !== undefined && local.street !== remote.street) patch.street = remote.street;
+  if (remote.postalCode !== undefined && local.postalCode !== remote.postalCode) patch.postalCode = remote.postalCode;
+  if (remote.phone !== undefined && local.phone !== remote.phone) patch.phone = remote.phone;
+  if (remote.website !== undefined && local.website !== remote.website) patch.website = remote.website;
+  if (remote.latitude !== undefined && local.latitude !== remote.latitude) patch.latitude = remote.latitude;
+  if (remote.longitude !== undefined && local.longitude !== remote.longitude) patch.longitude = remote.longitude;
+  return Object.keys(patch).length === 0 ? null : patch;
 }
 
 export function buildTrackCreateInputs(
@@ -305,10 +500,85 @@ export function buildTrackCreateInputs(
         set: set.label,
         position: track.position,
         segue: track.segue,
+        // Defaults mirror the Prisma schema so a pre-deploy MCP (no allTimer
+        // / note in payload) still produces explicit, predictable inserts.
+        note: track.note ?? null,
+        allTimer: track.allTimer ?? false,
       });
     }
   }
   return tracks;
+}
+
+// Shape-minimal local Track row used by the drift-update path. Keyed by
+// (showId, position) at the call site — `id` is the primary key we patch.
+export interface LocalTrackForDrift {
+  id: string;
+  position: number;
+  segue: string | null;
+  note: string | null;
+  allTimer: boolean | null;
+}
+
+export interface TrackDriftPatch {
+  segue?: string | null;
+  note?: string | null;
+  allTimer?: boolean;
+}
+
+/**
+ * Diff the local tracks of a single show against the remote setlist payload
+ * and return one {trackId, patch} per drifted track. Drift fields: segue,
+ * note, allTimer. Pre-deploy MCP omits allTimer/note entirely — those keys
+ * are treated as "no opinion" and never produce a patch, so an older upstream
+ * can't clobber admin-set values.
+ */
+export function buildTrackDriftUpdates(
+  local: LocalTrackForDrift[],
+  remote: McpSetlist,
+): Array<{ trackId: string; patch: TrackDriftPatch }> {
+  const remoteByPosition = new Map<number, McpSetlistTrack>();
+  for (const set of remote.sets) {
+    for (const track of set.tracks) {
+      remoteByPosition.set(track.position, track);
+    }
+  }
+  const out: Array<{ trackId: string; patch: TrackDriftPatch }> = [];
+  for (const localTrack of local) {
+    const remoteTrack = remoteByPosition.get(localTrack.position);
+    if (!remoteTrack) continue;
+    const patch: TrackDriftPatch = {};
+    if (localTrack.segue !== remoteTrack.segue) patch.segue = remoteTrack.segue;
+    if (remoteTrack.note !== undefined && localTrack.note !== remoteTrack.note) {
+      patch.note = remoteTrack.note;
+    }
+    if (remoteTrack.allTimer !== undefined) {
+      const localFlag = localTrack.allTimer ?? false;
+      const remoteFlag = remoteTrack.allTimer ?? false;
+      if (localFlag !== remoteFlag) patch.allTimer = remoteFlag;
+    }
+    if (Object.keys(patch).length > 0) out.push({ trackId: localTrack.id, patch });
+  }
+  return out;
+}
+
+/**
+ * Compute the minimum create/delete operations needed to replace one track's
+ * local annotation set with whatever prod returned. Identity is by `desc`
+ * text — Annotation has no other mutable content, so an edited description
+ * surfaces as one delete + one create. `undefined` remote = "no opinion"
+ * (older MCP) and produces empty deltas; an explicit empty array wipes local.
+ */
+export function diffTrackAnnotations(
+  local: Array<{ id: string; desc: string | null }>,
+  remote: string[] | undefined,
+): { toCreateDescs: string[]; toDeleteIds: string[] } {
+  if (remote === undefined) return { toCreateDescs: [], toDeleteIds: [] };
+  const remoteSet = new Set(remote);
+  const localSet = new Set(local.map((a) => a.desc ?? ""));
+  const toDeleteIds = local.filter((a) => !remoteSet.has(a.desc ?? "")).map((a) => a.id);
+  const toCreateDescs = remote.filter((d) => !localSet.has(d));
+  return { toCreateDescs, toDeleteIds };
 }
 
 // --- JSON-RPC transport ---
@@ -362,6 +632,11 @@ interface SyncStats {
 
 async function syncMissingShows(): Promise<void> {
   const isDryRun = process.argv.includes("--dry-run");
+  // --full-track-sync: fetch setlists for every existing local show in scope,
+  // not just missing-or-needs-venue. Catches Track.allTimer / Track.note /
+  // Track.segue / annotation edits on shows that haven't otherwise changed.
+  // Default run stays fast; opt in for periodic catch-up.
+  const isFullTrackSync = process.argv.includes("--full-track-sync");
   const years = parseYearsArg(process.argv.slice(2), new Date());
   const now = new Date();
   const db = prisma;
@@ -458,11 +733,14 @@ async function syncMissingShows(): Promise<void> {
       select: {
         id: true,
         slug: true,
+        date: true,
         averageRating: true,
         ratingsCount: true,
         notes: true,
         relistenUrl: true,
         venueId: true,
+        countForStats: true,
+        dayOrder: true,
       },
     });
     const existingBySlug = new Map(existingLocal.map((s) => [s.slug, s]));
@@ -475,8 +753,10 @@ async function syncMissingShows(): Promise<void> {
     const needsVenueSlugs = existingLocal.filter((s) => s.venueId === null).map((s) => s.slug);
     console.log(`📥 ${missingShows.length} missing locally (${stats.showsAlreadyLocal} already present, ${needsVenueSlugs.length} need venue back-fill)`);
 
-    if (missingShows.length === 0 && needsVenueSlugs.length === 0) {
+    if (missingShows.length === 0 && needsVenueSlugs.length === 0 && !isFullTrackSync) {
       // Pure aggregate-drift run: do the simple update loop and bail out.
+      // (When --full-track-sync is set we fall through to the full pipeline so
+      // every existing show's setlist gets diffed for Track / Annotation drift.)
       for (const remote of existingRemoteShows) {
         const local = existingBySlug.get(remote.slug);
         if (!local) continue;
@@ -493,6 +773,16 @@ async function syncMissingShows(): Promise<void> {
         try {
           await db.show.update({ where: { slug: remote.slug }, data: { ...patch, updatedAt: now } });
           changedSlugs.add(remote.slug);
+          // countForStats flip on an existing show invalidates the gap chain
+          // from that show's date forward — feed the date into the rebuild
+          // trigger so the post-batch stats sweep picks it up. (Aggregate
+          // drift alone doesn't shift gap math.)
+          if (patch.countForStats !== undefined) {
+            const showDate = String(local.date);
+            if (earliestInsertedDate === null || showDate < earliestInsertedDate) {
+              earliestInsertedDate = showDate;
+            }
+          }
           stats.showsUpdated++;
           console.log(`  🔄 ${remote.slug} ${JSON.stringify(patch)}`);
         } catch (err) {
@@ -501,13 +791,33 @@ async function syncMissingShows(): Promise<void> {
         }
       }
       console.log(`📊 Existing shows: ${stats.showsUpdated} updated, ${stats.showsUnchanged} unchanged`);
+      // Even a pure aggregate-drift run can trip the rebuild trigger if a
+      // countForStats flip was observed above.
+      if (!isDryRun && earliestInsertedDate !== null) {
+        console.log(`📐 Rebuilding gaps + song stats since ${earliestInsertedDate} (countForStats flip)`);
+        try {
+          await statsService.rebuildGapsAndSongStatsSince(earliestInsertedDate);
+        } catch (err) {
+          console.error("  ❌ stats rebuild failed:", err);
+          stats.errors++;
+        }
+      }
       printSummary(stats, isDryRun);
       return;
     }
 
     // Step 3: fetch setlists for missing shows AND existing shows that need
-    // venue back-fill, in one batched call.
-    const setlistFetchSlugs = [...missingShows.map((s) => s.slug), ...needsVenueSlugs];
+    // venue back-fill, in one batched call. --full-track-sync adds every
+    // remaining existing-local slug so Track / Annotation drift can be diffed
+    // against the latest prod state, not just the inserts + venue back-fills.
+    const fullTrackSyncSlugs = isFullTrackSync
+      ? existingLocal.filter((s) => s.venueId !== null).map((s) => s.slug)
+      : [];
+    const setlistFetchSlugs = [
+      ...missingShows.map((s) => s.slug),
+      ...needsVenueSlugs,
+      ...fullTrackSyncSlugs,
+    ];
     const { setlists, errors: setlistErrors } = await mcpCall<{
       setlists: McpSetlist[];
       errors?: Array<{ slug: string; error: string }>;
@@ -548,32 +858,68 @@ async function syncMissingShows(): Promise<void> {
       }
     }
 
-    // Any resolved venue slugs missing locally get pulled from get_venues and inserted.
+    // Pull the full curated shape locally for every resolved venue slug so the
+    // same data drives both the "missing → create" branch and the
+    // "already-local → diff" branch below. No second DB round-trip needed.
     const neededVenueSlugs = Array.from(new Set(venueKeyToSlug.values()));
-    const localVenues = await db.venue.findMany({
+    const localVenueRows = await db.venue.findMany({
       where: { slug: { in: neededVenueSlugs } },
-      select: { slug: true, id: true },
+      select: {
+        slug: true,
+        id: true,
+        name: true,
+        city: true,
+        state: true,
+        country: true,
+        street: true,
+        postalCode: true,
+        phone: true,
+        website: true,
+        latitude: true,
+        longitude: true,
+      },
     });
-    const venueSlugToId = new Map<string, string>(localVenues.map((v) => [v.slug, v.id]));
-    const missingVenueSlugs = neededVenueSlugs.filter((slug) => !venueSlugToId.has(slug));
-    if (missingVenueSlugs.length > 0) {
+    const venueSlugToId = new Map<string, string>(localVenueRows.map((v) => [v.slug, v.id]));
+    const localVenueBySlug = new Map(localVenueRows.map((v) => [v.slug, v]));
+    // Fetch the full MCP venue shape for every in-scope slug — missing ones
+    // get created, already-local ones get diffed against buildVenueDriftUpdate.
+    if (neededVenueSlugs.length > 0) {
       const { venues: remoteVenues, errors: venueErrors } = await mcpCall<{
         venues: McpVenue[];
         errors?: Array<{ slug: string; error: string }>;
-      }>("get_venues", { slugs: missingVenueSlugs });
+      }>("get_venues", { slugs: neededVenueSlugs });
       if (venueErrors?.length) stats.errors += venueErrors.length;
       for (const venue of remoteVenues) {
+        const localId = venueSlugToId.get(venue.slug);
+        if (localId === undefined) {
+          if (isDryRun) {
+            venueSlugToId.set(venue.slug, `dry-run-venue-${venue.slug}`);
+            stats.venuesCreated++;
+            continue;
+          }
+          try {
+            const created = await db.venue.create({ data: buildVenueCreateInput(venue, now) });
+            venueSlugToId.set(created.slug, created.id);
+            stats.venuesCreated++;
+          } catch (err) {
+            console.error(`  ❌ failed to create venue ${venue.slug}:`, err);
+            stats.errors++;
+          }
+          continue;
+        }
+        const localVenue = localVenueBySlug.get(venue.slug);
+        if (!localVenue) continue;
+        const patch = buildVenueDriftUpdate(localVenue, venue);
+        if (patch === null) continue;
         if (isDryRun) {
-          venueSlugToId.set(venue.slug, `dry-run-venue-${venue.slug}`);
-          stats.venuesCreated++;
+          console.log(`  🔄 venue ${venue.slug} would update ${JSON.stringify(patch)} (dry run)`);
           continue;
         }
         try {
-          const created = await db.venue.create({ data: buildVenueCreateInput(venue, now) });
-          venueSlugToId.set(created.slug, created.id);
-          stats.venuesCreated++;
+          await db.venue.update({ where: { id: localId }, data: { ...patch, updatedAt: now } });
+          console.log(`  🔄 venue ${venue.slug} ${JSON.stringify(patch)}`);
         } catch (err) {
-          console.error(`  ❌ failed to create venue ${venue.slug}:`, err);
+          console.error(`  ❌ failed to update venue ${venue.slug}:`, err);
           stats.errors++;
         }
       }
@@ -607,6 +953,13 @@ async function syncMissingShows(): Promise<void> {
         await db.show.update({ where: { slug: remote.slug }, data: { ...patch, updatedAt: now } });
         changedSlugs.add(remote.slug);
         if (patch.venueId) stats.venuesLinked++;
+        // countForStats flip → expand the rebuild window to cover this show.
+        if (patch.countForStats !== undefined) {
+          const showDate = String(local.date);
+          if (earliestInsertedDate === null || showDate < earliestInsertedDate) {
+            earliestInsertedDate = showDate;
+          }
+        }
         stats.showsUpdated++;
         console.log(`  🔄 ${remote.slug} ${JSON.stringify(patch)}`);
       } catch (err) {
@@ -618,39 +971,77 @@ async function syncMissingShows(): Promise<void> {
 
     // Step 6: resolve songs (local + remote) into an id map the track builder
     // can consume. Songs already in the DB reuse their existing id; new songs
-    // get created via get_songs fetch.
+    // get created via get_songs fetch. We fetch the full MCP shape for EVERY
+    // in-scope song (not just missing ones) so the same call doubles as the
+    // source for buildSongDriftUpdate — admin edits to lyrics / cover /
+    // featuredLyric on prod mirror locally without a second round-trip.
     const allSongSlugs = collectSongSlugs(setlists);
-    const localSongs = await db.song.findMany({
+    const localSongRows = await db.song.findMany({
       where: { slug: { in: allSongSlugs } },
-      select: { slug: true, id: true },
+      select: {
+        slug: true,
+        id: true,
+        title: true,
+        lyrics: true,
+        cover: true,
+        legacyAuthor: true,
+        featuredLyric: true,
+        tabs: true,
+        notes: true,
+        history: true,
+        guitarTabsUrl: true,
+      },
     });
-    const songSlugToId = new Map<string, string>(localSongs.map((s) => [s.slug, s.id]));
+    const songSlugToId = new Map<string, string>(localSongRows.map((s) => [s.slug, s.id]));
+    const localSongBySlug = new Map(localSongRows.map((s) => [s.slug, s]));
     const missingSongSlugs = allSongSlugs.filter((slug) => !songSlugToId.has(slug));
     console.log(`🎵 ${allSongSlugs.length} distinct songs in setlists; ${missingSongSlugs.length} missing locally`);
 
-    if (missingSongSlugs.length > 0) {
+    if (allSongSlugs.length > 0) {
       const { songs: remoteSongs, errors: songErrors } = await mcpCall<{
         songs: McpSong[];
         errors?: Array<{ slug: string; error: string }>;
-      }>("get_songs", { slugs: missingSongSlugs });
+      }>("get_songs", { slugs: allSongSlugs });
       stats.songsFetched = remoteSongs.length;
       if (songErrors?.length) {
         console.warn(`⚠️  ${songErrors.length} song fetch errors:`, songErrors);
         stats.errors += songErrors.length;
       }
       for (const song of remoteSongs) {
+        const localId = songSlugToId.get(song.slug);
+        if (localId === undefined) {
+          // Not local yet → create.
+          if (isDryRun) {
+            songSlugToId.set(song.slug, `dry-run-song-${song.slug}`);
+            stats.songsCreated++;
+            continue;
+          }
+          try {
+            const created = await db.song.create({ data: buildSongCreateInput(song, now) });
+            songSlugToId.set(created.slug, created.id);
+            stats.songsCreated++;
+            songsChanged = true;
+          } catch (err) {
+            console.error(`  ❌ failed to create song ${song.slug}:`, err);
+            stats.errors++;
+          }
+          continue;
+        }
+        // Already local → diff curated admin fields and patch if drifted.
+        const localSong = localSongBySlug.get(song.slug);
+        if (!localSong) continue;
+        const patch = buildSongDriftUpdate(localSong, song);
+        if (patch === null) continue;
         if (isDryRun) {
-          songSlugToId.set(song.slug, `dry-run-song-${song.slug}`);
-          stats.songsCreated++;
+          console.log(`  🔄 song ${song.slug} would update ${JSON.stringify(patch)} (dry run)`);
           continue;
         }
         try {
-          const created = await db.song.create({ data: buildSongCreateInput(song, now) });
-          songSlugToId.set(created.slug, created.id);
-          stats.songsCreated++;
+          await db.song.update({ where: { id: localId }, data: { ...patch, updatedAt: now } });
           songsChanged = true;
+          console.log(`  🔄 song ${song.slug} ${JSON.stringify(patch)}`);
         } catch (err) {
-          console.error(`  ❌ failed to create song ${song.slug}:`, err);
+          console.error(`  ❌ failed to update song ${song.slug}:`, err);
           stats.errors++;
         }
       }
@@ -700,6 +1091,109 @@ async function syncMissingShows(): Promise<void> {
       } catch (err) {
         console.error(`  ❌ failed to insert show ${slug}:`, err);
         stats.errors++;
+      }
+    }
+
+    // Step 8: track + annotation drift for existing shows whose setlists
+    // were fetched (venue back-fill + --full-track-sync). Catches admin edits
+    // to Track.allTimer / Track.note / Track.segue and the per-track
+    // Annotation set without re-doing the show row itself. countForStats is
+    // pulled in so we know whether a flip should expand the rebuild window.
+    const driftShowSlugs = Array.from(new Set([...needsVenueSlugs, ...fullTrackSyncSlugs]));
+    if (driftShowSlugs.length > 0) {
+      const driftShows = await db.show.findMany({
+        where: { slug: { in: driftShowSlugs } },
+        select: {
+          slug: true,
+          date: true,
+          countForStats: true,
+          tracks: {
+            select: {
+              id: true,
+              position: true,
+              segue: true,
+              note: true,
+              allTimer: true,
+              annotations: { select: { id: true, desc: true } },
+            },
+          },
+        },
+      });
+      for (const show of driftShows) {
+        const setlist = setlistBySlug.get(show.slug);
+        if (!setlist) continue;
+        const trackPatches = buildTrackDriftUpdates(show.tracks, setlist);
+        // Map track-id → its remote annotation list for the per-track annotation diff.
+        const remoteAnnotationsByPosition = new Map<number, string[] | undefined>();
+        for (const set of setlist.sets) {
+          for (const track of set.tracks) {
+            remoteAnnotationsByPosition.set(track.position, track.annotations);
+          }
+        }
+        let touchedShow = false;
+        for (const { trackId, patch } of trackPatches) {
+          if (isDryRun) {
+            console.log(`  🔄 track ${trackId} would update ${JSON.stringify(patch)} (dry run)`);
+            touchedShow = true;
+            continue;
+          }
+          try {
+            await db.track.update({ where: { id: trackId }, data: { ...patch, updatedAt: now } });
+            touchedShow = true;
+            console.log(`  🔄 track ${trackId} ${JSON.stringify(patch)}`);
+          } catch (err) {
+            console.error(`  ❌ failed to update track ${trackId}:`, err);
+            stats.errors++;
+          }
+        }
+        // Annotation set replace: for each local track, compare to the remote
+        // annotation strings and apply the minimal create/delete delta.
+        for (const localTrack of show.tracks) {
+          const remoteAnnotations = remoteAnnotationsByPosition.get(localTrack.position);
+          const diff = diffTrackAnnotations(localTrack.annotations, remoteAnnotations);
+          if (diff.toCreateDescs.length === 0 && diff.toDeleteIds.length === 0) continue;
+          if (isDryRun) {
+            console.log(
+              `  🔄 track ${localTrack.id} annotations: +${diff.toCreateDescs.length} -${diff.toDeleteIds.length} (dry run)`,
+            );
+            touchedShow = true;
+            continue;
+          }
+          try {
+            if (diff.toDeleteIds.length > 0) {
+              await db.annotation.deleteMany({ where: { id: { in: diff.toDeleteIds } } });
+            }
+            if (diff.toCreateDescs.length > 0) {
+              await db.annotation.createMany({
+                data: diff.toCreateDescs.map((desc) => ({
+                  trackId: localTrack.id,
+                  desc,
+                  createdAt: now,
+                  updatedAt: now,
+                })),
+              });
+            }
+            touchedShow = true;
+            console.log(
+              `  🔄 track ${localTrack.id} annotations: +${diff.toCreateDescs.length} -${diff.toDeleteIds.length}`,
+            );
+          } catch (err) {
+            console.error(`  ❌ failed to sync annotations for track ${localTrack.id}:`, err);
+            stats.errors++;
+          }
+        }
+        if (touchedShow) {
+          changedSlugs.add(show.slug);
+          // Track / annotation drift on a stats-counting show shifts the gap
+          // chain (e.g. an all-timer flag change is cosmetic, but a segue
+          // change affects ordering; play it safe and expand the window).
+          if (show.countForStats) {
+            const showDate = String(show.date);
+            if (earliestInsertedDate === null || showDate < earliestInsertedDate) {
+              earliestInsertedDate = showDate;
+            }
+          }
+        }
       }
     }
 

--- a/packages/core/src/_shared/services.ts
+++ b/packages/core/src/_shared/services.ts
@@ -86,7 +86,7 @@ export function createServices(container: ServiceContainer): Services {
     tourDatesService: new TourDatesService(container.redis),
     nugs: new NugsService(container.redis, container.logger),
     archiveDotOrg: new ArchiveDotOrgService(container.redis, container.logger),
-    youtube: new YoutubeService(container.db),
+    youtube: new YoutubeService(container.db, container.cacheInvalidation),
     files: new FileService(container.db, container.logger, {
       accountId: container.env.CLOUDFLARE_ACCOUNT_ID,
       apiToken: container.env.CLOUDFLARE_IMAGES_API_TOKEN,

--- a/packages/core/src/page-composers/song-page-composer.test.ts
+++ b/packages/core/src/page-composers/song-page-composer.test.ts
@@ -486,6 +486,125 @@ describe("buildSongPerformanceCounts", () => {
 });
 
 // ---------------------------------------------------------------------------
+// buildJamCharts — all-timers ∪ tracks-with-notes
+// ---------------------------------------------------------------------------
+
+describe("buildJamCharts", () => {
+  // Flattens a $queryRaw mock call (TemplateStringsArray + Prisma.Sql
+  // interpolations) into a single SQL string so the test can assert the
+  // base WHERE clause is composed of the right two conditions. Prisma.Sql
+  // exposes its raw template parts under `.strings`.
+  function flattenSqlFromMockCall(call: unknown[]): string {
+    const [templateStrings, ...interpolations] = call as [readonly string[], ...unknown[]];
+    const interpolated = interpolations
+      .map((v) => {
+        if (v && typeof v === "object" && Array.isArray((v as { strings?: unknown[] }).strings)) {
+          return (v as { strings: string[] }).strings.join(" ");
+        }
+        return "";
+      })
+      .join(" ");
+    return `${[...templateStrings].join(" ")} ${interpolated}`;
+  }
+
+  function createComposer(rows: Array<Partial<PerformanceDto>>) {
+    const mockDb = {
+      $queryRaw: vi.fn().mockResolvedValue(rows.map((r) => makeDto(r as Partial<PerformanceDto>))),
+      // enrichPerformances looks up annotations + previous-show data per
+      // returned track. Stub both to empty so the test focuses on the
+      // base WHERE composition and the result shape.
+      annotation: { findMany: vi.fn().mockResolvedValue([]) },
+    };
+    const mockSongService = {} as never;
+    return { composer: new SongPageComposer(mockDb as never, mockSongService), mockDb };
+  }
+
+  // The whole point of the jam-charts page: include tracks flagged as
+  // all-timers AND tracks that carry a curated note, in a single result.
+  // The WHERE clause must OR the two conditions so neither set is
+  // dropped on the way to the UI.
+  test("base WHERE clause unions all_timer with note IS NOT NULL", async () => {
+    const { composer, mockDb } = createComposer([]);
+    await composer.buildJamCharts();
+    expect(mockDb.$queryRaw).toHaveBeenCalledTimes(1);
+    const sql = flattenSqlFromMockCall(mockDb.$queryRaw.mock.calls[0]);
+    expect(sql).toMatch(/tracks\.all_timer\s*=\s*true/);
+    expect(sql).toMatch(/tracks\.note\s+IS\s+NOT\s+NULL/);
+    // Empty-string notes must be filtered out too — the note column
+    // historically allows '' as well as NULL for "no note", and the UI
+    // treats both as absent.
+    expect(sql).toMatch(/tracks\.note\s*<>\s*''/);
+    // Both branches must be ORed together (otherwise note-only tracks
+    // get filtered out when all_timer is false).
+    expect(sql).toMatch(/all_timer.*OR.*note/s);
+  });
+
+  // The method returns the standard AllTimersPageView shape so the route
+  // can drop it straight into PerformanceTable without bespoke wiring.
+  test("returns AllTimersPageView shape (performances array) populated from rows", async () => {
+    const { composer } = createComposer([
+      { track_id: "t-allTimer", all_timer: true, note: null, song_id: "song-1" },
+      { track_id: "t-note", all_timer: false, note: "Big Type II Spaga." },
+    ]);
+    const result = await composer.buildJamCharts();
+    expect(result.performances).toHaveLength(2);
+    const ids = result.performances.map((p) => p.trackId).sort();
+    expect(ids).toEqual(["t-allTimer", "t-note"]);
+  });
+
+  // Filter options compose: jam-charts plus, say, a year range or cover
+  // filter, should AND together. Verifies the call still goes through and
+  // the additional filter shows up in the SQL.
+  test("forwards filter options through buildFilterQuery", async () => {
+    const { composer, mockDb } = createComposer([]);
+    await composer.buildJamCharts({ monthDay: "07-26" });
+    const sql = flattenSqlFromMockCall(mockDb.$queryRaw.mock.calls[0]);
+    expect(sql).toMatch(/shows\.date\s+LIKE/);
+  });
+});
+
+describe("buildSongPerformances populates songTitle/songSlug", () => {
+  // The single-song composer queries without a song join (the song is
+  // already known in context). The cross-song UI components that
+  // consume `SongPagePerformance` (TrackRatingOverlay's popover header,
+  // for instance) read `songTitle` / `songSlug` directly — so the
+  // composer must fill those fields from the page's song context, or
+  // the popover renders with an empty title.
+  test("propagates the page song's title and slug onto every returned performance", async () => {
+    const mockDb = {
+      $queryRaw: vi.fn().mockResolvedValue([makeDto({ track_id: "t-1" }), makeDto({ track_id: "t-2" })]),
+      annotation: { findMany: vi.fn().mockResolvedValue([]) },
+    };
+    const mockSongService = {
+      findBySlug: vi.fn().mockResolvedValue({
+        id: "song-1",
+        title: "King of the World",
+        slug: "king-of-the-world",
+        cover: false,
+        authorId: null,
+      }),
+    };
+    const composer = new SongPageComposer(mockDb as never, mockSongService as never);
+
+    const performances = await composer.buildSongPerformances("king-of-the-world");
+
+    expect(performances).toHaveLength(2);
+    for (const p of performances) {
+      expect(p.songTitle).toBe("King of the World");
+      expect(p.songSlug).toBe("king-of-the-world");
+    }
+  });
+});
+
+describe("CacheKeys.songs.jamCharts", () => {
+  // Mirrors the cache-key shape of `allTimers`. Versioned suffix is
+  // bumped together with the rest of the songs cache family.
+  test("returns a stable, versioned key string", () => {
+    expect(CacheKeys.songs.jamCharts()).toBe("songs:jam-charts:v4");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // isNarrowingFilter — gate for filteredGap computation
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/page-composers/song-page-composer.ts
+++ b/packages/core/src/page-composers/song-page-composer.ts
@@ -34,6 +34,8 @@ export interface PerformanceFilterOptions {
   standalone?: boolean;
   inverted?: boolean;
   dyslexic?: boolean;
+  /** Narrow to tracks carrying a curated jam-chart note (non-empty). */
+  jamChart?: boolean;
   allTimer?: boolean;
   monthDay?: string;
 }
@@ -142,6 +144,11 @@ export class SongPageComposer {
       ...this.transformToSongPagePerformanceView(row),
       cover: song.cover ?? undefined,
       authorId: song.authorId ?? null,
+      // Single-song rows skip the song join; fill in title/slug from the
+      // page's song context so cross-song renderers (e.g. the
+      // noteworthy-track popover header) see a populated title.
+      songTitle: song.title,
+      songSlug: song.slug,
     }));
     await this.enrichPerformances(performances);
 
@@ -207,11 +214,34 @@ export class SongPageComposer {
 
   /** Build the all-timers page view, optionally filtered by date range, cover, author, attendance, and performance tags. */
   async buildAllTimers(options?: PerformanceFilterOptions): Promise<AllTimersPageView> {
-    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery(
-      [Prisma.sql`tracks.all_timer = true`],
+    return this.buildCrossSongPerformanceView(Prisma.sql`tracks.all_timer = true`, options);
+  }
+
+  /**
+   * Build the Jam Charts page view. Includes any track that is either an
+   * all-timer OR carries a curated note — the union of the two
+   * noteworthy categories surfaced throughout the app. The note column
+   * historically allows empty strings as well as NULL for "no note", so
+   * both are filtered out to match what the UI treats as a real note.
+   */
+  async buildJamCharts(options?: PerformanceFilterOptions): Promise<AllTimersPageView> {
+    return this.buildCrossSongPerformanceView(
+      Prisma.sql`(tracks.all_timer = true OR (tracks.note IS NOT NULL AND tracks.note <> ''))`,
       options,
     );
+  }
 
+  /**
+   * Shared body of the cross-song page views (all-timers, jam-charts).
+   * The two endpoints differ only in their base WHERE condition; this
+   * helper composes the rest of the pipeline — filter merging, the
+   * cross-song SELECT with song title/slug, and per-track enrichment.
+   */
+  private async buildCrossSongPerformanceView(
+    baseCondition: Prisma.Sql,
+    options?: PerformanceFilterOptions,
+  ): Promise<AllTimersPageView> {
+    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery([baseCondition], options);
     const whereClause = Prisma.join(conditions, " AND ");
     const result = await this.queryPerformances({
       whereClause,
@@ -246,6 +276,13 @@ export class SongPageComposer {
       ...this.transformToSongPagePerformanceView(row),
       cover: song.cover ?? undefined,
       authorId: song.authorId ?? null,
+      // The per-song composer queries without a song join (the song is
+      // already known), so the raw rows don't carry song_title/song_slug.
+      // Fill them in from the page's song context so downstream renderers
+      // (e.g. the noteworthy-track popover header) don't see an empty
+      // title when this projection lands in a cross-song UI component.
+      songTitle: song.title,
+      songSlug: song.slug,
     }));
     await this.enrichPerformances(performances);
 
@@ -443,6 +480,7 @@ export class SongPageComposer {
           }
         : null,
     allTimer: (o) => (o.allTimer ? { condition: Prisma.sql`tracks.all_timer = true` } : null),
+    jamChart: (o) => (o.jamChart ? { condition: Prisma.sql`tracks.note IS NOT NULL AND tracks.note <> ''` } : null),
     monthDay: (o) => (o.monthDay ? { condition: Prisma.sql`shows.date LIKE ${`%-${o.monthDay}`}` } : null),
     inverted: (o) =>
       o.inverted
@@ -645,6 +683,7 @@ export function isNarrowingFilter(options: PerformanceFilterOptions | undefined)
       options.standalone ||
       options.inverted ||
       options.dyslexic ||
+      options.jamChart ||
       options.allTimer ||
       options.monthDay,
   );

--- a/packages/core/src/search/postgres-search-service.ts
+++ b/packages/core/src/search/postgres-search-service.ts
@@ -1,12 +1,15 @@
 import type { Logger, SearchResult, SearchRowResult } from "@bip/domain";
 import type { DbClient } from "../_shared/database/models";
 import type { SearchHistoryService } from "./search-history-service";
+import { buildMixedSearchResults } from "./search-result-builder";
 import { SegueQueryParser } from "./segue-query-parser";
 
 type VenueResult = {
   venue_id: string;
   venue_name: string;
   venue_slug: string;
+  venue_city: string | null;
+  venue_state: string | null;
   match_score: number;
 };
 
@@ -114,62 +117,34 @@ export class PostgresSearchService {
       const mediumVenueIds = venueResults.filter((v) => v.match_score >= 10).map((v) => v.venue_id);
       const weakVenueIds = venueResults.filter((v) => v.match_score >= 1).map((v) => v.venue_id);
 
-      // Try strong matches first
-      if (strongSongIds.length > 0 || strongVenueIds.length > 0) {
-        const showResults = await this.performShowSearch(
-          searchQuery,
-          strongSongIds,
-          strongVenueIds,
-          options.limit,
-          dateFilter,
-        );
-        if (showResults.length > 0) {
-          return this.convertShowResultsToSearchResults(showResults);
-        }
-      }
+      // Run show search at the strongest tier that has any matches; fall back
+      // through medium/weak so the show list still gets populated for fuzzy
+      // queries.
+      const tieredShows = await this.runTieredShowSearch(
+        searchQuery,
+        { strongSongIds, mediumSongIds, weakSongIds },
+        { strongVenueIds, mediumVenueIds, weakVenueIds },
+        options.limit,
+        dateFilter,
+      );
 
-      // Try medium matches
-      if (mediumSongIds.length > 0 || mediumVenueIds.length > 0) {
-        const showResults = await this.performShowSearch(
-          searchQuery,
-          mediumSongIds,
-          mediumVenueIds,
-          options.limit,
-          dateFilter,
-        );
-        if (showResults.length > 0) {
-          return this.convertShowResultsToSearchResults(showResults);
-        }
-      }
+      // If we found no song/venue matches at all, do a general show text search
+      // as a last resort.
+      const showSearchResults =
+        tieredShows.length === 0 && songResults.length === 0 && venueResults.length === 0
+          ? this.convertShowResultsToSearchResults(
+              await this.performShowSearch(searchQuery, [], [], Math.min(options.limit, 10), dateFilter),
+            )
+          : tieredShows;
 
-      // Try weak matches
-      if (weakSongIds.length > 0 || weakVenueIds.length > 0) {
-        const showResults = await this.performShowSearch(
-          searchQuery,
-          weakSongIds,
-          weakVenueIds,
-          options.limit,
-          dateFilter,
-        );
-        if (showResults.length > 0) {
-          return this.convertShowResultsToSearchResults(showResults);
-        }
-      }
-
-      // Only do general search if no songs or venues found at all
-      if (songResults.length === 0 && venueResults.length === 0) {
-        const generalResults = await this.performShowSearch(
-          searchQuery,
-          [],
-          [],
-          Math.min(options.limit, 10),
-          dateFilter,
-        );
-        return this.convertShowResultsToSearchResults(generalResults);
-      }
-
-      // If we found songs/venues but no shows, return empty
-      return [];
+      // Mix in matching song-page and venue-page links so users can navigate
+      // directly to those entities (e.g. searching "Shadows" surfaces
+      // /songs/shadows above shows that played it).
+      return buildMixedSearchResults({
+        songs: songResults,
+        venues: venueResults,
+        shows: showSearchResults,
+      });
     } catch (error) {
       this.logger.error(`Search failed: ${error}`);
       throw error;
@@ -286,15 +261,18 @@ export class PostgresSearchService {
             OR LOWER(v.city) LIKE '%' || LOWER($1) || '%'
         )
         SELECT
-          venue_id,
-          venue_name,
-          venue_slug,
+          search_matches.venue_id,
+          search_matches.venue_name,
+          search_matches.venue_slug,
+          v2.city as venue_city,
+          v2.state as venue_state,
           GREATEST(
             exact_score * 200,  -- Double weight for exact matches
             fts_rank * 60,
             trgm_sim * 100
           )::INTEGER as match_score
         FROM search_matches
+        JOIN venues v2 ON v2.id = search_matches.venue_id
         ORDER BY match_score DESC
         LIMIT 100
       `,
@@ -344,6 +322,26 @@ export class PostgresSearchService {
 
     this.logger.debug(`Song search SQL for query "${query}"`);
     return this.db.$queryRawUnsafe<SongResult[]>(sql, query);
+  }
+
+  private async runTieredShowSearch(
+    searchQuery: string,
+    songTiers: { strongSongIds: string[]; mediumSongIds: string[]; weakSongIds: string[] },
+    venueTiers: { strongVenueIds: string[]; mediumVenueIds: string[]; weakVenueIds: string[] },
+    limit: number,
+    dateFilter: { year?: number; month?: number; day?: number; remainingQuery: string },
+  ): Promise<SearchResult[]> {
+    const tiers: Array<{ songIds: string[]; venueIds: string[] }> = [
+      { songIds: songTiers.strongSongIds, venueIds: venueTiers.strongVenueIds },
+      { songIds: songTiers.mediumSongIds, venueIds: venueTiers.mediumVenueIds },
+      { songIds: songTiers.weakSongIds, venueIds: venueTiers.weakVenueIds },
+    ];
+    for (const tier of tiers) {
+      if (tier.songIds.length === 0 && tier.venueIds.length === 0) continue;
+      const rows = await this.performShowSearch(searchQuery, tier.songIds, tier.venueIds, limit, dateFilter);
+      if (rows.length > 0) return this.convertShowResultsToSearchResults(rows);
+    }
+    return [];
   }
 
   private async performShowSearch(

--- a/packages/core/src/search/search-result-builder.test.ts
+++ b/packages/core/src/search/search-result-builder.test.ts
@@ -1,0 +1,155 @@
+import type { SearchResult } from "@bip/domain";
+import { describe, expect, test } from "vitest";
+import { buildMixedSearchResults, type SongRowForResults, type VenueRowForResults } from "./search-result-builder";
+
+// Helpers for compact fixtures. Disco Biscuits song/venue choices keep test
+// intent obvious when scanning the assertions.
+function songRow(
+  opts: Partial<SongRowForResults> & Pick<SongRowForResults, "song_id" | "song_title" | "song_slug">,
+): SongRowForResults {
+  return { match_score: 100, ...opts };
+}
+function venueRow(
+  opts: Partial<VenueRowForResults> & Pick<VenueRowForResults, "venue_id" | "venue_name" | "venue_slug">,
+): VenueRowForResults {
+  return { match_score: 100, venue_city: null, venue_state: null, ...opts };
+}
+function showResult(opts: Partial<SearchResult> & Pick<SearchResult, "id" | "score">): SearchResult {
+  return {
+    entityType: "show",
+    entityId: opts.id,
+    entitySlug: opts.id,
+    displayText: "Some show",
+    url: `/shows/${opts.id}`,
+    ...opts,
+  };
+}
+
+describe("buildMixedSearchResults", () => {
+  // Core motivation: searching "Shadows" should surface the song page,
+  // not just the list of shows where it was played.
+  test("includes matching song as a song-entity SearchResult with /songs/<slug> url", () => {
+    const results = buildMixedSearchResults({
+      songs: [songRow({ song_id: "s1", song_title: "Shadows", song_slug: "shadows", match_score: 100 })],
+      venues: [],
+      shows: [],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      entityType: "song",
+      entityId: "s1",
+      entitySlug: "shadows",
+      url: "/songs/shadows",
+      score: 100,
+    });
+  });
+
+  // Songs with a stronger match score must outrank shows so the song-page link
+  // appears at the top of the results list.
+  test("orders a high-scoring song above lower-scoring shows", () => {
+    const results = buildMixedSearchResults({
+      songs: [
+        songRow({ song_id: "s1", song_title: "Basis For A Day", song_slug: "basis-for-a-day", match_score: 100 }),
+      ],
+      venues: [],
+      shows: [showResult({ id: "show1", score: 70 }), showResult({ id: "show2", score: 60 })],
+    });
+
+    expect(results[0].entityType).toBe("song");
+    expect(results.slice(1).map((r) => r.entityType)).toEqual(["show", "show"]);
+  });
+
+  // Venues should also be searchable from the global bar — searching "Camp Bisco"
+  // should surface the venue page, not just shows at that venue.
+  test("includes matching venue as a venue-entity SearchResult with /venues/<slug> url", () => {
+    const results = buildMixedSearchResults({
+      songs: [],
+      venues: [
+        venueRow({
+          venue_id: "v1",
+          venue_name: "Camp Bisco",
+          venue_slug: "camp-bisco",
+          venue_city: "Mariaville",
+          venue_state: "NY",
+          match_score: 100,
+        }),
+      ],
+      shows: [],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      entityType: "venue",
+      entityId: "v1",
+      entitySlug: "camp-bisco",
+      url: "/venues/camp-bisco",
+      venueName: "Camp Bisco",
+      venueLocation: "Mariaville, NY",
+      score: 100,
+    });
+  });
+
+  // Drop weak song matches (e.g., trigram-only hits) so the song bucket doesn't
+  // pollute results when the query doesn't really refer to a song.
+  test("filters out song matches below minSongScore", () => {
+    const results = buildMixedSearchResults({
+      songs: [
+        songRow({ song_id: "strong", song_title: "Shadows", song_slug: "shadows", match_score: 100 }),
+        songRow({ song_id: "weak", song_title: "Spaga", song_slug: "spaga", match_score: 20 }),
+      ],
+      venues: [],
+      shows: [],
+      minSongScore: 50,
+    });
+
+    expect(results.map((r) => r.entityId)).toEqual(["strong"]);
+  });
+
+  // Drop weak venue matches to avoid leaking unrelated venue hits.
+  test("filters out venue matches below minVenueScore", () => {
+    const results = buildMixedSearchResults({
+      songs: [],
+      venues: [
+        venueRow({ venue_id: "strong", venue_name: "Camp Bisco", venue_slug: "camp-bisco", match_score: 100 }),
+        venueRow({ venue_id: "weak", venue_name: "Random Bar", venue_slug: "random-bar", match_score: 5 }),
+      ],
+      shows: [],
+      minVenueScore: 50,
+    });
+
+    expect(results.map((r) => r.entityId)).toEqual(["strong"]);
+  });
+
+  // Cap the number of injected song/venue results so they don't crowd out shows.
+  test("caps songs at songLimit and venues at venueLimit", () => {
+    const results = buildMixedSearchResults({
+      songs: [
+        songRow({ song_id: "s1", song_title: "Shadows", song_slug: "shadows", match_score: 100 }),
+        songRow({ song_id: "s2", song_title: "Spaga", song_slug: "spaga", match_score: 99 }),
+        songRow({ song_id: "s3", song_title: "Basis For A Day", song_slug: "basis-for-a-day", match_score: 98 }),
+        songRow({ song_id: "s4", song_title: "M.E.M.P.H.I.S.", song_slug: "memphis", match_score: 97 }),
+      ],
+      venues: [],
+      shows: [],
+      songLimit: 2,
+    });
+
+    const songs = results.filter((r) => r.entityType === "song");
+    expect(songs.map((r) => r.entityId)).toEqual(["s1", "s2"]);
+  });
+
+  // Final array must be sorted by score descending across all entity types so
+  // the drawer can render it as-is.
+  test("sorts the combined results by score desc across all types", () => {
+    const results = buildMixedSearchResults({
+      songs: [songRow({ song_id: "song-weak", song_title: "Shadows", song_slug: "shadows", match_score: 55 })],
+      venues: [
+        venueRow({ venue_id: "venue-strong", venue_name: "Camp Bisco", venue_slug: "camp-bisco", match_score: 95 }),
+      ],
+      shows: [showResult({ id: "show-mid", score: 75 })],
+    });
+
+    expect(results.map((r) => r.entityId)).toEqual(["venue-strong", "show-mid", "song-weak"]);
+  });
+});

--- a/packages/core/src/search/search-result-builder.ts
+++ b/packages/core/src/search/search-result-builder.ts
@@ -1,0 +1,96 @@
+import type { SearchResult } from "@bip/domain";
+
+/**
+ * Raw song-search SQL row, narrowed to the fields needed for result building.
+ * Decoupled from the larger SongResult type in postgres-search-service.ts so
+ * the builder stays unit-testable without a database.
+ */
+export interface SongRowForResults {
+  song_id: string;
+  song_title: string;
+  song_slug: string;
+  match_score: number;
+}
+
+/**
+ * Raw venue-search SQL row, narrowed to the fields needed for result building.
+ * City/state are optional but used to build the displayed location string.
+ */
+export interface VenueRowForResults {
+  venue_id: string;
+  venue_name: string;
+  venue_slug: string;
+  match_score: number;
+  venue_city?: string | null;
+  venue_state?: string | null;
+}
+
+export interface BuildMixedSearchResultsOptions {
+  songs?: SongRowForResults[];
+  venues?: VenueRowForResults[];
+  shows: SearchResult[];
+  songLimit?: number;
+  venueLimit?: number;
+  minSongScore?: number;
+  minVenueScore?: number;
+}
+
+const DEFAULT_SONG_LIMIT = 3;
+const DEFAULT_VENUE_LIMIT = 3;
+const DEFAULT_MIN_SONG_SCORE = 50;
+const DEFAULT_MIN_VENUE_SCORE = 50;
+
+/**
+ * Compose the global search drawer's final result list from raw song, venue,
+ * and (already-converted) show results. Songs and venues are added as their
+ * own entity-typed SearchResults so the drawer can link directly to
+ * /songs/<slug> and /venues/<slug>, rather than only showing shows that played
+ * the song or were held at the venue. Weak matches are filtered and the
+ * combined list is sorted by score so the drawer can render it as-is.
+ */
+export function buildMixedSearchResults({
+  songs = [],
+  venues = [],
+  shows,
+  songLimit = DEFAULT_SONG_LIMIT,
+  venueLimit = DEFAULT_VENUE_LIMIT,
+  minSongScore = DEFAULT_MIN_SONG_SCORE,
+  minVenueScore = DEFAULT_MIN_VENUE_SCORE,
+}: BuildMixedSearchResultsOptions): SearchResult[] {
+  const songResults: SearchResult[] = songs
+    .filter((s) => s.match_score >= minSongScore)
+    .slice(0, songLimit)
+    .map((s) => ({
+      id: s.song_id,
+      entityType: "song",
+      entityId: s.song_id,
+      entitySlug: s.song_slug,
+      displayText: s.song_title,
+      score: Math.min(100, Math.round(s.match_score)),
+      url: `/songs/${s.song_slug}`,
+      songTitle: s.song_title,
+    }));
+
+  const venueResults: SearchResult[] = venues
+    .filter((v) => v.match_score >= minVenueScore)
+    .slice(0, venueLimit)
+    .map((v) => {
+      const location =
+        v.venue_city && v.venue_state
+          ? `${v.venue_city}, ${v.venue_state}`
+          : v.venue_city || v.venue_state || undefined;
+      return {
+        id: v.venue_id,
+        entityType: "venue",
+        entityId: v.venue_id,
+        entitySlug: v.venue_slug,
+        displayText: location ? `${v.venue_name} • ${location}` : v.venue_name,
+        score: Math.min(100, Math.round(v.match_score)),
+        url: `/venues/${v.venue_slug}`,
+        venueName: v.venue_name,
+        venueLocation: location,
+      };
+    });
+
+  return [...songResults, ...venueResults, ...shows].sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+}

--- a/packages/core/src/shows/youtube-service.test.ts
+++ b/packages/core/src/shows/youtube-service.test.ts
@@ -5,8 +5,19 @@ function makeMockDb() {
   return {
     showYoutube: {
       findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+    },
+    show: {
+      findUnique: vi.fn(),
+      update: vi.fn().mockResolvedValue(undefined),
     },
   };
+}
+
+function makeMockCacheInvalidation() {
+  return { invalidateShowComprehensive: vi.fn().mockResolvedValue(undefined) };
 }
 
 describe("YoutubeService.getVideoUrlsForShow", () => {
@@ -78,5 +89,133 @@ describe("YoutubeService.getFirstVideoUrlByShowIds", () => {
 
     expect(result).toEqual({});
     expect(db.showYoutube.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("YoutubeService.listEntriesForShow", () => {
+  // The admin editor needs row ids alongside URLs so it can target individual
+  // rows for deletion. URLs are still resolved server-side so the UI never
+  // builds the watch URL format on its own.
+  test("returns entries with id, videoId, and resolved url", async () => {
+    const db = makeMockDb();
+    db.showYoutube.findMany.mockResolvedValue([
+      { id: "row-1", videoId: "abc12345678" },
+      { id: "row-2", videoId: "xyz12345678" },
+    ]);
+    const service = new YoutubeService(db as never);
+
+    const result = await service.listEntriesForShow("show-1");
+
+    expect(result).toEqual([
+      { id: "row-1", videoId: "abc12345678", url: "https://www.youtube.com/watch?v=abc12345678" },
+      { id: "row-2", videoId: "xyz12345678", url: "https://www.youtube.com/watch?v=xyz12345678" },
+    ]);
+    expect(db.showYoutube.findMany).toHaveBeenCalledWith({
+      where: { showId: "show-1" },
+      select: { id: true, videoId: true },
+      orderBy: { createdAt: "asc" },
+    });
+  });
+});
+
+describe("YoutubeService.createForShow", () => {
+  // Adding a video must do three things atomically from the caller's
+  // perspective: persist the row, bump the show's denormalized count (so
+  // `hasYoutube` filters see it), and invalidate the show's cached pages so
+  // the public detail page reflects the change on next view.
+  test("persists the row, increments showYoutubesCount, and invalidates show caches", async () => {
+    const db = makeMockDb();
+    db.showYoutube.create.mockResolvedValue({ id: "row-new", videoId: "dQw4w9WgXcQ" });
+    db.show.findUnique.mockResolvedValue({ slug: "2001-09-01-wetlands" });
+    const cache = makeMockCacheInvalidation();
+    const service = new YoutubeService(db as never, cache as never);
+
+    const result = await service.createForShow("show-1", "dQw4w9WgXcQ");
+
+    expect(db.showYoutube.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ showId: "show-1", videoId: "dQw4w9WgXcQ" }),
+      select: { id: true, videoId: true },
+    });
+    expect(db.show.update).toHaveBeenCalledWith({
+      where: { id: "show-1" },
+      data: { showYoutubesCount: { increment: 1 } },
+    });
+    expect(cache.invalidateShowComprehensive).toHaveBeenCalledWith("show-1", "2001-09-01-wetlands");
+    expect(result).toEqual({
+      id: "row-new",
+      videoId: "dQw4w9WgXcQ",
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+  });
+
+  // Cache invalidation must not break the create when the cache service
+  // isn't wired (e.g. in environments where it's optional). The row is still
+  // persisted and the count is still bumped.
+  test("works without a cache invalidation service", async () => {
+    const db = makeMockDb();
+    db.showYoutube.create.mockResolvedValue({ id: "row-new", videoId: "abc12345678" });
+    const service = new YoutubeService(db as never);
+
+    const result = await service.createForShow("show-1", "abc12345678");
+
+    expect(db.showYoutube.create).toHaveBeenCalled();
+    expect(db.show.update).toHaveBeenCalled();
+    expect(result.url).toBe("https://www.youtube.com/watch?v=abc12345678");
+  });
+
+  // If the show row has no slug (data integrity edge case), the cache call
+  // is skipped — there's no slug-keyed cache to invalidate. The mutation
+  // itself still completes.
+  test("skips cache invalidation when the show has no slug", async () => {
+    const db = makeMockDb();
+    db.showYoutube.create.mockResolvedValue({ id: "row-new", videoId: "abc12345678" });
+    db.show.findUnique.mockResolvedValue({ slug: null });
+    const cache = makeMockCacheInvalidation();
+    const service = new YoutubeService(db as never, cache as never);
+
+    await service.createForShow("show-1", "abc12345678");
+
+    expect(cache.invalidateShowComprehensive).not.toHaveBeenCalled();
+  });
+});
+
+describe("YoutubeService.deleteEntry", () => {
+  // Symmetric to createForShow: delete the row, decrement the show's count,
+  // and invalidate caches. The showId is looked up from the row first so
+  // callers only need to pass the row id.
+  test("looks up the show, deletes the row, decrements count, invalidates caches", async () => {
+    const db = makeMockDb();
+    db.showYoutube.findUnique.mockResolvedValue({ showId: "show-1" });
+    db.show.findUnique.mockResolvedValue({ slug: "2001-09-01-wetlands" });
+    const cache = makeMockCacheInvalidation();
+    const service = new YoutubeService(db as never, cache as never);
+
+    await service.deleteEntry("row-1");
+
+    expect(db.showYoutube.findUnique).toHaveBeenCalledWith({
+      where: { id: "row-1" },
+      select: { showId: true },
+    });
+    expect(db.showYoutube.delete).toHaveBeenCalledWith({ where: { id: "row-1" } });
+    expect(db.show.update).toHaveBeenCalledWith({
+      where: { id: "show-1" },
+      data: { showYoutubesCount: { decrement: 1 } },
+    });
+    expect(cache.invalidateShowComprehensive).toHaveBeenCalledWith("show-1", "2001-09-01-wetlands");
+  });
+
+  // Deleting a row that no longer exists is a no-op — no delete, no count
+  // change, no cache churn. Prevents a 500 on a double-click or stale row id.
+  test("silently no-ops when the row does not exist", async () => {
+    const db = makeMockDb();
+    db.showYoutube.findUnique.mockResolvedValue(null);
+    const cache = makeMockCacheInvalidation();
+    const service = new YoutubeService(db as never, cache as never);
+
+    await service.deleteEntry("missing-id");
+
+    expect(db.showYoutube.delete).not.toHaveBeenCalled();
+    expect(db.show.update).not.toHaveBeenCalled();
+    expect(cache.invalidateShowComprehensive).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/shows/youtube-service.ts
+++ b/packages/core/src/shows/youtube-service.ts
@@ -1,7 +1,14 @@
+import type { CacheInvalidationService } from "../_shared/cache";
 import type { DbClient } from "../_shared/database/models";
 
 function videoUrl(videoId: string): string {
   return `https://www.youtube.com/watch?v=${videoId}`;
+}
+
+export interface ShowYoutubeEntry {
+  id: string;
+  videoId: string;
+  url: string;
 }
 
 /**
@@ -12,7 +19,10 @@ function videoUrl(videoId: string): string {
  * data is local.
  */
 export class YoutubeService {
-  constructor(private readonly db: DbClient) {}
+  constructor(
+    private readonly db: DbClient,
+    private readonly cacheInvalidation?: CacheInvalidationService,
+  ) {}
 
   /**
    * Return every curated video URL for a show in insertion order, so the
@@ -48,5 +58,66 @@ export class YoutubeService {
       if (!result[row.showId]) result[row.showId] = videoUrl(row.videoId);
     }
     return result;
+  }
+
+  /**
+   * Lists curated videos for a show with their row ids, so the admin editor
+   * can render a list and target individual rows for deletion.
+   */
+  async listEntriesForShow(showId: string): Promise<ShowYoutubeEntry[]> {
+    const rows = await this.db.showYoutube.findMany({
+      where: { showId },
+      select: { id: true, videoId: true },
+      orderBy: { createdAt: "asc" },
+    });
+    return rows.map((row) => ({ id: row.id, videoId: row.videoId, url: videoUrl(row.videoId) }));
+  }
+
+  /**
+   * Adds a curated video to a show. Also bumps the denormalized
+   * `Show.showYoutubesCount` so the `hasYoutube` filter sees the new row, and
+   * invalidates the show's cached pages.
+   */
+  async createForShow(showId: string, videoId: string): Promise<ShowYoutubeEntry> {
+    const now = new Date();
+    const created = await this.db.showYoutube.create({
+      data: { showId, videoId, createdAt: now, updatedAt: now },
+      select: { id: true, videoId: true },
+    });
+    await this.db.show.update({
+      where: { id: showId },
+      data: { showYoutubesCount: { increment: 1 } },
+    });
+    await this.invalidateShowCaches(showId);
+    return { id: created.id, videoId: created.videoId, url: videoUrl(created.videoId) };
+  }
+
+  /**
+   * Removes a curated video by row id. Decrements the show's count and
+   * invalidates the show's cached pages.
+   */
+  async deleteEntry(id: string): Promise<void> {
+    const existing = await this.db.showYoutube.findUnique({
+      where: { id },
+      select: { showId: true },
+    });
+    if (!existing) return;
+    await this.db.showYoutube.delete({ where: { id } });
+    await this.db.show.update({
+      where: { id: existing.showId },
+      data: { showYoutubesCount: { decrement: 1 } },
+    });
+    await this.invalidateShowCaches(existing.showId);
+  }
+
+  private async invalidateShowCaches(showId: string): Promise<void> {
+    if (!this.cacheInvalidation) return;
+    const show = await this.db.show.findUnique({
+      where: { id: showId },
+      select: { slug: true },
+    });
+    if (show?.slug) {
+      await this.cacheInvalidation.invalidateShowComprehensive(showId, show.slug);
+    }
   }
 }

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -67,6 +67,8 @@ export const CacheKeys = {
     index: () => "songs:index:full:v3",
     /** All-timers page data */
     allTimers: () => "songs:all-timers:v3",
+    /** Jam Charts page data (tracks that are all-timers OR carry a curated note) */
+    jamCharts: () => "songs:jam-charts:v4",
     /** Songs with history content */
     histories: () => "songs:histories:v3",
     /** All-timers for a specific calendar day (On This Day page) */

--- a/packages/domain/src/models/song.ts
+++ b/packages/domain/src/models/song.ts
@@ -11,6 +11,8 @@ export const songSchema = z.object({
   notes: z.string().nullable(),
   cover: z.boolean().nullable().default(false),
   authorId: z.string().uuid().nullable(),
+  // Optional — mirrors prod's legacy_author column, surfaced via sync.
+  legacyAuthor: z.string().nullable().optional(),
   history: z.string().nullable(),
   featuredLyric: z.string().nullable(),
   timesPlayed: z.number().default(0),

--- a/packages/domain/src/models/venue.ts
+++ b/packages/domain/src/models/venue.ts
@@ -10,6 +10,15 @@ export const venueSchema = z.object({
   createdAt: z.date(),
   updatedAt: z.date(),
   timesPlayed: z.number().default(0),
+  // Curated contact + geocode columns mirrored from prod via sync-missing-shows.
+  // Optional because callers that select a narrower set (search hits, venue
+  // pickers) don't carry these.
+  street: z.string().nullable().optional(),
+  postalCode: z.string().nullable().optional(),
+  phone: z.string().nullable().optional(),
+  website: z.string().nullable().optional(),
+  latitude: z.number().nullable().optional(),
+  longitude: z.number().nullable().optional(),
 });
 
 export const venueMinimalSchema = venueSchema.pick({


### PR DESCRIPTION
## Summary

- Mobile `/songs` with filters (`?attended=attended`, `/recent`, `/this-year`) now shows Song alongside the 5 filter columns (Filtered Plays, Avg Gap, Gap to End, Last, First). All-time pair cols and Filtered Since First hide on mobile to make room. Sparse `/songs` (no filter) is unchanged.
- Numeric cells across the table render in a right-aligned `inline-block` sized per column in `ch` units with `tabular-nums`. Place values stack across rows and bigger numbers extend further left, without right-aligning the cell.
- 5 new tests in `songs-columns.test.tsx` lock the mobile-hide flips and the `NumberCell` layout contract (40 tests total, was 35).

## Test plan

- [ ] Load `/songs?attended=attended` at ~390px width; all 6 visible columns fit without horizontal clip; numbers in Plays/Avg Gap/Gap to End align by ones digit.
- [ ] Load `/songs/recent` and `/songs/this-year` on mobile width; same layout.
- [ ] Load `/songs` (sparse, no filters) on mobile width; Song + Plays + Last Played + First Played render as before.
- [ ] Load `/songs?attended=attended` on desktop; both all-time and filtered column pairs are visible; numeric alignment also applies.
- [ ] `bun run test app/components/song/songs-columns.test.tsx` passes (40 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
