### PR TITLE
DataTable "Show all" toggle, rating columns tie-break on votes + date, wider rating cells

### DIFF
--- a/apps/web/app/components/performance/performance-columns.test.tsx
+++ b/apps/web/app/components/performance/performance-columns.test.tsx
@@ -660,6 +660,80 @@ describe("gapSortingFn", () => {
   });
 });
 
+// Rating column sort comparator: tracks with the same community average
+// resolve by vote count (more votes = more confidence), then by show date,
+// then by track position. Verified via the exported comparator directly so
+// edge cases stay focused on the comparator math rather than the full table.
+describe("ratingSortingFn", () => {
+  // Primary axis: higher rating > lower rating. Comparator returns a positive
+  // number when `a > b` so TanStack treats `b` as smaller in ascending order
+  // and surfaces `a` first when sorted descending (the column's default).
+  test("ascending: lower rating < higher rating", async () => {
+    const { ratingSortingFn } = await import("./performance-columns");
+    const fakeRow = (rating: number | null, ratingsCount: number, date: string, position: number) =>
+      ({ original: { rating, ratingsCount, position, show: { date } } }) as unknown as Parameters<
+        typeof ratingSortingFn
+      >[0];
+
+    expect(ratingSortingFn(fakeRow(3.5, 5, "2024-01-01", 1), fakeRow(4.5, 5, "2024-01-01", 1))).toBeLessThan(0);
+    expect(ratingSortingFn(fakeRow(4.5, 5, "2024-01-01", 1), fakeRow(3.5, 5, "2024-01-01", 1))).toBeGreaterThan(0);
+  });
+
+  // Missing ratings (null) collapse to -Infinity so unrated tracks cluster at
+  // the bottom on desc (best-first) and the top on asc — matching the gap
+  // column's treatment of debuts/repeats.
+  test("null ratings sort below all rated rows", async () => {
+    const { ratingSortingFn } = await import("./performance-columns");
+    const fakeRow = (rating: number | null, ratingsCount: number, date: string, position: number) =>
+      ({ original: { rating, ratingsCount, position, show: { date } } }) as unknown as Parameters<
+        typeof ratingSortingFn
+      >[0];
+
+    expect(ratingSortingFn(fakeRow(null, 0, "2024-01-01", 1), fakeRow(1.0, 1, "2024-01-01", 1))).toBeLessThan(0);
+  });
+
+  // First tiebreak: when two rows share a rating, the one with more votes
+  // sorts higher. More votes = higher confidence the average is real, so
+  // when scanning "best rated", a 4.8/100-votes version should beat a
+  // 4.8/3-votes version.
+  test("tied rating: more votes wins the tiebreak", async () => {
+    const { ratingSortingFn } = await import("./performance-columns");
+    const fakeRow = (rating: number | null, ratingsCount: number, date: string, position: number) =>
+      ({ original: { rating, ratingsCount, position, show: { date } } }) as unknown as Parameters<
+        typeof ratingSortingFn
+      >[0];
+
+    // 4.8/3-votes < 4.8/100-votes (less votes sorts first in asc).
+    expect(ratingSortingFn(fakeRow(4.8, 3, "2024-01-01", 1), fakeRow(4.8, 100, "2024-01-01", 1))).toBeLessThan(0);
+    expect(ratingSortingFn(fakeRow(4.8, 100, "2024-01-01", 1), fakeRow(4.8, 3, "2024-01-01", 1))).toBeGreaterThan(0);
+  });
+
+  // Second tiebreak: rating + votes both equal → fall through to show date so
+  // identical-quality performances across shows still cluster by show.
+  test("tied rating and votes: earlier date wins the tiebreak", async () => {
+    const { ratingSortingFn } = await import("./performance-columns");
+    const fakeRow = (rating: number | null, ratingsCount: number, date: string, position: number) =>
+      ({ original: { rating, ratingsCount, position, show: { date } } }) as unknown as Parameters<
+        typeof ratingSortingFn
+      >[0];
+
+    expect(ratingSortingFn(fakeRow(4.5, 10, "2018-06-01", 1), fakeRow(4.5, 10, "2024-08-15", 1))).toBeLessThan(0);
+    expect(ratingSortingFn(fakeRow(4.5, 10, "2024-08-15", 1), fakeRow(4.5, 10, "2018-06-01", 1))).toBeGreaterThan(0);
+  });
+
+  // Final tiebreak: rating + votes + date all equal (within-show repeat) →
+  // position breaks so repeats stay in setlist order relative to each other.
+  test("tied rating, votes, and date: position breaks the tie", async () => {
+    const { ratingSortingFn } = await import("./performance-columns");
+    const fakeRow = (rating: number | null, ratingsCount: number, date: string, position: number) =>
+      ({ original: { rating, ratingsCount, position, show: { date } } }) as unknown as Parameters<
+        typeof ratingSortingFn
+      >[0];
+
+    expect(ratingSortingFn(fakeRow(5.0, 12, "2012-08-15", 3), fakeRow(5.0, 12, "2012-08-15", 8))).toBeLessThan(0);
+  });
+});
+
 describe("createPerformanceColumns extras", () => {
   // Icon-only / ultra-narrow columns declare `fixedWidth` so they never
   // grow or shrink with the table — they hold a single glyph or 1-2

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -38,6 +38,28 @@ export const gapSortingFn = makeGapSortingFn("gap");
 export const filteredGapSortingFn = makeGapSortingFn("filteredGap");
 
 /**
+ * Sort comparator for the Rating column. Tracks with the same community
+ * average resolve by vote count first (more votes = more confidence in the
+ * average), then by show date, then by position so within-show repeats with
+ * matching rating + vote count stay in setlist order relative to each other.
+ *
+ * Missing ratings collapse to -Infinity so unrated rows cluster at the
+ * bottom on desc and the top on asc, matching the Gap column's treatment
+ * of debuts/repeats.
+ */
+export function ratingSortingFn(a: Row<SongPagePerformance>, b: Row<SongPagePerformance>): number {
+  const aRating = a.original.rating ?? Number.NEGATIVE_INFINITY;
+  const bRating = b.original.rating ?? Number.NEGATIVE_INFINITY;
+  if (aRating !== bRating) return aRating - bRating;
+  const aVotes = a.original.ratingsCount ?? 0;
+  const bVotes = b.original.ratingsCount ?? 0;
+  if (aVotes !== bVotes) return aVotes - bVotes;
+  const dateCmp = compareByShowDate(a.original, b.original);
+  if (dateCmp !== 0) return dateCmp;
+  return (a.original.position ?? 0) - (b.original.position ?? 0);
+}
+
+/**
  * Adapt a SongPagePerformance row to the minimal Track-like shape the
  * shared AllTimerCell + TrackRatingOverlay expect. The performance DTO
  * uses `notes` (plural) for the note field and exposes the song title
@@ -433,13 +455,21 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       id: "rating",
       header: ({ column }) => <SortableHeader column={column} label="Rating" />,
       enableSorting: true,
-      sortingFn: "basic",
-      // Desktop 7.25rem (~116px) = badge width (~91px) + cell padding
-      // (24px), no extra. Mobile fits the compact badge at 6rem. The
-      // 5-star editor is no longer inline — it pops in a popover that
-      // overlays the badge — so the column doesn't need to hold the
-      // wider expanded state.
-      meta: { fixedWidth: "7.25rem", mobileFixedWidth: "6rem" },
+      // Rating ties resolve to vote count (more votes = more confidence),
+      // then show date, then track position — same chain as gapSortingFn so
+      // identical-rating runs across multiple shows still read in a stable
+      // order. Sort defaults to descending ("best first") via sortDescFirst.
+      sortingFn: ratingSortingFn,
+      sortDescFirst: true,
+      // Sized for the busiest badge form: "★ 5.00 · 999 | 4½" — community
+      // average + 3-digit vote count + the viewer's own half-step rating
+      // (4½ is the widest valid user value; ratings cap at 5). Measured at
+      // ~120px on desktop / ~103px on mobile. Desktop 8.25rem (132px)
+      // leaves ~12px slack; mobile 6.75rem (108px) leaves ~5px so typical
+      // rows (no user rating, 1-2 digit count) don't carry obvious empty
+      // space. The 5-star editor pops in a popover that overlays the
+      // badge, so the column doesn't need a wider expanded state.
+      meta: { fixedWidth: "8.25rem", mobileFixedWidth: "6.75rem" },
       cell: (info) => {
         const rating = info.getValue();
         const ratingsCount = info.row.original.ratingsCount;

--- a/apps/web/app/components/setlist/setlist-columns.test.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.test.tsx
@@ -217,6 +217,96 @@ describe("createSetlistColumns", () => {
     ]);
   });
 
+  // Sort by Rating (desc, the default click order) puts the highest community
+  // average first. When two tracks share the same rating, the one with more
+  // votes wins the tiebreak — more votes = more confidence the average is
+  // real. Final fall-through is set+position so unrated rows still read in
+  // canonical setlist order.
+  test("sorting by Rating tiebreaks on vote count when averages match", async () => {
+    const user = userEvent.setup();
+    await renderTable([
+      // Two tracks tied at 4.5; "Confrontation" has more votes so it should
+      // sort ahead of "Crickets" when the table sorts rating descending.
+      makeTrack({
+        songId: "a",
+        position: 1,
+        set: "S1",
+        averageRating: 4.5,
+        ratingsCount: 3,
+        song: { id: "a", title: "Crickets", slug: "c" },
+      }),
+      makeTrack({
+        songId: "b",
+        position: 2,
+        set: "S1",
+        averageRating: 4.5,
+        ratingsCount: 50,
+        song: { id: "b", title: "Confrontation", slug: "co" },
+      }),
+      makeTrack({
+        songId: "c",
+        position: 3,
+        set: "S1",
+        averageRating: 3.0,
+        ratingsCount: 100,
+        song: { id: "c", title: "Above the Waves", slug: "a" },
+      }),
+    ]);
+    // First click on Rating sorts descending ("best first" via sortDescFirst).
+    await user.click(screen.getByRole("button", { name: /Rating/i }));
+    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 7 === 3);
+    // 4.5/50 (Confrontation) > 4.5/3 (Crickets) > 3.0 (Above the Waves).
+    expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
+      "Confrontation",
+      "Crickets",
+      "Above the Waves",
+    ]);
+  });
+
+  // Rating + vote count both equal → fall through to set+position. The
+  // Rating column's first click sorts descending (sortDescFirst), and
+  // TanStack inverts the whole comparator on desc — including the
+  // set+position fallback — so the rows read in reverse setlist order when
+  // every primary axis is tied. Same behavior as the Last Played and Song
+  // columns: tiebreak direction follows primary direction.
+  test("sorting by Rating with identical rating+votes falls back to set+position", async () => {
+    const user = userEvent.setup();
+    await renderTable([
+      makeTrack({
+        songId: "a",
+        position: 3,
+        set: "S1",
+        averageRating: null,
+        ratingsCount: 0,
+        song: { id: "a", title: "Crickets", slug: "c" },
+      }),
+      makeTrack({
+        songId: "b",
+        position: 1,
+        set: "S1",
+        averageRating: null,
+        ratingsCount: 0,
+        song: { id: "b", title: "Above the Waves", slug: "a" },
+      }),
+      makeTrack({
+        songId: "c",
+        position: 2,
+        set: "S1",
+        averageRating: null,
+        ratingsCount: 0,
+        song: { id: "c", title: "Basis for a Day", slug: "b" },
+      }),
+    ]);
+    await user.click(screen.getByRole("button", { name: /Rating/i }));
+    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 7 === 3);
+    // All three tied → set+position takes over, inverted by desc → 3, 2, 1.
+    expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
+      "Crickets",
+      "Basis for a Day",
+      "Above the Waves",
+    ]);
+  });
+
   // Track number resets per set so each set/encore reads "1, 2, 3, …"
   // independent of the cumulative position in the show.
   test("renders Track # 1-indexed within each set/encore", async () => {

--- a/apps/web/app/components/setlist/setlist-common-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-common-columns.tsx
@@ -49,19 +49,26 @@ export function createRatingColumn<T extends TrackLight>(ctx: SetlistRatingConte
   return columnHelper.accessor((row) => row.averageRating ?? Number.NEGATIVE_INFINITY, {
     id: "rating",
     header: ({ column }) => <SortableHeader column={column} label="Rating" />,
-    // Bounded content (star + "X.XX" + dot + count). The 5-star picker
-    // now floats in a popover instead of expanding the badge inline, so
-    // the column only needs to fit the compact badge. Desktop 7rem (~112px)
-    // gives ~96px content area (after 1rem horizontal padding) so the
-    // widest "★ 5.00 · 99" badge (~91px) sits with a few pixels of
-    // breathing room. Mobile 6rem fits the same compact rendering.
-    meta: { fixedWidth: "7rem", mobileFixedWidth: "6rem" },
+    // Sized for the busiest badge form: "★ 5.00 · 999 | 4½" — community
+    // average + 3-digit vote count + the viewer's own half-step rating
+    // (4½ is the widest valid user value; ratings cap at 5). Matches the
+    // performance table's rating column width so the column reads
+    // consistently across setlist and song-detail tables. The 5-star
+    // picker pops in a popover overlay, so the column doesn't need a
+    // wider expanded state.
+    meta: { fixedWidth: "8.25rem", mobileFixedWidth: "6.75rem" },
     enableSorting: true,
-    // Ties resolve to canonical set+position so "all unrated tracks" still
-    // read top-to-bottom in the order they were played.
-    sortingFn: withSetPositionTiebreak<T>(
-      (a, b) => (a.averageRating ?? Number.NEGATIVE_INFINITY) - (b.averageRating ?? Number.NEGATIVE_INFINITY),
-    ),
+    // Ties resolve first to vote count (more votes = more confidence in the
+    // average), then to canonical set+position so "all unrated tracks" still
+    // read top-to-bottom in the order they were played. Every row in a
+    // setlist shares the same show date, so date can't disambiguate here —
+    // set+position is the canonical narrative tiebreak instead.
+    sortingFn: withSetPositionTiebreak<T>((a, b) => {
+      const aRating = a.averageRating ?? Number.NEGATIVE_INFINITY;
+      const bRating = b.averageRating ?? Number.NEGATIVE_INFINITY;
+      if (aRating !== bRating) return aRating - bRating;
+      return (a.ratingsCount ?? 0) - (b.ratingsCount ?? 0);
+    }),
     sortDescFirst: true,
     cell: (info) => {
       const row = info.row.original;

--- a/apps/web/app/components/ui/data-table.test.tsx
+++ b/apps/web/app/components/ui/data-table.test.tsx
@@ -1,6 +1,8 @@
 import type { ColumnDef } from "@tanstack/react-table";
-import { setup } from "@test/test-utils";
-import { screen } from "@testing-library/react";
+import { setupWithRouter } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
 import { describe, expect, test } from "vitest";
 import { computeColumnWidths, DataTable } from "./data-table";
 
@@ -21,7 +23,7 @@ describe("DataTable", () => {
   // Baseline smoke test: given columns + data, the table renders header labels
   // and one row per data item. If this fails, every other test is suspect.
   test("renders column headers and row cells", async () => {
-    await setup(<DataTable columns={basicColumns} data={rows} hideSearch />);
+    await setupWithRouter(<DataTable columns={basicColumns} data={rows} hideSearch />);
 
     expect(screen.getByText("Name")).toBeInTheDocument();
     expect(screen.getByText("Count")).toBeInTheDocument();
@@ -34,7 +36,7 @@ describe("DataTable", () => {
   // table on that column using TanStack's column filter. Verifies the
   // input→filter wiring; pages like /songs and /admin/authors rely on it.
   test("search filter narrows visible rows by searchKey", async () => {
-    const { user } = await setup(
+    const { user } = await setupWithRouter(
       <DataTable columns={basicColumns} data={rows} searchKey="name" searchPlaceholder="Search..." />,
     );
 
@@ -52,7 +54,7 @@ describe("DataTable", () => {
   // The `rowClassName` callback lets callers style individual rows based on
   // row data (e.g., attendance-row highlighting on top-rated shows).
   test("rowClassName callback adds class to each row", async () => {
-    await setup(
+    await setupWithRouter(
       <DataTable
         columns={basicColumns}
         data={rows}
@@ -75,7 +77,7 @@ describe("DataTable", () => {
   // all — Previous/Next buttons and "Page X of Y" are meaningless with no
   // data to page through.
   test("hides pagination controls when data is empty", async () => {
-    await setup(<DataTable columns={basicColumns} data={[]} hideSearch />);
+    await setupWithRouter(<DataTable columns={basicColumns} data={[]} hideSearch />);
 
     expect(screen.queryByRole("button", { name: "Previous" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
@@ -86,7 +88,7 @@ describe("DataTable", () => {
   // instead of a bare table body. Matters for filtered views where the user's
   // query yields zero rows.
   test("empty state renders 'No results found'", async () => {
-    await setup(<DataTable columns={basicColumns} data={[]} hideSearch />);
+    await setupWithRouter(<DataTable columns={basicColumns} data={[]} hideSearch />);
 
     expect(screen.getByText("No results found")).toBeInTheDocument();
   });
@@ -95,7 +97,7 @@ describe("DataTable", () => {
   // their place. Used by /songs during filter-refetch to avoid showing stale
   // data while the new API response is in flight.
   test("isLoading state renders 'Loading...'", async () => {
-    await setup(<DataTable columns={basicColumns} data={rows} hideSearch isLoading />);
+    await setupWithRouter(<DataTable columns={basicColumns} data={rows} hideSearch isLoading />);
 
     expect(screen.getByText("Loading...")).toBeInTheDocument();
     // When loading, rows should not render
@@ -106,7 +108,7 @@ describe("DataTable", () => {
   // total) pass `hidePagination` to suppress the paginator. Confirms that the
   // Previous/Next buttons don't render in that mode.
   test("hidePagination removes Previous/Next buttons", async () => {
-    await setup(<DataTable columns={basicColumns} data={rows} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={basicColumns} data={rows} hideSearch hidePagination />);
 
     expect(screen.queryByRole("button", { name: "Previous" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
@@ -121,7 +123,7 @@ describe("DataTable", () => {
       count: i,
     }));
 
-    await setup(<DataTable columns={basicColumns} data={manyRows} hideSearch pageSize={3} />);
+    await setupWithRouter(<DataTable columns={basicColumns} data={manyRows} hideSearch pageSize={3} />);
 
     expect(screen.getAllByRole("button", { name: "Previous" })).toHaveLength(2);
     expect(screen.getAllByRole("button", { name: "Next" })).toHaveLength(2);
@@ -130,7 +132,7 @@ describe("DataTable", () => {
   // When all data fits on a single page, page navigation controls are hidden
   // (Previous/Next buttons and page input) but the results summary still shows.
   test("page controls are hidden when data fits on one page", async () => {
-    await setup(<DataTable columns={basicColumns} data={rows} hideSearch />);
+    await setupWithRouter(<DataTable columns={basicColumns} data={rows} hideSearch />);
 
     expect(screen.queryByRole("button", { name: "Previous" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
@@ -145,7 +147,7 @@ describe("DataTable", () => {
       count: i,
     }));
 
-    await setup(<DataTable columns={basicColumns} data={manyRows} hideSearch pageSize={3} />);
+    await setupWithRouter(<DataTable columns={basicColumns} data={manyRows} hideSearch pageSize={3} />);
 
     // 10 rows / 3 per page = 4 pages
     const pageInputs = screen.getAllByRole("spinbutton");
@@ -162,7 +164,9 @@ describe("DataTable", () => {
       count: i,
     }));
 
-    const { user } = await setup(<DataTable columns={basicColumns} data={manyRows} hideSearch pageSize={3} />);
+    const { user } = await setupWithRouter(
+      <DataTable columns={basicColumns} data={manyRows} hideSearch pageSize={3} />,
+    );
 
     expect(screen.getByText("Row 0")).toBeInTheDocument();
 
@@ -183,7 +187,9 @@ describe("DataTable", () => {
       count: i,
     }));
 
-    const { user } = await setup(<DataTable columns={basicColumns} data={manyRows} hideSearch pageSize={3} />);
+    const { user } = await setupWithRouter(
+      <DataTable columns={basicColumns} data={manyRows} hideSearch pageSize={3} />,
+    );
 
     const pageInputs = screen.getAllByRole("spinbutton");
 
@@ -203,7 +209,7 @@ describe("DataTable", () => {
       count: i,
     }));
 
-    await setup(<DataTable columns={basicColumns} data={manyRows} hideSearch hidePagination />);
+    await setupWithRouter(<DataTable columns={basicColumns} data={manyRows} hideSearch hidePagination />);
 
     expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
   });
@@ -223,7 +229,7 @@ describe("DataTable", () => {
       { accessorKey: "count", header: "Count", meta: { hideOnMobile: true } },
     ];
 
-    await setup(<DataTable columns={columnsWithHidden} data={rows} hideSearch />);
+    await setupWithRouter(<DataTable columns={columnsWithHidden} data={rows} hideSearch />);
 
     expect(screen.getByText("Name")).toBeInTheDocument();
     expect(screen.getByText("Count")).toBeInTheDocument();
@@ -241,7 +247,7 @@ describe("DataTable", () => {
       { accessorKey: "count", header: "Count" /* default weight 1 */ },
     ];
 
-    const { container } = await setup(<DataTable columns={columnsWithWeights} data={rows} hideSearch />);
+    const { container } = await setupWithRouter(<DataTable columns={columnsWithWeights} data={rows} hideSearch />);
 
     const cols = container.querySelectorAll("colgroup col");
     expect(cols).toHaveLength(2);
@@ -259,11 +265,95 @@ describe("DataTable", () => {
       { accessorKey: "count", header: "Count", meta: { fixedWidth: "3rem" } },
     ];
 
-    const { container } = await setup(<DataTable columns={columns} data={rows} hideSearch />);
+    const { container } = await setupWithRouter(<DataTable columns={columns} data={rows} hideSearch />);
 
     const cols = container.querySelectorAll("colgroup col");
     expect((cols[0] as HTMLElement).style.width).toBe("100%");
     expect((cols[1] as HTMLElement).style.width).toBe("3rem");
+  });
+
+  // The "Show all" toggle lets users opt out of pagination on demand. It only
+  // surfaces when there's more than one page worth of data — a tiny table
+  // doesn't need a "show all" affordance because everything already fits.
+  test("Show all toggle appears when data exceeds pageSize", async () => {
+    const manyRows = Array.from({ length: 6 }, (_, i) => ({
+      id: String(i),
+      name: `Row ${i}`,
+      count: i,
+    }));
+
+    await setupWithRouter(<DataTable columns={basicColumns} data={manyRows} hideSearch pageSize={3} />);
+
+    expect(screen.getAllByRole("button", { name: "Show all" }).length).toBeGreaterThanOrEqual(1);
+  });
+
+  // When everything already fits on one page, "Show all" would be a no-op,
+  // so it's hidden to keep the footer chrome quiet.
+  test("Show all toggle hidden when data fits on one page", async () => {
+    await setupWithRouter(<DataTable columns={basicColumns} data={rows} hideSearch />);
+
+    expect(screen.queryByRole("button", { name: "Show all" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Paginate" })).not.toBeInTheDocument();
+  });
+
+  // `hidePagination` is the caller-side "this table never paginates" switch.
+  // It should suppress the user-facing toggle entirely — there's no pagination
+  // to opt out of when the caller already opted out for everyone.
+  test("Show all toggle hidden when hidePagination is true", async () => {
+    const manyRows = Array.from({ length: 10 }, (_, i) => ({
+      id: String(i),
+      name: `Row ${i}`,
+      count: i,
+    }));
+
+    await setupWithRouter(<DataTable columns={basicColumns} data={manyRows} hideSearch hidePagination />);
+
+    expect(screen.queryByRole("button", { name: "Show all" })).not.toBeInTheDocument();
+  });
+
+  // Clicking "Show all" expands the table to render every row at once and
+  // flips the button label to "Paginate" so the user has a way back.
+  test("clicking Show all renders every row and flips the label", async () => {
+    const user = userEvent.setup();
+    const manyRows = Array.from({ length: 6 }, (_, i) => ({
+      id: String(i),
+      name: `Row ${i}`,
+      count: i,
+    }));
+
+    await setupWithRouter(<DataTable columns={basicColumns} data={manyRows} hideSearch pageSize={3} />);
+
+    // Pagination state: only the first three rows are rendered.
+    expect(screen.getByText("Row 0")).toBeInTheDocument();
+    expect(screen.queryByText("Row 5")).not.toBeInTheDocument();
+
+    await user.click(screen.getAllByRole("button", { name: "Show all" })[0]);
+
+    // After toggle: all six rows render and the button now says Paginate.
+    expect(screen.getByText("Row 0")).toBeInTheDocument();
+    expect(screen.getByText("Row 5")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Paginate" }).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByRole("button", { name: "Show all" })).not.toBeInTheDocument();
+  });
+
+  // Landing on a URL with ?all=1 should render the table in show-all mode on
+  // first paint, without the user clicking anything.
+  test("?all=1 in the URL renders every row on mount", () => {
+    const manyRows = Array.from({ length: 6 }, (_, i) => ({
+      id: String(i),
+      name: `Row ${i}`,
+      count: i,
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/songs/histories?all=1"]}>
+        <DataTable columns={basicColumns} data={manyRows} hideSearch pageSize={3} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Row 0")).toBeInTheDocument();
+    expect(screen.getByText("Row 5")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Paginate" }).length).toBeGreaterThanOrEqual(1);
   });
 });
 

--- a/apps/web/app/components/ui/data-table.tsx
+++ b/apps/web/app/components/ui/data-table.tsx
@@ -56,6 +56,7 @@ import { type ReactNode, useEffect, useRef, useState } from "react";
 import { Input } from "~/components/ui/input";
 import { PaginationControls } from "~/components/ui/pagination-controls";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/ui/table";
+import { useShowAll } from "~/hooks/use-show-all";
 import { cn } from "~/lib/utils";
 
 /**
@@ -162,6 +163,11 @@ export function DataTable<TData, TValue>({
   const [sorting, setSorting] = useState<SortingState>(initialSorting ?? []);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  // `?all=1` opts the user into a single-page render of every row. `hidePagination`
+  // is the caller-side equivalent (the table conceptually has no pages) — when
+  // it's set, we don't surface the toggle at all.
+  const [showAll, setShowAll] = useShowAll();
+  const paginationDisabled = hidePagination || showAll;
 
   // Measure the table wrapper so col widths can be computed in pixels.
   // Chrome's `table-layout: fixed` algorithm distributes leftover space
@@ -208,7 +214,7 @@ export function DataTable<TData, TValue>({
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
-    ...(hidePagination ? {} : { getPaginationRowModel: getPaginationRowModel() }),
+    ...(paginationDisabled ? {} : { getPaginationRowModel: getPaginationRowModel() }),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     onColumnVisibilityChange: setColumnVisibility,
@@ -219,23 +225,38 @@ export function DataTable<TData, TValue>({
     },
     initialState: {
       pagination: {
-        pageSize: hidePagination ? data.length : pageSize,
+        pageSize: paginationDisabled ? Math.max(1, data.length) : pageSize,
       },
     },
   });
 
+  // `initialState.pagination.pageSize` is read once at mount, so flipping
+  // `?all=1` mid-session needs an explicit `setPageSize` for the visible row
+  // count to change. Also re-applies when `data` grows (e.g. a filter clears).
+  useEffect(() => {
+    table.setPageSize(paginationDisabled ? Math.max(1, data.length) : pageSize);
+  }, [paginationDisabled, pageSize, data.length, table]);
+
   const hasResults = table.getFilteredRowModel().rows.length > 0;
   const currentPage = table.getState().pagination.pageIndex + 1;
   const totalPages = table.getPageCount();
+  const filteredRowCount = table.getFilteredRowModel().rows.length;
+  // Only offer the toggle when there's actually more than one page worth of
+  // data (otherwise there's nothing to "show all" of). Once the user has
+  // toggled on, keep it visible so they have a way back to paginated mode.
+  const canShowAll = !hidePagination && (showAll || filteredRowCount > pageSize);
 
   const paginationBlock = !hasResults ? null : (
     <PaginationControls
       page={currentPage}
       totalPages={totalPages}
       pageSize={table.getState().pagination.pageSize}
-      total={table.getFilteredRowModel().rows.length}
+      total={filteredRowCount}
       onPageChange={(nextPage) => table.setPageIndex(nextPage - 1)}
       hidePaginationText={hidePaginationText}
+      showAll={showAll}
+      onToggleShowAll={hidePagination ? undefined : setShowAll}
+      canShowAll={canShowAll}
     />
   );
 

--- a/apps/web/app/components/ui/pagination-controls.tsx
+++ b/apps/web/app/components/ui/pagination-controls.tsx
@@ -11,6 +11,15 @@ interface PaginationControlsProps {
   onPageChange: (nextPage: number) => void;
   /** Hides the "Showing N to M of T" copy on the left while keeping the controls. */
   hidePaginationText?: boolean;
+  /**
+   * Optional opt-in "Show all / Paginate" toggle. Rendered next to the
+   * results count when both `onToggleShowAll` and `canShowAll` are provided.
+   * DataTable wires this up via the `useShowAll` hook; standalone callers
+   * (server-side paginators) omit these props and the toggle stays hidden.
+   */
+  showAll?: boolean;
+  onToggleShowAll?: (next: boolean) => void;
+  canShowAll?: boolean;
 }
 
 /**
@@ -26,6 +35,9 @@ export function PaginationControls({
   total,
   onPageChange,
   hidePaginationText = false,
+  showAll = false,
+  onToggleShowAll,
+  canShowAll = false,
 }: PaginationControlsProps) {
   function handlePageInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {
     if (event.key !== "Enter") return;
@@ -38,20 +50,32 @@ export function PaginationControls({
 
   const from = (page - 1) * pageSize + 1;
   const to = Math.min(page * pageSize, total);
+  const showAllToggle = canShowAll && onToggleShowAll && (
+    <button
+      type="button"
+      onClick={() => onToggleShowAll(!showAll)}
+      className="text-sm text-content-text-secondary underline decoration-dotted underline-offset-4 hover:text-brand-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring/20 rounded-sm"
+    >
+      {showAll ? "Paginate" : "Show all"}
+    </button>
+  );
 
   return (
-    <div className="flex items-center justify-between px-2">
+    <div className="flex items-center justify-between px-2 gap-3">
       {!hidePaginationText ? (
-        total === 0 ? (
-          <div className="text-sm text-content-text-secondary font-medium">0 results</div>
-        ) : (
-          <div className="text-sm text-content-text-secondary font-medium">
-            <span className="hidden sm:inline">{`Showing ${from} to ${to} of ${total} results`}</span>
-            <span className="sm:hidden">{`${from}–${to} of ${total}`}</span>
-          </div>
-        )
+        <div className="flex items-center gap-3 min-w-0">
+          {total === 0 ? (
+            <span className="text-sm text-content-text-secondary font-medium">0 results</span>
+          ) : (
+            <span className="text-sm text-content-text-secondary font-medium">
+              <span className="hidden sm:inline">{`Showing ${from} to ${to} of ${total} results`}</span>
+              <span className="sm:hidden">{`${from}–${to} of ${total}`}</span>
+            </span>
+          )}
+          {showAllToggle}
+        </div>
       ) : (
-        <div />
+        <div className="flex items-center">{showAllToggle ?? null}</div>
       )}
       {totalPages > 1 && (
         <div className="flex items-center space-x-2">

--- a/apps/web/app/hooks/use-show-all.test.tsx
+++ b/apps/web/app/hooks/use-show-all.test.tsx
@@ -1,0 +1,66 @@
+import { setupWithRouter } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { describe, expect, test } from "vitest";
+import { useShowAll } from "./use-show-all";
+
+function Harness() {
+  const [showAll, setShowAll] = useShowAll();
+  const location = useLocation();
+  return (
+    <>
+      <div data-testid="show-all">{String(showAll)}</div>
+      <div data-testid="search">{location.search}</div>
+      <button type="button" onClick={() => setShowAll(true)}>
+        on
+      </button>
+      <button type="button" onClick={() => setShowAll(false)}>
+        off
+      </button>
+    </>
+  );
+}
+
+describe("useShowAll", () => {
+  // Default is paginated — the absence of ?all= keeps existing routes behaving
+  // exactly as they do today.
+  test("defaults to false when no all param is set", async () => {
+    await setupWithRouter(<Harness />);
+    expect(screen.getByTestId("show-all").textContent).toBe("false");
+  });
+
+  // Shared links that include ?all=1 should land directly in show-all mode.
+  test("reads ?all=1 from the URL on mount", () => {
+    render(
+      <MemoryRouter initialEntries={["/songs/histories?all=1"]}>
+        <Harness />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("show-all").textContent).toBe("true");
+  });
+
+  // Toggling on writes ?all=1, toggling off drops the param entirely so the
+  // bare URL stays clean (matches useSetlistView's round-trip behavior).
+  test("toggling on writes ?all=1; toggling off drops the param", async () => {
+    const user = userEvent.setup();
+    await setupWithRouter(<Harness />);
+
+    await user.click(screen.getByText("on"));
+    expect(screen.getByTestId("search").textContent).toBe("?all=1");
+
+    await user.click(screen.getByText("off"));
+    expect(screen.getByTestId("search").textContent).toBe("");
+  });
+
+  // Unrecognized values (?all=true, ?all=yes, ?all=0) fall through to false
+  // rather than guessing intent — only the canonical "1" enables show-all.
+  test("falls back to false for non-1 values", () => {
+    render(
+      <MemoryRouter initialEntries={["/songs/histories?all=yes"]}>
+        <Harness />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("show-all").textContent).toBe("false");
+  });
+});

--- a/apps/web/app/hooks/use-show-all.ts
+++ b/apps/web/app/hooks/use-show-all.ts
@@ -1,0 +1,32 @@
+import { useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
+
+/**
+ * URL-syncs an opt-in "show all rows" toggle for the shared DataTable. Reads
+ * `?all=1` on mount and writes the param when the user flips the toggle.
+ * Switching back to paginated mode drops the param entirely so the bare URL
+ * stays clean.
+ */
+export function useShowAll(): [boolean, (next: boolean) => void] {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const showAll = searchParams.get("all") === "1";
+
+  const setShowAll = useCallback(
+    (next: boolean) => {
+      setSearchParams(
+        (prev) => {
+          if (next) {
+            prev.set("all", "1");
+          } else {
+            prev.delete("all");
+          }
+          return prev;
+        },
+        { replace: true, preventScrollReset: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  return [showAll, setShowAll];
+}


### PR DESCRIPTION
## Summary

- **"Show all" toggle on every DataTable.** Next to the pagination footer, a quiet "Show all / Paginate" link lets you opt out of pagination and render every row at once. State is URL-synced via `?all=1` so the choice survives reload + sharing. Default stays paginated; the toggle only surfaces when there's actually more than one page worth of data, and routes that pass `hidePagination` see no change.
- **Rating columns tie-break on votes, then date.** When two performances share the same community average, the one with more votes sorts ahead (more votes = more confidence in the average); identical rating + votes falls through to show date so cross-show duplicates cluster sensibly. Applies to the song-detail performance table and both setlist gap chart views (catalog + personal).
- **Rating column gains breathing room.** Width sized to comfortably hold the busiest badge form (`★ 5.00 · 999 | 4½`) without clipping. Desktop 8.25rem, mobile 6.75rem -- mobile is sized tight to the worst case so typical rows don't carry obvious empty space.

## Test plan

- [ ] `make test` -- 828 web + 280 core tests pass, including new coverage for `useShowAll`, the DataTable toggle, and both rating sort comparators.
- [ ] `make tc` clean.
- [ ] Visit `/songs` (546 rows): click "Show all", URL gains `?all=1`, all rows render, button flips to "Paginate". Reload preserves the state.
- [ ] Visit `/songs/jam-charts`, sort by Rating: 999-vote badges render without clipping; ties resolve by votes then date.
- [ ] Visit a show page (e.g. `/shows/<slug>?view=gap-chart`): rating column width matches the song-detail table; sorting by Rating tiebreaks on vote count.
- [ ] Mobile (390px viewport): rating column fits 3-digit counts and typical rows look tight (no obvious empty space).

## Notes

`/users/$username` (Attended Shows / Ratings tabs) is intentionally out of scope for "Show all" -- those tabs use server-side pagination over 7,000+ row datasets, so "load everything" would be expensive and slow. Same comparator chain is already applied server-side for the Top Rated Shows endpoint; the three MCP API routes that sort by rating still rely on a single-key sort and could be tightened in a follow-up.
