### PR TITLE
Songs by debut year chart on the show page

### DIFF
--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -342,7 +342,7 @@ describe("SetlistCard", () => {
     await user.click(screen.getByRole("button", { name: /gap chart/i }));
     // Average gap formats to one decimal place — terse, matches the rest
     // of the rarity stat presentation on the song-detail page.
-    expect(screen.getByText(/Average \/ median song gap:\s*7\.5\s*\/\s*6\.0/)).toBeInTheDocument();
+    expect(screen.getByText(/average \/ median song gap:\s*7\.5\s*\/\s*6\.0/)).toBeInTheDocument();
     // Label is split into stacked <span>Last</span><span>Played</span>
     // so the accessible name concatenates without whitespace.
     expect(screen.getByRole("columnheader", { name: /LastPlayed/i })).toBeInTheDocument();
@@ -360,7 +360,7 @@ describe("SetlistCard", () => {
         showRating={null}
       />,
     );
-    const summary = screen.getByText(/Average \/ median song gap:\s*7\.5\s*\/\s*6\.0/);
+    const summary = screen.getByText(/average \/ median song gap:\s*7\.5\s*\/\s*6\.0/);
     const trackText = screen.getByText("Basis for a Day");
     // DOM order: track text comes before the summary line. compareDocumentPosition
     // returns DOCUMENT_POSITION_FOLLOWING (4) when `summary` follows `trackText`.

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -70,13 +70,13 @@ function SetlistCardComponent({
   // stay one-liners. The catalog summary is server-computed; the personal
   // summary is hoisted from SetlistTablePersonal via onSummaryChange.
   const catalogSummary: SetlistViewSummary = {
-    label: "Average / median song gap",
+    label: "average / median song gap",
     average: setlist.averageSongGap,
     median: setlist.medianSongGap,
     debutCount: setlist.debutCount,
   };
   const personalSummaryView: SetlistViewSummary = {
-    label: "Your average / median song gap",
+    label: "your average / median song gap",
     average: personalSummary.average,
     median: personalSummary.median,
     debutCount: personalSummary.debutCount,

--- a/apps/web/app/components/setlist/setlist-view-control.test.tsx
+++ b/apps/web/app/components/setlist/setlist-view-control.test.tsx
@@ -5,7 +5,7 @@ import { SetlistViewControl, type SetlistViewSummary } from "./setlist-view-cont
 
 /** Compact summary builder for tests — sane defaults, override what matters. */
 function summary(overrides: Partial<SetlistViewSummary> = {}): SetlistViewSummary {
-  return { label: "Average / median song gap", average: null, median: null, debutCount: 0, ...overrides };
+  return { label: "average / median song gap", average: null, median: null, debutCount: 0, ...overrides };
 }
 
 describe("SetlistViewControl", () => {
@@ -35,7 +35,7 @@ describe("SetlistViewControl", () => {
         summary={summary({ average: 4.2, median: 3.0, debutCount: 2 })}
       />,
     );
-    expect(screen.getByText(/Average \/ median song gap: 4\.2 \/ 3\.0 · 2 debuts/)).toBeInTheDocument();
+    expect(screen.getByText(/average \/ median song gap: 4\.2 \/ 3\.0 · 2 debuts/)).toBeInTheDocument();
   });
 
   // Singular grammar — `· 1 debut`, not `· 1 debuts`.
@@ -77,10 +77,10 @@ describe("SetlistViewControl", () => {
         view="personal"
         onChange={vi.fn()}
         showPersonal
-        summary={{ label: "Your average / median song gap", average: 6.59, median: 5, debutCount: 2 }}
+        summary={{ label: "your average / median song gap", average: 6.59, median: 5, debutCount: 2 }}
       />,
     );
-    expect(screen.getByText(/Your average \/ median song gap: 6\.6 \/ 5\.0 · 2 debuts/)).toBeInTheDocument();
-    expect(screen.queryByText(/^Average \/ median song gap:/)).not.toBeInTheDocument();
+    expect(screen.getByText(/your average \/ median song gap: 6\.6 \/ 5\.0 · 2 debuts/)).toBeInTheDocument();
+    expect(screen.queryByText(/^average \/ median song gap:/)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/components/setlist/setlist-view-control.tsx
+++ b/apps/web/app/components/setlist/setlist-view-control.tsx
@@ -1,4 +1,4 @@
-import { cn } from "~/lib/utils";
+import { SegmentButton } from "~/components/ui/segment-button";
 import type { SetlistView } from "./setlist-card";
 
 /**
@@ -8,7 +8,7 @@ import type { SetlistView } from "./setlist-card";
  * renderer without view-specific branching.
  */
 export interface SetlistViewSummary {
-  /** Prefix text. `"Average / median song gap"` or `"Your average / median song gap"`. */
+  /** Prefix text. `"average / median song gap"` or `"your average / median song gap"`. */
   label: string;
   /** Average gap value. Null when no rows qualify; the line is hidden. */
   average: number | null;
@@ -47,9 +47,17 @@ export function SetlistViewControl({ view, onChange, showPersonal, summary }: Se
   return (
     <div className="flex items-center justify-between gap-3 text-sm">
       <div className="inline-flex items-center">
-        <SegmentButton view={view} target="setlist" label="setlist" onChange={onChange} />
-        <SegmentButton view={view} target="gap-chart" label="gap chart" onChange={onChange} />
-        {showPersonal && <SegmentButton view={view} target="personal" label="personal gap chart" onChange={onChange} />}
+        <SegmentButton active={view === "setlist"} onClick={() => onChange("setlist")}>
+          setlist
+        </SegmentButton>
+        <SegmentButton active={view === "gap-chart"} onClick={() => onChange("gap-chart")}>
+          gap chart
+        </SegmentButton>
+        {showPersonal && (
+          <SegmentButton active={view === "personal"} onClick={() => onChange("personal")}>
+            personal gap chart
+          </SegmentButton>
+        )}
       </div>
       {summary && <SummaryLine summary={summary} />}
     </div>
@@ -76,33 +84,4 @@ function SummaryLine({ summary }: { summary: SetlistViewSummary }) {
     return <span className="text-content-text-secondary text-right">{debutSuffix}</span>;
   }
   return null;
-}
-
-function SegmentButton({
-  view,
-  target,
-  label,
-  onChange,
-}: {
-  view: SetlistView;
-  target: SetlistView;
-  label: string;
-  onChange: (next: SetlistView) => void;
-}) {
-  const active = view === target;
-  return (
-    <button
-      type="button"
-      aria-pressed={active}
-      onClick={() => onChange(target)}
-      className={cn(
-        "px-2 py-1 border-b-2 transition-colors cursor-pointer",
-        active
-          ? "border-brand-primary text-content-text-primary"
-          : "border-transparent text-content-text-tertiary hover:text-content-text-secondary",
-      )}
-    >
-      {label}
-    </button>
-  );
 }

--- a/apps/web/app/components/show/debut-year-chart.test.tsx
+++ b/apps/web/app/components/show/debut-year-chart.test.tsx
@@ -1,0 +1,247 @@
+import { setupWithRouter } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { computeDebutYearStats, DebutYearChart, type DebutYearTrack } from "./debut-year-chart";
+
+// Recharts ResponsiveContainer measures parent layout via ResizeObserver,
+// which jsdom doesn't implement. Stub it to a fixed-size div so the inner
+// BarChart actually renders during tests.
+vi.mock("recharts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("recharts")>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 600, height: 240 }}>{children}</div>
+    ),
+  };
+});
+
+function track(songId: string, year: number | null): DebutYearTrack {
+  // Titles humanize the slug so table assertions can target real-looking
+  // song names ("Mindless Dribble" from "mindless-dribble") without each
+  // call site having to spell them out.
+  const title = songId
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+  return {
+    songId,
+    song: year === null ? null : { title, slug: songId, dateFirstPlayed: new Date(Date.UTC(year, 0, 1)) },
+  };
+}
+
+describe("computeDebutYearStats", () => {
+  // A song played twice in a show contributes a single data point — the
+  // chart should reflect the show's *song selection*, not its bar count.
+  // Distribution spans the band's catalog window (1995 → show year), so
+  // every show's chart is on the same axis.
+  test("dedupes repeated songs by songId; X-axis spans 1995 through the show year", () => {
+    const result = computeDebutYearStats(
+      [track("spaga", 1998), track("spaga", 1998), track("vassillios", 2001)],
+      "2001-12-31",
+    );
+
+    expect(result.distribution.map(({ year, count }) => ({ year, count }))).toEqual([
+      { year: 1995, count: 0 },
+      { year: 1996, count: 0 },
+      { year: 1997, count: 0 },
+      { year: 1998, count: 1 },
+      { year: 1999, count: 0 },
+      { year: 2000, count: 0 },
+      { year: 2001, count: 1 },
+    ]);
+    expect(result.distribution[3].songs).toEqual([{ title: "Spaga", slug: "spaga" }]);
+    expect(result.distribution[6].songs).toEqual([{ title: "Vassillios", slug: "vassillios" }]);
+    expect(result.average).toBe(2000);
+    expect(result.median).toBe(2000);
+  });
+
+  // The histogram zero-fills every year from the band's start through the
+  // show year so visual gaps read as gaps (not as a compressed continuous
+  // run) and so a 1996 show and a 2024 show are visually comparable.
+  test("fills zero-count years from START_YEAR through the show year", () => {
+    const result = computeDebutYearStats(
+      [track("mindless-dribble", 1995), track("crickets", 1998), track("munchkin-invasion", 2001)],
+      "2001-12-31",
+    );
+
+    expect(result.distribution.map(({ year, count }) => ({ year, count }))).toEqual([
+      { year: 1995, count: 1 },
+      { year: 1996, count: 0 },
+      { year: 1997, count: 0 },
+      { year: 1998, count: 1 },
+      { year: 1999, count: 0 },
+      { year: 2000, count: 0 },
+      { year: 2001, count: 1 },
+    ]);
+  });
+
+  // X-axis extends to the show year even when no song debuted that recently
+  // — a modern show drawing entirely from the 1990s should reveal the era
+  // gap as a long tail of zero-count years.
+  test("X-axis extends to the show year even when no song debuted that recently", () => {
+    const result = computeDebutYearStats([track("crickets", 1996), track("spaga", 1998)], "2024-08-15");
+
+    expect(result.distribution[0]).toMatchObject({ year: 1995, count: 0 });
+    expect(result.distribution[result.distribution.length - 1]).toMatchObject({ year: 2024, count: 0 });
+    expect(result.distribution.length).toBe(2024 - 1995 + 1);
+  });
+
+  // A song dated after the show is a data-integrity edge case (stats not
+  // rebuilt) — skip it so the chart stays bounded by the show year.
+  test("ignores songs whose dateFirstPlayed is after the show", () => {
+    const result = computeDebutYearStats([track("crickets", 1996), track("future-song", 2005)], "2001-12-31");
+
+    expect(result.distribution[result.distribution.length - 1]).toMatchObject({ year: 2001, count: 0 });
+    expect(result.average).toBe(1996);
+  });
+
+  // A song dated before START_YEAR (1995) is a data anomaly — skip it so
+  // the X-axis floor stays consistent across all shows.
+  test("ignores songs whose dateFirstPlayed is before START_YEAR", () => {
+    const result = computeDebutYearStats([track("ancient-song", 1990), track("crickets", 1998)], "2001-12-31");
+
+    expect(result.distribution[0]).toMatchObject({ year: 1995, count: 0 });
+    expect(result.average).toBe(1998);
+  });
+
+  // Odd-count median is the middle value; average is the rounded mean so
+  // a hand calculation matches the displayed integer year.
+  test("odd-count median equals the middle year, average rounded to integer", () => {
+    const result = computeDebutYearStats(
+      [track("aceetobee", 1996), track("konkrete", 1999), track("plan-b", 2002)],
+      "2002-12-31",
+    );
+
+    expect(result.median).toBe(1999);
+    expect(result.average).toBe(1999);
+  });
+
+  // Even-count median rounds the mean of the two middle values up to an
+  // integer year — half-year results would read as noise for a stat that
+  // means "year the songs came from."
+  test("even-count median rounds to an integer year", () => {
+    const result = computeDebutYearStats(
+      [track("crickets", 1996), track("spaga", 1998), track("vassillios", 1999), track("konkrete", 2001)],
+      "2001-12-31",
+    );
+
+    expect(result.median).toBe(1999);
+    expect(result.average).toBe(1999);
+  });
+
+  // Songs missing dateFirstPlayed are defensively skipped — they don't
+  // belong in any year's bar and would corrupt avg/median if included.
+  test("skips songs with no dateFirstPlayed", () => {
+    const result = computeDebutYearStats(
+      [track("spaga", 1998), track("uncatalogued", null), track("vassillios", 2001)],
+      "2001-12-31",
+    );
+
+    expect(result.distribution.map(({ year, count }) => ({ year, count }))).toEqual([
+      { year: 1995, count: 0 },
+      { year: 1996, count: 0 },
+      { year: 1997, count: 0 },
+      { year: 1998, count: 1 },
+      { year: 1999, count: 0 },
+      { year: 2000, count: 0 },
+      { year: 2001, count: 1 },
+    ]);
+    expect(result.average).toBe(2000);
+  });
+
+  // No qualifying songs → all-null result, signaling the chart to render
+  // nothing rather than an axis with no bars.
+  test("empty input returns null average/median and empty distribution", () => {
+    expect(computeDebutYearStats([], "2001-12-31")).toEqual({
+      distribution: [],
+      average: null,
+      median: null,
+    });
+  });
+
+  // The table view lists song titles per year; sort alphabetically so a
+  // reader can scan the names predictably (not in setlist position order).
+  test("sorts songs within each year alphabetically by title", () => {
+    const result = computeDebutYearStats(
+      [track("svenghali", 1996), track("aceetobee", 1996), track("munchkin-invasion", 1996)],
+      "2001-12-31",
+    );
+
+    // 1996 is index 1 in the distribution (1995 sits at index 0 as the
+    // catalog-window floor) — assert against that row's `songs` field.
+    expect(result.distribution[1]).toMatchObject({
+      year: 1996,
+      songs: [
+        { title: "Aceetobee", slug: "aceetobee" },
+        { title: "Munchkin Invasion", slug: "munchkin-invasion" },
+        { title: "Svenghali", slug: "svenghali" },
+      ],
+    });
+  });
+});
+
+describe("DebutYearChart", () => {
+  const setlist = {
+    show: { date: "2001-12-31" },
+    sets: [
+      {
+        tracks: [track("spaga", 1998), track("vassillios", 2001), track("crickets", 2001)],
+      },
+    ],
+  };
+
+  // The card carries a title so readers see "Songs by debut year" without
+  // having to interpret the chart from context.
+  test("renders the section heading", async () => {
+    await setupWithRouter(<DebutYearChart setlist={setlist} />);
+    expect(screen.getByText(/songs by debut year/i)).toBeInTheDocument();
+  });
+
+  // Summary line mirrors the song-gap line on SetlistCard ("average /
+  // median song gap: X / Y") so the chart reads as one of a family of
+  // setlist-stat lines rather than a one-off format. The "debut year"
+  // suffix is dropped because the title above already supplies that
+  // context.
+  test("renders the average / median summary line", async () => {
+    await setupWithRouter(<DebutYearChart setlist={setlist} />);
+    expect(screen.getByText("average / median: 2000 / 2001")).toBeInTheDocument();
+  });
+
+  // Empty distribution → render nothing. Avoids an empty-axis card on
+  // shows whose songs all lack dateFirstPlayed (shouldn't happen in
+  // practice; safety net).
+  test("renders nothing when no songs have a debut year", async () => {
+    const empty = { show: { date: "2001-12-31" }, sets: [{ tracks: [track("uncatalogued", null)] }] };
+    const { container } = await setupWithRouter(<DebutYearChart setlist={empty} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  // Chart is the default — toggling to table swaps the bar chart for a
+  // tabular layout that lists the songs that debuted in each non-zero year.
+  test("toggles between chart and table; chart is the default", async () => {
+    const { user } = await setupWithRouter(<DebutYearChart setlist={setlist} />);
+    const chartButton = screen.getByRole("button", { name: /^chart$/i });
+    const tableButton = screen.getByRole("button", { name: /^table$/i });
+    expect(chartButton).toHaveAttribute("aria-pressed", "true");
+    expect(tableButton).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(tableButton);
+    expect(tableButton).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("columnheader", { name: /year/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /songs/i })).toBeInTheDocument();
+    // Only non-zero years appear as rows — the histogram's zero-fill is
+    // visual context, not tabular data. The Songs cell links to each
+    // distinct song that debuted in that year.
+    expect(screen.getByRole("cell", { name: "1998" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "2001" })).toBeInTheDocument();
+    expect(screen.queryByRole("cell", { name: "1999" })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Spaga" })).toHaveAttribute("href", "/songs/spaga");
+    expect(screen.getByRole("link", { name: "Vassillios" })).toHaveAttribute("href", "/songs/vassillios");
+    expect(screen.getByRole("link", { name: "Crickets" })).toHaveAttribute("href", "/songs/crickets");
+
+    await user.click(chartButton);
+    expect(chartButton).toHaveAttribute("aria-pressed", "true");
+    expect(screen.queryByRole("columnheader", { name: /year/i })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/show/debut-year-chart.tsx
+++ b/apps/web/app/components/show/debut-year-chart.tsx
@@ -1,0 +1,218 @@
+import { average, median } from "@bip/domain";
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { SegmentButton } from "~/components/ui/segment-button";
+import { CHART_COLORS } from "~/lib/chart-colors";
+import { START_YEAR } from "~/lib/song-filters";
+
+type SongRef = { title: string; slug: string };
+
+export type DebutYearTrack = {
+  songId: string;
+  song?: { title: string; slug: string; dateFirstPlayed: Date | null } | null;
+};
+
+export type DebutYearSetlist = {
+  show: { date: string };
+  sets: { tracks: DebutYearTrack[] }[];
+};
+
+type DistributionRow = {
+  year: number;
+  count: number;
+  songs: SongRef[];
+};
+
+type DebutYearStats = {
+  distribution: DistributionRow[];
+  average: number | null;
+  median: number | null;
+};
+
+/**
+ * Roll up a setlist's tracks into a year-by-year debut histogram plus
+ * average and median debut year. Each distinct song contributes once,
+ * so a song played twice in the show doesn't double-count its year.
+ * Distribution always spans START_YEAR through the show's own year,
+ * zero-filling any year with no qualifying debuts.
+ */
+export function computeDebutYearStats(tracks: DebutYearTrack[], showDate: string): DebutYearStats {
+  const showYear = Number(showDate.slice(0, 4));
+  const seen = new Set<string>();
+  const years: number[] = [];
+  const songsByYear = new Map<number, SongRef[]>();
+  for (const t of tracks) {
+    if (seen.has(t.songId)) continue;
+    const song = t.song;
+    const debut = song?.dateFirstPlayed;
+    if (!debut) continue;
+    // `new Date(value)` normalizes both an actual Date (tests) and the ISO
+    // string that the React Router loader serializes Date fields into at
+    // runtime — the static type stays honest while the runtime stays loose.
+    const year = new Date(debut).getUTCFullYear();
+    if (Number.isNaN(year)) continue;
+    // Bound to the band's catalog window: skip songs whose dateFirstPlayed
+    // is before the band started (data anomaly) or after this show (stats
+    // not yet rebuilt). Keeps the X-axis range stable across all shows.
+    if (year < START_YEAR || year > showYear) continue;
+    seen.add(t.songId);
+    years.push(year);
+    const list = songsByYear.get(year) ?? [];
+    list.push({ title: song.title, slug: song.slug });
+    songsByYear.set(year, list);
+  }
+
+  if (years.length === 0) {
+    return { distribution: [], average: null, median: null };
+  }
+
+  const counts = new Map<number, number>();
+  for (const y of years) counts.set(y, (counts.get(y) ?? 0) + 1);
+  // X-axis floor is fixed at START_YEAR so every show's chart starts at
+  // the same year; the ceiling is the show year so a 1999 show doesn't
+  // render empty bars for years that hadn't happened yet.
+  const min = START_YEAR;
+  const max = showYear;
+  const distribution: DistributionRow[] = [];
+  for (let y = min; y <= max; y++) {
+    // Songs are collected in track-iteration order; sort alphabetically so
+    // the table view reads predictably regardless of setlist position.
+    const songs = (songsByYear.get(y) ?? []).slice().sort((a, b) => a.title.localeCompare(b.title));
+    distribution.push({ year: y, count: counts.get(y) ?? 0, songs });
+  }
+
+  // years is non-empty thanks to the early return above, so the helpers
+  // can't return null here — round to integer years for display.
+  return {
+    distribution,
+    average: Math.round(average(years) as number),
+    median: Math.round(median(years) as number),
+  };
+}
+
+interface DebutYearChartProps {
+  setlist: DebutYearSetlist;
+}
+
+/**
+ * Right-rail card that summarizes which years the songs in this show
+ * debuted in. Chart and table views share one toggle; the chart is the
+ * default. Sized for the show page's ~280px right rail.
+ */
+export function DebutYearChart({ setlist }: DebutYearChartProps) {
+  const [view, setView] = useState<"chart" | "table">("chart");
+  const tracks = setlist.sets.flatMap((s) => s.tracks);
+  const { distribution, average, median } = computeDebutYearStats(tracks, setlist.show.date);
+  if (distribution.length === 0) return null;
+
+  // X labels would collide at a 30-year range in the narrow rail; thin
+  // them to roughly every 5 years (six labels total) so they stay legible.
+  const labelStride = Math.max(1, Math.ceil(distribution.length / 6));
+  const labelInterval = labelStride - 1;
+
+  return (
+    <div className="glass-content rounded-lg p-3">
+      <h3 className="text-sm font-semibold text-content-text-primary mb-2">Songs by debut year</h3>
+      <div className="flex items-center justify-between gap-2 mb-2 text-xs">
+        <div className="inline-flex items-center">
+          <SegmentButton active={view === "chart"} onClick={() => setView("chart")}>
+            chart
+          </SegmentButton>
+          <SegmentButton active={view === "table"} onClick={() => setView("table")}>
+            table
+          </SegmentButton>
+        </div>
+        {average !== null && median !== null && (
+          <span className="text-content-text-secondary text-right">
+            average / median: {average} / {median}
+          </span>
+        )}
+      </div>
+      {view === "chart" ? (
+        <div className="h-28">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={distribution} margin={{ top: 4, right: 4, left: -16, bottom: 4 }} barCategoryGap="10%">
+              <XAxis dataKey="year" stroke={CHART_COLORS.axis} fontSize={10} interval={labelInterval} />
+              <YAxis stroke={CHART_COLORS.axis} fontSize={10} allowDecimals={false} width={28} />
+              <Tooltip content={<DebutYearTooltip />} isAnimationActive={false} />
+              <Bar dataKey="count" fill={CHART_COLORS.accent} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      ) : (
+        <DebutYearTable distribution={distribution} />
+      )}
+    </div>
+  );
+}
+
+function DebutYearTable({ distribution }: { distribution: DistributionRow[] }) {
+  // Drop zero-count rows in the table view — the histogram zero-fills to
+  // make visual gaps read, but blank rows are pure noise in a tabular layout.
+  const rows = distribution.filter((d) => d.count > 0);
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="text-left text-content-text-tertiary border-b border-glass-border/30">
+          <th className="font-medium py-2 pr-4">Year</th>
+          <th className="font-medium py-2">Songs</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.year} className="border-b border-glass-border/20 last:border-0 align-top">
+            <td className="py-2 pr-4 text-content-text-primary whitespace-nowrap">{row.year}</td>
+            <td className="py-2 text-content-text-secondary">
+              {row.songs.map((song, index) => (
+                <span key={song.slug}>
+                  <Link
+                    to={`/songs/${song.slug}`}
+                    className="text-brand-primary hover:text-brand-secondary transition-colors"
+                  >
+                    {song.title}
+                  </Link>
+                  {index < row.songs.length - 1 && <span>, </span>}
+                </span>
+              ))}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+interface DebutYearTooltipProps {
+  active?: boolean;
+  payload?: Array<{ payload?: DistributionRow }>;
+}
+
+function DebutYearTooltip({ active, payload }: DebutYearTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  const datum = payload[0]?.payload;
+  if (!datum) return null;
+  const { year, count, songs } = datum;
+  if (count === 0) return null;
+  const songsLabel = count === 1 ? "song" : "songs";
+  return (
+    <div
+      className="rounded-md border px-3 py-2 text-sm"
+      style={{
+        backgroundColor: CHART_COLORS.tooltipBg,
+        borderColor: CHART_COLORS.tooltipBorder,
+        color: CHART_COLORS.tooltipText,
+      }}
+    >
+      <div className="font-medium">{year}</div>
+      <div className="text-content-text-tertiary">
+        {count} {songsLabel}
+      </div>
+      <ul className="mt-1">
+        {songs.map((song) => (
+          <li key={song.slug}>{song.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/app/components/song/yearly-play-chart.tsx
+++ b/apps/web/app/components/song/yearly-play-chart.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { CHART_COLORS } from "~/lib/chart-colors";
 import { START_YEAR } from "~/lib/song-filters";
 import { cn } from "~/lib/utils";
 import {
@@ -61,10 +62,10 @@ export function YearlyPlayChart({ yearlyPlayData, showsByYear }: YearlyPlayChart
       <div className="h-80">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 20 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#374151" opacity={0.3} />
-            <XAxis dataKey="year" stroke="#9CA3AF" fontSize={12} />
+            <CartesianGrid strokeDasharray="3 3" stroke={CHART_COLORS.grid} opacity={0.3} />
+            <XAxis dataKey="year" stroke={CHART_COLORS.axis} fontSize={12} />
             <YAxis
-              stroke="#9CA3AF"
+              stroke={CHART_COLORS.axis}
               fontSize={12}
               tickFormatter={isPercent ? (v: number) => `${Math.round(v * 100)}%` : undefined}
             />
@@ -72,10 +73,10 @@ export function YearlyPlayChart({ yearlyPlayData, showsByYear }: YearlyPlayChart
             <Line
               type="monotone"
               dataKey="value"
-              stroke="#8B5CF6"
+              stroke={CHART_COLORS.accent}
               strokeWidth={2}
-              dot={{ fill: "#8B5CF6", strokeWidth: 2, r: 4 }}
-              activeDot={{ r: 6, stroke: "#8B5CF6", strokeWidth: 2 }}
+              dot={{ fill: CHART_COLORS.accent, strokeWidth: 2, r: 4 }}
+              activeDot={{ r: 6, stroke: CHART_COLORS.accent, strokeWidth: 2 }}
             />
           </LineChart>
         </ResponsiveContainer>
@@ -108,7 +109,11 @@ export function YearlyChartTooltip({ active, payload }: YearlyChartTooltipProps)
   return (
     <div
       className="rounded-md border px-3 py-2 text-sm"
-      style={{ backgroundColor: "#1F2937", borderColor: "#374151", color: "#F3F4F6" }}
+      style={{
+        backgroundColor: CHART_COLORS.tooltipBg,
+        borderColor: CHART_COLORS.tooltipBorder,
+        color: CHART_COLORS.tooltipText,
+      }}
     >
       <div className="font-medium">{year}</div>
       <div>

--- a/apps/web/app/components/ui/segment-button.test.tsx
+++ b/apps/web/app/components/ui/segment-button.test.tsx
@@ -1,0 +1,63 @@
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { SegmentButton } from "./segment-button";
+
+describe("SegmentButton", () => {
+  // aria-pressed reflects the `active` prop so screen readers announce
+  // the current selection. The visual branch (border-brand-primary vs
+  // border-transparent) follows the same flag.
+  test("active=true sets aria-pressed and the brand-primary border", async () => {
+    await setup(
+      <SegmentButton active={true} onClick={vi.fn()}>
+        chart
+      </SegmentButton>,
+    );
+    const button = screen.getByRole("button", { name: "chart" });
+    expect(button).toHaveAttribute("aria-pressed", "true");
+    expect(button.className).toContain("border-brand-primary");
+    expect(button.className).toContain("text-content-text-primary");
+  });
+
+  // The inactive segment renders with a transparent border (no visible
+  // underline) and the tertiary text tone so the active segment stands
+  // out as the selection.
+  test("active=false renders the inactive border and tertiary text", async () => {
+    await setup(
+      <SegmentButton active={false} onClick={vi.fn()}>
+        table
+      </SegmentButton>,
+    );
+    const button = screen.getByRole("button", { name: "table" });
+    expect(button).toHaveAttribute("aria-pressed", "false");
+    expect(button.className).toContain("border-transparent");
+    expect(button.className).toContain("text-content-text-tertiary");
+  });
+
+  // Clicking fires the supplied handler. Verified via spy rather than
+  // observing visual state — the caller owns the active/inactive flip.
+  test("invokes onClick when clicked", async () => {
+    const onClick = vi.fn();
+    const { user } = await setup(
+      <SegmentButton active={false} onClick={onClick}>
+        gap chart
+      </SegmentButton>,
+    );
+    await user.click(screen.getByRole("button", { name: "gap chart" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  // Rendered as a button (not a div/anchor) so it inherits keyboard
+  // activation (Enter/Space) and focus management for free. type="button"
+  // prevents accidental form submits when nested inside a <form>.
+  test("renders as <button type='button'>", async () => {
+    const { container } = await setup(
+      <SegmentButton active={true} onClick={vi.fn()}>
+        personal
+      </SegmentButton>,
+    );
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(button).toHaveAttribute("type", "button");
+  });
+});

--- a/apps/web/app/components/ui/segment-button.tsx
+++ b/apps/web/app/components/ui/segment-button.tsx
@@ -1,0 +1,35 @@
+import { cn } from "~/lib/utils";
+
+interface SegmentButtonProps {
+  /** True when this segment is the currently-selected one. Drives the
+   *  bottom-border color and the `aria-pressed` attribute that exposes
+   *  the toggle state to screen readers. */
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+/**
+ * Bottom-border tab/segment button. Used by SetlistViewControl
+ * (setlist/gap chart/personal) and DebutYearChart (chart/table). Lives in
+ * `~/components/ui/` because the visual primitive is shared across
+ * feature areas — wrap it in feature-specific renderers rather than
+ * duplicating the className.
+ */
+export function SegmentButton({ active, onClick, children }: SegmentButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={cn(
+        "px-2 py-1 border-b-2 transition-colors cursor-pointer",
+        active
+          ? "border-brand-primary text-content-text-primary"
+          : "border-transparent text-content-text-tertiary hover:text-content-text-secondary",
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/web/app/lib/chart-colors.ts
+++ b/apps/web/app/lib/chart-colors.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared recharts color palette. Recharts elements (XAxis/YAxis/Bar/Line)
+ * take literal color strings via `stroke`/`fill` props, not className, so
+ * the project's Tailwind/CSS design tokens aren't directly reachable —
+ * this file is the single source of truth for the chart palette.
+ */
+export const CHART_COLORS = {
+  axis: "#9CA3AF",
+  grid: "#374151",
+  accent: "#8B5CF6",
+  tooltipBg: "#1F2937",
+  tooltipBorder: "#374151",
+  tooltipText: "#F3F4F6",
+} as const;

--- a/apps/web/app/routes/shows/$slug.tsx
+++ b/apps/web/app/routes/shows/$slug.tsx
@@ -11,6 +11,7 @@ import { SetlistCard } from "~/components/setlist/setlist-card";
 import { SetlistHighlights } from "~/components/setlist/setlist-highlights";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
 import { ArchiveRecordingsCard } from "~/components/show/archive-recordings-card";
+import { DebutYearChart } from "~/components/show/debut-year-chart";
 import { type ExternalLink, ExternalLinkCard } from "~/components/show/external-link-card";
 import { ShowPhotos } from "~/components/show/show-photos";
 import { ShowDate } from "~/components/show-date";
@@ -322,6 +323,8 @@ export default function Show() {
 
             {/* Highlights panel */}
             <SetlistHighlights setlist={setlist} />
+
+            <DebutYearChart setlist={setlist} />
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Every show page now carries a "Songs by debut year" card in the right rail. It shows how many distinct songs in that show's setlist debuted in each year, from 1995 through the show's year, with average and median debut year shown alongside. A chart/table toggle swaps the bar chart for a table listing the song titles per year. Hovering a bar surfaces the year, song count, and song list.

Songs played more than once in the show count once. The X-axis floor is fixed at the band's catalog start (1995) so every show's chart sits on the same axis; the ceiling is the show's year so older shows don't render empty bars for years that hadn't happened yet.

## Other changes in this PR

- New `SegmentButton` primitive in `~/components/ui/` extracted from the styling used by `SetlistViewControl`. The new chart and the existing setlist toggle both consume it.
- New `CHART_COLORS` constant in `~/lib/` so the debut-year chart and the existing per-year chart on `/songs/:slug` share one palette.
- "Average / median song gap" and "Your average / median song gap" labels lowercased to match the new chart's summary line.

## Test plan

- [ ] Visit a 1998 show, a 2024 show, and a show with debuts (`gap=null` tracks). Confirm the chart's X-axis spans 1995 through the show's year in each case.
- [ ] Hover a bar: tooltip shows year, song count, and the list of debuted songs (alphabetized).
- [ ] Toggle to "table" view: only non-zero years appear as rows, songs link to `/songs/:slug`.
- [ ] Toggle to "chart" view: bar chart returns; table is gone.
- [ ] Right-rail order on desktop: external links, Show Highlights, then Songs by debut year (sticky group).
- [ ] Mobile (right rail collapsed inline): chart still legible, toggle still works.
- [ ] Confirm the song-gap summary line on SetlistCard now reads "average / median song gap: …" (lowercase a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
