### PR TITLE
Fix Track rating cache and orphan stub-show double-counts; extend sync script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ db-restore:
 	@echo "Production data restored successfully."
 
 db-sync-missing-shows:
-	cd packages/core && doppler run -- bun run scripts/sync-missing-shows.ts $(if $(YEARS),--years=$(YEARS)) $(if $(DRY_RUN),--dry-run)
+	cd packages/core && doppler run -- bun run scripts/sync-missing-shows.ts $(if $(HELP),--help) $(if $(YEARS),--years=$(YEARS)) $(if $(DRY_RUN),--dry-run) $(if $(PRUNE_GHOST_SHOWS),--prune-ghost-shows)
 
 db-load-data-dump:
 	psql "$$(doppler secrets get DATABASE_URL --plain | sed 's|postgresql://postgres:|postgresql://supabase_admin:|')" -f $(PROD_DATA_PATH)

--- a/packages/core/scripts/sync-missing-shows.test.ts
+++ b/packages/core/scripts/sync-missing-shows.test.ts
@@ -1,21 +1,20 @@
 import { describe, expect, test } from "vitest";
 import {
+  buildSetlistReconciliation,
   buildShowCreateInput,
   buildSongCreateInput,
-  buildTrackCreateInputs,
-  buildTrackDriftUpdates,
-  diffTrackAnnotations,
   buildSongDriftUpdate,
-  buildVenueDriftUpdate,
   buildShowDriftUpdate,
   buildVenueCreateInput,
+  buildVenueDriftUpdate,
   collectSongSlugs,
   collectVenueKeys,
+  diffTrackAnnotations,
   isStubSlug,
   matchVenue,
   parseYearsArg,
   showNeedsUpdate,
-  type LocalTrackForDrift,
+  type LocalTrackForReconcile,
   type McpSearchVenueResult,
   type McpSetlist,
   type McpShow,
@@ -52,6 +51,32 @@ describe("parseYearsArg", () => {
   // which would hide user intent (e.g. --years=abc shouldn't sync the current year).
   test("throws on non-numeric year values", () => {
     expect(() => parseYearsArg(["--years=abc"], new Date())).toThrow();
+  });
+
+  // Range syntax: backfilling a decade is a common request, and listing each
+  // year manually is tedious. Bounds are inclusive on both ends.
+  test("expands a YYYY-YYYY range to every year in the range", () => {
+    expect(parseYearsArg(["--years=2010-2015"], new Date())).toEqual([2010, 2011, 2012, 2013, 2014, 2015]);
+  });
+
+  // Ranges and single years mix in one --years value. Output is deduplicated
+  // and sorted so callers don't need to defend against either.
+  test("mixes ranges and single years, deduplicating overlaps", () => {
+    expect(parseYearsArg(["--years=2010-2012,2015,2011-2013"], new Date())).toEqual([2010, 2011, 2012, 2013, 2015]);
+  });
+
+  // A reversed range is almost always a typo (--years=2026-2010); throwing
+  // tells the user instead of silently returning an empty list and syncing nothing.
+  test("throws when range end is before start", () => {
+    expect(() => parseYearsArg(["--years=2026-2010"], new Date())).toThrow();
+  });
+
+  // Three-part or empty-part ranges (2010-2015-2020, 2010-, -2026) are
+  // malformed — fail loudly rather than guess what the user meant.
+  test("throws on malformed ranges", () => {
+    expect(() => parseYearsArg(["--years=2010-2015-2020"], new Date())).toThrow();
+    expect(() => parseYearsArg(["--years=2010-"], new Date())).toThrow();
+    expect(() => parseYearsArg(["--years=-2026"], new Date())).toThrow();
   });
 });
 
@@ -292,7 +317,7 @@ describe("showNeedsUpdate", () => {
   test("returns false when every aggregate matches", () => {
     expect(
       showNeedsUpdate(
-        { averageRating: 4.2, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr" },
+        { date: "2025-07-04", averageRating: 4.2, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr" },
         remote,
       ),
     ).toBe(false);
@@ -304,7 +329,7 @@ describe("showNeedsUpdate", () => {
   test("returns true when ratingsCount drifts", () => {
     expect(
       showNeedsUpdate(
-        { averageRating: 4.2, ratingsCount: 18, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr" },
+        { date: "2025-07-04", averageRating: 4.2, ratingsCount: 18, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr" },
         remote,
       ),
     ).toBe(true);
@@ -315,7 +340,7 @@ describe("showNeedsUpdate", () => {
   test("returns false for averageRating differences within float tolerance", () => {
     expect(
       showNeedsUpdate(
-        { averageRating: 4.1999999, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr" },
+        { date: "2025-07-04", averageRating: 4.1999999, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr" },
         remote,
       ),
     ).toBe(false);
@@ -325,7 +350,7 @@ describe("showNeedsUpdate", () => {
   test("returns true for averageRating differences beyond float tolerance", () => {
     expect(
       showNeedsUpdate(
-        { averageRating: 4.1, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr" },
+        { date: "2025-07-04", averageRating: 4.1, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr" },
         remote,
       ),
     ).toBe(true);
@@ -335,7 +360,7 @@ describe("showNeedsUpdate", () => {
   test("returns true when notes drifts", () => {
     expect(
       showNeedsUpdate(
-        { averageRating: 4.2, ratingsCount: 19, notes: "old note", relistenUrl: "https://relisten.example/rr" },
+        { date: "2025-07-04", averageRating: 4.2, ratingsCount: 19, notes: "old note", relistenUrl: "https://relisten.example/rr" },
         remote,
       ),
     ).toBe(true);
@@ -345,7 +370,7 @@ describe("showNeedsUpdate", () => {
   test("returns true when relistenUrl drifts from null to a value", () => {
     expect(
       showNeedsUpdate(
-        { averageRating: 4.2, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: null },
+        { date: "2025-07-04", averageRating: 4.2, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: null },
         remote,
       ),
     ).toBe(true);
@@ -357,7 +382,7 @@ describe("showNeedsUpdate", () => {
     const remoteWithNulls: McpShow = { ...remote, notes: null, relistenUrl: null };
     expect(
       showNeedsUpdate(
-        { averageRating: 4.2, ratingsCount: 19, notes: null, relistenUrl: null },
+        { date: "2025-07-04", averageRating: 4.2, ratingsCount: 19, notes: null, relistenUrl: null },
         remoteWithNulls,
       ),
     ).toBe(false);
@@ -370,7 +395,7 @@ describe("showNeedsUpdate", () => {
     const remoteWithFlag: McpShow = { ...remote, countForStats: false };
     expect(
       showNeedsUpdate(
-        { averageRating: 4.2, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr", countForStats: true, dayOrder: null },
+        { date: "2025-07-04", averageRating: 4.2, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr", countForStats: true, dayOrder: null },
         remoteWithFlag,
       ),
     ).toBe(true);
@@ -382,7 +407,7 @@ describe("showNeedsUpdate", () => {
     const remoteWithOrder: McpShow = { ...remote, dayOrder: 2 };
     expect(
       showNeedsUpdate(
-        { averageRating: 4.2, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr", countForStats: true, dayOrder: 1 },
+        { date: "2025-07-04", averageRating: 4.2, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr", countForStats: true, dayOrder: 1 },
         remoteWithOrder,
       ),
     ).toBe(true);
@@ -394,10 +419,22 @@ describe("showNeedsUpdate", () => {
   test("ignores countForStats/dayOrder when remote omits them", () => {
     expect(
       showNeedsUpdate(
-        { averageRating: 4.2, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr", countForStats: false, dayOrder: 3 },
+        { date: "2025-07-04", averageRating: 4.2, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr", countForStats: false, dayOrder: 3 },
         remote,
       ),
     ).toBe(false);
+  });
+
+  // Date drift: the dev DB carries a few shows with a slug whose date prefix
+  // doesn't match the date column (legacy data + slug-collision suffixes).
+  // showNeedsUpdate must catch these so the orchestrator can rewrite the row.
+  test("returns true when date drifts", () => {
+    expect(
+      showNeedsUpdate(
+        { date: "2025-07-03", averageRating: 4.2, ratingsCount: 19, notes: "Fourth of July run opener", relistenUrl: "https://relisten.example/rr" },
+        remote,
+      ),
+    ).toBe(true);
   });
 });
 
@@ -530,6 +567,7 @@ describe("buildShowDriftUpdate", () => {
     relistenUrl: null,
   };
   const localInSync = {
+    date: "2025-11-15",
     averageRating: 3.7,
     ratingsCount: 12,
     notes: null,
@@ -638,6 +676,30 @@ describe("buildShowDriftUpdate", () => {
       relistenUrl: null,
       countForStats: false,
       dayOrder: 2,
+    });
+  });
+
+  // Date drift in isolation: the row got dump-frozen with a date column that
+  // doesn't match the slug (or doesn't match prod after a prod-side correction).
+  // Patch contains only the date — caller does one UPDATE and the orchestrator
+  // expands the gap rebuild window to the earlier of (old, new) date.
+  test("emits the date field when it drifts", () => {
+    const localWrongDate = { ...localInSync, date: "2025-11-14" };
+    const patch = buildShowDriftUpdate(localWrongDate, remote, "venue-brooklyn-steel-uuid");
+    expect(patch).toEqual({ date: "2025-11-15" });
+  });
+
+  // Date drift combined with aggregate drift: same UPDATE call carries both.
+  test("combines date drift with aggregate drift in one patch", () => {
+    const remoteWith: McpShow = { ...remote, ratingsCount: 13 };
+    const localWrongBoth = { ...localInSync, date: "2025-11-14", ratingsCount: 12 };
+    const patch = buildShowDriftUpdate(localWrongBoth, remoteWith, "venue-brooklyn-steel-uuid");
+    expect(patch).toEqual({
+      date: "2025-11-15",
+      averageRating: 3.7,
+      ratingsCount: 13,
+      notes: null,
+      relistenUrl: null,
     });
   });
 });
@@ -883,206 +945,445 @@ describe("buildSongCreateInput", () => {
   });
 });
 
-// buildTrackCreateInputs is where the slug→id resolution happens for Song FKs.
-// A missing mapping must skip the track, not insert a NULL songId (the column
-// is non-nullable — Prisma would reject it anyway, but a pre-filter surfaces
-// the problem earlier and keeps the insert-many call atomic.
-describe("buildTrackCreateInputs", () => {
-  // Canonical multi-set insertion: set label + position + segue pass through;
-  // songId gets resolved via the slug→id map keyed off the upserted songs.
-  test("resolves songId via slug map and preserves set/position/segue", () => {
-    const setlist: McpSetlist = {
-      showSlug: "2026-02-06-miami-beach-bandshell-miami-beach-fl",
+// buildSetlistReconciliation is the heart of the setlist sync: per-show
+// insert / update / delete decisions, matched on (set, position). The key
+// must be the composite tuple because position is unique only within a set —
+// a three-set show reuses position 1 three times, so a position-only key
+// collapses across sets. The structurallyChanged flag drives downstream
+// effects (SegueRun regen, stats rebuild window), so the helper has to be
+// precise about which diffs count as structural (insert / delete / songId
+// change) vs cosmetic (segue / note / allTimer / annotation drift).
+describe("buildSetlistReconciliation", () => {
+  const songMap = new Map([
+    ["basis-for-a-day", "song-basis-uuid"],
+    ["aceetobee", "song-aceetobee-uuid"],
+    ["crystal-ball", "song-crystal-uuid"],
+    ["helicopters", "song-helicopters-uuid"],
+    ["munchkin-invasion", "song-munchkin-uuid"],
+    ["spacebirdmatingcall", "song-spacebird-uuid"],
+    ["reactor", "song-reactor-uuid"],
+  ]);
+
+  // Canonical idempotent re-run: local already matches prod on every field.
+  // No ops, neither structurally nor cosmetically changed.
+  test("returns an empty reconciliation when local matches remote", () => {
+    const local: LocalTrackForReconcile[] = [
+      {
+        id: "track-1-uuid",
+        set: "S1",
+        position: 1,
+        songId: "song-basis-uuid",
+        segue: ">",
+        note: null,
+        allTimer: false,
+        annotations: [],
+      },
+    ];
+    const remote: McpSetlist = {
+      showSlug: "show-x",
       showDate: "2026-02-06",
-      venue: { name: "Miami Beach Bandshell", city: "Miami Beach", state: "FL" },
+      venue: { name: "v", city: "c", state: "s" },
       sets: [
         {
           label: "S1",
           tracks: [
-            { position: 1, songTitle: "Basis for a Day", songSlug: "basis-for-a-day", segue: ">" },
-            { position: 2, songTitle: "Aceetobee", songSlug: "aceetobee", segue: null },
+            { position: 1, songTitle: "Basis for a Day", songSlug: "basis-for-a-day", segue: ">", allTimer: false, note: null, annotations: [] },
           ],
         },
       ],
     };
-    const songSlugToId = new Map([
-      ["basis-for-a-day", "song-basis-uuid"],
-      ["aceetobee", "song-aceetobee-uuid"],
-    ]);
-    const tracks = buildTrackCreateInputs(setlist, "show-miami-uuid", songSlugToId);
-    expect(tracks).toEqual([
-      { showId: "show-miami-uuid", songId: "song-basis-uuid", set: "S1", position: 1, segue: ">", note: null, allTimer: false },
-      { showId: "show-miami-uuid", songId: "song-aceetobee-uuid", set: "S1", position: 2, segue: null, note: null, allTimer: false },
-    ]);
+    const recon = buildSetlistReconciliation(local, remote, songMap);
+    expect(recon).toEqual({
+      toInsert: [],
+      toUpdate: [],
+      toDelete: [],
+      structurallyChanged: false,
+      cosmeticallyChanged: false,
+      unresolvedSongSlugs: [],
+    });
   });
 
-  // allTimer and note are admin-curated on prod (admins toggle the all-timer
-  // flag from track pages, and inline track annotations carry the `note`
-  // string). New MCP payloads include both per track; the builder must
-  // mirror them into the insert. Defaults: allTimer=false, note=null when MCP
-  // omits — keeps pre-deploy MCP responses parsing.
-  test("mirrors allTimer and note from MCP tracks into the insert", () => {
-    const setlist: McpSetlist = {
-      showSlug: "2025-07-04-red-rocks-morrison-co",
-      showDate: "2025-07-04",
-      venue: { name: "Red Rocks", city: "Morrison", state: "CO" },
-      sets: [
-        {
-          label: "S2",
-          tracks: [
-            // Curated all-timer with an inline note — a typical Red Rocks moment.
-            { position: 1, songTitle: "Crystal Ball", songSlug: "crystal-ball", segue: ">", allTimer: true, note: "Glow-stick war peak" },
-            // Vanilla track, defaults apply.
-            { position: 2, songTitle: "Helicopters", songSlug: "helicopters", segue: null },
-          ],
-        },
-      ],
-    };
-    const songSlugToId = new Map([
-      ["crystal-ball", "song-crystal-uuid"],
-      ["helicopters", "song-helicopters-uuid"],
-    ]);
-    const tracks = buildTrackCreateInputs(setlist, "show-rr-uuid", songSlugToId);
-    expect(tracks[0]).toMatchObject({ allTimer: true, note: "Glow-stick war peak" });
-    expect(tracks[1]).toMatchObject({ allTimer: false, note: null });
-  });
-
-  // If a song slug is missing from the map (upstream skipped or errored), we
-  // skip the track rather than fail the whole show. The show will still land;
-  // missing tracks are logged elsewhere.
-  test("skips tracks whose song slug is not in the resolution map", () => {
-    const setlist: McpSetlist = {
-      showSlug: "2026-02-06-miami-beach-bandshell-miami-beach-fl",
-      showDate: "2026-02-06",
-      venue: { name: "Miami Beach Bandshell", city: "Miami Beach", state: "FL" },
+  // The Pine Creek failure mode: local has one track, prod has 15 across S1
+  // / S2 / E1. Every (set, position) the local doesn't have becomes an insert,
+  // every local key absent from remote becomes a delete. structurallyChanged
+  // must flip on so SegueRun regen + stats rebuild fire.
+  test("handles a near-empty local against a full prod setlist", () => {
+    const local: LocalTrackForReconcile[] = [
+      {
+        id: "lone-local-track",
+        set: "S1",
+        position: 1,
+        songId: "song-spacebird-uuid", // local has the wrong song at S1/1
+        segue: null,
+        note: null,
+        allTimer: false,
+        annotations: [],
+      },
+    ];
+    const remote: McpSetlist = {
+      showSlug: "pine-creek",
+      showDate: "2025-08-30",
+      venue: { name: "Pine Creek Lodge", city: "Livingston", state: "MT" },
       sets: [
         {
           label: "S1",
           tracks: [
-            { position: 1, songTitle: "Shem-Rah-Boo", songSlug: "shem-rah-boo", segue: null },
-            { position: 2, songTitle: "Munchkin Invasion", songSlug: "munchkin-invasion", segue: null },
+            // S1/1 exists in both but the songId differs → update + structural.
+            { position: 1, songTitle: "Spectacle", songSlug: "basis-for-a-day", segue: ">" },
+            { position: 2, songTitle: "Spacebird", songSlug: "spacebirdmatingcall", segue: ">" },
           ],
         },
-      ],
-    };
-    const songSlugToId = new Map([["shem-rah-boo", "song-shem-uuid"]]);
-    const tracks = buildTrackCreateInputs(setlist, "show-uuid", songSlugToId);
-    expect(tracks).toHaveLength(1);
-    expect(tracks[0]?.songId).toBe("song-shem-uuid");
-  });
-});
-
-// buildTrackDriftUpdates computes per-track patches for existing local tracks
-// in a single show. The key is (showId, position) — within one show, position
-// is unique. Drift fields: segue, note, allTimer. Returns a list of {trackId,
-// patch} so the caller can issue scoped UPDATE statements without re-fetching.
-// Empty array means "nothing changed".
-describe("buildTrackDriftUpdates", () => {
-  // Canonical drift: prod marked track 3 (Crystal Ball) as an all-timer and
-  // added a note. Local row catches up on next sync. Other tracks unchanged
-  // → not in the result.
-  test("emits a patch only for the track whose fields drifted", () => {
-    const local: LocalTrackForDrift[] = [
-      { id: "track-1-uuid", position: 1, segue: ">", note: null, allTimer: false },
-      { id: "track-2-uuid", position: 2, segue: null, note: null, allTimer: false },
-      { id: "track-3-uuid", position: 3, segue: ">", note: null, allTimer: false },
-    ];
-    const remote: McpSetlist = {
-      showSlug: "2025-07-04-red-rocks-morrison-co",
-      showDate: "2025-07-04",
-      venue: { name: "Red Rocks", city: "Morrison", state: "CO" },
-      sets: [
         {
           label: "S2",
           tracks: [
-            { position: 1, songTitle: "Helicopters", songSlug: "helicopters", segue: ">" },
-            { position: 2, songTitle: "Munchkin Invasion", songSlug: "munchkin-invasion", segue: null },
-            { position: 3, songTitle: "Crystal Ball", songSlug: "crystal-ball", segue: ">", allTimer: true, note: "Glow-stick war peak" },
+            // S2/1 — note that a position-only key would collide with S1/1.
+            { position: 1, songTitle: "Reactor", songSlug: "reactor", segue: ">" },
           ],
         },
       ],
     };
-    const patches = buildTrackDriftUpdates(local, remote);
-    expect(patches).toEqual([
-      { trackId: "track-3-uuid", patch: { allTimer: true, note: "Glow-stick war peak" } },
-    ]);
+    const recon = buildSetlistReconciliation(local, remote, songMap);
+    expect(recon.toInsert).toHaveLength(2);
+    expect(recon.toInsert.map((i) => `${i.set}/${i.position}`).sort()).toEqual(["S1/2", "S2/1"]);
+    expect(recon.toUpdate).toHaveLength(1);
+    expect(recon.toUpdate[0]?.patch.songId).toBe("song-basis-uuid");
+    expect(recon.toDelete).toHaveLength(0);
+    expect(recon.structurallyChanged).toBe(true);
   });
 
-  // Idempotency: when local already matches remote on every field, no patches.
-  // This is the no-op re-run path — the orchestrator must skip the UPDATE
-  // entirely so updatedAt doesn't churn.
-  test("returns an empty list when nothing drifted", () => {
-    const local: LocalTrackForDrift[] = [
-      { id: "track-1-uuid", position: 1, segue: ">", note: null, allTimer: false },
+  // Regression: a position-only key would collapse S1/1 and S2/1 into one
+  // bucket. The composite key keeps them distinct so both ends of a track
+  // that repeats across sets (e.g. set-ender → set-opener) sync correctly.
+  test("treats the same position in different sets as distinct slots", () => {
+    const local: LocalTrackForReconcile[] = [
+      // Local has Reactor at S1/6 only — S2/1 is missing.
+      {
+        id: "track-s1-6",
+        set: "S1",
+        position: 6,
+        songId: "song-reactor-uuid",
+        segue: ">",
+        note: null,
+        allTimer: false,
+        annotations: [],
+      },
     ];
     const remote: McpSetlist = {
-      showSlug: "2026-02-06-miami-beach-bandshell-miami-beach-fl",
-      showDate: "2026-02-06",
-      venue: { name: "Miami Beach Bandshell", city: "Miami Beach", state: "FL" },
+      showSlug: "pine-creek",
+      showDate: "2025-08-30",
+      venue: { name: "Pine Creek Lodge", city: "Livingston", state: "MT" },
       sets: [
-        { label: "S1", tracks: [{ position: 1, songTitle: "Basis for a Day", songSlug: "basis-for-a-day", segue: ">", allTimer: false, note: null }] },
+        {
+          label: "S1",
+          tracks: [{ position: 6, songTitle: "Reactor", songSlug: "reactor", segue: ">" }],
+        },
+        {
+          label: "S2",
+          tracks: [{ position: 1, songTitle: "Reactor", songSlug: "reactor", segue: ">" }],
+        },
       ],
     };
-    expect(buildTrackDriftUpdates(local, remote)).toEqual([]);
+    const recon = buildSetlistReconciliation(local, remote, songMap);
+    // S1/6 matches, S2/1 is inserted, nothing deleted.
+    expect(recon.toUpdate).toHaveLength(0);
+    expect(recon.toDelete).toHaveLength(0);
+    expect(recon.toInsert).toHaveLength(1);
+    expect(recon.toInsert[0]?.set).toBe("S2");
+    expect(recon.toInsert[0]?.position).toBe(1);
+    expect(recon.structurallyChanged).toBe(true);
   });
 
-  // Segue edits land too — sometimes prod fixes a `>` to `,` after the fact.
-  // (Tracks can drift segue independently of admin flags.)
-  test("emits a patch when segue drifts", () => {
-    const local: LocalTrackForDrift[] = [
-      { id: "track-1-uuid", position: 1, segue: ">", note: null, allTimer: false },
+  // Local has a track at S1/3 that prod removed (setlist correction). The
+  // delete op carries the annotation ids so the caller can wipe them in the
+  // same transaction.
+  test("emits delete ops for local tracks absent from remote, including their annotation ids", () => {
+    const local: LocalTrackForReconcile[] = [
+      {
+        id: "track-1-uuid",
+        set: "S1",
+        position: 1,
+        songId: "song-basis-uuid",
+        segue: null,
+        note: null,
+        allTimer: false,
+        annotations: [],
+      },
+      {
+        id: "track-3-uuid",
+        set: "S1",
+        position: 3,
+        songId: "song-aceetobee-uuid",
+        segue: null,
+        note: null,
+        allTimer: false,
+        annotations: [
+          { id: "ann-a-uuid", desc: "stray" },
+          { id: "ann-b-uuid", desc: "still stray" },
+        ],
+      },
     ];
     const remote: McpSetlist = {
-      showSlug: "2026-02-06-miami-beach-bandshell-miami-beach-fl",
-      showDate: "2026-02-06",
-      venue: { name: "Miami Beach Bandshell", city: "Miami Beach", state: "FL" },
+      showSlug: "show",
+      showDate: "2025-08-30",
+      venue: { name: "v", city: "c", state: "s" },
       sets: [
-        { label: "S1", tracks: [{ position: 1, songTitle: "Basis for a Day", songSlug: "basis-for-a-day", segue: "," }] },
+        {
+          label: "S1",
+          tracks: [{ position: 1, songTitle: "Basis for a Day", songSlug: "basis-for-a-day", segue: null }],
+        },
       ],
     };
-    expect(buildTrackDriftUpdates(local, remote)).toEqual([
-      { trackId: "track-1-uuid", patch: { segue: "," } },
-    ]);
+    const recon = buildSetlistReconciliation(local, remote, songMap);
+    expect(recon.toDelete).toHaveLength(1);
+    expect(recon.toDelete[0]?.trackId).toBe("track-3-uuid");
+    expect(recon.toDelete[0]?.annotationIds).toEqual(["ann-a-uuid", "ann-b-uuid"]);
+    expect(recon.structurallyChanged).toBe(true);
   });
 
-  // Pre-deploy MCP responses omit allTimer / note. Treat omission as "no
-  // opinion" — don't claim drift just because the remote payload is sparse,
-  // or every existing track would get its admin fields clobbered to defaults
+  // Same (set, position), different songId on prod — a setlist correction.
+  // Patch songId, flag as structural so the gap rebuild window expands.
+  test("treats a same-slot songId change as a structural update", () => {
+    const local: LocalTrackForReconcile[] = [
+      {
+        id: "track-1-uuid",
+        set: "S1",
+        position: 1,
+        songId: "song-helicopters-uuid", // local had Helicopters here
+        segue: null,
+        note: null,
+        allTimer: false,
+        annotations: [],
+      },
+    ];
+    const remote: McpSetlist = {
+      showSlug: "show",
+      showDate: "2025-08-30",
+      venue: { name: "v", city: "c", state: "s" },
+      sets: [
+        {
+          label: "S1",
+          tracks: [{ position: 1, songTitle: "Crystal Ball", songSlug: "crystal-ball", segue: null }],
+        },
+      ],
+    };
+    const recon = buildSetlistReconciliation(local, remote, songMap);
+    expect(recon.toUpdate).toHaveLength(1);
+    expect(recon.toUpdate[0]?.patch).toEqual({ songId: "song-crystal-uuid" });
+    expect(recon.structurallyChanged).toBe(true);
+    expect(recon.cosmeticallyChanged).toBe(false);
+  });
+
+  // Cosmetic-only drift: segue / note / allTimer changed, songId is unchanged.
+  // Must NOT flip structurallyChanged (no SegueRun regen needed for a segue
+  // marker change — the trackIds array is still valid).
+  test("flags cosmetic-only drift without setting structurallyChanged", () => {
+    const local: LocalTrackForReconcile[] = [
+      {
+        id: "track-1-uuid",
+        set: "S1",
+        position: 1,
+        songId: "song-crystal-uuid",
+        segue: ">",
+        note: null,
+        allTimer: false,
+        annotations: [],
+      },
+    ];
+    const remote: McpSetlist = {
+      showSlug: "show",
+      showDate: "2025-08-30",
+      venue: { name: "v", city: "c", state: "s" },
+      sets: [
+        {
+          label: "S1",
+          tracks: [
+            { position: 1, songTitle: "Crystal Ball", songSlug: "crystal-ball", segue: ",", allTimer: true, note: "Glow-stick war peak" },
+          ],
+        },
+      ],
+    };
+    const recon = buildSetlistReconciliation(local, remote, songMap);
+    expect(recon.toUpdate[0]?.patch).toEqual({ segue: ",", allTimer: true, note: "Glow-stick war peak" });
+    expect(recon.structurallyChanged).toBe(false);
+    expect(recon.cosmeticallyChanged).toBe(true);
+  });
+
+  // Pre-deploy MCP shape: no allTimer / note / annotations keys. Don't claim
+  // drift just because the payload is sparse, or admin-set values get wiped
   // on the next sync.
-  test("ignores allTimer / note when remote omits them", () => {
-    const local: LocalTrackForDrift[] = [
-      { id: "track-1-uuid", position: 1, segue: null, note: "kept locally", allTimer: true },
+  test("ignores allTimer / note / annotations when remote omits them", () => {
+    const local: LocalTrackForReconcile[] = [
+      {
+        id: "track-1-uuid",
+        set: "S1",
+        position: 1,
+        songId: "song-crystal-uuid",
+        segue: null,
+        note: "kept locally",
+        allTimer: true,
+        annotations: [{ id: "ann-a-uuid", desc: "still here" }],
+      },
     ];
     const remote: McpSetlist = {
-      showSlug: "2026-02-06-miami-beach-bandshell-miami-beach-fl",
-      showDate: "2026-02-06",
-      venue: { name: "Miami Beach Bandshell", city: "Miami Beach", state: "FL" },
+      showSlug: "show",
+      showDate: "2025-08-30",
+      venue: { name: "v", city: "c", state: "s" },
       sets: [
-        // No allTimer / note keys at all — pre-deploy MCP shape.
-        { label: "S1", tracks: [{ position: 1, songTitle: "Basis for a Day", songSlug: "basis-for-a-day", segue: null }] },
+        {
+          label: "S1",
+          tracks: [{ position: 1, songTitle: "Crystal Ball", songSlug: "crystal-ball", segue: null }],
+        },
       ],
     };
-    expect(buildTrackDriftUpdates(local, remote)).toEqual([]);
+    const recon = buildSetlistReconciliation(local, remote, songMap);
+    expect(recon.toUpdate).toEqual([]);
+    expect(recon.structurallyChanged).toBe(false);
+    expect(recon.cosmeticallyChanged).toBe(false);
   });
 
-  // Position is the only stable key within a show — a track that appears in
-  // local but not in the remote setlist (e.g. removed upstream) gets skipped,
-  // not patched. Deletion is intentionally not handled by drift; it's a
-  // separate cleanup concern.
-  test("skips local tracks whose position is absent from the remote setlist", () => {
-    const local: LocalTrackForDrift[] = [
-      { id: "track-1-uuid", position: 1, segue: null, note: null, allTimer: false },
-      { id: "track-99-uuid", position: 99, segue: null, note: null, allTimer: true },
+  // Annotation drift in isolation: track itself matches but the desc list
+  // changed. Lands as a toUpdate op with the annotation delta — caller still
+  // patches via track id, not a separate path.
+  test("emits annotation delta on an otherwise-matching track", () => {
+    const local: LocalTrackForReconcile[] = [
+      {
+        id: "track-1-uuid",
+        set: "S1",
+        position: 1,
+        songId: "song-crystal-uuid",
+        segue: null,
+        note: null,
+        allTimer: false,
+        annotations: [{ id: "ann-keep-uuid", desc: "first time played" }, { id: "ann-drop-uuid", desc: "to remove" }],
+      },
     ];
     const remote: McpSetlist = {
-      showSlug: "2026-02-06-miami-beach-bandshell-miami-beach-fl",
-      showDate: "2026-02-06",
-      venue: { name: "Miami Beach Bandshell", city: "Miami Beach", state: "FL" },
+      showSlug: "show",
+      showDate: "2025-08-30",
+      venue: { name: "v", city: "c", state: "s" },
       sets: [
-        { label: "S1", tracks: [{ position: 1, songTitle: "Basis for a Day", songSlug: "basis-for-a-day", segue: null }] },
+        {
+          label: "S1",
+          tracks: [
+            {
+              position: 1,
+              songTitle: "Crystal Ball",
+              songSlug: "crystal-ball",
+              segue: null,
+              annotations: ["first time played", "with horns"],
+            },
+          ],
+        },
       ],
     };
-    expect(buildTrackDriftUpdates(local, remote)).toEqual([]);
+    const recon = buildSetlistReconciliation(local, remote, songMap);
+    expect(recon.toUpdate).toHaveLength(1);
+    expect(recon.toUpdate[0]?.patch).toEqual({});
+    expect(recon.toUpdate[0]?.annotationDiff.toCreateDescs).toEqual(["with horns"]);
+    expect(recon.toUpdate[0]?.annotationDiff.toDeleteIds).toEqual(["ann-drop-uuid"]);
+    expect(recon.cosmeticallyChanged).toBe(true);
+    expect(recon.structurallyChanged).toBe(false);
+  });
+
+  // Inserts carry their annotation strings inline (no track id exists yet)
+  // so the caller can use a nested Prisma create. Defaults: allTimer=false,
+  // note=null when the remote payload omits them.
+  test("inserts carry inline annotation descs and default allTimer/note", () => {
+    const recon = buildSetlistReconciliation(
+      [],
+      {
+        showSlug: "show",
+        showDate: "2025-08-30",
+        venue: { name: "v", city: "c", state: "s" },
+        sets: [
+          {
+            label: "S1",
+            tracks: [
+              {
+                position: 1,
+                songTitle: "Crystal Ball",
+                songSlug: "crystal-ball",
+                segue: ">",
+                annotations: ["with horns"],
+              },
+              { position: 2, songTitle: "Helicopters", songSlug: "helicopters", segue: null, allTimer: true },
+            ],
+          },
+        ],
+      },
+      songMap,
+    );
+    expect(recon.toInsert).toHaveLength(2);
+    expect(recon.toInsert[0]).toMatchObject({
+      set: "S1",
+      position: 1,
+      songId: "song-crystal-uuid",
+      segue: ">",
+      note: null,
+      allTimer: false,
+      annotationDescs: ["with horns"],
+    });
+    expect(recon.toInsert[1]).toMatchObject({ allTimer: true, annotationDescs: [] });
+    expect(recon.structurallyChanged).toBe(true);
+  });
+
+  // Unresolved song slug on a remote-only slot: report it, don't insert. The
+  // local row is untouched — better to skip than to insert with a wrong songId.
+  test("reports unresolved song slugs on inserts without inserting them", () => {
+    const recon = buildSetlistReconciliation(
+      [],
+      {
+        showSlug: "show",
+        showDate: "2025-08-30",
+        venue: { name: "v", city: "c", state: "s" },
+        sets: [
+          {
+            label: "S1",
+            tracks: [{ position: 1, songTitle: "Mystery Song", songSlug: "mystery-song", segue: null }],
+          },
+        ],
+      },
+      songMap,
+    );
+    expect(recon.toInsert).toEqual([]);
+    expect(recon.unresolvedSongSlugs).toEqual(["mystery-song"]);
+    expect(recon.structurallyChanged).toBe(false);
+  });
+
+  // Unresolved song slug on an existing slot: don't drop the local track,
+  // don't try to patch songId, but still process other drift on the row.
+  test("reports unresolved song slugs on updates without clobbering songId", () => {
+    const local: LocalTrackForReconcile[] = [
+      {
+        id: "track-1-uuid",
+        set: "S1",
+        position: 1,
+        songId: "song-crystal-uuid",
+        segue: null,
+        note: null,
+        allTimer: false,
+        annotations: [],
+      },
+    ];
+    const recon = buildSetlistReconciliation(
+      local,
+      {
+        showSlug: "show",
+        showDate: "2025-08-30",
+        venue: { name: "v", city: "c", state: "s" },
+        sets: [
+          {
+            label: "S1",
+            tracks: [{ position: 1, songTitle: "Mystery", songSlug: "mystery-song", segue: ">" }],
+          },
+        ],
+      },
+      songMap,
+    );
+    expect(recon.unresolvedSongSlugs).toEqual(["mystery-song"]);
+    expect(recon.toUpdate).toHaveLength(1);
+    expect(recon.toUpdate[0]?.patch).toEqual({ segue: ">" });
+    expect(recon.toDelete).toEqual([]);
   });
 });
 

--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -20,6 +20,7 @@ import { Prisma } from "@prisma/client";
 import { CacheInvalidationService, CacheService } from "../src/_shared/cache";
 import prisma from "../src/_shared/prisma/client";
 import { RedisService } from "../src/_shared/redis";
+import { SegueRunGeneratorService } from "../src/segue-run/segue-run-generator-service";
 import { StatsService } from "../src/stats/stats-service";
 import { createTestLogger } from "../src/_shared/test-logger";
 
@@ -135,21 +136,43 @@ export function isStubSlug(slug: string | null): boolean {
   return !!slug && /^\d{4}-\d{2}-\d{2}$/.test(slug);
 }
 
+/**
+ * Parse `--years=` into a deduplicated, sorted year list. Accepts single
+ * years, ranges (`2010-2026`), and comma-separated mixes of the two
+ * (`2010-2015,2020,2025`). Range bounds are inclusive on both ends.
+ */
 export function parseYearsArg(argv: string[], now: Date): number[] {
   const flag = argv.find((a) => a.startsWith("--years="));
   if (!flag) return [now.getUTCFullYear()];
   const raw = flag.slice("--years=".length);
-  const years = raw
+  const pieces = raw
     .split(",")
     .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-    .map((s) => {
-      const n = Number(s);
-      if (!Number.isInteger(n)) throw new Error(`Invalid year in --years: ${s}`);
-      return n;
-    });
-  if (years.length === 0) throw new Error("--years must contain at least one year");
-  return years;
+    .filter((s) => s.length > 0);
+  const collected = new Set<number>();
+  for (const piece of pieces) {
+    if (piece.includes("-")) {
+      const [startStr, endStr, ...rest] = piece.split("-");
+      if (rest.length > 0 || !startStr || !endStr) {
+        throw new Error(`Invalid year range in --years: ${piece}`);
+      }
+      const start = Number(startStr);
+      const end = Number(endStr);
+      if (!Number.isInteger(start) || !Number.isInteger(end)) {
+        throw new Error(`Invalid year in range: ${piece}`);
+      }
+      if (end < start) {
+        throw new Error(`Year range end before start: ${piece}`);
+      }
+      for (let y = start; y <= end; y++) collected.add(y);
+      continue;
+    }
+    const n = Number(piece);
+    if (!Number.isInteger(n)) throw new Error(`Invalid year in --years: ${piece}`);
+    collected.add(n);
+  }
+  if (collected.size === 0) throw new Error("--years must contain at least one year");
+  return Array.from(collected).sort((a, b) => a - b);
 }
 
 export function collectSongSlugs(setlists: McpSetlist[]): string[] {
@@ -238,6 +261,7 @@ export function buildShowCreateInput(
 // Shape-minimal view of a local Show row (only the aggregate fields we mirror)
 // — used as the left operand to showNeedsUpdate.
 export interface LocalShowAggregates {
+  date: string;
   averageRating: number | null;
   ratingsCount: number;
   notes: string | null;
@@ -249,6 +273,7 @@ export interface LocalShowAggregates {
 const AVERAGE_RATING_TOLERANCE = 1e-6;
 
 export function showNeedsUpdate(local: LocalShowAggregates, remote: McpShow): boolean {
+  if (local.date !== remote.date) return true;
   if (local.ratingsCount !== remote.ratingsCount) return true;
   if (local.notes !== remote.notes) return true;
   if (local.relistenUrl !== remote.relistenUrl) return true;
@@ -276,6 +301,7 @@ export interface LocalShowForDrift extends LocalShowAggregates {
 // resolution succeeded — we never overwrite an already-set venueId from the
 // drift path; rename/merge is a separate concern.
 export interface ShowDriftUpdate {
+  date?: string;
   averageRating?: number | null;
   ratingsCount?: number;
   notes?: string | null;
@@ -301,6 +327,7 @@ export function buildShowDriftUpdate(
   remote: McpShow,
   resolvedVenueId: string | null,
 ): ShowDriftUpdate | null {
+  const dateDrift = local.date !== remote.date;
   const aggregatesDrift =
     local.ratingsCount !== remote.ratingsCount ||
     local.notes !== remote.notes ||
@@ -311,8 +338,9 @@ export function buildShowDriftUpdate(
   const dayOrderDrift =
     remote.dayOrder !== undefined && (local.dayOrder ?? null) !== remote.dayOrder;
   const venueDrift = local.venueId === null && resolvedVenueId !== null;
-  if (!aggregatesDrift && !countForStatsDrift && !dayOrderDrift && !venueDrift) return null;
+  if (!dateDrift && !aggregatesDrift && !countForStatsDrift && !dayOrderDrift && !venueDrift) return null;
   const update: ShowDriftUpdate = {};
+  if (dateDrift) update.date = remote.date;
   if (aggregatesDrift) {
     update.averageRating = remote.averageRating;
     update.ratingsCount = remote.ratingsCount;
@@ -484,82 +512,176 @@ export function buildVenueDriftUpdate(local: LocalVenueCurated, remote: McpVenue
   return Object.keys(patch).length === 0 ? null : patch;
 }
 
-export function buildTrackCreateInputs(
-  setlist: McpSetlist,
-  showId: string,
-  songSlugToId: Map<string, string>,
-): Prisma.TrackCreateManyInput[] {
-  const tracks: Prisma.TrackCreateManyInput[] = [];
-  for (const set of setlist.sets) {
-    for (const track of set.tracks) {
-      const songId = songSlugToId.get(track.songSlug);
-      if (!songId) continue;
-      tracks.push({
-        showId,
-        songId,
-        set: set.label,
-        position: track.position,
-        segue: track.segue,
-        // Defaults mirror the Prisma schema so a pre-deploy MCP (no allTimer
-        // / note in payload) still produces explicit, predictable inserts.
-        note: track.note ?? null,
-        allTimer: track.allTimer ?? false,
-      });
-    }
-  }
-  return tracks;
-}
-
-// Shape-minimal local Track row used by the drift-update path. Keyed by
-// (showId, position) at the call site — `id` is the primary key we patch.
-export interface LocalTrackForDrift {
+// Shape-minimal local Track row used by the setlist reconciliation path.
+// Annotations are inlined so the per-track annotation diff can run in the same
+// pass without a second query.
+export interface LocalTrackForReconcile {
   id: string;
+  set: string;
   position: number;
+  songId: string;
   segue: string | null;
   note: string | null;
   allTimer: boolean | null;
+  annotations: Array<{ id: string; desc: string | null }>;
 }
 
-export interface TrackDriftPatch {
+export interface TrackPatch {
+  songId?: string;
   segue?: string | null;
   note?: string | null;
   allTimer?: boolean;
 }
 
+export interface TrackInsertOp {
+  set: string;
+  position: number;
+  songId: string;
+  segue: string | null;
+  note: string | null;
+  allTimer: boolean;
+  annotationDescs: string[];
+}
+
+export interface TrackUpdateOp {
+  trackId: string;
+  patch: TrackPatch;
+  annotationDiff: { toCreateDescs: string[]; toDeleteIds: string[] };
+}
+
+export interface TrackDeleteOp {
+  trackId: string;
+  annotationIds: string[];
+}
+
+export interface SetlistReconciliation {
+  toInsert: TrackInsertOp[];
+  toUpdate: TrackUpdateOp[];
+  toDelete: TrackDeleteOp[];
+  /**
+   * True when an insert, delete, or songId change happened — i.e. the show's
+   * setlist shape moved. Drives cache invalidation, SegueRun regen, and
+   * stats-rebuild window expansion. Pure segue/note/allTimer/annotation drift
+   * doesn't count as structural.
+   */
+  structurallyChanged: boolean;
+  /** True when annotations, segue, note, or allTimer changed. */
+  cosmeticallyChanged: boolean;
+  /** Remote songSlugs we couldn't resolve to a local song id. Reported, not inserted. */
+  unresolvedSongSlugs: string[];
+}
+
 /**
- * Diff the local tracks of a single show against the remote setlist payload
- * and return one {trackId, patch} per drifted track. Drift fields: segue,
- * note, allTimer. Pre-deploy MCP omits allTimer/note entirely — those keys
- * are treated as "no opinion" and never produce a patch, so an older upstream
- * can't clobber admin-set values.
+ * Diff a show's local tracks against the remote setlist and emit per-track
+ * insert/update/delete ops. The match key is (set, position) because position
+ * is unique only within a set — a show with three sets will reuse position 1
+ * three times, so any position-only key collapses across sets.
+ *
+ * Same-key match: patch songId / segue / note / allTimer if drifted, and
+ * compute the annotation delta. Remote-only key: insert a new track + its
+ * annotations. Local-only key: delete the track and its annotations.
+ *
+ * `undefined` on remote.note / remote.allTimer / remote.annotations still means
+ * "no opinion" (pre-deploy MCP) so admin-set values aren't clobbered.
  */
-export function buildTrackDriftUpdates(
-  local: LocalTrackForDrift[],
+export function buildSetlistReconciliation(
+  local: LocalTrackForReconcile[],
   remote: McpSetlist,
-): Array<{ trackId: string; patch: TrackDriftPatch }> {
-  const remoteByPosition = new Map<number, McpSetlistTrack>();
+  songSlugToId: Map<string, string>,
+): SetlistReconciliation {
+  const keyOf = (set: string, position: number): string => `${set}|${position}`;
+
+  const remoteByKey = new Map<string, { set: string; track: McpSetlistTrack }>();
   for (const set of remote.sets) {
     for (const track of set.tracks) {
-      remoteByPosition.set(track.position, track);
+      remoteByKey.set(keyOf(set.label, track.position), { set: set.label, track });
     }
   }
-  const out: Array<{ trackId: string; patch: TrackDriftPatch }> = [];
-  for (const localTrack of local) {
-    const remoteTrack = remoteByPosition.get(localTrack.position);
-    if (!remoteTrack) continue;
-    const patch: TrackDriftPatch = {};
-    if (localTrack.segue !== remoteTrack.segue) patch.segue = remoteTrack.segue;
-    if (remoteTrack.note !== undefined && localTrack.note !== remoteTrack.note) {
-      patch.note = remoteTrack.note;
+  const localByKey = new Map(local.map((t) => [keyOf(t.set, t.position), t]));
+
+  const toInsert: TrackInsertOp[] = [];
+  const toUpdate: TrackUpdateOp[] = [];
+  const toDelete: TrackDeleteOp[] = [];
+  const unresolvedSongSlugs: string[] = [];
+  let structurallyChanged = false;
+  let cosmeticallyChanged = false;
+
+  for (const [key, { set, track }] of remoteByKey) {
+    const localTrack = localByKey.get(key);
+    if (!localTrack) {
+      const songId = songSlugToId.get(track.songSlug);
+      if (!songId) {
+        unresolvedSongSlugs.push(track.songSlug);
+        continue;
+      }
+      toInsert.push({
+        set,
+        position: track.position,
+        songId,
+        segue: track.segue,
+        note: track.note ?? null,
+        allTimer: track.allTimer ?? false,
+        annotationDescs: track.annotations ?? [],
+      });
+      structurallyChanged = true;
+      continue;
     }
-    if (remoteTrack.allTimer !== undefined) {
+    const patch: TrackPatch = {};
+    const remoteSongId = songSlugToId.get(track.songSlug);
+    if (remoteSongId === undefined) {
+      // We have a local track at this slot but can't resolve the prod songId.
+      // Don't drop the track; report and leave songId alone.
+      unresolvedSongSlugs.push(track.songSlug);
+    } else if (remoteSongId !== localTrack.songId) {
+      patch.songId = remoteSongId;
+      structurallyChanged = true;
+    }
+    if (localTrack.segue !== track.segue) {
+      patch.segue = track.segue;
+      cosmeticallyChanged = true;
+    }
+    if (track.note !== undefined && localTrack.note !== track.note) {
+      patch.note = track.note;
+      cosmeticallyChanged = true;
+    }
+    if (track.allTimer !== undefined) {
       const localFlag = localTrack.allTimer ?? false;
-      const remoteFlag = remoteTrack.allTimer ?? false;
-      if (localFlag !== remoteFlag) patch.allTimer = remoteFlag;
+      const remoteFlag = track.allTimer ?? false;
+      if (localFlag !== remoteFlag) {
+        patch.allTimer = remoteFlag;
+        cosmeticallyChanged = true;
+      }
     }
-    if (Object.keys(patch).length > 0) out.push({ trackId: localTrack.id, patch });
+    const annotationDiff = diffTrackAnnotations(localTrack.annotations, track.annotations);
+    if (annotationDiff.toCreateDescs.length > 0 || annotationDiff.toDeleteIds.length > 0) {
+      cosmeticallyChanged = true;
+    }
+    if (Object.keys(patch).length > 0 || annotationDiff.toCreateDescs.length > 0 || annotationDiff.toDeleteIds.length > 0) {
+      toUpdate.push({
+        trackId: localTrack.id,
+        patch,
+        annotationDiff,
+      });
+    }
   }
-  return out;
+
+  for (const [key, localTrack] of localByKey) {
+    if (remoteByKey.has(key)) continue;
+    toDelete.push({
+      trackId: localTrack.id,
+      annotationIds: localTrack.annotations.map((a) => a.id),
+    });
+    structurallyChanged = true;
+  }
+
+  return {
+    toInsert,
+    toUpdate,
+    toDelete,
+    structurallyChanged,
+    cosmeticallyChanged,
+    unresolvedSongSlugs,
+  };
 }
 
 /**
@@ -623,20 +745,70 @@ interface SyncStats {
   showsCreated: number;
   songsFetched: number;
   songsCreated: number;
+  songsOrphanedDeleted: number;
+  songsOrphanedWithTracks: number;
+  showsOrphanedDeleted: number;
+  showsOrphanedWithUserData: number;
   venuesCreated: number;
   venuesLinked: number;
   venuesUnmatched: number;
+  setlistsReconciled: number;
+  setlistsStructurallyChanged: number;
   tracksCreated: number;
+  tracksUpdated: number;
+  tracksDeleted: number;
+  annotationsCreated: number;
+  annotationsDeleted: number;
+  segueRunsRegenerated: number;
+  unresolvedSongSlugs: number;
   errors: number;
 }
 
+function printUsage(): void {
+  console.log(`Usage: bun run scripts/sync-missing-shows.ts [options]
+
+Pull Disco Biscuits shows/setlists/songs from prod (${MCP_URL}) into the local DB.
+Mirrors every in-scope show's full setlist: inserts new tracks, deletes tracks
+prod removed, patches songId/segue/note/allTimer drift, and replaces
+annotations. Idempotent — re-running only writes the rows that drifted.
+
+Options:
+  --years=SPEC             Years to sync, as a comma-separated list of single
+                           years and/or inclusive ranges. Default: current
+                           calendar year (UTC). Examples:
+                             --years=2025
+                             --years=2024,2025
+                             --years=2010-2026
+                             --years=2010-2015,2020,2024-2026
+  --dry-run                Log every change without writing to the DB or Redis.
+  --prune-ghost-shows      Cascade-delete local shows in synced years that prod
+                           no longer has, even when attendance / favorite /
+                           review / photo / youtube / rating rows are attached
+                           (those are dump-frozen prod data; the equivalent
+                           shows on prod under the new slug still carry them).
+                           Without this flag, ghost shows with user data are
+                           logged and skipped.
+  --help, -h               Show this message and exit.
+
+Examples:
+  bun run scripts/sync-missing-shows.ts --years=2025
+  bun run scripts/sync-missing-shows.ts --years=2010-2026 --dry-run
+  bun run scripts/sync-missing-shows.ts --years=2010-2026 --prune-ghost-shows
+`);
+}
+
 async function syncMissingShows(): Promise<void> {
+  if (process.argv.includes("--help") || process.argv.includes("-h")) {
+    printUsage();
+    return;
+  }
   const isDryRun = process.argv.includes("--dry-run");
-  // --full-track-sync: fetch setlists for every existing local show in scope,
-  // not just missing-or-needs-venue. Catches Track.allTimer / Track.note /
-  // Track.segue / annotation edits on shows that haven't otherwise changed.
-  // Default run stays fast; opt in for periodic catch-up.
-  const isFullTrackSync = process.argv.includes("--full-track-sync");
+  // --prune-ghost-shows: delete local shows in synced years that prod
+  // doesn't have, even when user data (attendance, favorite, review, photo,
+  // youtube) is attached. Default skip-with-user-data is safe for shared
+  // DBs but blocks cleanup on dev DBs seeded from a prod dump (every old
+  // show carries prod's user data, which then prevents rename cleanup).
+  const pruneGhostShows = process.argv.includes("--prune-ghost-shows");
   const years = parseYearsArg(process.argv.slice(2), new Date());
   const now = new Date();
   const db = prisma;
@@ -654,6 +826,10 @@ async function syncMissingShows(): Promise<void> {
   // StatsService is wired without a cache here — the script never reads
   // cached aggregates, only triggers the post-batch gap rebuild.
   const statsService = new StatsService(prisma, cache ?? undefined);
+  // SegueRun rows reference Track ids in a non-FK String[] array. When the
+  // setlist reconcile inserts or deletes a track, those arrays go stale; we
+  // call generateSegueRunsForShow per structurally-changed show to rebuild.
+  const segueRunService = new SegueRunGeneratorService(prisma, logger);
   if (redis) await redis.connect();
 
   // Track every show whose row materially changed this run — used at the end
@@ -676,10 +852,22 @@ async function syncMissingShows(): Promise<void> {
     showsCreated: 0,
     songsFetched: 0,
     songsCreated: 0,
+    songsOrphanedDeleted: 0,
+    songsOrphanedWithTracks: 0,
+    showsOrphanedDeleted: 0,
+    showsOrphanedWithUserData: 0,
     venuesCreated: 0,
     venuesLinked: 0,
     venuesUnmatched: 0,
+    setlistsReconciled: 0,
+    setlistsStructurallyChanged: 0,
     tracksCreated: 0,
+    tracksUpdated: 0,
+    tracksDeleted: 0,
+    annotationsCreated: 0,
+    annotationsDeleted: 0,
+    segueRunsRegenerated: 0,
+    unresolvedSongSlugs: 0,
     errors: 0,
   };
 
@@ -696,11 +884,13 @@ async function syncMissingShows(): Promise<void> {
     }
     stats.showsRemote = remoteShows.length;
 
-    // Step 2a: drop prod stub rows (bare YYYY-MM-DD slug). These are orphan
-    // duplicates that coexist with the real show on the same date — they have
-    // no venue and no setlist, so we don't mirror them locally.
+    // Step 2a: drop prod stub rows that have a bare YYYY-MM-DD slug AND no
+    // venue — those are placeholder rows for unhappened/unconfirmed dates.
+    // A bare-date slug WITH a venue (e.g. 2009-03-08 Langerado Festival) is a
+    // real prod show; admins skipped the venue-suffix slug for historical
+    // reasons. Mirror those so per-year counts stay aligned with prod.
     const realShows = remoteShows.filter((s) => {
-      if (isStubSlug(s.slug)) {
+      if (isStubSlug(s.slug) && !s.venueName) {
         stats.stubsSkipped++;
         return false;
       }
@@ -723,7 +913,6 @@ async function syncMissingShows(): Promise<void> {
       console.warn(`⚠️  ${fullShowErrors.length} get_shows fetch errors:`, fullShowErrors);
       stats.errors += fullShowErrors.length;
     }
-    const remoteBySlug = new Map<string, McpShow>(remoteFullShows.map((s) => [s.slug, s]));
 
     // Step 2c: partition into missing-locally vs already-local. We pull venueId
     // for existing rows so the drift-update branch can back-fill venues that
@@ -753,75 +942,15 @@ async function syncMissingShows(): Promise<void> {
     const needsVenueSlugs = existingLocal.filter((s) => s.venueId === null).map((s) => s.slug);
     console.log(`📥 ${missingShows.length} missing locally (${stats.showsAlreadyLocal} already present, ${needsVenueSlugs.length} need venue back-fill)`);
 
-    if (missingShows.length === 0 && needsVenueSlugs.length === 0 && !isFullTrackSync) {
-      // Pure aggregate-drift run: do the simple update loop and bail out.
-      // (When --full-track-sync is set we fall through to the full pipeline so
-      // every existing show's setlist gets diffed for Track / Annotation drift.)
-      for (const remote of existingRemoteShows) {
-        const local = existingBySlug.get(remote.slug);
-        if (!local) continue;
-        const patch = buildShowDriftUpdate(local, remote, local.venueId);
-        if (patch === null) {
-          stats.showsUnchanged++;
-          continue;
-        }
-        if (isDryRun) {
-          console.log(`  🔄 ${remote.slug} would update ${JSON.stringify(patch)} (dry run)`);
-          stats.showsUpdated++;
-          continue;
-        }
-        try {
-          await db.show.update({ where: { slug: remote.slug }, data: { ...patch, updatedAt: now } });
-          changedSlugs.add(remote.slug);
-          // countForStats flip on an existing show invalidates the gap chain
-          // from that show's date forward — feed the date into the rebuild
-          // trigger so the post-batch stats sweep picks it up. (Aggregate
-          // drift alone doesn't shift gap math.)
-          if (patch.countForStats !== undefined) {
-            const showDate = String(local.date);
-            if (earliestInsertedDate === null || showDate < earliestInsertedDate) {
-              earliestInsertedDate = showDate;
-            }
-          }
-          stats.showsUpdated++;
-          console.log(`  🔄 ${remote.slug} ${JSON.stringify(patch)}`);
-        } catch (err) {
-          console.error(`  ❌ failed to update show ${remote.slug}:`, err);
-          stats.errors++;
-        }
-      }
-      console.log(`📊 Existing shows: ${stats.showsUpdated} updated, ${stats.showsUnchanged} unchanged`);
-      // Even a pure aggregate-drift run can trip the rebuild trigger if a
-      // countForStats flip was observed above.
-      if (!isDryRun && earliestInsertedDate !== null) {
-        console.log(`📐 Rebuilding gaps + song stats since ${earliestInsertedDate} (countForStats flip)`);
-        try {
-          await statsService.rebuildGapsAndSongStatsSince(earliestInsertedDate);
-        } catch (err) {
-          console.error("  ❌ stats rebuild failed:", err);
-          stats.errors++;
-        }
-      }
-      printSummary(stats, isDryRun);
-      return;
-    }
-
-    // Step 3: fetch setlists for missing shows AND existing shows that need
-    // venue back-fill, in one batched call. --full-track-sync adds every
-    // remaining existing-local slug so Track / Annotation drift can be diffed
-    // against the latest prod state, not just the inserts + venue back-fills.
-    const fullTrackSyncSlugs = isFullTrackSync
-      ? existingLocal.filter((s) => s.venueId !== null).map((s) => s.slug)
-      : [];
-    const setlistFetchSlugs = [
-      ...missingShows.map((s) => s.slug),
-      ...needsVenueSlugs,
-      ...fullTrackSyncSlugs,
-    ];
+    // Step 3: fetch the full setlist for EVERY in-scope show in one batched
+    // call. Drives both the missing-show inserts and the per-existing-show
+    // setlist reconciliation below. Prod admins can add / remove / swap
+    // tracks on already-local shows, so every show in scope needs its setlist
+    // fetched, not just the inserts.
     const { setlists, errors: setlistErrors } = await mcpCall<{
       setlists: McpSetlist[];
       errors?: Array<{ slug: string; error: string }>;
-    }>("get_setlists", { showSlugs: setlistFetchSlugs });
+    }>("get_setlists", { showSlugs: realSlugs });
     if (setlistErrors?.length) {
       console.warn(`⚠️  ${setlistErrors.length} setlist fetch errors:`, setlistErrors);
       stats.errors += setlistErrors.length;
@@ -960,6 +1089,17 @@ async function syncMissingShows(): Promise<void> {
             earliestInsertedDate = showDate;
           }
         }
+        // date drift shifts the show's chronological position. Expand the
+        // rebuild window to the EARLIER of (old date, new date) so the gap
+        // chain gets recomputed in both directions.
+        if (patch.date !== undefined) {
+          const oldDate = String(local.date);
+          const newDate = patch.date;
+          const earlier = oldDate < newDate ? oldDate : newDate;
+          if (earliestInsertedDate === null || earlier < earliestInsertedDate) {
+            earliestInsertedDate = earlier;
+          }
+        }
         stats.showsUpdated++;
         console.log(`  🔄 ${remote.slug} ${JSON.stringify(patch)}`);
       } catch (err) {
@@ -1047,8 +1187,10 @@ async function syncMissingShows(): Promise<void> {
       }
     }
 
-    // Step 7: per-show transaction — insert Show (with venueId + bandId resolved),
-    // then its Tracks.
+    // Step 7: insert missing show rows (no tracks yet — those land in step 8).
+    // Splitting insert-show from insert-tracks lets step 8 run one unified
+    // reconcile loop over every in-scope show, missing or existing, using the
+    // same buildSetlistReconciliation helper.
     for (const show of missingShows) {
       const slug = show.slug;
       const setlist = setlistBySlug.get(slug);
@@ -1059,140 +1201,383 @@ async function syncMissingShows(): Promise<void> {
       const venueId = venueSlug ? venueSlugToId.get(venueSlug) ?? null : null;
       if (venueId) stats.venuesLinked++;
 
-      try {
-        if (isDryRun) {
-          const trackCount = setlist ? buildTrackCreateInputs(setlist, "dry-run-show", songSlugToId).length : 0;
-          console.log(`  🆕 show ${slug} (${trackCount} tracks, venue=${venueId ? "✓" : "—"}) (dry run)`);
-          stats.showsCreated++;
-          stats.tracksCreated += trackCount;
-          continue;
-        }
-        await db.$transaction(async (tx) => {
-          const createdShow = await tx.show.create({
-            data: buildShowCreateInput(show, now, { venueId, bandId: band?.id ?? null }),
-          });
-          let trackCount = 0;
-          if (setlist) {
-            const trackInputs = buildTrackCreateInputs(setlist, createdShow.id, songSlugToId);
-            if (trackInputs.length > 0) {
-              const result = await tx.track.createMany({ data: trackInputs });
-              trackCount = result.count;
-            }
-          }
-          changedSlugs.add(slug);
-          const showDate = String(show.date);
-          if (earliestInsertedDate === null || showDate < earliestInsertedDate) {
-            earliestInsertedDate = showDate;
-          }
-          stats.showsCreated++;
-          stats.tracksCreated += trackCount;
-          console.log(`  ✅ ${slug} (${trackCount} tracks, venue=${venueId ? "✓" : "—"})`);
+      if (isDryRun) {
+        console.log(`  🆕 show ${slug} (venue=${venueId ? "✓" : "—"}) (dry run)`);
+        stats.showsCreated++;
+        // Synthesize an existingLocal entry so the reconcile loop below also
+        // logs the would-be track inserts for this slug.
+        existingBySlug.set(slug, {
+          id: `dry-run-show-${slug}`,
+          slug,
+          date: show.date,
+          averageRating: show.averageRating,
+          ratingsCount: show.ratingsCount,
+          notes: show.notes,
+          relistenUrl: show.relistenUrl,
+          venueId,
+          countForStats: show.countForStats ?? true,
+          dayOrder: show.dayOrder ?? null,
         });
+        const showDate = String(show.date);
+        if (earliestInsertedDate === null || showDate < earliestInsertedDate) {
+          earliestInsertedDate = showDate;
+        }
+        continue;
+      }
+      try {
+        const createdShow = await db.show.create({
+          data: buildShowCreateInput(show, now, { venueId, bandId: band?.id ?? null }),
+        });
+        existingBySlug.set(slug, {
+          id: createdShow.id,
+          slug,
+          date: createdShow.date,
+          averageRating: createdShow.averageRating,
+          ratingsCount: createdShow.ratingsCount,
+          notes: createdShow.notes,
+          relistenUrl: createdShow.relistenUrl,
+          venueId: createdShow.venueId,
+          countForStats: createdShow.countForStats,
+          dayOrder: createdShow.dayOrder,
+        });
+        changedSlugs.add(slug);
+        const showDate = String(show.date);
+        if (earliestInsertedDate === null || showDate < earliestInsertedDate) {
+          earliestInsertedDate = showDate;
+        }
+        stats.showsCreated++;
+        console.log(`  🆕 show ${slug} (venue=${venueId ? "✓" : "—"})`);
       } catch (err) {
         console.error(`  ❌ failed to insert show ${slug}:`, err);
         stats.errors++;
       }
     }
 
-    // Step 8: track + annotation drift for existing shows whose setlists
-    // were fetched (venue back-fill + --full-track-sync). Catches admin edits
-    // to Track.allTimer / Track.note / Track.segue and the per-track
-    // Annotation set without re-doing the show row itself. countForStats is
-    // pulled in so we know whether a flip should expand the rebuild window.
-    const driftShowSlugs = Array.from(new Set([...needsVenueSlugs, ...fullTrackSyncSlugs]));
-    if (driftShowSlugs.length > 0) {
-      const driftShows = await db.show.findMany({
-        where: { slug: { in: driftShowSlugs } },
+    // Step 8: reconcile every in-scope show's setlist against prod. One DB
+    // query pulls the local track + annotation graph for every show; the pure
+    // buildSetlistReconciliation helper diffs against the remote setlist
+    // matched on (set, position) and emits insert / update / delete ops. The
+    // SegueRun regen + stats-rebuild-window expansion fire only for shows
+    // whose setlist shape actually moved (insert / delete / songId change),
+    // not for cosmetic-only diffs.
+    const showIdsToReconcile = Array.from(existingBySlug.values())
+      .filter((s) => !String(s.id).startsWith("dry-run-show-"))
+      .map((s) => s.id);
+    const localTracksByShowId = new Map<string, LocalTrackForReconcile[]>();
+    if (showIdsToReconcile.length > 0) {
+      const localTrackRows = await db.track.findMany({
+        where: { showId: { in: showIdsToReconcile } },
         select: {
-          slug: true,
-          date: true,
-          countForStats: true,
-          tracks: {
-            select: {
-              id: true,
-              position: true,
-              segue: true,
-              note: true,
-              allTimer: true,
-              annotations: { select: { id: true, desc: true } },
-            },
-          },
+          id: true,
+          showId: true,
+          set: true,
+          position: true,
+          songId: true,
+          segue: true,
+          note: true,
+          allTimer: true,
+          annotations: { select: { id: true, desc: true } },
         },
       });
-      for (const show of driftShows) {
-        const setlist = setlistBySlug.get(show.slug);
-        if (!setlist) continue;
-        const trackPatches = buildTrackDriftUpdates(show.tracks, setlist);
-        // Map track-id → its remote annotation list for the per-track annotation diff.
-        const remoteAnnotationsByPosition = new Map<number, string[] | undefined>();
-        for (const set of setlist.sets) {
-          for (const track of set.tracks) {
-            remoteAnnotationsByPosition.set(track.position, track.annotations);
-          }
+      for (const row of localTrackRows) {
+        const arr = localTracksByShowId.get(row.showId);
+        const tr: LocalTrackForReconcile = {
+          id: row.id,
+          set: row.set,
+          position: row.position,
+          songId: row.songId,
+          segue: row.segue,
+          note: row.note,
+          allTimer: row.allTimer,
+          annotations: row.annotations,
+        };
+        if (arr) arr.push(tr);
+        else localTracksByShowId.set(row.showId, [tr]);
+      }
+    }
+
+    for (const [slug, local] of existingBySlug) {
+      const setlist = setlistBySlug.get(slug);
+      if (!setlist) continue;
+      const localTracks = localTracksByShowId.get(local.id) ?? [];
+      const recon = buildSetlistReconciliation(localTracks, setlist, songSlugToId);
+      if (recon.unresolvedSongSlugs.length > 0) {
+        stats.unresolvedSongSlugs += recon.unresolvedSongSlugs.length;
+        console.warn(
+          `⚠️  ${slug}: ${recon.unresolvedSongSlugs.length} unresolved songSlug(s): ${recon.unresolvedSongSlugs.join(", ")}`,
+        );
+      }
+      if (recon.toInsert.length === 0 && recon.toUpdate.length === 0 && recon.toDelete.length === 0) {
+        continue;
+      }
+      stats.setlistsReconciled++;
+      if (recon.structurallyChanged) stats.setlistsStructurallyChanged++;
+      const showDate = String(local.date);
+
+      if (isDryRun) {
+        if (recon.toInsert.length > 0) {
+          console.log(`  ➕ ${slug}: +${recon.toInsert.length} track(s) (dry run)`);
         }
-        let touchedShow = false;
-        for (const { trackId, patch } of trackPatches) {
-          if (isDryRun) {
-            console.log(`  🔄 track ${trackId} would update ${JSON.stringify(patch)} (dry run)`);
-            touchedShow = true;
-            continue;
-          }
-          try {
-            await db.track.update({ where: { id: trackId }, data: { ...patch, updatedAt: now } });
-            touchedShow = true;
-            console.log(`  🔄 track ${trackId} ${JSON.stringify(patch)}`);
-          } catch (err) {
-            console.error(`  ❌ failed to update track ${trackId}:`, err);
-            stats.errors++;
-          }
+        if (recon.toUpdate.length > 0) {
+          console.log(`  🔄 ${slug}: ~${recon.toUpdate.length} track(s) (dry run)`);
         }
-        // Annotation set replace: for each local track, compare to the remote
-        // annotation strings and apply the minimal create/delete delta.
-        for (const localTrack of show.tracks) {
-          const remoteAnnotations = remoteAnnotationsByPosition.get(localTrack.position);
-          const diff = diffTrackAnnotations(localTrack.annotations, remoteAnnotations);
-          if (diff.toCreateDescs.length === 0 && diff.toDeleteIds.length === 0) continue;
-          if (isDryRun) {
-            console.log(
-              `  🔄 track ${localTrack.id} annotations: +${diff.toCreateDescs.length} -${diff.toDeleteIds.length} (dry run)`,
-            );
-            touchedShow = true;
-            continue;
+        if (recon.toDelete.length > 0) {
+          console.log(`  ➖ ${slug}: -${recon.toDelete.length} track(s) (dry run)`);
+        }
+        // Match the live counters: only count an update when the track row
+        // itself has a non-empty patch. Annotation-only updates are reflected
+        // in the annotation counters, not tracksUpdated.
+        stats.tracksCreated += recon.toInsert.length;
+        stats.tracksUpdated += recon.toUpdate.filter((u) => Object.keys(u.patch).length > 0).length;
+        stats.tracksDeleted += recon.toDelete.length;
+        for (const ins of recon.toInsert) stats.annotationsCreated += ins.annotationDescs.length;
+        for (const upd of recon.toUpdate) {
+          stats.annotationsCreated += upd.annotationDiff.toCreateDescs.length;
+          stats.annotationsDeleted += upd.annotationDiff.toDeleteIds.length;
+        }
+        for (const del of recon.toDelete) stats.annotationsDeleted += del.annotationIds.length;
+        changedSlugs.add(slug);
+        if (recon.structurallyChanged && local.countForStats && (earliestInsertedDate === null || showDate < earliestInsertedDate)) {
+          earliestInsertedDate = showDate;
+        }
+        continue;
+      }
+
+      try {
+        await db.$transaction(async (tx) => {
+          for (const ins of recon.toInsert) {
+            await tx.track.create({
+              data: {
+                showId: local.id,
+                songId: ins.songId,
+                set: ins.set,
+                position: ins.position,
+                segue: ins.segue,
+                note: ins.note,
+                allTimer: ins.allTimer,
+                createdAt: now,
+                updatedAt: now,
+                annotations: ins.annotationDescs.length > 0
+                  ? {
+                      create: ins.annotationDescs.map((desc) => ({ desc, createdAt: now, updatedAt: now })),
+                    }
+                  : undefined,
+              },
+            });
+            stats.tracksCreated++;
+            stats.annotationsCreated += ins.annotationDescs.length;
           }
-          try {
-            if (diff.toDeleteIds.length > 0) {
-              await db.annotation.deleteMany({ where: { id: { in: diff.toDeleteIds } } });
+          for (const upd of recon.toUpdate) {
+            if (Object.keys(upd.patch).length > 0) {
+              await tx.track.update({
+                where: { id: upd.trackId },
+                data: { ...upd.patch, updatedAt: now },
+              });
+              stats.tracksUpdated++;
             }
-            if (diff.toCreateDescs.length > 0) {
-              await db.annotation.createMany({
-                data: diff.toCreateDescs.map((desc) => ({
-                  trackId: localTrack.id,
+            if (upd.annotationDiff.toDeleteIds.length > 0) {
+              await tx.annotation.deleteMany({ where: { id: { in: upd.annotationDiff.toDeleteIds } } });
+              stats.annotationsDeleted += upd.annotationDiff.toDeleteIds.length;
+            }
+            if (upd.annotationDiff.toCreateDescs.length > 0) {
+              await tx.annotation.createMany({
+                data: upd.annotationDiff.toCreateDescs.map((desc) => ({
+                  trackId: upd.trackId,
                   desc,
                   createdAt: now,
                   updatedAt: now,
                 })),
               });
+              stats.annotationsCreated += upd.annotationDiff.toCreateDescs.length;
             }
-            touchedShow = true;
-            console.log(
-              `  🔄 track ${localTrack.id} annotations: +${diff.toCreateDescs.length} -${diff.toDeleteIds.length}`,
-            );
+          }
+          for (const del of recon.toDelete) {
+            if (del.annotationIds.length > 0) {
+              await tx.annotation.deleteMany({ where: { id: { in: del.annotationIds } } });
+              stats.annotationsDeleted += del.annotationIds.length;
+            }
+            await tx.track.delete({ where: { id: del.trackId } });
+            stats.tracksDeleted++;
+          }
+        });
+        changedSlugs.add(slug);
+        console.log(
+          `  📝 ${slug}: +${recon.toInsert.length} ~${recon.toUpdate.length} -${recon.toDelete.length} track(s)`,
+        );
+        if (recon.structurallyChanged) {
+          try {
+            const showWithTracks = await db.show.findUnique({
+              where: { id: local.id },
+              include: { tracks: { include: { song: true }, orderBy: [{ set: "asc" }, { position: "asc" }] } },
+            });
+            if (showWithTracks) {
+              const count = await segueRunService.generateSegueRunsForShow(showWithTracks);
+              stats.segueRunsRegenerated += count;
+            }
           } catch (err) {
-            console.error(`  ❌ failed to sync annotations for track ${localTrack.id}:`, err);
+            console.error(`  ❌ SegueRun regen failed for ${slug}:`, err);
             stats.errors++;
           }
+          if (local.countForStats && (earliestInsertedDate === null || showDate < earliestInsertedDate)) {
+            earliestInsertedDate = showDate;
+          }
         }
-        if (touchedShow) {
-          changedSlugs.add(show.slug);
-          // Track / annotation drift on a stats-counting show shifts the gap
-          // chain (e.g. an all-timer flag change is cosmetic, but a segue
-          // change affects ordering; play it safe and expand the window).
-          if (show.countForStats) {
-            const showDate = String(show.date);
-            if (earliestInsertedDate === null || showDate < earliestInsertedDate) {
-              earliestInsertedDate = showDate;
+      } catch (err) {
+        console.error(`  ❌ failed to reconcile setlist for ${slug}:`, err);
+        stats.errors++;
+      }
+    }
+
+    // Step 8b: ghost-show detection. Local shows in the synced years whose
+    // slug isn't in prod's per-year list are renames / merges / deletes
+    // upstream — the step 8 reconcile loop never touches them because it
+    // only iterates prod's shows. Cascade-delete the sync-managed rows
+    // (annotations → tracks → segueRuns → showYoutubes → show) when no
+    // user data references the show; log + skip otherwise.
+    const yearSet = new Set(years);
+    const prodSlugSet = new Set(realSlugs);
+    const inYearLocalShows = await db.show.findMany({
+      where: {
+        OR: years.map((y) => ({
+          AND: [
+            { date: { gte: `${y}-01-01` } },
+            { date: { lte: `${y}-12-31` } },
+          ],
+        })),
+      },
+      select: {
+        id: true,
+        slug: true,
+        date: true,
+        _count: {
+          select: {
+            tracks: true,
+            attendances: true,
+            favorites: true,
+            reviews: true,
+            showPhotos: true,
+            showYoutubes: true,
+          },
+        },
+      },
+    });
+    const ghostShows = inYearLocalShows.filter((s) => {
+      if (!s.slug) return false;
+      if (!prodSlugSet.has(s.slug)) {
+        const showYear = Number(s.date.slice(0, 4));
+        return yearSet.has(showYear);
+      }
+      return false;
+    });
+    if (ghostShows.length > 0) {
+      console.log(`👻 ${ghostShows.length} ghost show(s) found in synced years (local but not on prod)`);
+    }
+    for (const ghost of ghostShows) {
+      const userDataCount =
+        ghost._count.attendances +
+        ghost._count.favorites +
+        ghost._count.reviews +
+        ghost._count.showPhotos +
+        ghost._count.showYoutubes;
+      if (userDataCount > 0 && !pruneGhostShows) {
+        stats.showsOrphanedWithUserData++;
+        console.warn(
+          `  ⚠️  show ${ghost.slug} (${ghost._count.tracks} tracks, ${userDataCount} user-data row(s)); skipping — re-run with --prune-ghost-shows to delete`,
+        );
+        continue;
+      }
+      if (isDryRun) {
+        console.log(`  🗑️  show ${ghost.slug} (${ghost._count.tracks} tracks) would be deleted (not on prod) (dry run)`);
+        stats.showsOrphanedDeleted++;
+        continue;
+      }
+      try {
+        await db.$transaction(async (tx) => {
+          const localTrackRows = await tx.track.findMany({
+            where: { showId: ghost.id },
+            select: { id: true },
+          });
+          const trackIds = localTrackRows.map((t) => t.id);
+          if (trackIds.length > 0) {
+            // Ratings are polymorphic — drop Show + Track ratings for this show.
+            await tx.rating.deleteMany({
+              where: { rateableType: "Track", rateableId: { in: trackIds } },
+            });
+            await tx.annotation.deleteMany({ where: { trackId: { in: trackIds } } });
+            await tx.track.deleteMany({ where: { showId: ghost.id } });
+          }
+          // Other Tracks may still reference the ghost as previousPerformanceShow.
+          // Null those out — rebuildGapsAndSongStatsSince at end of run rebuilds.
+          await tx.track.updateMany({
+            where: { previousPerformanceShowId: ghost.id },
+            data: { previousPerformanceShowId: null },
+          });
+          await tx.segueRun.deleteMany({ where: { showId: ghost.id } });
+          // User-data tables: only present when --prune-ghost-shows opted in
+          // (without the flag, the loop already `continue`d above). All five
+          // tables have NoAction onDelete so we have to wipe them manually.
+          await tx.attendance.deleteMany({ where: { showId: ghost.id } });
+          await tx.favorite.deleteMany({ where: { showId: ghost.id } });
+          await tx.review.deleteMany({ where: { showId: ghost.id } });
+          await tx.showPhoto.deleteMany({ where: { showId: ghost.id } });
+          await tx.showYoutube.deleteMany({ where: { showId: ghost.id } });
+          await tx.rating.deleteMany({
+            where: { rateableType: "Show", rateableId: ghost.id },
+          });
+          await tx.show.delete({ where: { id: ghost.id } });
+        });
+        changedSlugs.add(ghost.slug ?? "");
+        songsChanged = true;
+        if (earliestInsertedDate === null || ghost.date < earliestInsertedDate) {
+          earliestInsertedDate = ghost.date;
+        }
+        stats.showsOrphanedDeleted++;
+        console.log(`  🗑️  show ${ghost.slug} (${ghost._count.tracks} tracks) deleted (not on prod)`);
+      } catch (err) {
+        console.error(`  ❌ failed to delete ghost show ${ghost.slug}:`, err);
+        stats.errors++;
+      }
+    }
+
+    // Step 8c: orphan-song detection. Local songs whose slug prod doesn't
+    // return on get_songs are renames / merges / deletes upstream. Delete the
+    // zero-track orphans (safe — nothing references them) and log the rest
+    // with their track count so the user can do the manual re-point. Runs
+    // after ghost-show deletion so songs that became zero-track via that
+    // cleanup get auto-deleted here.
+    const localSongCountRows = await db.song.findMany({
+      select: { id: true, slug: true, title: true, _count: { select: { tracks: true } } },
+    });
+    if (localSongCountRows.length > 0) {
+      const { errors: orphanErrors } = await mcpCall<{
+        songs: McpSong[];
+        errors?: Array<{ slug: string; error: string }>;
+      }>("get_songs", { slugs: localSongCountRows.map((s) => s.slug) });
+      const orphanSlugs = new Set((orphanErrors ?? []).map((e) => e.slug));
+      const localSongBySlugMap = new Map(localSongCountRows.map((s) => [s.slug, s]));
+      for (const orphanSlug of orphanSlugs) {
+        const local = localSongBySlugMap.get(orphanSlug);
+        if (!local) continue;
+        if (local._count.tracks === 0) {
+          if (isDryRun) {
+            console.log(`  🗑️  song ${orphanSlug} (0 tracks) would be deleted (not on prod) (dry run)`);
+          } else {
+            try {
+              await db.song.delete({ where: { id: local.id } });
+              songsChanged = true;
+              console.log(`  🗑️  song ${orphanSlug} (0 tracks) deleted (not on prod)`);
+            } catch (err) {
+              console.error(`  ❌ failed to delete orphan song ${orphanSlug}:`, err);
+              stats.errors++;
+              continue;
             }
           }
+          stats.songsOrphanedDeleted++;
+        } else {
+          stats.songsOrphanedWithTracks++;
+          console.warn(
+            `  ⚠️  song ${orphanSlug} ("${local.title}") has ${local._count.tracks} local track(s) but isn't on prod — likely a rename or merge upstream; manual cleanup needed`,
+          );
         }
       }
     }
@@ -1249,10 +1634,17 @@ function printSummary(stats: SyncStats, isDryRun: boolean): void {
   console.log(`Shows created: ${stats.showsCreated}`);
   console.log(`Songs fetched: ${stats.songsFetched}`);
   console.log(`Songs created: ${stats.songsCreated}`);
+  console.log(`Songs orphaned (deleted / with tracks): ${stats.songsOrphanedDeleted} / ${stats.songsOrphanedWithTracks}`);
+  console.log(`Shows orphaned (deleted / with user data): ${stats.showsOrphanedDeleted} / ${stats.showsOrphanedWithUserData}`);
   console.log(`Venues created: ${stats.venuesCreated}`);
   console.log(`Venues linked on shows: ${stats.venuesLinked}`);
   console.log(`Venues unmatched (left NULL): ${stats.venuesUnmatched}`);
-  console.log(`Tracks created: ${stats.tracksCreated}`);
+  console.log(`Setlists reconciled: ${stats.setlistsReconciled}`);
+  console.log(`Setlists structurally changed: ${stats.setlistsStructurallyChanged}`);
+  console.log(`Tracks created / updated / deleted: ${stats.tracksCreated} / ${stats.tracksUpdated} / ${stats.tracksDeleted}`);
+  console.log(`Annotations created / deleted: ${stats.annotationsCreated} / ${stats.annotationsDeleted}`);
+  console.log(`SegueRuns regenerated: ${stats.segueRunsRegenerated}`);
+  console.log(`Unresolved song slugs: ${stats.unresolvedSongSlugs}`);
   console.log(`Errors: ${stats.errors}`);
 }
 

--- a/packages/core/src/_shared/show-ordering.ts
+++ b/packages/core/src/_shared/show-ordering.ts
@@ -93,6 +93,32 @@ export const STATS_SHOWS_WHERE = {
 } satisfies Prisma.ShowWhereInput;
 
 /**
+ * Filter that excludes orphan placeholder shows — bare YYYY-MM-DD slug, no
+ * venue, no setlist. These exist on prod alongside the real show on the same
+ * date (e.g. `2025-10-31` next to `2025-10-31-suwannee-music-park-live-oak-fl`)
+ * and double-count in user-facing listings. The signal we key on is the
+ * missing venue: every real show has one resolved at sync time, and a user
+ * can't act on a venueless row anyway.
+ *
+ * Apply to display-facing queries that count or enumerate shows. Admin
+ * tooling that needs to surface these placeholders for cleanup should
+ * intentionally NOT use this.
+ */
+export const NON_STUB_SHOWS_WHERE = {
+  venueId: { not: null },
+} satisfies Prisma.ShowWhereInput;
+
+/**
+ * Raw-SQL fragment matching NON_STUB_SHOWS_WHERE — splice into `WHERE` /
+ * `AND` chains in `$queryRaw` calls. Pass the alias used for the shows
+ * table in your query.
+ */
+export function nonStubShowsSql(alias: ShowAlias = "shows"): Prisma.Sql {
+  const a = Prisma.raw(alias);
+  return Prisma.sql`${a}.venue_id IS NOT NULL`;
+}
+
+/**
  * Raw-SQL fragment matching STATS_SHOWS_WHERE — splice into `WHERE` /
  * `AND` chains in `$queryRaw` calls. Pass the alias used for the shows
  * table in your query.

--- a/packages/core/src/ratings/rating-service.test.ts
+++ b/packages/core/src/ratings/rating-service.test.ts
@@ -5,6 +5,7 @@ import { RatingService } from "./rating-service";
 // methods under test don't touch it.
 const cacheInvalidation = {
   invalidateAttendanceCaches: vi.fn(),
+  invalidateShow: vi.fn(),
   invalidateShowComprehensive: vi.fn(),
 } as never;
 
@@ -403,6 +404,7 @@ describe("RatingService.clearForUser", () => {
 
     const service = new RatingService(db, {
       invalidateAttendanceCaches: vi.fn(),
+      invalidateShow: vi.fn(),
       invalidateShowComprehensive: invalidate,
     } as never);
     await service.clearForUser({
@@ -413,5 +415,76 @@ describe("RatingService.clearForUser", () => {
     });
 
     expect(invalidate).toHaveBeenCalledWith(undefined, "2024-08-12-cap-theatre");
+  });
+
+  // Track-type clears must invalidate the show's setlist cache. The cached
+  // setlist payload at CacheKeys.show.data(slug) embeds each track's
+  // averageRating/ratingsCount, so the recompute on Track.update would be
+  // shadowed by the stale Redis payload on the next read.
+  test("invalidates the show cache when clearing a Track rating with a showSlug", async () => {
+    const invalidateShow = vi.fn();
+    const db = {
+      rating: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+        aggregate: vi.fn().mockResolvedValue({ _avg: { value: 3.5 }, _count: { id: 2 } }),
+      },
+      show: { update: vi.fn() },
+      track: { update: vi.fn() },
+    } as never;
+
+    const service = new RatingService(db, {
+      invalidateAttendanceCaches: vi.fn(),
+      invalidateShow,
+      invalidateShowComprehensive: vi.fn(),
+    } as never);
+    await service.clearForUser({
+      rateableId: "track-1",
+      rateableType: "Track",
+      userId: "u1",
+      showSlug: "2024-08-12-cap-theatre",
+    });
+
+    expect(invalidateShow).toHaveBeenCalledWith("2024-08-12-cap-theatre");
+  });
+});
+
+describe("RatingService.upsert", () => {
+  // Same motivation as the Track-clear case in clearForUser: the show's
+  // cached setlist embeds Track.averageRating/ratingsCount, so the upsert
+  // path has to bust the show cache for the rating mutation to surface.
+  test("invalidates the show cache when upserting a Track rating with a showSlug", async () => {
+    const invalidateShow = vi.fn();
+    const now = new Date("2024-08-12T00:00:00Z");
+    const db = {
+      rating: {
+        upsert: vi.fn().mockResolvedValue({
+          id: "r1",
+          userId: "u1",
+          rateableId: "track-1",
+          rateableType: "Track",
+          value: 4,
+          createdAt: now,
+          updatedAt: now,
+        }),
+        aggregate: vi.fn().mockResolvedValue({ _avg: { value: 4.0 }, _count: { id: 1 } }),
+      },
+      show: { update: vi.fn() },
+      track: { update: vi.fn() },
+    } as never;
+
+    const service = new RatingService(db, {
+      invalidateAttendanceCaches: vi.fn(),
+      invalidateShow,
+      invalidateShowComprehensive: vi.fn(),
+    } as never);
+    await service.upsert({
+      rateableId: "track-1",
+      rateableType: "Track",
+      userId: "u1",
+      value: 4,
+      showSlug: "2024-08-12-cap-theatre",
+    });
+
+    expect(invalidateShow).toHaveBeenCalledWith("2024-08-12-cap-theatre");
   });
 });

--- a/packages/core/src/ratings/rating-service.ts
+++ b/packages/core/src/ratings/rating-service.ts
@@ -143,6 +143,12 @@ export class RatingService {
 
     if (data.rateableType === "Show" && data.showSlug) {
       await this.cacheInvalidation.invalidateShowComprehensive(undefined, data.showSlug);
+    } else if (data.rateableType === "Track" && data.showSlug) {
+      // The show's cached setlist payload at CacheKeys.show.data(slug)
+      // embeds Track.averageRating/ratingsCount on each track, so a rating
+      // mutation has to bust that cache for subsequent reads to surface the
+      // new denormalized values.
+      await this.cacheInvalidation.invalidateShow(data.showSlug);
     }
 
     // Update the related show/track average rating and count
@@ -355,6 +361,11 @@ export class RatingService {
 
     if (data.rateableType === "Show" && data.showSlug) {
       await this.cacheInvalidation.invalidateShowComprehensive(undefined, data.showSlug);
+    } else if (data.rateableType === "Track" && data.showSlug) {
+      // Same reason as the upsert path: Track.averageRating/ratingsCount
+      // live inside the cached setlist payload, so a recompute has to bust
+      // the show cache.
+      await this.cacheInvalidation.invalidateShow(data.showSlug);
     }
 
     return stats;

--- a/packages/core/src/setlists/setlist-service.test.ts
+++ b/packages/core/src/setlists/setlist-service.test.ts
@@ -124,6 +124,21 @@ describe("SetlistService.findManyLight", () => {
     expect(call.where.showPhotosCount).toEqual({ gt: 0 });
     expect(call.where.showYoutubesCount).toEqual({ equals: 0 });
   });
+
+  // Year listings on prod include orphan placeholder shows (bare YYYY-MM-DD
+  // slug, no venue) which double-count alongside the real show on the same
+  // date. They render as a blank row in the list with no setlist data, so the
+  // query must drop them at the SQL boundary. Keyed on the missing venue —
+  // see NON_STUB_SHOWS_WHERE.
+  test("excludes orphan stub shows (no venue) from year listings", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never);
+
+    await service.findManyLight({ filters: { year: 2024 } });
+
+    const call = db.show.findMany.mock.calls[0][0];
+    expect(call.where.venueId).toEqual({ not: null });
+  });
 });
 
 describe("eligibleGapsForAggregation", () => {

--- a/packages/core/src/setlists/setlist-service.ts
+++ b/packages/core/src/setlists/setlist-service.ts
@@ -11,7 +11,13 @@ import {
 } from "@bip/domain";
 import type { DbAnnotation, DbClient, DbShow, DbSong, DbTrack, DbVenue } from "../_shared/database/models";
 import type { PaginationOptions, SortOptions } from "../_shared/database/types";
-import { resolveShowOrderBy, SHOW_ORDER_ASC, SHOW_ORDER_DESC, STATS_SHOWS_WHERE } from "../_shared/show-ordering";
+import {
+  NON_STUB_SHOWS_WHERE,
+  resolveShowOrderBy,
+  SHOW_ORDER_ASC,
+  SHOW_ORDER_DESC,
+  STATS_SHOWS_WHERE,
+} from "../_shared/show-ordering";
 
 /**
  * Filter options for setlist queries. The `hasPhotos` / `hasYoutube` flags
@@ -523,7 +529,10 @@ export class SetlistService {
 
     const results = await this.db.show.findMany({
       where: {
-        venueId,
+        // venueId: explicit caller value when given (the venue-detail page
+        // looks shows up by venueId), otherwise apply the stub filter to drop
+        // orphan placeholder shows that have no venue assigned.
+        venueId: venueId !== undefined ? venueId : NON_STUB_SHOWS_WHERE.venueId,
         date: monthDay
           ? { endsWith: `-${monthDay}` }
           : year

--- a/packages/core/src/shows/show-service.test.ts
+++ b/packages/core/src/shows/show-service.test.ts
@@ -106,6 +106,22 @@ describe("ShowService.getShowDatesWithFlags", () => {
       showYoutubesCount: true,
     });
   });
+
+  // Prod has orphan placeholder shows (bare YYYY-MM-DD slug, no venue) that
+  // coexist with the real show on the same date — e.g. `2025-10-31` sitting
+  // beside `2025-10-31-suwannee-music-park-live-oak-fl`. Including them in the
+  // per-year count over-reports by one for each date that has a stub. Filter
+  // them at the SQL boundary so every caller of getShowDatesWithFlags inherits
+  // the fix (the year page is the only one today; others may join later).
+  test("excludes orphan stub shows that have no venue assigned", async () => {
+    const db = makeMockDb();
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), makeStatsStub());
+
+    await service.getShowDatesWithFlags();
+
+    const call = db.show.findMany.mock.calls[0][0];
+    expect(call.where).toEqual({ venueId: { not: null } });
+  });
 });
 
 describe("ShowService.reorderByDate", () => {

--- a/packages/core/src/shows/show-service.ts
+++ b/packages/core/src/shows/show-service.ts
@@ -6,6 +6,7 @@ import { buildIncludeClause, buildWhereClause } from "../_shared/database/query-
 import type { FilterCondition, QueryOptions } from "../_shared/database/types";
 import {
   DAY_ORDER_NULL_SENTINEL,
+  NON_STUB_SHOWS_WHERE,
   resolveShowOrderBy,
   SHOW_ORDER_ASC,
   SHOW_ORDER_DESC,
@@ -105,6 +106,7 @@ export class ShowService {
    */
   async getShowDatesWithFlags(): Promise<Array<{ date: string; hasPhotos: boolean; hasYoutube: boolean }>> {
     const results = await this.db.show.findMany({
+      where: NON_STUB_SHOWS_WHERE,
       select: {
         date: true,
         showPhotosCount: true,

--- a/packages/core/src/stats/stats-service.test.ts
+++ b/packages/core/src/stats/stats-service.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, test } from "vitest";
-import { countShowsAfter, countShowsBetween, countShowsOnOrAfter, songStatsChanged } from "./stats-service";
+import { describe, expect, test, vi } from "vitest";
+import type { CacheService } from "../_shared/cache";
+import {
+  countShowsAfter,
+  countShowsBetween,
+  countShowsOnOrAfter,
+  StatsService,
+  songStatsChanged,
+} from "./stats-service";
 
 const baseFresh = {
   timesPlayed: 3,
@@ -146,9 +153,9 @@ describe("countShowsAfter", () => {
     expect(countShowsAfter(["2010-01-01", "2015-06-15", "2020-12-31", "2024-07-04"], "2018-01-01")).toBe(2);
   });
 
-  // Large array sanity — binary search handles 2k entries without churn,
-  // and the result still matches the linear answer.
-  test("matches a linear scan on a 2000-element array", () => {
+  // Large array sanity — binary search handles 480 entries (40 years × 12
+  // months) without churn, and the result still matches the linear answer.
+  test("matches a linear scan on a 480-element array", () => {
     const dates: string[] = [];
     for (let year = 1990; year < 2030; year++) {
       for (let month = 1; month <= 12; month++) {
@@ -222,5 +229,50 @@ describe("countShowsBetween", () => {
   test("returns 0 when no dates fall in range", () => {
     const dates = ["2024-01-01", "2024-02-01"];
     expect(countShowsBetween(dates, "2025-01-01", "2025-12-31")).toBe(0);
+  });
+});
+
+// Both getShowsByYear and getStatsShowDates feed denominators for rarity
+// stats — % since debut, shows since last played. Prod's per-date "stub"
+// rows (bare YYYY-MM-DD slug, no venue, no tracks) sit alongside the real
+// shows and inflate those denominators by one for each stub. The fix is in
+// the SQL: every show-counting predicate must add `venue_id IS NOT NULL`
+// so the rarity math only counts real shows.
+describe("StatsService stub filtering in raw SQL", () => {
+  function makeStubbedService() {
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const db = { $queryRaw: queryRaw } as unknown as ConstructorParameters<typeof StatsService>[0];
+    // Cache: pass through to the producer so we can intercept the SQL it issues.
+    const cache = {
+      getOrSet: async <T>(_key: unknown, producer: () => Promise<T>) => producer(),
+    } as unknown as CacheService;
+    return { service: new StatsService(db, cache), queryRaw };
+  }
+
+  // `$queryRaw` is called as a tag template. Prisma passes the cooked
+  // template-string chunks as the first arg and every interpolated
+  // `Prisma.Sql` fragment as the rest. Concatenate both so the assertion
+  // can `.toContain()` the stub predicate from `nonStubShowsSql`.
+  function joinSqlFromCall(call: unknown[]): string {
+    const chunks = (call[0] as readonly string[]).join("?");
+    const fragments = call
+      .slice(1)
+      .map((arg) => (arg as { sql: string }).sql)
+      .join(" ");
+    return `${chunks} ${fragments}`;
+  }
+
+  test("getShowsByYear's SQL excludes orphan stub shows (venue_id IS NOT NULL)", async () => {
+    const { service, queryRaw } = makeStubbedService();
+    await service.getShowsByYear();
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    expect(joinSqlFromCall(queryRaw.mock.calls[0])).toContain("venue_id IS NOT NULL");
+  });
+
+  test("getStatsShowDates's SQL excludes orphan stub shows (venue_id IS NOT NULL)", async () => {
+    const { service, queryRaw } = makeStubbedService();
+    await service.getStatsShowDates();
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    expect(joinSqlFromCall(queryRaw.mock.calls[0])).toContain("venue_id IS NOT NULL");
   });
 });

--- a/packages/core/src/stats/stats-service.ts
+++ b/packages/core/src/stats/stats-service.ts
@@ -1,7 +1,7 @@
 import { CacheKeys } from "@bip/domain";
 import type { CacheService } from "../_shared/cache/cache-service";
 import type { DbClient } from "../_shared/database/models";
-import { STATS_SHOWS_WHERE, statsShowsSql, TRACK_BY_SHOW_ORDER_ASC } from "../_shared/show-ordering";
+import { nonStubShowsSql, STATS_SHOWS_WHERE, statsShowsSql, TRACK_BY_SHOW_ORDER_ASC } from "../_shared/show-ordering";
 import {
   computeSongStats,
   computeTrackGaps,
@@ -55,6 +55,7 @@ export class StatsService {
           FROM shows
           WHERE date IS NOT NULL
             AND ${statsShowsSql("shows")}
+            AND ${nonStubShowsSql("shows")}
           GROUP BY 1
           ORDER BY 1
         `;
@@ -87,6 +88,7 @@ export class StatsService {
           FROM shows
           WHERE date IS NOT NULL
             AND ${statsShowsSql("shows")}
+            AND ${nonStubShowsSql("shows")}
           ORDER BY date
         `;
         return rows.map((r) => r.d);

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -127,10 +127,17 @@ export const CacheKeys = {
    * and songs and back rarity/normalization features).
    */
   stats: {
-    /** Map of `{year: showCount}` for the entire show catalog. */
-    showsByYear: () => "stats:shows-by-year",
-    /** Sorted ISO date strings (YYYY-MM-DD) for every count_for_stats=true show. */
-    showDates: () => "stats:show-dates",
+    /**
+     * Map of `{year: showCount}` for the entire show catalog. `:v2` bump:
+     * now excludes orphan stub shows (venue_id IS NULL); semantics changed,
+     * pre-bump cached values would over-count by the number of stubs.
+     */
+    showsByYear: () => "stats:shows-by-year:v2",
+    /**
+     * Sorted ISO date strings (YYYY-MM-DD) for every count_for_stats=true
+     * show. `:v2` bump: now excludes orphan stub shows (venue_id IS NULL).
+     */
+    showDates: () => "stats:show-dates:v2",
   },
 } as const;
 


### PR DESCRIPTION
## Summary

- **Show pages**: rating a song no longer leaves a "Rate" badge with a golden outline after hard reload. `RatingService.upsert` and `RatingService.clearForUser` now invalidate the show's cached setlist payload when a Track rating mutation includes a showSlug, so the badge picks up the new community average on the next read.
- **Year listings + rarity stats**: per-year show counts, `/shows/year/:year`, and the rarity-stat denominators (% since debut, shows since last played) no longer over-report by the number of prod's orphan placeholder rows (bare YYYY-MM-DD slug, no venue). Every show-counting query applies `venue_id IS NOT NULL` via the new `NON_STUB_SHOWS_WHERE` / `nonStubShowsSql` helpers. Cache keys `stats:shows-by-year` and `stats:show-dates` bumped to `:v2`.
- **`make db-sync-missing-shows`**: now reconciles the full setlist of every in-scope show, not just inserts. Inserts new tracks, deletes tracks prod removed, patches songId/segue/note/allTimer drift, and replaces per-track annotations. Cascade-deletes ghost shows (local but absent from prod) under `--prune-ghost-shows`. Adds `--help`.

## Test plan

- [ ] `make tc` is clean.
- [ ] `make test` passes the full suite (296 core + 846 web).
- [ ] On a show in your local DB, rate a song from the gap-chart view, hard reload, confirm the badge shows the community average + your golden personal score (not "Rate" with a golden outline).
- [ ] `/shows/year/2025` show count matches prod's count (no orphan-stub inflation).
- [ ] `make db-sync-missing-shows YEARS=2025 DRY_RUN=1` reports drift on a known-modified show without writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
