### PR TITLE
Rock opera tagging + per-show full-performance annotations

### DIFF
--- a/apps/web/app/components/setlist/rock-opera-annotations.test.tsx
+++ b/apps/web/app/components/setlist/rock-opera-annotations.test.tsx
@@ -1,0 +1,184 @@
+import type { RockOperaPerformanceAnnotation } from "@bip/domain";
+import { setupWithRouter } from "@test/test-utils";
+import { screen, within } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { RockOperaAnnotations } from "./rock-opera-annotations";
+
+function makeAnnotation(overrides: Partial<RockOperaPerformanceAnnotation> = {}): RockOperaPerformanceAnnotation {
+  return {
+    rockOpera: { slug: "hot-air-balloon", name: "The Hot Air Balloon", shortName: "HAB" },
+    performanceNumber: 3,
+    previousPerformance: { date: "1999-01-24", slug: "1999-01-24-natick", gap: 7 },
+    nextPerformance: { date: "1999-05-11", slug: "1999-05-11-fourth", gap: 12 },
+    ...overrides,
+  };
+}
+
+describe("RockOperaAnnotations", () => {
+  // Empty list short-circuits with no DOM — caller doesn't need a guard.
+  test("renders nothing when performances is empty", async () => {
+    const { container } = await setupWithRouter(<RockOperaAnnotations performances={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // The lead sentence with ordinal suffix + linked rock opera name. The
+  // star sits in its own non-shrinking flex column so wrapped text aligns
+  // under "This was…" (visual concern verified by inspection; functional
+  // assertion is just that the markup exists).
+  test("renders the 'Nth full performance of <name>' sentence linking to the resource page", async () => {
+    await setupWithRouter(<RockOperaAnnotations performances={[makeAnnotation({ performanceNumber: 3 })]} />);
+
+    expect(screen.getByText(/3rd full performance of/i)).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: "The Hot Air Balloon" });
+    expect(link).toHaveAttribute("href", "/resources/hot-air-balloon");
+  });
+
+  // Ordinal helper covers the 1st/2nd/3rd edge cases — spot-check each so
+  // a regression in the helper or its usage surfaces here.
+  test.each([
+    [1, "1st"],
+    [2, "2nd"],
+    [3, "3rd"],
+    [4, "4th"],
+    [11, "11th"],
+    [21, "21st"],
+  ])("renders ordinal '%s' for performance number %i", async (num, ordinal) => {
+    await setupWithRouter(<RockOperaAnnotations performances={[makeAnnotation({ performanceNumber: num })]} />);
+    expect(screen.getByText(new RegExp(`${ordinal} full performance of`, "i"))).toBeInTheDocument();
+  });
+
+  // Previous/Next rows render with M/D/YYYY dates, "X shows earlier/later"
+  // gap notes, and links to the prev/next show pages. The 3-column grid
+  // ordering (label, date, gap-note) is checked indirectly via the
+  // rendered text content.
+  test("renders previous and next adjacent rows with linked dates + gap notes", async () => {
+    await setupWithRouter(
+      <RockOperaAnnotations
+        performances={[
+          makeAnnotation({
+            previousPerformance: { date: "1999-01-24", slug: "1999-01-24-natick", gap: 7 },
+            nextPerformance: { date: "1999-05-11", slug: "1999-05-11-fourth", gap: 12 },
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Previous:")).toBeInTheDocument();
+    expect(screen.getByText("Next:")).toBeInTheDocument();
+    expect(screen.getByText("(7 shows earlier)")).toBeInTheDocument();
+    expect(screen.getByText("(12 shows later)")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /1\/24\/1999/ })).toHaveAttribute("href", "/shows/1999-01-24-natick");
+    expect(screen.getByRole("link", { name: /5\/11\/1999/ })).toHaveAttribute("href", "/shows/1999-05-11-fourth");
+  });
+
+  // Singular form: "1 show earlier" — guards against the off-by-one
+  // pluralization bug where "1 shows" leaks through.
+  test("uses singular 'show' (no s) when gap is exactly 1", async () => {
+    await setupWithRouter(
+      <RockOperaAnnotations
+        performances={[
+          makeAnnotation({
+            previousPerformance: { date: "1999-01-24", slug: "1999-01-24-natick", gap: 1 },
+            nextPerformance: { date: "1999-05-11", slug: "1999-05-11-fourth", gap: 1 },
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("(1 show earlier)")).toBeInTheDocument();
+    expect(screen.getByText("(1 show later)")).toBeInTheDocument();
+  });
+
+  // 1st-ever performance: no "Previous:" row at all. Same for the most
+  // recent performance and "Next:". Drives the empty-row branch in the
+  // adjacent-performance grid.
+  test("hides the Previous row when previousPerformance is null", async () => {
+    await setupWithRouter(
+      <RockOperaAnnotations
+        performances={[
+          makeAnnotation({
+            previousPerformance: null,
+            nextPerformance: { date: "1999-05-11", slug: "1999-05-11-fourth", gap: 12 },
+          }),
+        ]}
+      />,
+    );
+    expect(screen.queryByText("Previous:")).toBeNull();
+    expect(screen.getByText("Next:")).toBeInTheDocument();
+  });
+
+  test("hides the Next row when nextPerformance is null", async () => {
+    await setupWithRouter(
+      <RockOperaAnnotations
+        performances={[
+          makeAnnotation({
+            previousPerformance: { date: "1999-01-24", slug: "1999-01-24-natick", gap: 7 },
+            nextPerformance: null,
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("Previous:")).toBeInTheDocument();
+    expect(screen.queryByText("Next:")).toBeNull();
+  });
+
+  // Both nulls (a one-and-only performance, e.g. Revolution In Motion):
+  // the entire prev/next grid is suppressed. The lead sentence still
+  // renders.
+  test("omits the adjacent grid entirely when both prev and next are null", async () => {
+    await setupWithRouter(
+      <RockOperaAnnotations performances={[makeAnnotation({ previousPerformance: null, nextPerformance: null })]} />,
+    );
+    expect(screen.queryByText("Previous:")).toBeNull();
+    expect(screen.queryByText("Next:")).toBeNull();
+    expect(screen.getByText(/3rd full performance of/i)).toBeInTheDocument();
+  });
+
+  // Defensive: when an adjacent performance has no slug (Show.slug is
+  // nullable in Prisma), the date renders as plain text, not a broken
+  // link to `/shows/null`.
+  test("renders the date as plain text when an adjacent slug is null", async () => {
+    await setupWithRouter(
+      <RockOperaAnnotations
+        performances={[
+          makeAnnotation({
+            previousPerformance: { date: "1999-01-24", slug: null, gap: 7 },
+            nextPerformance: null,
+          }),
+        ]}
+      />,
+    );
+    expect(screen.queryByRole("link", { name: /1\/24\/1999/ })).toBeNull();
+    expect(screen.getByText("1/24/1999")).toBeInTheDocument();
+  });
+
+  // Multiple annotations on the same show (rare — a show tagged with two
+  // rock operas) → one block per opera. Verifies the .map() over the
+  // outer list and that each block carries its own data.
+  test("renders one block per annotation when a show is tagged with multiple operas", async () => {
+    const { container } = await setupWithRouter(
+      <RockOperaAnnotations
+        performances={[
+          makeAnnotation({
+            rockOpera: { slug: "hot-air-balloon", name: "The Hot Air Balloon", shortName: "HAB" },
+            performanceNumber: 1,
+            previousPerformance: null,
+          }),
+          makeAnnotation({
+            rockOpera: { slug: "chemical-warfare-brigade", name: "Chemical Warfare Brigade", shortName: "CWB" },
+            performanceNumber: 5,
+            nextPerformance: null,
+          }),
+        ]}
+      />,
+    );
+    const habLink = screen.getByRole("link", { name: "The Hot Air Balloon" });
+    const cwbLink = screen.getByRole("link", { name: "Chemical Warfare Brigade" });
+    expect(habLink).toHaveAttribute("href", "/resources/hot-air-balloon");
+    expect(cwbLink).toHaveAttribute("href", "/resources/chemical-warfare-brigade");
+    // Two outer rows under the wrapper — sanity check on the .map() length.
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.children).toHaveLength(2);
+    expect(within(wrapper as HTMLElement).getByText(/1st full performance of/i)).toBeInTheDocument();
+    expect(within(wrapper as HTMLElement).getByText(/5th full performance of/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/setlist/rock-opera-annotations.tsx
+++ b/apps/web/app/components/setlist/rock-opera-annotations.tsx
@@ -1,0 +1,101 @@
+import type { AdjacentRockOperaPerformance, RockOperaPerformanceAnnotation } from "@bip/domain";
+import { Link } from "react-router-dom";
+import { ShowDate } from "~/components/show-date";
+import { getOrdinalSuffix } from "~/lib/utils";
+
+interface RockOperaAnnotationsProps {
+  performances: RockOperaPerformanceAnnotation[];
+}
+
+/**
+ * Show-level rock opera callouts rendered inside SetlistCard, just above
+ * the show notes block. One row per tagged rock opera: a "Nth full
+ * performance of <Name>" sentence (hanging-indent star so wrapped text
+ * aligns under "This was…"), plus a 3-column inline-grid of adjacent
+ * Previous / Next performances with `M/D/YYYY` dates and "X shows earlier
+ * / later" gap notes. Renders nothing when `performances` is empty.
+ */
+export function RockOperaAnnotations({ performances }: RockOperaAnnotationsProps) {
+  if (performances.length === 0) return null;
+  return (
+    <div className="mb-4 space-y-3">
+      {performances.map((performance) => (
+        <RockOperaAnnotation key={performance.rockOpera.slug} performance={performance} />
+      ))}
+    </div>
+  );
+}
+
+function RockOperaAnnotation({ performance }: { performance: RockOperaPerformanceAnnotation }) {
+  return (
+    <div className="text-sm text-content-text-secondary italic py-1">
+      {/* flex layout puts the star in its own non-wrapping column so
+          wrapped text aligns under "This was…", not under the star. */}
+      <p className="flex gap-1.5">
+        <span aria-hidden className="shrink-0">
+          ★
+        </span>
+        <span>
+          This was the {performance.performanceNumber}
+          {getOrdinalSuffix(performance.performanceNumber)} full performance of{" "}
+          <Link
+            to={`/resources/${performance.rockOpera.slug}`}
+            className="text-brand-primary hover:text-brand-secondary not-italic whitespace-nowrap"
+          >
+            {performance.rockOpera.name}
+          </Link>
+          .
+        </span>
+      </p>
+      <AdjacentPerformances previous={performance.previousPerformance} next={performance.nextPerformance} />
+    </div>
+  );
+}
+
+function AdjacentPerformances({
+  previous,
+  next,
+}: {
+  previous: AdjacentRockOperaPerformance | null;
+  next: AdjacentRockOperaPerformance | null;
+}) {
+  if (!previous && !next) return null;
+  return (
+    // inline-grid so the block sizes to its widest row (label column
+    // right-aligned, date column right-aligned, gap-note column).
+    // Fragment-wrapped cells render as direct grid children.
+    <div className="mt-1 pl-4 inline-grid grid-cols-[auto_auto_auto] gap-x-2 text-xs not-italic">
+      {previous && <AdjacentRow label="Previous:" point={previous} suffix="earlier" />}
+      {next && <AdjacentRow label="Next:" point={next} suffix="later" />}
+    </div>
+  );
+}
+
+function AdjacentRow({
+  label,
+  point,
+  suffix,
+}: {
+  label: string;
+  point: AdjacentRockOperaPerformance;
+  suffix: "earlier" | "later";
+}) {
+  const dateCellClass = "text-right text-brand-primary hover:text-brand-secondary";
+  return (
+    <>
+      <span className="text-right text-content-text-tertiary">{label}</span>
+      {point.slug ? (
+        <Link to={`/shows/${point.slug}`} className={dateCellClass}>
+          <ShowDate date={point.date} />
+        </Link>
+      ) : (
+        <span className="text-right">
+          <ShowDate date={point.date} />
+        </span>
+      )}
+      <span className="text-content-text-tertiary">
+        ({point.gap} show{point.gap === 1 ? "" : "s"} {suffix})
+      </span>
+    </>
+  );
+}

--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -96,6 +96,7 @@ function makeSetlist(overrides: { showDate?: string } = {}): SetlistLight {
     averageSongGap: null,
     medianSongGap: null,
     debutCount: 0,
+    rockOperaPerformances: [],
   };
 }
 

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -10,6 +10,7 @@ import { useSession } from "~/hooks/use-session";
 import { useAttendanceMutation } from "~/hooks/use-show-user-data";
 import { cn } from "~/lib/utils";
 import { AnniversaryBadge } from "./anniversary-badge";
+import { RockOperaAnnotations } from "./rock-opera-annotations";
 import { SetlistTable } from "./setlist-table";
 import { SetlistTablePersonal } from "./setlist-table-personal";
 import { SetlistViewControl, type SetlistViewSummary } from "./setlist-view-control";
@@ -306,6 +307,7 @@ function SetlistCardComponent({
       >
         <div className={cn(collapsible && "overflow-hidden")}>
           <CardContent className="relative z-10 px-3 py-3 md:px-6 md:py-5">
+            <RockOperaAnnotations performances={setlist.rockOperaPerformances} />
             {setlist.show.notes && (
               <div
                 className="mb-4 text-sm text-content-text-secondary italic border-l border-glass-border pl-3 py-1"

--- a/apps/web/app/components/setlist/setlist-highlights.test.tsx
+++ b/apps/web/app/components/setlist/setlist-highlights.test.tsx
@@ -15,6 +15,7 @@ function makeSetlist(sets: Array<{ label: string; tracks: Partial<Track>[] }>): 
     averageSongGap: null,
     medianSongGap: null,
     debutCount: 0,
+    rockOperaPerformances: [],
     sets: sets.map((set, sortIdx) => ({
       label: set.label,
       sort: sortIdx,

--- a/apps/web/app/components/setlist/setlist-list.test.tsx
+++ b/apps/web/app/components/setlist/setlist-list.test.tsx
@@ -86,6 +86,7 @@ function makeSetlist(id: string, title: string, averageRating: number | null = 4
     averageSongGap: null,
     medianSongGap: null,
     debutCount: 0,
+    rockOperaPerformances: [],
   };
 }
 

--- a/apps/web/app/components/show/show-form.test.tsx
+++ b/apps/web/app/components/show/show-form.test.tsx
@@ -11,6 +11,7 @@ const baseValues: ShowFormValues = {
   notes: "",
   relistenUrl: "",
   countForStats: true,
+  rockOperaIds: [],
 };
 
 describe("ShowForm countForStats", () => {

--- a/apps/web/app/components/show/show-form.tsx
+++ b/apps/web/app/components/show/show-form.tsx
@@ -1,10 +1,11 @@
-import type { Band } from "@bip/domain";
+import type { Band, RockOpera } from "@bip/domain";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { ControllerRenderProps } from "react-hook-form";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { ShowYoutubeManager } from "~/components/show/show-youtube-manager";
 import { Button } from "~/components/ui/button";
+import { Checkbox } from "~/components/ui/checkbox";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "~/components/ui/form";
 import { GlassSelect } from "~/components/ui/glass-select";
 import { Input } from "~/components/ui/input";
@@ -21,6 +22,7 @@ const showFormSchema = z.object({
   notes: z.string(),
   relistenUrl: z.string(),
   countForStats: z.boolean(),
+  rockOperaIds: z.array(z.string().uuid()),
 });
 
 export type ShowFormValues = z.infer<typeof showFormSchema>;
@@ -32,9 +34,22 @@ interface ShowFormProps {
   cancelHref?: string;
   bands?: Band[];
   showId?: string;
+  /**
+   * Full list of rock operas to render as a checkbox group. Empty array
+   * hides the group entirely (e.g. on a fresh-install local DB with no
+   * rock operas seeded yet).
+   */
+  rockOperas?: RockOpera[];
 }
 
-export function ShowForm({ defaultValues, onSubmit, submitLabel = "Submit", cancelHref, showId }: ShowFormProps) {
+export function ShowForm({
+  defaultValues,
+  onSubmit,
+  submitLabel = "Submit",
+  cancelHref,
+  showId,
+  rockOperas = [],
+}: ShowFormProps) {
   const form = useForm<ShowFormValues>({
     resolver: zodResolver(showFormSchema),
     defaultValues: defaultValues || {
@@ -44,6 +59,7 @@ export function ShowForm({ defaultValues, onSubmit, submitLabel = "Submit", canc
       notes: "",
       relistenUrl: "",
       countForStats: true,
+      rockOperaIds: [],
     },
   });
 
@@ -105,6 +121,49 @@ export function ShowForm({ defaultValues, onSubmit, submitLabel = "Submit", canc
             </FormItem>
           )}
         />
+
+        {rockOperas.length > 0 && (
+          <FormField
+            control={form.control}
+            name="rockOperaIds"
+            render={({ field }: { field: ControllerRenderProps<ShowFormValues, "rockOperaIds"> }) => {
+              const value = field.value ?? [];
+              return (
+                <FormItem>
+                  <div className="text-sm font-medium text-content-text-secondary">Full rock opera performances</div>
+                  <p className="text-xs text-content-text-tertiary">
+                    Tag this show as a full performance of one or more rock operas.
+                  </p>
+                  <div className="flex flex-col gap-2 pt-1">
+                    {rockOperas.map((opera) => {
+                      const checked = value.includes(opera.id);
+                      const checkboxId = `rock-opera-${opera.id}`;
+                      return (
+                        <div key={opera.id} className="flex items-center gap-2">
+                          <Checkbox
+                            id={checkboxId}
+                            checked={checked}
+                            onCheckedChange={(next) => {
+                              if (next) {
+                                field.onChange([...value, opera.id]);
+                              } else {
+                                field.onChange(value.filter((id) => id !== opera.id));
+                              }
+                            }}
+                          />
+                          <label htmlFor={checkboxId} className="text-sm text-content-text-primary cursor-pointer">
+                            {opera.name}
+                          </label>
+                        </div>
+                      );
+                    })}
+                  </div>
+                  <FormMessage />
+                </FormItem>
+              );
+            }}
+          />
+        )}
 
         <FormField
           control={form.control}

--- a/apps/web/app/lib/favicon.ts
+++ b/apps/web/app/lib/favicon.ts
@@ -22,4 +22,9 @@ export const EXTERNAL_SOURCE_DOMAINS = {
   nugs: "nugs.net",
   youtube: "youtube.com",
   archive: "archive.org",
+  spotify: "spotify.com",
+  appleMusic: "music.apple.com",
+  // Odesli (song.link / album.link) — the "any other service" chooser
+  // we link to when we want listeners on Tidal / Deezer / Amazon / etc.
+  songLink: "song.link",
 } as const;

--- a/apps/web/app/lib/rock-operas.ts
+++ b/apps/web/app/lib/rock-operas.ts
@@ -1,0 +1,33 @@
+/**
+ * Canonical client-side identifiers for the three known rock operas.
+ *
+ * The DB's `rock_operas` table is the runtime source of truth (the
+ * RockOpera lookup is queried via `services.rockOperas.findAll()` and
+ * mirrored from prod via `sync-missing-shows`). These constants exist so
+ * static call sites that link to one of the three known operas — the
+ * resource pages themselves, the home page hero, the resources index,
+ * band-history prose — share a single string per opera instead of
+ * scattering `"hot-air-balloon"` literals throughout the codebase.
+ *
+ * If a fourth rock opera is added in the future, the DB will start
+ * returning it from `findAll()` automatically; this file only needs to
+ * grow when a STATIC reference (a Link `to=`, an image filename, etc.)
+ * needs to be wired up.
+ */
+
+export const ROCK_OPERA_SLUG = {
+  HOT_AIR_BALLOON: "hot-air-balloon",
+  CHEMICAL_WARFARE_BRIGADE: "chemical-warfare-brigade",
+  REVOLUTION_IN_MOTION: "revolution-in-motion",
+} as const;
+
+export type RockOperaSlug = (typeof ROCK_OPERA_SLUG)[keyof typeof ROCK_OPERA_SLUG];
+
+/**
+ * Build the resource page path for a known rock opera slug. Keeps the
+ * `/resources/` prefix in one place so a future route rename only
+ * touches this file.
+ */
+export function rockOperaPath(slug: RockOperaSlug): string {
+  return `/resources/${slug}`;
+}

--- a/apps/web/app/lib/utils.test.ts
+++ b/apps/web/app/lib/utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test, vi } from "vitest";
-import { addDaysYearAgnostic, formatMonthDay, getAnniversaryYears, getOrdinalSuffix, isValidMonthDay } from "./utils";
+import {
+  addDaysYearAgnostic,
+  formatMonthDay,
+  getAnniversaryYears,
+  getOrdinalSuffix,
+  isValidMonthDay,
+  slugifyAnchor,
+} from "./utils";
 
 describe("formatMonthDay", () => {
   // Converts zero-padded MM-DD to human-readable "Month Day" format
@@ -296,5 +303,46 @@ describe("getAnniversaryYears", () => {
     vi.setSystemTime(new Date("2026-04-14"));
     expect(getAnniversaryYears("2027-01-01")).toBeNull();
     vi.useRealTimers();
+  });
+});
+
+describe("slugifyAnchor", () => {
+  // Canonical case: a song / act / section title becomes a kebab-case
+  // anchor fragment that pairs with `<element id="...">` on the same page.
+  test("lowercases and joins words with single hyphens", () => {
+    expect(slugifyAnchor("Hot Air Balloon")).toBe("hot-air-balloon");
+  });
+
+  // Punctuation in titles (apostrophes, periods, slashes, parens) collapses
+  // to hyphens. Rock opera titles include "Spaga's Last Stand",
+  // "To Be Continued...", "Tourists (Rocket Ship)" — keep them anchor-safe.
+  test("collapses punctuation runs into single hyphens", () => {
+    expect(slugifyAnchor("Spaga's Last Stand")).toBe("spaga-s-last-stand");
+    expect(slugifyAnchor("To Be Continued...")).toBe("to-be-continued");
+    expect(slugifyAnchor("Tourists (Rocket Ship)")).toBe("tourists-rocket-ship");
+  });
+
+  // Leading and trailing hyphens get trimmed so the anchor doesn't have
+  // dead "-" characters (which break some smooth-scroll polyfills and look
+  // ugly in URL fragments).
+  test("trims leading and trailing hyphens", () => {
+    expect(slugifyAnchor("!Shocked!")).toBe("shocked");
+    expect(slugifyAnchor("...Quiet Storm...")).toBe("quiet-storm");
+  });
+
+  // Numbers are preserved — "Act 1", "Plan B", "JP8000" should all yield
+  // anchors that read like their source titles.
+  test("preserves digits", () => {
+    expect(slugifyAnchor("Act 1")).toBe("act-1");
+    expect(slugifyAnchor("Plan B")).toBe("plan-b");
+    expect(slugifyAnchor("JP8000")).toBe("jp8000");
+  });
+
+  // All-non-alphanumeric input would collapse to a single hyphen, then
+  // get trimmed to empty. Documented behavior so callers can decide
+  // whether to fall back; today nothing in the codebase relies on this.
+  test("returns empty string when input has no alphanumeric characters", () => {
+    expect(slugifyAnchor("!!!")).toBe("");
+    expect(slugifyAnchor("   ")).toBe("");
   });
 });

--- a/apps/web/app/lib/utils.ts
+++ b/apps/web/app/lib/utils.ts
@@ -25,6 +25,20 @@ export function getSafeRedirectUrl(url: string | null): string {
 export const ATTENDED_ROW_CLASS = "!border-l-2 !border-l-green-500 bg-green-500/5";
 
 /**
+ * Slugify a display name into an in-page anchor fragment: lowercase,
+ * non-alphanumeric runs become single hyphens, leading/trailing hyphens
+ * trimmed. Used by static pages (rock opera resources, anywhere we
+ * generate `id="..."` and matching `<a href="#...">` from prose-style
+ * names). Not a URL slug — for that, use core's `slugify`.
+ */
+export function slugifyAnchor(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/**
  * Canonical desktop short date for show-related dates across the app
  * (year listings, top-rated, songs/all-timers performance tables, song-detail
  * stat cards). Output is `M/D/YYYY` with no leading zeros.

--- a/apps/web/app/routes/_index.tsx
+++ b/apps/web/app/routes/_index.tsx
@@ -12,6 +12,7 @@ import { publicLoader } from "~/lib/base-loaders";
 import { logger } from "~/lib/logger";
 import { showUserDataQueryKey } from "~/lib/query-keys";
 import { createPrefetchClient } from "~/lib/query-prefetch";
+import { ROCK_OPERA_SLUG, rockOperaPath } from "~/lib/rock-operas";
 import { getHomeMeta } from "~/lib/seo";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
@@ -356,7 +357,7 @@ export default function Index() {
 
             {/* Revolution in Motion */}
             <div>
-              <Link to="/resources/revolution-in-motion" className="block group">
+              <Link to={rockOperaPath(ROCK_OPERA_SLUG.REVOLUTION_IN_MOTION)} className="block group">
                 <div className="card-premium rounded-lg overflow-hidden">
                   <div className="relative">
                     <img

--- a/apps/web/app/routes/mcp/index.tsx
+++ b/apps/web/app/routes/mcp/index.tsx
@@ -211,6 +211,15 @@ const tools = [
       required: ["slugs"],
     },
   },
+  {
+    name: "get_rock_operas",
+    description: "Get the list of rock operas (Hot Air Balloon, Chemical Warfare Brigade, etc.) and their slugs",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      required: [],
+    },
+  },
 ];
 
 async function handleToolCall(name: string, args: Record<string, unknown>): Promise<unknown> {
@@ -532,7 +541,10 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
         try {
           const show = await services.shows.findBySlug(slug);
           if (show) {
-            const venue = show.venueId ? await services.venues.findById(show.venueId) : null;
+            const [venue, rockOperaAnnotations] = await Promise.all([
+              show.venueId ? services.venues.findById(show.venueId) : Promise.resolve(null),
+              services.rockOperas.findPerformancesForShow(show.id),
+            ]);
             shows.push({
               slug: show.slug,
               date: show.date,
@@ -547,6 +559,9 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
               // (dayOrder). Sync mirrors them on insert + drift-update.
               countForStats: show.countForStats,
               dayOrder: show.dayOrder,
+              // Admin-curated full-rock-opera tagging. Sync mirrors via
+              // findManyRockOperaSlugsForShow in buildShowDriftUpdate.
+              rockOperaSlugs: rockOperaAnnotations.map((annotation) => annotation.rockOpera.slug),
             });
           } else {
             errors.push({ slug, error: "Not found" });
@@ -557,6 +572,17 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
       }
 
       return { shows, ...(errors.length > 0 && { errors }) };
+    }
+
+    case "get_rock_operas": {
+      const rockOperas = await services.rockOperas.findAll();
+      return {
+        rockOperas: rockOperas.map((opera) => ({
+          slug: opera.slug,
+          name: opera.name,
+          shortName: opera.shortName,
+        })),
+      };
     }
 
     case "get_songs": {

--- a/apps/web/app/routes/resources/_index.tsx
+++ b/apps/web/app/routes/resources/_index.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from "react";
 import ResourceCard from "~/components/resources/resource-card";
 import { publicLoader } from "~/lib/base-loaders";
+import { ROCK_OPERA_SLUG, rockOperaPath } from "~/lib/rock-operas";
 
 export const loader = publicLoader<void>(async () => {});
 
@@ -52,7 +53,7 @@ export default function Resources(): ReactElement {
               title="The Hot Air Balloon"
               content="The band's first full length rock opera, written by Jon Gutwillig and debuted at the band's 1998 New Year's Eve show at Silk City in Philadelphia."
               image="https://pub-6aa5e67069a14fc286677addbdd10c65.r2.dev/public/hot-air-balloon.jpg"
-              url="/resources/hot-air-balloon"
+              url={rockOperaPath(ROCK_OPERA_SLUG.HOT_AIR_BALLOON)}
             />
           </div>
           <div className="h-full">
@@ -60,7 +61,7 @@ export default function Resources(): ReactElement {
               title="The Chemical Warfare Brigade"
               content="The band's second full length rock opera, written by Marc Brownstein, and debuted Dec 30, 2000 at the Vanderbilt on Long Island."
               image="https://pub-6aa5e67069a14fc286677addbdd10c65.r2.dev/public/cwb.jpg"
-              url="/resources/chemical-warfare-brigade"
+              url={rockOperaPath(ROCK_OPERA_SLUG.CHEMICAL_WARFARE_BRIGADE)}
             />
           </div>
           <div className="h-full">
@@ -68,7 +69,7 @@ export default function Resources(): ReactElement {
               title="Revolution in Motion"
               content="The band's third rock opera, a sci-fi concept album created by Jon Gutwillig, Joey Friedman, and Aron Magner. Follow a blacksheep alien prince whose collision with humanity rewrites the fate of two worlds."
               image="https://pub-6aa5e67069a14fc286677addbdd10c65.r2.dev/public/revolution-in-motion.png"
-              url="/resources/revolution-in-motion"
+              url={rockOperaPath(ROCK_OPERA_SLUG.REVOLUTION_IN_MOTION)}
             />
           </div>
           <div className="h-full">

--- a/apps/web/app/routes/resources/band-history.tsx
+++ b/apps/web/app/routes/resources/band-history.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
 import { Card, CardContent, CardHeader } from "~/components/ui/card";
 import { publicLoader } from "~/lib/base-loaders";
+import { ROCK_OPERA_SLUG, rockOperaPath } from "~/lib/rock-operas";
 
 const Link = (props: React.ComponentProps<typeof RouterLink>) => (
   <RouterLink {...props} className={`text-brand hover:text-hover-accent ${props.className || ""}`} />
@@ -550,9 +551,9 @@ const BandHistory: React.FC = () => {
               June was a month that found the band reaching for the{" "}
               <span style={{ color: "black", backgroundColor: "hotpink", padding: 4 }}>stars</span> on a nightly basis.
               Starting things off with a full performance of{" "}
-              <Link to="/resources/chemical-warfare-brigade">Chemical Warfare Brigade</Link> in Providence, RI on{" "}
-              <Link to="/shows/2009-06-03-lupo-s-heartbreak-hotel-providence-ri">6/3</Link>, the band then traveled to
-              Buffalo for a free outdoors show in Lafayette Square.{" "}
+              <Link to={rockOperaPath(ROCK_OPERA_SLUG.CHEMICAL_WARFARE_BRIGADE)}>Chemical Warfare Brigade</Link> in
+              Providence, RI on <Link to="/shows/2009-06-03-lupo-s-heartbreak-hotel-providence-ri">6/3</Link>, the band
+              then traveled to Buffalo for a free outdoors show in Lafayette Square.{" "}
               <Link to="/shows/2009-06-05-house-of-blues-cleveland-oh">6/05</Link> in Cleveland, OH might be one of the
               most complete shows of this banner year start to finish, but it would be criminal to not at least mention
               the Vassillios &gt; HAB and the Basis from this storied evening.{" "}

--- a/apps/web/app/routes/resources/chemical-warfare-brigade.tsx
+++ b/apps/web/app/routes/resources/chemical-warfare-brigade.tsx
@@ -1,8 +1,15 @@
 import type React from "react";
 import { Link } from "react-router-dom";
+import { SetlistList } from "~/components/setlist/setlist-list";
+import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
+import { ROCK_OPERA_SLUG, rockOperaPath } from "~/lib/rock-operas";
+import { slugifyAnchor } from "~/lib/utils";
+import { getRockOperaPerformances, type RockOperaPerformancesLoaderData } from "./rock-opera-performances";
 
-export const loader = publicLoader<void>(async () => {});
+export const loader = publicLoader<RockOperaPerformancesLoaderData>(({ context }) =>
+  getRockOperaPerformances(ROCK_OPERA_SLUG.CHEMICAL_WARFARE_BRIGADE, context),
+);
 
 export function meta() {
   return [
@@ -549,6 +556,7 @@ function SongCard({ song, index }: { song: (typeof songs)[number]; index: number
 // ─── Page ────────────────────────────────────────────────────────────────────
 
 const ChemicalWarfareBrigade: React.FC = () => {
+  const { performances, externalSources } = useSerializedLoaderData<RockOperaPerformancesLoaderData>();
   return (
     <div className="space-y-10 md:space-y-14">
       {/* ── Hero Banner ── */}
@@ -591,8 +599,52 @@ const ChemicalWarfareBrigade: React.FC = () => {
         </p>
       </div>
 
+      {/* ── Table of Contents ── */}
+      <nav
+        aria-label="Page contents"
+        className="rounded-xl border border-purple-500/20 bg-gradient-to-br from-purple-950/30 to-purple-900/5 p-5 md:p-6"
+      >
+        <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-4">Contents</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3 text-base">
+          <a href="#characters" className="text-brand-primary hover:text-brand-secondary">
+            Characters
+          </a>
+          <a href="#full-performances" className="text-brand-primary hover:text-brand-secondary">
+            Full Performances
+          </a>
+          <div>
+            <a href="#the-story" className="text-brand-primary hover:text-brand-secondary font-medium">
+              The Story
+            </a>
+            <ul className="mt-1.5 ml-3 space-y-1 text-sm text-content-text-secondary">
+              {acts.map((act) => (
+                <li key={act.name}>
+                  <a href={`#cwb-${slugifyAnchor(act.name)}`} className="hover:text-brand-secondary">
+                    {act.name}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <a href="#songs" className="text-brand-primary hover:text-brand-secondary font-medium">
+              Songs
+            </a>
+            <ul className="mt-1.5 ml-3 space-y-1 text-sm text-content-text-secondary">
+              {songs.map((song) => (
+                <li key={song.name}>
+                  <a href={`#cwb-${slugifyAnchor(song.name)}`} className="hover:text-brand-secondary">
+                    {song.name}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </nav>
+
       {/* ── Characters ── */}
-      <section>
+      <section id="characters" className="scroll-mt-20">
         <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-5">Characters</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {characters.map((char) => (
@@ -602,22 +654,40 @@ const ChemicalWarfareBrigade: React.FC = () => {
       </section>
 
       {/* ── The Story ── */}
-      <section>
+      <section id="the-story" className="scroll-mt-20">
         <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-5">The Story</h2>
         <div className="space-y-4">
           {acts.map((act, i) => (
-            <ActCard key={act.name} act={act} index={i} />
+            <div key={act.name} id={`cwb-${slugifyAnchor(act.name)}`} className="scroll-mt-20">
+              <ActCard act={act} index={i} />
+            </div>
           ))}
         </div>
       </section>
 
       {/* ── Songs ── */}
-      <section>
+      <section id="songs" className="scroll-mt-20">
         <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-5">Songs</h2>
         <div className="space-y-4">
           {songs.map((song, i) => (
-            <SongCard key={song.name} song={song} index={i} />
+            <div key={song.name} id={`cwb-${slugifyAnchor(song.name)}`} className="scroll-mt-20">
+              <SongCard song={song} index={i} />
+            </div>
           ))}
+        </div>
+      </section>
+
+      {/* ── Full Performances ── */}
+      <section id="full-performances" className="scroll-mt-20">
+        <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-5">Full Performances</h2>
+        <div className="space-y-1">
+          <SetlistList
+            setlists={performances}
+            externalSources={externalSources}
+            numbered
+            collapsible
+            empty={<p className="text-sm text-content-text-tertiary">No full performances tagged yet.</p>}
+          />
         </div>
       </section>
 
@@ -625,7 +695,10 @@ const ChemicalWarfareBrigade: React.FC = () => {
       <section className="rounded-xl border border-purple-500/20 bg-gradient-to-br from-purple-950/40 to-purple-900/10 p-5 md:p-8">
         <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-4">Related</h2>
         <div className="space-y-2">
-          <Link to="/resources/hot-air-balloon" className="text-brand-primary hover:text-brand-secondary block">
+          <Link
+            to={rockOperaPath(ROCK_OPERA_SLUG.HOT_AIR_BALLOON)}
+            className="text-brand-primary hover:text-brand-secondary block"
+          >
             The Hot Air Balloon
           </Link>
           <a

--- a/apps/web/app/routes/resources/hot-air-balloon.tsx
+++ b/apps/web/app/routes/resources/hot-air-balloon.tsx
@@ -1,8 +1,15 @@
 import type React from "react";
 import { Link } from "react-router-dom";
+import { SetlistList } from "~/components/setlist/setlist-list";
+import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
+import { ROCK_OPERA_SLUG } from "~/lib/rock-operas";
+import { slugifyAnchor } from "~/lib/utils";
+import { getRockOperaPerformances, type RockOperaPerformancesLoaderData } from "./rock-opera-performances";
 
-export const loader = publicLoader<void>(async () => {});
+export const loader = publicLoader<RockOperaPerformancesLoaderData>(({ context }) =>
+  getRockOperaPerformances(ROCK_OPERA_SLUG.HOT_AIR_BALLOON, context),
+);
 
 export function meta() {
   return [
@@ -472,6 +479,7 @@ function StoryCard({ song, index, actLabel }: { song: SongSection; index: number
 // ─── Page ────────────────────────────────────────────────────────────────────
 
 const HotAirBalloon: React.FC = () => {
+  const { performances, externalSources } = useSerializedLoaderData<RockOperaPerformancesLoaderData>();
   return (
     <div className="space-y-10 md:space-y-14">
       {/* ── Hero Banner ── */}
@@ -513,8 +521,52 @@ const HotAirBalloon: React.FC = () => {
         </p>
       </div>
 
+      {/* ── Table of Contents ── */}
+      <nav
+        aria-label="Page contents"
+        className="rounded-xl border border-purple-500/20 bg-gradient-to-br from-purple-950/30 to-purple-900/5 p-5 md:p-6"
+      >
+        <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-4">Contents</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3 text-base">
+          <a href="#characters" className="text-brand-primary hover:text-brand-secondary">
+            Characters
+          </a>
+          <a href="#full-performances" className="text-brand-primary hover:text-brand-secondary">
+            Full Performances
+          </a>
+          <div>
+            <a href="#act-1" className="text-brand-primary hover:text-brand-secondary font-medium">
+              Act I
+            </a>
+            <ul className="mt-1.5 ml-3 space-y-1 text-sm text-content-text-secondary">
+              {act1.map((song) => (
+                <li key={song.name}>
+                  <a href={`#hab-${slugifyAnchor(song.name)}`} className="hover:text-brand-secondary">
+                    {song.name}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <a href="#act-2" className="text-brand-primary hover:text-brand-secondary font-medium">
+              Act II
+            </a>
+            <ul className="mt-1.5 ml-3 space-y-1 text-sm text-content-text-secondary">
+              {act2.map((song) => (
+                <li key={song.name}>
+                  <a href={`#hab-${slugifyAnchor(song.name)}`} className="hover:text-brand-secondary">
+                    {song.name}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </nav>
+
       {/* ── Characters ── */}
-      <section>
+      <section id="characters" className="scroll-mt-20">
         <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-5">Characters</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {characters.map((char) => (
@@ -524,22 +576,40 @@ const HotAirBalloon: React.FC = () => {
       </section>
 
       {/* ── Act I ── */}
-      <section>
+      <section id="act-1" className="scroll-mt-20">
         <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-5">Act I</h2>
         <div className="space-y-4">
           {act1.map((song, i) => (
-            <StoryCard key={song.name} song={song} index={i} actLabel="Act I" />
+            <div key={song.name} id={`hab-${slugifyAnchor(song.name)}`} className="scroll-mt-20">
+              <StoryCard song={song} index={i} actLabel="Act I" />
+            </div>
           ))}
         </div>
       </section>
 
       {/* ── Act II ── */}
-      <section>
+      <section id="act-2" className="scroll-mt-20">
         <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-5">Act II</h2>
         <div className="space-y-4">
           {act2.map((song, i) => (
-            <StoryCard key={song.name} song={song} index={i} actLabel="Act II" />
+            <div key={song.name} id={`hab-${slugifyAnchor(song.name)}`} className="scroll-mt-20">
+              <StoryCard song={song} index={i} actLabel="Act II" />
+            </div>
           ))}
+        </div>
+      </section>
+
+      {/* ── Full Performances ── */}
+      <section id="full-performances" className="scroll-mt-20">
+        <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-5">Full Performances</h2>
+        <div className="space-y-1">
+          <SetlistList
+            setlists={performances}
+            externalSources={externalSources}
+            numbered
+            collapsible
+            empty={<p className="text-sm text-content-text-tertiary">No full performances tagged yet.</p>}
+          />
         </div>
       </section>
     </div>

--- a/apps/web/app/routes/resources/revolution-in-motion.tsx
+++ b/apps/web/app/routes/resources/revolution-in-motion.tsx
@@ -1,9 +1,18 @@
+import { Podcast } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
 import { Link } from "react-router-dom";
+import { SetlistList } from "~/components/setlist/setlist-list";
+import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
+import { EXTERNAL_SOURCE_DOMAINS, faviconSrc } from "~/lib/favicon";
+import { ROCK_OPERA_SLUG } from "~/lib/rock-operas";
+import { slugifyAnchor } from "~/lib/utils";
+import { getRockOperaPerformances, type RockOperaPerformancesLoaderData } from "./rock-opera-performances";
 
-export const loader = publicLoader<void>(async () => {});
+export const loader = publicLoader<RockOperaPerformancesLoaderData>(({ context }) =>
+  getRockOperaPerformances(ROCK_OPERA_SLUG.REVOLUTION_IN_MOTION, context),
+);
 
 export function meta() {
   return [
@@ -261,73 +270,71 @@ const places = [
   { name: "The Wormhole", description: "Cosmic anomaly that transports the JP-8000 between Polyfuzia and Earth." },
 ];
 
-const listenLinks = [
-  // Albums
+/**
+ * Service URLs are kept as direct deep-links (no song.link wrapper)
+ * because Odesli's ISRC-fingerprint match can't pair these albums'
+ * Spotify and Apple Music releases — going through the chooser would
+ * silently drop whichever side it can't resolve. Direct links always
+ * land somewhere.
+ */
+const albumLinks: Array<{
+  label: string;
+  spotify?: string;
+  appleMusic?: string;
+  youtube?: string;
+  songLink?: string;
+}> = [
   {
     label: "Studio Album",
-    platform: "Spotify",
-    url: "https://open.spotify.com/album/0uPgoCXqTnQHJG3DZIJsHw?si=tOGABWMRRwWha_b5FXjwgQ",
-  },
-  {
-    label: "Studio Album",
-    platform: "YouTube",
-    url: "https://youtu.be/u7zLw5bxFBo?list=PLGwX3lC4qIF1wHftTP21qVuujFo3gTbJv",
+    spotify: "https://open.spotify.com/album/0uPgoCXqTnQHJG3DZIJsHw?si=tOGABWMRRwWha_b5FXjwgQ",
+    appleMusic: "https://music.apple.com/us/album/revolution-in-motion/1728324671",
+    youtube: "https://youtu.be/u7zLw5bxFBo?list=PLGwX3lC4qIF1wHftTP21qVuujFo3gTbJv",
+    songLink: "https://album.link/i/1728324671",
   },
   {
     label: "Live at Webster Hall",
-    platform: "Spotify",
-    url: "https://open.spotify.com/album/0rGWjTzqLiOrLK4vbeemap?si=S6msCxqXR0auGtY7vHJOkA",
+    spotify: "https://open.spotify.com/album/0rGWjTzqLiOrLK4vbeemap?si=S6msCxqXR0auGtY7vHJOkA",
+    appleMusic:
+      "https://music.apple.com/us/album/revolution-in-motion-live-3-29-2024-webster-hall-new-york-ny/1805195096",
+    songLink: "https://album.link/i/1805195096",
   },
   {
     label: "Instrumental",
-    platform: "Spotify",
-    url: "https://open.spotify.com/album/5BfTU8jKekyoZ9Pzo05TrR?si=54IWEib1Sy-c56TMk1mTcA",
-  },
-  // Video
-  { label: "Comic Film", platform: "YouTube", url: "https://youtu.be/vD-VmObIg5M" },
-  // Podcast
-  {
-    label: "TDAD Ep. 1",
-    platform: "Spotify",
-    url: "https://open.spotify.com/episode/6s4tAeUX33pSaDumUmkOQM?si=db8bdf1c97b7468b",
+    spotify: "https://open.spotify.com/album/5BfTU8jKekyoZ9Pzo05TrR?si=54IWEib1Sy-c56TMk1mTcA",
+    appleMusic: "https://music.apple.com/us/album/revolution-in-motion-the-instrumentals-instrumental/1811777941",
+    songLink: "https://album.link/i/1811777941",
   },
   {
-    label: "TDAD Ep. 2",
-    platform: "Spotify",
-    url: "https://open.spotify.com/episode/54Zjuh6fwPsiO8gTLZsYNC?si=e734ccc483a54f04",
+    label: "Comic Film",
+    youtube: "https://youtu.be/vD-VmObIg5M",
   },
-  {
-    label: "TDAD Ep. 3",
-    platform: "Spotify",
-    url: "https://open.spotify.com/episode/10MMvZkLjms2Neeio5saxk?si=0f83eda6565d4f58",
-  },
-  {
-    label: "TDAD Ep. 4",
-    platform: "Spotify",
-    url: "https://open.spotify.com/episode/40MdETGDzLMX953uretRsT?si=_R8KGhETRjuIfcvmPaS1RA",
-  },
-  {
-    label: "TDAD Ep. 5",
-    platform: "Spotify",
-    url: "https://open.spotify.com/episode/3roMHKm8JXNbxM6QVmsCd5?si=5514142a431743a6",
-  },
+];
+
+// Podcast — pod.link routes the listener to whichever podcast app they
+// prefer (Apple Podcasts, Spotify, Overcast, etc.), so a single icon
+// link per episode is enough.
+const podcastEpisodes: Array<{ label: string; url: string }> = [
+  { label: "TDAD Ep. 1", url: "https://pod.link/1460530534/episode/NjVhZDYwNzQyZTY0MTQwMDE2ZjExYzcy" },
+  { label: "TDAD Ep. 2", url: "https://pod.link/1460530534/episode/NjVkMmJmMDgyMTNjMzAwMDE4NmE0Mzhi" },
+  { label: "TDAD Ep. 3", url: "https://pod.link/1460530534/episode/NjVmNzg0ZWY0N2RhZGYwMDE3ZGQ1ZTFm" },
+  { label: "TDAD Ep. 4", url: "https://pod.link/1460530534/episode/NjYwOWZjZmQ4NGQzOGEwMDE2YWY2NDY5" },
+  { label: "TDAD Ep. 5", url: "https://pod.link/1460530534/episode/NjYxNGMyZmU3MTA1ZWMwMDE2NjQ0MGQx" },
 ];
 
 // ─── Icons ───────────────────────────────────────────────────────────────────
 
-function SpotifyIcon({ className }: { className?: string }) {
+function ServiceIconLink({ domain, href, label }: { domain: string; href: string; label: string }) {
   return (
-    <svg viewBox="0 0 24 24" fill="currentColor" className={className} role="img" aria-label="Spotify">
-      <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
-    </svg>
-  );
-}
-
-function YouTubeIcon({ className }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 24 24" fill="currentColor" className={className} role="img" aria-label="YouTube">
-      <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
-    </svg>
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={label}
+      title={label}
+      className="shrink-0 rounded p-1 hover:bg-purple-500/20 transition-colors"
+    >
+      <img src={faviconSrc(domain)} alt="" className="h-4 w-4" />
+    </a>
   );
 }
 
@@ -457,6 +464,7 @@ function GlossaryPill({ item }: { item: (typeof glossary)[number] }) {
 // ─── Page ────────────────────────────────────────────────────────────────────
 
 const RevolutionInMotion: React.FC = () => {
+  const { performances, externalSources } = useSerializedLoaderData<RockOperaPerformancesLoaderData>();
   return (
     <div className="space-y-10 md:space-y-14">
       {/* ── Hero Banner ── */}
@@ -496,50 +504,120 @@ const RevolutionInMotion: React.FC = () => {
         <div className="lg:col-span-2">
           <div className="rounded-xl border border-purple-500/20 bg-gradient-to-br from-purple-950/40 to-purple-900/10 p-5">
             <h3 className="text-base font-semibold tracking-[3px] text-purple-400/70 uppercase mb-4">Listen & Watch</h3>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-[3fr_2fr] gap-4">
               <div className="space-y-2">
-                {listenLinks
-                  .filter((l) => !l.label.startsWith("TDAD"))
-                  .map((link) => (
-                    <a
-                      key={link.url}
-                      href={link.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-2.5 rounded-lg border border-purple-500/10 bg-purple-950/30 px-3 py-2.5 text-sm text-purple-200 hover:border-purple-500/30 hover:bg-purple-900/20 transition-colors"
-                    >
-                      {link.platform === "YouTube" ? (
-                        <YouTubeIcon className="w-4 h-4 text-red-400 shrink-0" />
-                      ) : (
-                        <SpotifyIcon className="w-4 h-4 text-green-400 shrink-0" />
+                {albumLinks.map((album) => (
+                  <div
+                    key={album.label}
+                    className="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-lg border border-purple-500/10 bg-purple-950/30 px-3 py-2.5 text-sm text-purple-200"
+                  >
+                    <span className="truncate">{album.label}</span>
+                    {/* ml-auto so the icon group stays right-aligned
+                        whether it sits on the same line as the label
+                        or wraps to its own line. */}
+                    <div className="ml-auto flex items-center gap-0.5 shrink-0">
+                      {album.spotify && (
+                        <ServiceIconLink
+                          domain={EXTERNAL_SOURCE_DOMAINS.spotify}
+                          href={album.spotify}
+                          label={`${album.label} on Spotify`}
+                        />
                       )}
-                      <span className="truncate">{link.label}</span>
-                    </a>
-                  ))}
+                      {album.appleMusic && (
+                        <ServiceIconLink
+                          domain={EXTERNAL_SOURCE_DOMAINS.appleMusic}
+                          href={album.appleMusic}
+                          label={`${album.label} on Apple Music`}
+                        />
+                      )}
+                      {album.youtube && (
+                        <ServiceIconLink
+                          domain={EXTERNAL_SOURCE_DOMAINS.youtube}
+                          href={album.youtube}
+                          label={`${album.label} on YouTube`}
+                        />
+                      )}
+                      {album.songLink && (
+                        <ServiceIconLink
+                          domain={EXTERNAL_SOURCE_DOMAINS.songLink}
+                          href={album.songLink}
+                          label={`${album.label} on other services`}
+                        />
+                      )}
+                    </div>
+                  </div>
+                ))}
               </div>
-              <div className="space-y-2">
-                {listenLinks
-                  .filter((l) => l.label.startsWith("TDAD"))
-                  .map((link) => (
-                    <a
-                      key={link.url}
-                      href={link.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-2.5 rounded-lg border border-purple-500/10 bg-purple-950/30 px-3 py-2.5 text-sm text-purple-200 hover:border-purple-500/30 hover:bg-purple-900/20 transition-colors"
-                    >
-                      <SpotifyIcon className="w-4 h-4 text-green-400 shrink-0" />
-                      <span className="truncate">{link.label}</span>
-                    </a>
-                  ))}
+              {/* 2 columns on mobile (panel is full-width below the
+                  albums so two short "TDAD Ep. N" labels fit comfortably
+                  per row), single column at sm+ where the panel is the
+                  narrow right side and there's no room to pair them. */}
+              <div className="grid grid-cols-2 sm:grid-cols-1 gap-2">
+                {podcastEpisodes.map((episode) => (
+                  <a
+                    key={episode.url}
+                    href={episode.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2.5 rounded-lg border border-purple-500/10 bg-purple-950/30 px-3 py-2.5 text-sm text-purple-200 hover:border-purple-500/30 hover:bg-purple-900/20 transition-colors"
+                  >
+                    <Podcast className="w-4 h-4 text-purple-300 shrink-0" aria-label="Podcast" />
+                    <span className="truncate">{episode.label}</span>
+                  </a>
+                ))}
               </div>
             </div>
           </div>
         </div>
       </div>
 
+      {/* ── Table of Contents ── */}
+      <nav
+        aria-label="Page contents"
+        className="rounded-xl border border-purple-500/20 bg-gradient-to-br from-purple-950/30 to-purple-900/5 p-5 md:p-6"
+      >
+        <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-4">Contents</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3 text-base">
+          <a href="#characters" className="text-brand-primary hover:text-brand-secondary">
+            Characters
+          </a>
+          <a href="#tracklist" className="text-brand-primary hover:text-brand-secondary">
+            Track Listing
+          </a>
+          <a href="#places" className="text-brand-primary hover:text-brand-secondary">
+            Places
+          </a>
+          <a href="#glossary" className="text-brand-primary hover:text-brand-secondary">
+            Glossary
+          </a>
+          <a href="#background" className="text-brand-primary hover:text-brand-secondary">
+            Background & Development
+          </a>
+          <a href="#releases" className="text-brand-primary hover:text-brand-secondary">
+            Releases
+          </a>
+          <a href="#full-performances" className="text-brand-primary hover:text-brand-secondary">
+            Full Performances
+          </a>
+          <div>
+            <a href="#the-story" className="text-brand-primary hover:text-brand-secondary font-medium">
+              The Story
+            </a>
+            <ul className="mt-1.5 ml-3 space-y-1 text-sm text-content-text-secondary">
+              {storyParts.map((part) => (
+                <li key={part.title}>
+                  <a href={`#rim-${slugifyAnchor(part.title)}`} className="hover:text-brand-secondary">
+                    {part.title}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </nav>
+
       {/* ── Characters ── */}
-      <section>
+      <section id="characters" className="scroll-mt-20">
         <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-5">Characters</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {characters.map((char) => (
@@ -549,11 +627,13 @@ const RevolutionInMotion: React.FC = () => {
       </section>
 
       {/* ── The Story ── */}
-      <section>
+      <section id="the-story" className="scroll-mt-20">
         <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-5">The Story</h2>
         <div className="space-y-4">
           {storyParts.map((part, i) => (
-            <StoryCard key={part.title} part={part} index={i} />
+            <div key={part.title} id={`rim-${slugifyAnchor(part.title)}`} className="scroll-mt-20">
+              <StoryCard part={part} index={i} />
+            </div>
           ))}
         </div>
       </section>
@@ -561,7 +641,10 @@ const RevolutionInMotion: React.FC = () => {
       {/* ── Reference Grid ── */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {/* Tracklist */}
-        <div className="rounded-xl border border-purple-500/20 bg-gradient-to-br from-purple-950/40 to-purple-900/10 p-5">
+        <div
+          id="tracklist"
+          className="scroll-mt-20 rounded-xl border border-purple-500/20 bg-gradient-to-br from-purple-950/40 to-purple-900/10 p-5"
+        >
           <h3 className="text-base font-semibold tracking-[3px] text-purple-400/70 uppercase mb-4">Track Listing</h3>
           <ol className="space-y-1.5">
             {tracklist.map((track, i) => (
@@ -576,7 +659,10 @@ const RevolutionInMotion: React.FC = () => {
         </div>
 
         {/* Places */}
-        <div className="rounded-xl border border-purple-500/20 bg-gradient-to-br from-purple-950/40 to-purple-900/10 p-5">
+        <div
+          id="places"
+          className="scroll-mt-20 rounded-xl border border-purple-500/20 bg-gradient-to-br from-purple-950/40 to-purple-900/10 p-5"
+        >
           <h3 className="text-base font-semibold tracking-[3px] text-purple-400/70 uppercase mb-4">Places</h3>
           <div className="space-y-4">
             {places.map((place) => (
@@ -590,7 +676,7 @@ const RevolutionInMotion: React.FC = () => {
       </div>
 
       {/* ── Glossary ── */}
-      <section>
+      <section id="glossary" className="scroll-mt-20">
         <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-4">Glossary</h2>
         <p className="text-sm text-content-text-tertiary mb-4">Tap a term to see its definition</p>
         <div className="flex flex-wrap gap-2">
@@ -601,7 +687,10 @@ const RevolutionInMotion: React.FC = () => {
       </section>
 
       {/* ── Background & Development ── */}
-      <section className="rounded-xl border border-purple-500/20 bg-gradient-to-br from-purple-950/40 to-purple-900/10 p-5 md:p-8">
+      <section
+        id="background"
+        className="scroll-mt-20 rounded-xl border border-purple-500/20 bg-gradient-to-br from-purple-950/40 to-purple-900/10 p-5 md:p-8"
+      >
         <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-6">
           Background & Development
         </h2>
@@ -678,7 +767,7 @@ const RevolutionInMotion: React.FC = () => {
       </section>
 
       {/* ── Releases ── */}
-      <section>
+      <section id="releases" className="scroll-mt-20">
         <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-5">
           Releases & Performances
         </h2>
@@ -718,6 +807,20 @@ const RevolutionInMotion: React.FC = () => {
               <p className="text-sm text-content-text-secondary leading-relaxed">{release.detail}</p>
             </div>
           ))}
+        </div>
+      </section>
+
+      {/* ── Full Performances ── */}
+      <section id="full-performances" className="scroll-mt-20">
+        <h2 className="text-base font-semibold tracking-[4px] text-purple-400/60 uppercase mb-5">Full Performances</h2>
+        <div className="space-y-1">
+          <SetlistList
+            setlists={performances}
+            externalSources={externalSources}
+            numbered
+            collapsible
+            empty={<p className="text-sm text-content-text-tertiary">No full performances tagged yet.</p>}
+          />
         </div>
       </section>
     </div>

--- a/apps/web/app/routes/resources/rock-opera-performances.test.ts
+++ b/apps/web/app/routes/resources/rock-opera-performances.test.ts
@@ -1,0 +1,234 @@
+import type { Setlist } from "@bip/domain";
+import { type DehydratedState, QueryClient } from "@tanstack/react-query";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const cacheGetOrSet = vi.fn();
+const findPerformanceShowIds = vi.fn();
+const findPerformancesForShow = vi.fn();
+const findManyByShowIds = vi.fn();
+const computeShowExternalSourcesFn = vi.fn();
+const computeShowUserDataFn = vi.fn();
+const prefetchQuery = vi.fn();
+
+vi.mock("~/server/services", () => ({
+  services: {
+    cache: { getOrSet: cacheGetOrSet },
+    rockOperas: {
+      findPerformanceShowIds: (...args: unknown[]) => findPerformanceShowIds(...args),
+      findPerformancesForShow: (...args: unknown[]) => findPerformancesForShow(...args),
+    },
+    setlists: { findManyByShowIds: (...args: unknown[]) => findManyByShowIds(...args) },
+  },
+}));
+
+vi.mock("~/server/show-external-sources", () => ({
+  computeShowExternalSources: (...args: unknown[]) => computeShowExternalSourcesFn(...args),
+}));
+
+vi.mock("~/server/show-user-data", () => ({
+  computeShowUserData: (...args: unknown[]) => computeShowUserDataFn(...args),
+}));
+
+// Use a real QueryClient so dehydrate() can call getDefaultOptions(),
+// but spy on `prefetchQuery` so tests can assert what the loader queued
+// for hydration.
+vi.mock("~/lib/query-prefetch", () => ({
+  createPrefetchClient: () => {
+    const client = new QueryClient();
+    client.prefetchQuery = prefetchQuery as never;
+    return client;
+  },
+}));
+
+const { getRockOperaPerformances } = await import("./rock-opera-performances");
+
+function makeSetlist(showId: string, date: string): Setlist {
+  return {
+    show: { id: showId, slug: `${date}-show`, date } as Setlist["show"],
+    venue: { id: "v-1", slug: "v", name: "Venue", city: "City", state: "ST", country: "US" } as Setlist["venue"],
+    sets: [],
+    annotations: [],
+    averageSongGap: null,
+    medianSongGap: null,
+    debutCount: 0,
+    rockOperaPerformances: [], // composer default; loader overlays real data
+  };
+}
+
+const context = { currentUser: null } as never;
+
+describe("getRockOperaPerformances", () => {
+  beforeEach(() => {
+    cacheGetOrSet.mockReset();
+    findPerformanceShowIds.mockReset();
+    findPerformancesForShow.mockReset();
+    findManyByShowIds.mockReset();
+    computeShowExternalSourcesFn.mockReset();
+    computeShowUserDataFn.mockReset();
+    prefetchQuery.mockReset();
+    // Default: cache misses every time and runs the loader closure inline.
+    cacheGetOrSet.mockImplementation(async (_key: string, loader: () => Promise<unknown>) => loader());
+  });
+
+  // When the opera has zero tagged shows we return an empty payload AND
+  // skip the prefetch (showUserDataQueryKey([]) would be a wasted call
+  // and the badges have nothing to seed). Drives the "newly added rock
+  // opera with no full performances tagged yet" empty state.
+  test("returns empty payload + skips prefetch when no shows are tagged", async () => {
+    findPerformanceShowIds.mockResolvedValue([]);
+
+    const result = await getRockOperaPerformances("hot-air-balloon", context);
+
+    expect(result.performances).toEqual([]);
+    expect(result.externalSources).toEqual({});
+    expect(findManyByShowIds).not.toHaveBeenCalled();
+    expect(prefetchQuery).not.toHaveBeenCalled();
+  });
+
+  // The cache key is the canonical `rockOperas.performances(slug)` so
+  // `CacheInvalidationService.invalidateRockOperaAssignment` clears the
+  // right entry on every admin tag change. Guards against a typo / drift
+  // away from the centralized key.
+  test("uses the canonical rockOperas.performances cache key", async () => {
+    findPerformanceShowIds.mockResolvedValue([]);
+
+    await getRockOperaPerformances("hot-air-balloon", context);
+
+    const usedKey = cacheGetOrSet.mock.calls[0][0] as string;
+    expect(usedKey).toMatch(/^rock-operas:performances:hot-air-balloon/);
+  });
+
+  // Setlists must be loaded by show id in chronological-asc order so the
+  // SetlistList `numbered` gutter renders 1..N naturally (oldest = #1).
+  // Drives the resource page's display contract.
+  test("requests setlists ordered by date asc", async () => {
+    findPerformanceShowIds.mockResolvedValue(["show-1", "show-2"]);
+    findManyByShowIds.mockResolvedValue([makeSetlist("show-1", "1998-12-31"), makeSetlist("show-2", "1999-01-24")]);
+    findPerformancesForShow.mockResolvedValue([]);
+    computeShowExternalSourcesFn.mockResolvedValue({});
+
+    await getRockOperaPerformances("hot-air-balloon", context);
+
+    expect(findManyByShowIds).toHaveBeenCalledWith(["show-1", "show-2"], {
+      sort: [{ field: "date", direction: "asc" }],
+    });
+  });
+
+  // SetlistService now overlays rockOperaPerformances on every returned
+  // setlist (in findManyByShowIds), so the loader just passes its result
+  // through untouched. The loader itself no longer makes annotation
+  // lookups — verified by mocking findManyByShowIds with already-overlay'd
+  // setlists and asserting they pass through verbatim.
+  test("passes through rockOperaPerformances populated by SetlistService", async () => {
+    findPerformanceShowIds.mockResolvedValue(["show-1", "show-2"]);
+    const setlistsWithAnnotations = [
+      {
+        ...makeSetlist("show-1", "1998-12-31"),
+        rockOperaPerformances: [
+          {
+            rockOpera: { slug: "hot-air-balloon", name: "The Hot Air Balloon", shortName: "HAB" },
+            performanceNumber: 1,
+            previousPerformance: null,
+            nextPerformance: { date: "1999-01-24", slug: "1999-01-24-show", gap: 7 },
+          },
+        ],
+      },
+      {
+        ...makeSetlist("show-2", "1999-01-24"),
+        rockOperaPerformances: [
+          {
+            rockOpera: { slug: "hot-air-balloon", name: "The Hot Air Balloon", shortName: "HAB" },
+            performanceNumber: 2,
+            previousPerformance: { date: "1998-12-31", slug: "1998-12-31-show", gap: 7 },
+            nextPerformance: null,
+          },
+        ],
+      },
+    ];
+    findManyByShowIds.mockResolvedValue(setlistsWithAnnotations);
+    computeShowExternalSourcesFn.mockResolvedValue({});
+
+    const result = await getRockOperaPerformances("hot-air-balloon", context);
+
+    expect(result.performances).toHaveLength(2);
+    expect(result.performances[0].rockOperaPerformances[0]).toMatchObject({ performanceNumber: 1 });
+    expect(result.performances[1].rockOperaPerformances[0]).toMatchObject({ performanceNumber: 2 });
+    // Loader doesn't make its own per-show annotation lookups now.
+    expect(findPerformancesForShow).not.toHaveBeenCalled();
+  });
+
+  // Each performance's show is handed to computeShowExternalSources in
+  // one batch so nugs / archive / youtube favicons resolve in a single
+  // server-side pass — not one per row.
+  test("computes external sources from every performance's show in one call", async () => {
+    findPerformanceShowIds.mockResolvedValue(["show-1", "show-2"]);
+    const setlists = [makeSetlist("show-1", "1998-12-31"), makeSetlist("show-2", "1999-01-24")];
+    findManyByShowIds.mockResolvedValue(setlists);
+    findPerformancesForShow.mockResolvedValue([]);
+    computeShowExternalSourcesFn.mockResolvedValue({ "show-1": {}, "show-2": {} });
+
+    await getRockOperaPerformances("hot-air-balloon", context);
+
+    expect(computeShowExternalSourcesFn).toHaveBeenCalledTimes(1);
+    const passedShows = computeShowExternalSourcesFn.mock.calls[0][0] as Array<{ id: string }>;
+    expect(passedShows.map((s) => s.id)).toEqual(["show-1", "show-2"]);
+  });
+
+  // SetlistList's per-show badges (attendance + rating) hydrate from the
+  // React Query cache the loader seeds. Without this prefetch the
+  // badges would flash empty on first render before the client query
+  // resolves. Same pattern as /shows/top-rated.
+  test("prefetches show user data keyed by every performance's show id", async () => {
+    findPerformanceShowIds.mockResolvedValue(["show-1", "show-2"]);
+    findManyByShowIds.mockResolvedValue([makeSetlist("show-1", "1998-12-31"), makeSetlist("show-2", "1999-01-24")]);
+    findPerformancesForShow.mockResolvedValue([]);
+    computeShowExternalSourcesFn.mockResolvedValue({});
+
+    await getRockOperaPerformances("hot-air-balloon", context);
+
+    expect(prefetchQuery).toHaveBeenCalledTimes(1);
+    const prefetchArgs = prefetchQuery.mock.calls[0][0] as { queryKey: unknown[]; queryFn: () => unknown };
+    // showUserDataQueryKey embeds the show ids — assert they're present
+    // so re-arranging the key shape doesn't silently drop the hydration.
+    expect(JSON.stringify(prefetchArgs.queryKey)).toContain("show-1");
+    expect(JSON.stringify(prefetchArgs.queryKey)).toContain("show-2");
+  });
+
+  // Re-rendering a cached page skips every DB / annotation / external
+  // source call — only the prefetch runs (using the cached `performances`
+  // show ids). Drives the cache invalidation contract: if you DIDN'T
+  // bump the cache key, you don't pay for the inner work on hit.
+  test("uses cached payload on subsequent calls (no inner queries fired)", async () => {
+    const cachedPayload = {
+      performances: [makeSetlist("show-1", "1998-12-31")],
+      externalSources: { "show-1": {} },
+    };
+    cacheGetOrSet.mockResolvedValueOnce(cachedPayload);
+
+    const result = await getRockOperaPerformances("hot-air-balloon", context);
+
+    expect(findPerformanceShowIds).not.toHaveBeenCalled();
+    expect(findManyByShowIds).not.toHaveBeenCalled();
+    expect(findPerformancesForShow).not.toHaveBeenCalled();
+    expect(computeShowExternalSourcesFn).not.toHaveBeenCalled();
+    expect(result.performances).toBe(cachedPayload.performances);
+    // Prefetch still runs on cache hit so the React Query SSR seeding
+    // works even when the heavy loader work was cached.
+    expect(prefetchQuery).toHaveBeenCalledTimes(1);
+  });
+
+  // The dehydrated React Query state is always part of the payload so
+  // the root HydrationBoundary can warm the cache before SetlistList
+  // mounts. Drives the SSR-paint guarantee.
+  test("includes a dehydrated React Query state in the returned payload", async () => {
+    findPerformanceShowIds.mockResolvedValue([]);
+
+    const result = await getRockOperaPerformances("hot-air-balloon", context);
+
+    expect(result.dehydratedState).toBeDefined();
+    expect(typeof result.dehydratedState).toBe("object");
+    // dehydrate() returns { mutations, queries } — only check that the
+    // shape exists so we don't couple to React Query internals.
+    expect(result.dehydratedState as DehydratedState).toHaveProperty("queries");
+  });
+});

--- a/apps/web/app/routes/resources/rock-opera-performances.ts
+++ b/apps/web/app/routes/resources/rock-opera-performances.ts
@@ -1,0 +1,67 @@
+import { CacheKeys, type Setlist } from "@bip/domain";
+import { type DehydratedState, dehydrate } from "@tanstack/react-query";
+import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
+import type { PublicContext } from "~/lib/base-loaders";
+import { showUserDataQueryKey } from "~/lib/query-keys";
+import { createPrefetchClient } from "~/lib/query-prefetch";
+import { services } from "~/server/services";
+import { computeShowExternalSources } from "~/server/show-external-sources";
+import { computeShowUserData } from "~/server/show-user-data";
+
+export interface RockOperaPerformancesLoaderData {
+  /**
+   * Setlists for every full performance of the rock opera, oldest first.
+   * The 1st-ever performance is the FIRST item; SetlistList renders this
+   * order directly with `numbered`, so the gutter naturally shows 1..N.
+   */
+  performances: Setlist[];
+  externalSources: Record<string, ShowExternalSources>;
+  dehydratedState: DehydratedState;
+}
+
+/**
+ * Shared loader payload for the rock opera resource pages
+ * (`/resources/hot-air-balloon`, `/resources/chemical-warfare-brigade`,
+ * `/resources/revolution-in-motion`). Cached under the
+ * `rock-operas:performances:{slug}` key — invalidated by
+ * `CacheInvalidationService.invalidateRockOperaAssignment` whenever an
+ * admin tags or untags a show.
+ */
+export async function getRockOperaPerformances(
+  rockOperaSlug: string,
+  context: Pick<PublicContext, "currentUser">,
+): Promise<RockOperaPerformancesLoaderData> {
+  const cacheKey = CacheKeys.rockOperas.performances(rockOperaSlug);
+  const cached = await services.cache.getOrSet(cacheKey, async () => {
+    const showIds = await services.rockOperas.findPerformanceShowIds(rockOperaSlug);
+    if (showIds.length === 0) {
+      return { performances: [] as Setlist[], externalSources: {} };
+    }
+    // Sort ASC so the oldest (1st-ever full performance) lands first in
+    // the array — SetlistList's `numbered` gutter then displays 1..N
+    // naturally. SetlistService overlays rockOperaPerformances on every
+    // returned setlist, so no further annotation lookup is needed here.
+    const setlists = await services.setlists.findManyByShowIds(showIds, {
+      sort: [{ field: "date", direction: "asc" }],
+    });
+    const externalSources = await computeShowExternalSources(setlists.map((s) => s.show));
+    return { performances: setlists, externalSources };
+  });
+
+  // Prefetch per-show user data (attendance + ratings) so SetlistList's
+  // badges paint with the SSR HTML — same pattern as /shows/top-rated.
+  const showIds = cached.performances.map((s) => s.show.id);
+  const queryClient = createPrefetchClient();
+  if (showIds.length > 0) {
+    await queryClient.prefetchQuery({
+      queryKey: showUserDataQueryKey(showIds),
+      queryFn: () => computeShowUserData(context, showIds),
+    });
+  }
+
+  return {
+    performances: cached.performances,
+    externalSources: cached.externalSources,
+    dehydratedState: dehydrate(queryClient),
+  };
+}

--- a/apps/web/app/routes/shows/$slug.edit.test.ts
+++ b/apps/web/app/routes/shows/$slug.edit.test.ts
@@ -15,11 +15,18 @@ const findVenues = vi.fn();
 const findTracksByShowId = vi.fn();
 const updateShow = vi.fn();
 
+const findAllRockOperas = vi.fn().mockResolvedValue([]);
+const findRockOperaPerformancesForShow = vi.fn().mockResolvedValue([]);
+
 vi.mock("~/server/services", () => ({
   services: {
     shows: { findBySlug, findByDate, update: updateShow },
     venues: { findMany: findVenues },
     tracks: { findByShowId: findTracksByShowId },
+    rockOperas: {
+      findAll: findAllRockOperas,
+      findPerformancesForShow: findRockOperaPerformancesForShow,
+    },
   },
 }));
 

--- a/apps/web/app/routes/shows/$slug.edit.tsx
+++ b/apps/web/app/routes/shows/$slug.edit.tsx
@@ -1,4 +1,4 @@
-import type { Band, Show, Track, Venue } from "@bip/domain";
+import type { Band, RockOpera, Show, Track, Venue } from "@bip/domain";
 import { ArrowLeft } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
@@ -19,6 +19,8 @@ interface LoaderData {
   venues: Venue[];
   tracks: Track[];
   sameDateShows: ShowDayOrderRow[];
+  rockOperas: RockOpera[];
+  currentRockOperaIds: string[];
 }
 
 export const loader = adminLoader(async ({ params }) => {
@@ -48,7 +50,19 @@ export const loader = adminLoader(async ({ params }) => {
     venueName: s.venue?.name ?? null,
   }));
 
-  return { show, bands, venues, tracks, sameDateShows };
+  // Rock opera checkbox source + current selection. The annotations call
+  // returns each opera's slug; we map back to id for the form value via
+  // the full list. Tiny lookup tables, both queries are cheap.
+  const [rockOperas, currentRockOperaAnnotations] = await Promise.all([
+    services.rockOperas.findAll(),
+    services.rockOperas.findPerformancesForShow(show.id),
+  ]);
+  const slugToId = new Map(rockOperas.map((o) => [o.slug, o.id]));
+  const currentRockOperaIds = currentRockOperaAnnotations
+    .map((annotation) => slugToId.get(annotation.rockOpera.slug))
+    .filter((id): id is string => id !== undefined);
+
+  return { show, bands, venues, tracks, sameDateShows, rockOperas, currentRockOperaIds };
 });
 
 export const action = adminAction(async ({ request, params }) => {
@@ -65,6 +79,9 @@ export const action = adminAction(async ({ request, params }) => {
     notes: (formData.get("notes") as string) || null,
     relistenUrl: (formData.get("relistenUrl") as string) || null,
     countForStats: formData.get("countForStats") === "true",
+    // Multi-select: every checked id is appended under the same FormData key
+    // so `getAll` returns the full selection (empty array = clear all tags).
+    rockOperaIds: formData.getAll("rockOperaIds").map(String),
   };
 
   // Update the show
@@ -74,7 +91,7 @@ export const action = adminAction(async ({ request, params }) => {
 });
 
 export default function EditShow() {
-  const { show, bands, tracks, sameDateShows } = useSerializedLoaderData<LoaderData>();
+  const { show, bands, tracks, sameDateShows, rockOperas, currentRockOperaIds } = useSerializedLoaderData<LoaderData>();
   const navigate = useNavigate();
   const [defaultValues, setDefaultValues] = useState<ShowFormValues | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(true);
@@ -89,10 +106,11 @@ export default function EditShow() {
         notes: show.notes || "",
         relistenUrl: show.relistenUrl || "",
         countForStats: show.countForStats ?? true,
+        rockOperaIds: currentRockOperaIds,
       });
       setIsLoading(false);
     }
-  }, [show]);
+  }, [show, currentRockOperaIds]);
 
   const handleSubmit = async (data: ShowFormValues) => {
     const loadingToast = toast.loading("Updating show...");
@@ -105,6 +123,9 @@ export default function EditShow() {
       formData.append("notes", data.notes);
       formData.append("relistenUrl", data.relistenUrl);
       formData.append("countForStats", data.countForStats ? "true" : "false");
+      for (const id of data.rockOperaIds) {
+        formData.append("rockOperaIds", id);
+      }
 
       const response = await fetch(`/shows/${show.slug}/edit`, {
         method: "POST",
@@ -148,6 +169,7 @@ export default function EditShow() {
               cancelHref={`/shows/${show.slug}`}
               bands={bands}
               showId={show.id}
+              rockOperas={rockOperas}
             />
           </CardContent>
         </Card>

--- a/packages/core/scripts/sync-missing-shows.test.ts
+++ b/packages/core/scripts/sync-missing-shows.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  buildRockOperaAssignmentDiff,
   buildSetlistReconciliation,
   buildShowCreateInput,
   buildSongCreateInput,
@@ -1436,6 +1437,49 @@ describe("diffTrackAnnotations", () => {
     expect(diffTrackAnnotations(local, [])).toEqual({
       toCreateDescs: [],
       toDeleteIds: ["ann-a-uuid", "ann-b-uuid"],
+    });
+  });
+});
+
+// buildRockOperaAssignmentDiff drives the show ↔ rock_operas join sync. Same
+// "undefined means no opinion (pre-deploy MCP), explicit array is authoritative"
+// semantics as diffTrackAnnotations / buildVenueDriftUpdate. Identity is by
+// rock opera slug — slugs are the stable wire identifier (HAB resource page is
+// served at /resources/hot-air-balloon regardless of UUID).
+describe("buildRockOperaAssignmentDiff", () => {
+  // Canonical case: local has the show tagged with CWB, prod has HAB + RIM.
+  // Add HAB + RIM, remove CWB. Drives the sync transactional diff that mirrors
+  // admin-curated rock-opera tagging.
+  test("returns the add/remove delta to reach the remote set", () => {
+    expect(
+      buildRockOperaAssignmentDiff(["chemical-warfare-brigade"], ["hot-air-balloon", "revolution-in-motion"]),
+    ).toEqual({
+      toAdd: ["hot-air-balloon", "revolution-in-motion"],
+      toRemove: ["chemical-warfare-brigade"],
+    });
+  });
+
+  // No drift: same set in any order. No writes — keeps re-runs idempotent and
+  // avoids churning updatedAt on either side.
+  test("returns empty deltas when local and remote match (order-insensitive)", () => {
+    expect(buildRockOperaAssignmentDiff(["hot-air-balloon", "chemical-warfare-brigade"], ["chemical-warfare-brigade", "hot-air-balloon"]))
+      .toEqual({ toAdd: [], toRemove: [] });
+  });
+
+  // Pre-deploy MCP omits rockOperaSlugs entirely. `undefined` means "no
+  // opinion" — never wipe local tags. (Versus explicit empty array which
+  // means "prod has cleared this show's tags; delete local".)
+  test("returns empty deltas when remote is undefined (pre-deploy MCP)", () => {
+    expect(buildRockOperaAssignmentDiff(["hot-air-balloon"], undefined)).toEqual({ toAdd: [], toRemove: [] });
+  });
+
+  // Explicit empty array: prod cleared all tags for this show — local must be
+  // wiped. Distinguishing from `undefined` is the same pattern as
+  // diffTrackAnnotations.
+  test("removes all local tags when remote is explicitly empty", () => {
+    expect(buildRockOperaAssignmentDiff(["hot-air-balloon", "chemical-warfare-brigade"], [])).toEqual({
+      toAdd: [],
+      toRemove: ["hot-air-balloon", "chemical-warfare-brigade"],
     });
   });
 });

--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -56,6 +56,16 @@ export interface McpShow {
   relistenUrl: string | null;
   countForStats?: boolean;
   dayOrder?: number | null;
+  // Admin-curated rock opera tagging. Same optional + drift semantics as
+  // `countForStats`: undefined = pre-deploy MCP, explicit array (including
+  // empty) = authoritative. See buildRockOperaAssignmentDiff.
+  rockOperaSlugs?: string[];
+}
+
+export interface McpRockOpera {
+  slug: string;
+  name: string;
+  shortName: string;
 }
 
 export interface McpSetlistTrack {
@@ -691,6 +701,32 @@ export function buildSetlistReconciliation(
  * surfaces as one delete + one create. `undefined` remote = "no opinion"
  * (older MCP) and produces empty deltas; an explicit empty array wipes local.
  */
+/**
+ * Compute the add/remove ops needed to align a show's local rock opera
+ * tagging with prod. Identity is by rock opera slug (the stable wire id;
+ * resource pages are routed by slug). `undefined` remote = "no opinion"
+ * (pre-deploy MCP) and yields empty deltas so admin-set local tags aren't
+ * clobbered; explicit empty array = "prod has cleared this show's tags"
+ * and removes all local rows.
+ */
+export interface RockOperaAssignmentDiff {
+  toAdd: string[];
+  toRemove: string[];
+}
+
+export function buildRockOperaAssignmentDiff(
+  local: string[],
+  remote: string[] | undefined,
+): RockOperaAssignmentDiff {
+  if (remote === undefined) return { toAdd: [], toRemove: [] };
+  const localSet = new Set(local);
+  const remoteSet = new Set(remote);
+  return {
+    toAdd: remote.filter((slug) => !localSet.has(slug)),
+    toRemove: local.filter((slug) => !remoteSet.has(slug)),
+  };
+}
+
 export function diffTrackAnnotations(
   local: Array<{ id: string; desc: string | null }>,
   remote: string[] | undefined,
@@ -761,6 +797,9 @@ interface SyncStats {
   annotationsDeleted: number;
   segueRunsRegenerated: number;
   unresolvedSongSlugs: number;
+  rockOperasUpserted: number;
+  rockOperaAssignmentsAdded: number;
+  rockOperaAssignmentsRemoved: number;
   errors: number;
 }
 
@@ -868,6 +907,9 @@ async function syncMissingShows(): Promise<void> {
     annotationsDeleted: 0,
     segueRunsRegenerated: 0,
     unresolvedSongSlugs: 0,
+    rockOperasUpserted: 0,
+    rockOperaAssignmentsAdded: 0,
+    rockOperaAssignmentsRemoved: 0,
     errors: 0,
   };
 
@@ -961,6 +1003,65 @@ async function syncMissingShows(): Promise<void> {
     // bandId is nullable, so a missing band just means shows land without band FK.
     const band = await db.band.findFirst({ where: { slug: DEFAULT_BAND_SLUG } });
     if (!band) console.warn(`⚠️  No band with slug "${DEFAULT_BAND_SLUG}" in local DB; bandId will be NULL`);
+
+    // Step 4b: rock opera lookup table. Independent of the per-show data —
+    // mirror the small (3-row) lookup so the per-show assignment diff in step
+    // 7b can resolve every slug from the McpShow.rockOperaSlugs payload.
+    // Pre-deploy MCP returns no such tool; tolerate by skipping rock opera
+    // sync entirely for this run.
+    const rockOperaSlugToId = new Map<string, string>();
+    try {
+      const { rockOperas } = await mcpCall<{ rockOperas: McpRockOpera[] }>("get_rock_operas", {});
+      const existingRockOperas = await db.rockOpera.findMany({
+        select: { id: true, slug: true, name: true, shortName: true },
+      });
+      const existingBySlugRO = new Map(existingRockOperas.map((r) => [r.slug, r]));
+      for (const remote of rockOperas) {
+        const local = existingBySlugRO.get(remote.slug);
+        if (local) {
+          rockOperaSlugToId.set(local.slug, local.id);
+          // Cheap name / shortName drift — patch when prod renames an opera.
+          if (local.name !== remote.name || local.shortName !== remote.shortName) {
+            if (isDryRun) {
+              console.log(`  🔄 rock_opera ${remote.slug} would update name/shortName (dry run)`);
+              stats.rockOperasUpserted++;
+              continue;
+            }
+            try {
+              await db.rockOpera.update({
+                where: { id: local.id },
+                data: { name: remote.name, shortName: remote.shortName, updatedAt: now },
+              });
+              stats.rockOperasUpserted++;
+              console.log(`  🔄 rock_opera ${remote.slug} updated`);
+            } catch (err) {
+              console.error(`  ❌ failed to update rock_opera ${remote.slug}:`, err);
+              stats.errors++;
+            }
+          }
+        } else {
+          if (isDryRun) {
+            rockOperaSlugToId.set(remote.slug, `dry-run-rock-opera-${remote.slug}`);
+            stats.rockOperasUpserted++;
+            console.log(`  🆕 rock_opera ${remote.slug} (dry run)`);
+            continue;
+          }
+          try {
+            const created = await db.rockOpera.create({
+              data: { slug: remote.slug, name: remote.name, shortName: remote.shortName, updatedAt: now },
+            });
+            rockOperaSlugToId.set(created.slug, created.id);
+            stats.rockOperasUpserted++;
+            console.log(`  🆕 rock_opera ${remote.slug}`);
+          } catch (err) {
+            console.error(`  ❌ failed to create rock_opera ${remote.slug}:`, err);
+            stats.errors++;
+          }
+        }
+      }
+    } catch (err) {
+      console.warn(`⚠️  get_rock_operas failed — skipping rock opera assignment sync:`, err);
+    }
 
     // Step 5: resolve venues. For each unique (name, city, state) from the
     // setlists, search_venues by name and disambiguate on city+state. Cache the
@@ -1250,6 +1351,86 @@ async function syncMissingShows(): Promise<void> {
       } catch (err) {
         console.error(`  ❌ failed to insert show ${slug}:`, err);
         stats.errors++;
+      }
+    }
+
+    // Step 7b: mirror rock opera assignments for every in-scope show. Runs
+    // after show inserts (step 7) so every prod slug exists in `existingBySlug`
+    // with a real local id. Skipped silently when rockOperaSlugToId is empty
+    // (pre-deploy MCP couldn't serve get_rock_operas) — the per-show diff
+    // logic still wouldn't have ids to write to.
+    if (rockOperaSlugToId.size > 0) {
+      const reconcileShowIds = Array.from(existingBySlug.values())
+        .filter((s) => !String(s.id).startsWith("dry-run-show-"))
+        .map((s) => s.id);
+      const localTagRows = reconcileShowIds.length === 0
+        ? []
+        : await db.rockOperaPerformance.findMany({
+            where: { showId: { in: reconcileShowIds } },
+            include: { rockOpera: { select: { slug: true } } },
+          });
+      const localTagsByShowId = new Map<string, string[]>();
+      for (const row of localTagRows) {
+        const arr = localTagsByShowId.get(row.showId);
+        if (arr) arr.push(row.rockOpera.slug);
+        else localTagsByShowId.set(row.showId, [row.rockOpera.slug]);
+      }
+
+      // remoteFullShows still has the rockOperaSlugs from get_shows. Loop
+      // those and diff against local for every in-scope show — captures both
+      // newly-inserted shows (which have empty local tags) and existing
+      // shows whose admin-curated tags changed on prod.
+      const remoteShowsBySlug = new Map(remoteFullShows.map((s) => [s.slug, s]));
+      for (const [slug, local] of existingBySlug) {
+        const remote = remoteShowsBySlug.get(slug);
+        if (!remote) continue;
+        const isDryRunShow = String(local.id).startsWith("dry-run-show-");
+        const localSlugs = isDryRunShow ? [] : (localTagsByShowId.get(local.id) ?? []);
+        const diff = buildRockOperaAssignmentDiff(localSlugs, remote.rockOperaSlugs);
+        if (diff.toAdd.length === 0 && diff.toRemove.length === 0) continue;
+
+        if (isDryRun || isDryRunShow) {
+          console.log(`  🎭 ${slug}: +[${diff.toAdd.join(",")}] -[${diff.toRemove.join(",")}] rock opera tag(s) (dry run)`);
+          stats.rockOperaAssignmentsAdded += diff.toAdd.length;
+          stats.rockOperaAssignmentsRemoved += diff.toRemove.length;
+          continue;
+        }
+
+        const addIds = diff.toAdd
+          .map((s) => rockOperaSlugToId.get(s))
+          .filter((id): id is string => id !== undefined);
+        const removeIds = diff.toRemove
+          .map((s) => rockOperaSlugToId.get(s))
+          .filter((id): id is string => id !== undefined);
+        try {
+          await db.$transaction(async (tx) => {
+            if (removeIds.length > 0) {
+              await tx.rockOperaPerformance.deleteMany({
+                where: { showId: local.id, rockOperaId: { in: removeIds } },
+              });
+            }
+            if (addIds.length > 0) {
+              await tx.rockOperaPerformance.createMany({
+                data: addIds.map((rockOperaId) => ({ showId: local.id, rockOperaId })),
+              });
+            }
+          });
+          stats.rockOperaAssignmentsAdded += diff.toAdd.length;
+          stats.rockOperaAssignmentsRemoved += diff.toRemove.length;
+          changedSlugs.add(slug);
+          // Invalidate rock opera resource-page caches for every slug
+          // whose performance list changed. Neighbor invalidation
+          // (other shows' show.data entries whose annotations shifted)
+          // is handled by invalidateShowListings at the end of the run.
+          if (cacheInvalidation) {
+            const affectedSlugs = Array.from(new Set([...diff.toAdd, ...diff.toRemove]));
+            await cacheInvalidation.invalidateRockOperaAssignment(affectedSlugs);
+          }
+          console.log(`  🎭 ${slug}: +${diff.toAdd.length} -${diff.toRemove.length} rock opera tag(s)`);
+        } catch (err) {
+          console.error(`  ❌ failed to sync rock opera tags for ${slug}:`, err);
+          stats.errors++;
+        }
       }
     }
 
@@ -1645,6 +1826,8 @@ function printSummary(stats: SyncStats, isDryRun: boolean): void {
   console.log(`Annotations created / deleted: ${stats.annotationsCreated} / ${stats.annotationsDeleted}`);
   console.log(`SegueRuns regenerated: ${stats.segueRunsRegenerated}`);
   console.log(`Unresolved song slugs: ${stats.unresolvedSongSlugs}`);
+  console.log(`Rock operas upserted: ${stats.rockOperasUpserted}`);
+  console.log(`Rock opera assignments added / removed: ${stats.rockOperaAssignmentsAdded} / ${stats.rockOperaAssignmentsRemoved}`);
   console.log(`Errors: ${stats.errors}`);
 }
 

--- a/packages/core/src/_shared/cache/cache-invalidation-service.test.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.test.ts
@@ -81,4 +81,33 @@ describe("CacheInvalidationService.invalidateShowListings", () => {
 
     expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.users.allSongHistory());
   });
+
+  // Rock opera resource pages cache full Setlists (with tracks, annotations,
+  // ratings, notes, date) for every tagged show. Any non-rock-opera mutation
+  // on a tagged show — notes, a track edit, a rating, even a date shift —
+  // makes that fat payload stale. Wildcard wipe so the cache rebuilds on the
+  // next visit; cost is trivial (~3 keys for 3 rock operas).
+  test("wipes the rock opera resource-page cache on show-listing changes", async () => {
+    const cache = makeCache();
+    const service = new CacheInvalidationService(cache as never, logger);
+
+    await service.invalidateShowListings();
+
+    expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.rockOperas.allPerformances());
+  });
+
+  // show.data caches per-slug Setlists with rockOperaPerformances baked
+  // in by the SetlistService overlay. A date change on one tagged show
+  // — or any rock opera assignment — shifts every neighbor's rank /
+  // prev / next, so neighbor show.data entries are stale even though
+  // their own row didn't move. Wipe the whole per-slug pattern so the
+  // next request rebuilds with fresh annotations.
+  test("wipes per-slug show.data on show-listing changes", async () => {
+    const cache = makeCache();
+    const service = new CacheInvalidationService(cache as never, logger);
+
+    await service.invalidateShowListings();
+
+    expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.show.allData());
+  });
 });

--- a/packages/core/src/_shared/cache/cache-invalidation-service.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.ts
@@ -58,6 +58,16 @@ export class CacheInvalidationService {
       // Per-user song-history embeds the catalog of tracks at each attended
       // show; a show metadata or tracks change can shift values.
       this.cache.delPattern(CacheKeys.users.allSongHistory()),
+      // Rock opera resource pages embed full Setlists (with tracks,
+      // annotations, ratings, notes, date) for every tagged show. Any
+      // show-affecting mutation can stale them.
+      this.cache.delPattern(CacheKeys.rockOperas.allPerformances()),
+      // show.data caches per-slug Setlists with rockOperaPerformances
+      // baked in (SetlistService overlays them in findByShowSlug etc.).
+      // When a tagged show's date moves or any rock opera assignment
+      // changes, neighbors' annotations (rank/prev/next) shift — wipe
+      // every show.data so the next request rebuilds with fresh data.
+      this.cache.delPattern(CacheKeys.show.allData()),
       this.cloudflareCache?.purgeYearListings(),
     ]);
   }
@@ -113,6 +123,19 @@ export class CacheInvalidationService {
       // SetlistCard "personal" view reads this user's song-history blob.
       this.cache.del(CacheKeys.users.songHistory(userId)),
     ]);
+  }
+
+  /**
+   * Invalidate rock opera resource-page caches after an assignment
+   * change. Per-show annotation invalidation is handled at the
+   * listings layer because annotations now ride inside the cached
+   * Setlist payloads (show.data, shows.list, etc.) — see
+   * `invalidateShowListings`.
+   */
+  async invalidateRockOperaAssignment(rockOperaSlugs: string[]): Promise<void> {
+    if (rockOperaSlugs.length === 0) return;
+    this.logger.info(`Invalidating rock opera resource caches: slugs=${rockOperaSlugs.join(",")}`);
+    await Promise.all(rockOperaSlugs.map((slug) => this.cache.del(CacheKeys.rockOperas.performances(slug))));
   }
 
   /**

--- a/packages/core/src/_shared/prisma/migrations/20260526185750_add_rock_operas/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260526185750_add_rock_operas/migration.sql
@@ -1,0 +1,109 @@
+-- CreateTable
+CREATE TABLE "rock_operas" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "slug" VARCHAR NOT NULL,
+    "name" VARCHAR NOT NULL,
+    "short_name" VARCHAR NOT NULL,
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "rock_operas_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "rock_opera_performances" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "show_id" UUID NOT NULL,
+    "rock_opera_id" UUID NOT NULL,
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "rock_opera_performances_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "rock_operas_slug_unique" ON "rock_operas"("slug");
+
+-- CreateIndex
+CREATE INDEX "rock_opera_performances_rock_opera_id_idx" ON "rock_opera_performances"("rock_opera_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "rock_opera_performances_show_rock_opera_unique" ON "rock_opera_performances"("show_id", "rock_opera_id");
+
+-- AddForeignKey
+ALTER TABLE "rock_opera_performances" ADD CONSTRAINT "fk_rock_opera_performances_shows_show_id" FOREIGN KEY ("show_id") REFERENCES "shows"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "rock_opera_performances" ADD CONSTRAINT "fk_rock_opera_performances_rock_operas_rock_opera_id" FOREIGN KEY ("rock_opera_id") REFERENCES "rock_operas"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- Seed the three known rock operas.
+INSERT INTO "rock_operas" ("slug", "name", "short_name", "updated_at")
+VALUES
+  ('hot-air-balloon',           'The Hot Air Balloon',       'HAB', NOW()),
+  ('chemical-warfare-brigade',  'Chemical Warfare Brigade',  'CWB', NOW()),
+  ('revolution-in-motion',      'Revolution In Motion',      'RIM', NOW());
+
+-- Seed the 16 known full performances. For each (date, slug) tuple we
+-- resolve the matching count_for_stats=true Disco Biscuits show. If 0 or
+-- 2+ shows match (e.g. same-day late-night/Tractorbeam sets, or the show
+-- hasn't been synced locally yet), we RAISE NOTICE and skip so the admin
+-- can finish via the show edit UI rather than risk a silent mis-tag.
+DO $$
+DECLARE
+  band_uuid UUID;
+  show_uuid UUID;
+  opera_uuid UUID;
+  match_count INT;
+  performance TEXT[];
+  performances CONSTANT TEXT[][] := ARRAY[
+    ARRAY['1998-12-31', 'hot-air-balloon'],
+    ARRAY['1999-01-24', 'hot-air-balloon'],
+    ARRAY['1999-03-04', 'hot-air-balloon'],
+    ARRAY['1999-05-11', 'hot-air-balloon'],
+    ARRAY['1999-06-12', 'hot-air-balloon'],
+    ARRAY['1999-10-23', 'hot-air-balloon'],
+    ARRAY['2004-01-17', 'hot-air-balloon'],
+    ARRAY['2007-10-31', 'hot-air-balloon'],
+    ARRAY['2018-12-31', 'hot-air-balloon'],
+    ARRAY['2000-12-30', 'chemical-warfare-brigade'],
+    ARRAY['2001-04-26', 'chemical-warfare-brigade'],
+    ARRAY['2002-11-06', 'chemical-warfare-brigade'],
+    ARRAY['2003-11-28', 'chemical-warfare-brigade'],
+    ARRAY['2009-06-03', 'chemical-warfare-brigade'],
+    ARRAY['2026-05-24', 'chemical-warfare-brigade'],
+    ARRAY['2024-03-29', 'revolution-in-motion']
+  ];
+BEGIN
+  SELECT id INTO band_uuid FROM bands WHERE slug = 'the-disco-biscuits';
+  IF band_uuid IS NULL THEN
+    RAISE NOTICE 'Skipping rock opera performance seed: no band with slug=the-disco-biscuits';
+    RETURN;
+  END IF;
+
+  FOREACH performance SLICE 1 IN ARRAY performances LOOP
+    SELECT COUNT(*) INTO match_count
+    FROM shows
+    WHERE date = performance[1] AND band_id = band_uuid AND count_for_stats = true;
+
+    IF match_count = 0 THEN
+      RAISE NOTICE 'No matching show for date=% rock_opera=%; tag manually after sync.',
+        performance[1], performance[2];
+      CONTINUE;
+    END IF;
+
+    IF match_count > 1 THEN
+      RAISE NOTICE 'Multiple matching shows for date=% rock_opera=%; tag manually to pick the right one.',
+        performance[1], performance[2];
+      CONTINUE;
+    END IF;
+
+    SELECT id INTO show_uuid
+    FROM shows
+    WHERE date = performance[1] AND band_id = band_uuid AND count_for_stats = true;
+
+    SELECT id INTO opera_uuid FROM rock_operas WHERE slug = performance[2];
+
+    INSERT INTO rock_opera_performances (show_id, rock_opera_id)
+    VALUES (show_uuid, opera_uuid)
+    ON CONFLICT (show_id, rock_opera_id) DO NOTHING;
+  END LOOP;
+END $$;

--- a/packages/core/src/_shared/prisma/schema.prisma
+++ b/packages/core/src/_shared/prisma/schema.prisma
@@ -344,10 +344,37 @@ model Show {
   previousPerformanceTracks Track[]            @relation("TrackPreviousPerformance")
   segueRuns         SegueRun[]
   files             ShowToFile[]
+  rockOperaPerformances RockOperaPerformance[]
 
   @@index([likesCount])
   @@index([date])
   @@map("shows")
+}
+
+model RockOpera {
+  id           String                 @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  slug         String                 @unique(map: "rock_operas_slug_unique") @db.VarChar
+  name         String                 @db.VarChar
+  shortName    String                 @map("short_name") @db.VarChar
+  createdAt    DateTime               @default(now()) @map("created_at") @db.Timestamp(6)
+  updatedAt    DateTime               @updatedAt @map("updated_at") @db.Timestamp(6)
+  performances RockOperaPerformance[]
+
+  @@map("rock_operas")
+}
+
+model RockOperaPerformance {
+  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  showId      String   @map("show_id") @db.Uuid
+  rockOperaId String   @map("rock_opera_id") @db.Uuid
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamp(6)
+
+  show      Show      @relation(fields: [showId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_rock_opera_performances_shows_show_id")
+  rockOpera RockOpera @relation(fields: [rockOperaId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_rock_opera_performances_rock_operas_rock_opera_id")
+
+  @@unique([showId, rockOperaId], map: "rock_opera_performances_show_rock_opera_unique")
+  @@index([rockOperaId])
+  @@map("rock_opera_performances")
 }
 
 model SideProject {

--- a/packages/core/src/_shared/services.ts
+++ b/packages/core/src/_shared/services.ts
@@ -7,6 +7,7 @@ import { FileService } from "../files/file-service";
 import { SongPageComposer } from "../page-composers/song-page-composer";
 import { RatingService } from "../ratings/rating-service";
 import { ReviewService } from "../reviews/review-service";
+import { RockOperaService } from "../rock-operas/rock-opera-service";
 import { PostgresSearchService } from "../search/postgres-search-service";
 import { SearchHistoryService } from "../search/search-history-service";
 import { SetlistService } from "../setlists/setlist-service";
@@ -39,6 +40,7 @@ export interface Services {
   users: UserService;
   personalSongHistory: PersonalSongHistoryService;
   reviews: ReviewService;
+  rockOperas: RockOperaService;
   ratings: RatingService;
   attendances: AttendanceService;
   songPageComposer: SongPageComposer;
@@ -66,6 +68,10 @@ export function createServices(container: ServiceContainer): Services {
   // StatsService is constructed first so ShowService can hand it the
   // post-mutation rebuild dependency.
   const statsService = new StatsService(container.db, container.cache);
+  // RockOperaService is constructed before SetlistService because every
+  // setlist returned overlays rock opera annotations via a batched
+  // lookup — SetlistService takes RockOperaService as a constructor dep.
+  const rockOperaService = new RockOperaService(container.db, container.logger, statsService);
 
   return {
     annotations: new AnnotationService(container.db, container.logger, container.cacheInvalidation),
@@ -75,11 +81,12 @@ export function createServices(container: ServiceContainer): Services {
     songs: songService,
     stats: statsService,
     tracks: new TrackService(container.db, container.logger, container.cacheInvalidation),
-    setlists: new SetlistService(container.db),
+    setlists: new SetlistService(container.db, rockOperaService),
     venues: new VenueService(container.db, container.logger),
     users: new UserService(container.db, container.logger),
     personalSongHistory: new PersonalSongHistoryService(container.db, container.cache),
     reviews: new ReviewService(container.db, container.logger),
+    rockOperas: rockOperaService,
     ratings: new RatingService(container.db, container.cacheInvalidation),
     attendances: new AttendanceService(container.db, container.logger),
     songPageComposer: new SongPageComposer(container.db, songService, statsService),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export * from "./blog-posts/blog-post-service";
 export * from "./page-composers/song-page-composer";
 export * from "./ratings/rating-service";
 export * from "./reviews/review-service";
+export * from "./rock-operas/rock-opera-service";
 export * from "./search/postgres-search-service";
 export * from "./setlists/setlist-service";
 export * from "./shows/archive-dot-org-service";

--- a/packages/core/src/rock-operas/rock-opera-service.test.ts
+++ b/packages/core/src/rock-operas/rock-opera-service.test.ts
@@ -1,0 +1,238 @@
+import type { Logger } from "@bip/domain";
+import { describe, expect, test, vi } from "vitest";
+import { SHOW_ORDER_ASC } from "../_shared/show-ordering";
+import type { StatsService } from "../stats/stats-service";
+import { RockOperaService } from "./rock-opera-service";
+
+function makeLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  } as unknown as Logger;
+}
+
+function makeMockDb() {
+  return {
+    rockOpera: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue(null),
+    },
+    rockOperaPerformance: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    show: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+  };
+}
+
+// Stats stub — only `getStatsShowDates` is read by RockOperaService.
+// Tests drive its return value to control the gap-counting input.
+function makeStatsStub(dates: string[] = []): StatsService {
+  return {
+    getStatsShowDates: vi.fn().mockResolvedValue(dates),
+  } as unknown as StatsService;
+}
+
+describe("RockOperaService.findAll", () => {
+  // Admin form's checkbox group needs the full list. Order by name so the
+  // checkboxes render in a stable alphabetical sequence and don't shift
+  // when a new opera is added.
+  test("returns all rock operas ordered alphabetically by name", async () => {
+    const db = makeMockDb();
+    db.rockOpera.findMany.mockResolvedValue([
+      {
+        id: "1",
+        slug: "chemical-warfare-brigade",
+        name: "Chemical Warfare Brigade",
+        shortName: "CWB",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "2",
+        slug: "hot-air-balloon",
+        name: "The Hot Air Balloon",
+        shortName: "HAB",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    const service = new RockOperaService(db as never, makeLogger(), makeStatsStub());
+
+    const result = await service.findAll();
+
+    expect(db.rockOpera.findMany).toHaveBeenCalledWith({ orderBy: { name: "asc" } });
+    expect(result.map((r) => r.slug)).toEqual(["chemical-warfare-brigade", "hot-air-balloon"]);
+  });
+});
+
+describe("RockOperaService.findPerformanceShowIds", () => {
+  // Resource pages render performances in chronological order. We rely on
+  // SHOW_ORDER_ASC (date + day_order NULLS LAST + id) so same-day shows
+  // tiebreak consistently with the rest of the app, and Postgres returns
+  // ids in the canonical order the show pages use.
+  test("queries shows tagged with the rock opera, ordered SHOW_ORDER_ASC", async () => {
+    const db = makeMockDb();
+    db.show.findMany.mockResolvedValue([{ id: "show-a" }, { id: "show-b" }]);
+    const service = new RockOperaService(db as never, makeLogger(), makeStatsStub());
+
+    const ids = await service.findPerformanceShowIds("hot-air-balloon");
+
+    const call = db.show.findMany.mock.calls[0][0];
+    expect(call.where).toEqual({
+      rockOperaPerformances: { some: { rockOpera: { slug: "hot-air-balloon" } } },
+    });
+    expect(call.orderBy).toBe(SHOW_ORDER_ASC);
+    expect(call.select).toEqual({ id: true });
+    expect(ids).toEqual(["show-a", "show-b"]);
+  });
+
+  // No tagged performances → empty list, no follow-up queries. Resource
+  // page surfaces an empty section rather than an error.
+  test("returns [] when no shows are tagged", async () => {
+    const db = makeMockDb();
+    const service = new RockOperaService(db as never, makeLogger(), makeStatsStub());
+
+    const ids = await service.findPerformanceShowIds("revolution-in-motion");
+
+    expect(ids).toEqual([]);
+  });
+});
+
+describe("RockOperaService.findPerformancesForShow", () => {
+  // Untagged show → no annotations, no follow-up queries. SetlistCard
+  // renders nothing in the rock-opera annotation slot. findPerformancesForShow
+  // is a thin wrapper around the batched findPerformancesForShows; the
+  // query shape uses `showId IN [...]` even for the single-show call.
+  test("returns [] for a show with no rock opera tags", async () => {
+    const db = makeMockDb();
+    db.rockOperaPerformance.findMany.mockResolvedValue([]);
+    const service = new RockOperaService(db as never, makeLogger(), makeStatsStub());
+
+    const result = await service.findPerformancesForShow("show-untagged");
+
+    expect(result).toEqual([]);
+    expect(db.rockOperaPerformance.findMany).toHaveBeenCalledWith({
+      where: { showId: { in: ["show-untagged"] } },
+      include: { rockOpera: true },
+    });
+  });
+
+  // Middle-of-list performance → annotation carries the 1-based rank plus
+  // pointers to the chronologically adjacent performances with `gap` =
+  // count of count_for_stats=true shows strictly between (matches
+  // Track.gap semantics).
+  test("returns annotation with rank + adjacent performance pointers + gap", async () => {
+    const db = makeMockDb();
+    db.rockOperaPerformance.findMany.mockResolvedValue([
+      {
+        showId: "show-target",
+        rockOperaId: "ro-1",
+        rockOpera: {
+          id: "ro-1",
+          slug: "hot-air-balloon",
+          name: "The Hot Air Balloon",
+          shortName: "HAB",
+        },
+      },
+    ]);
+    db.show.findMany.mockResolvedValue([
+      { id: "show-1st", date: "1998-12-31", slug: "1998-12-31-silk-city" },
+      { id: "show-2nd", date: "1999-01-24", slug: "1999-01-24-natick" },
+      { id: "show-target", date: "1999-03-04", slug: "1999-03-04-target" },
+      { id: "show-4th", date: "1999-05-11", slug: "1999-05-11-fourth" },
+    ]);
+    // Stats dates between performances: 7 shows in (1999-01-24, 1999-03-04),
+    // 12 shows in (1999-03-04, 1999-05-11). countShowsBetween uses strictly-
+    // between semantics, so endpoint dates are excluded from the input.
+    const statsDates = [
+      ...Array.from({ length: 7 }, (_, i) => `1999-02-${String(i + 1).padStart(2, "0")}`),
+      ...Array.from({ length: 12 }, (_, i) => `1999-04-${String(i + 1).padStart(2, "0")}`),
+    ].sort();
+    const service = new RockOperaService(db as never, makeLogger(), makeStatsStub(statsDates));
+
+    const result = await service.findPerformancesForShow("show-target");
+
+    expect(result).toEqual([
+      {
+        rockOpera: { slug: "hot-air-balloon", name: "The Hot Air Balloon", shortName: "HAB" },
+        performanceNumber: 3,
+        previousPerformance: { date: "1999-01-24", slug: "1999-01-24-natick", gap: 7 },
+        nextPerformance: { date: "1999-05-11", slug: "1999-05-11-fourth", gap: 12 },
+      },
+    ]);
+  });
+
+  // First-ever performance has no `previousPerformance`; last has no
+  // `nextPerformance`. Both come back as null so the renderer can hide
+  // those lines cleanly.
+  test("nulls previousPerformance for the 1st performance and nextPerformance for the last", async () => {
+    const db = makeMockDb();
+    db.rockOperaPerformance.findMany.mockResolvedValue([
+      {
+        showId: "show-only",
+        rockOperaId: "ro-1",
+        rockOpera: { id: "ro-1", slug: "revolution-in-motion", name: "Revolution In Motion", shortName: "RIM" },
+      },
+    ]);
+    db.show.findMany.mockResolvedValue([{ id: "show-only", date: "2024-03-29", slug: "2024-03-29-webster-hall" }]);
+    const service = new RockOperaService(db as never, makeLogger(), makeStatsStub([]));
+
+    const result = await service.findPerformancesForShow("show-only");
+
+    expect(result[0].previousPerformance).toBeNull();
+    expect(result[0].nextPerformance).toBeNull();
+  });
+
+  // Tagged with two operas → one annotation per opera, each rank and gap
+  // computed independently against its own chronological list.
+  test("computes independent ranks when a show is tagged with multiple operas", async () => {
+    const db = makeMockDb();
+    db.rockOperaPerformance.findMany.mockResolvedValue([
+      {
+        showId: "show-target",
+        rockOperaId: "ro-1",
+        rockOpera: { id: "ro-1", slug: "hot-air-balloon", name: "The Hot Air Balloon", shortName: "HAB" },
+      },
+      {
+        showId: "show-target",
+        rockOperaId: "ro-2",
+        rockOpera: { id: "ro-2", slug: "chemical-warfare-brigade", name: "Chemical Warfare Brigade", shortName: "CWB" },
+      },
+    ]);
+    db.show.findMany
+      .mockResolvedValueOnce([
+        { id: "show-target", date: "1998-12-31", slug: "show-target-slug" },
+        { id: "show-x", date: "1999-01-24", slug: "show-x-slug" },
+      ])
+      .mockResolvedValueOnce([
+        { id: "show-a", date: "2000-12-30", slug: "show-a-slug" },
+        { id: "show-b", date: "2001-04-26", slug: "show-b-slug" },
+        { id: "show-c", date: "2002-11-06", slug: "show-c-slug" },
+        { id: "show-d", date: "2003-11-28", slug: "show-d-slug" },
+        { id: "show-target", date: "2009-06-03", slug: "show-target-slug" },
+      ]);
+    // Two stub stats dates: one falls between HAB target & next, one
+    // between CWB show-d & target. Verifies gap is computed per-opera.
+    const service = new RockOperaService(db as never, makeLogger(), makeStatsStub(["1999-01-10", "2005-01-01"]));
+
+    const result = await service.findPerformancesForShow("show-target");
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      rockOpera: { slug: "hot-air-balloon" },
+      performanceNumber: 1,
+      previousPerformance: null,
+      nextPerformance: { date: "1999-01-24", gap: 1 },
+    });
+    expect(result[1]).toMatchObject({
+      rockOpera: { slug: "chemical-warfare-brigade" },
+      performanceNumber: 5,
+      previousPerformance: { date: "2003-11-28", gap: 1 },
+      nextPerformance: null,
+    });
+  });
+});

--- a/packages/core/src/rock-operas/rock-opera-service.ts
+++ b/packages/core/src/rock-operas/rock-opera-service.ts
@@ -1,0 +1,128 @@
+import type { AdjacentRockOperaPerformance, Logger, RockOpera, RockOperaPerformanceAnnotation } from "@bip/domain";
+import type { DbClient } from "../_shared/database/models";
+import { SHOW_ORDER_ASC } from "../_shared/show-ordering";
+import { countShowsBetween, type StatsService } from "../stats/stats-service";
+
+type DbRockOpera = {
+  id: string;
+  slug: string;
+  name: string;
+  shortName: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function mapRockOperaToDomain(row: DbRockOpera): RockOpera {
+  return {
+    id: row.id,
+    slug: row.slug,
+    name: row.name,
+    shortName: row.shortName,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export class RockOperaService {
+  constructor(
+    private readonly db: DbClient,
+    private readonly logger: Logger,
+    private readonly stats: StatsService,
+  ) {}
+
+  async findAll(): Promise<RockOpera[]> {
+    const rows = await this.db.rockOpera.findMany({ orderBy: { name: "asc" } });
+    return rows.map(mapRockOperaToDomain);
+  }
+
+  async findBySlug(slug: string): Promise<RockOpera | null> {
+    const row = await this.db.rockOpera.findUnique({ where: { slug } });
+    return row ? mapRockOperaToDomain(row) : null;
+  }
+
+  async findPerformanceShowIds(rockOperaSlug: string): Promise<string[]> {
+    const shows = await this.db.show.findMany({
+      where: { rockOperaPerformances: { some: { rockOpera: { slug: rockOperaSlug } } } },
+      orderBy: SHOW_ORDER_ASC,
+      select: { id: true },
+    });
+    return shows.map((s) => s.id);
+  }
+
+  async findPerformancesForShow(showId: string): Promise<RockOperaPerformanceAnnotation[]> {
+    const map = await this.findPerformancesForShows([showId]);
+    return map.get(showId) ?? [];
+  }
+
+  /**
+   * Cost is bounded regardless of input size: 1 query for tagged rows
+   * across all input shows, 1 query per unique opera referenced, and 1
+   * cached read for the stats show-date array. Lets list-page callers
+   * pass every show id on the page in a single call without paying a
+   * round-trip per row.
+   */
+  async findPerformancesForShows(showIds: string[]): Promise<Map<string, RockOperaPerformanceAnnotation[]>> {
+    const result = new Map<string, RockOperaPerformanceAnnotation[]>();
+    if (showIds.length === 0) return result;
+
+    const tagged = await this.db.rockOperaPerformance.findMany({
+      where: { showId: { in: showIds } },
+      include: { rockOpera: true },
+    });
+    if (tagged.length === 0) return result;
+
+    const uniqueRockOperaIds = Array.from(new Set(tagged.map((t) => t.rockOperaId)));
+    const operaShowLists = new Map<string, Array<{ id: string; date: string; slug: string | null }>>();
+    await Promise.all(
+      uniqueRockOperaIds.map(async (rockOperaId) => {
+        const shows = await this.db.show.findMany({
+          where: { rockOperaPerformances: { some: { rockOperaId } } },
+          orderBy: SHOW_ORDER_ASC,
+          select: { id: true, date: true, slug: true },
+        });
+        operaShowLists.set(rockOperaId, shows);
+      }),
+    );
+
+    const statsShowDates = await this.stats.getStatsShowDates();
+
+    for (const row of tagged) {
+      const operaShows = operaShowLists.get(row.rockOperaId);
+      if (!operaShows) continue;
+      const index = operaShows.findIndex((s) => s.id === row.showId);
+      if (index === -1) {
+        this.logger.warn(
+          `findPerformancesForShows: show ${row.showId} tagged with ${row.rockOpera.slug} but not present in opera's chronological list`,
+        );
+        continue;
+      }
+      const current = operaShows[index];
+      const prev = index > 0 ? operaShows[index - 1] : null;
+      const next = index < operaShows.length - 1 ? operaShows[index + 1] : null;
+
+      const previousPerformance: AdjacentRockOperaPerformance | null = prev
+        ? { date: prev.date, slug: prev.slug, gap: countShowsBetween(statsShowDates, prev.date, current.date) }
+        : null;
+      const nextPerformance: AdjacentRockOperaPerformance | null = next
+        ? { date: next.date, slug: next.slug, gap: countShowsBetween(statsShowDates, current.date, next.date) }
+        : null;
+
+      const annotation: RockOperaPerformanceAnnotation = {
+        rockOpera: {
+          slug: row.rockOpera.slug,
+          name: row.rockOpera.name,
+          shortName: row.rockOpera.shortName,
+        },
+        performanceNumber: index + 1,
+        previousPerformance,
+        nextPerformance,
+      };
+
+      const existing = result.get(row.showId);
+      if (existing) existing.push(annotation);
+      else result.set(row.showId, [annotation]);
+    }
+
+    return result;
+  }
+}

--- a/packages/core/src/setlists/setlist-service.test.ts
+++ b/packages/core/src/setlists/setlist-service.test.ts
@@ -1,5 +1,6 @@
 import { average, median } from "@bip/domain";
 import { describe, expect, test, vi } from "vitest";
+import type { RockOperaService } from "../rock-operas/rock-opera-service";
 import { computeDebutCount, eligibleGapsForAggregation, SetlistService } from "./setlist-service";
 
 // Minimal mock DbClient — only the paths used by tests
@@ -13,11 +14,25 @@ function makeMockDb() {
   };
 }
 
+// RockOperaService stub — SetlistService overlays annotations onto every
+// returned setlist via `findPerformancesForShows`. Default to an empty
+// map so existing tests don't have to wire annotation data; tests that
+// care can swap in a custom mock.
+function makeRockOperaStub(): RockOperaService {
+  return {
+    findPerformancesForShows: vi.fn().mockResolvedValue(new Map()),
+    findPerformancesForShow: vi.fn().mockResolvedValue([]),
+    findAll: vi.fn().mockResolvedValue([]),
+    findBySlug: vi.fn().mockResolvedValue(null),
+    findPerformanceShowIds: vi.fn().mockResolvedValue([]),
+  } as unknown as RockOperaService;
+}
+
 describe("SetlistService.findManyLight", () => {
   // monthDay filter passes endsWith to Prisma's date where clause
   test("applies endsWith date filter when monthDay is provided", async () => {
     const db = makeMockDb();
-    const service = new SetlistService(db as never);
+    const service = new SetlistService(db as never, makeRockOperaStub());
 
     await service.findManyLight({
       filters: { monthDay: "04-04" },
@@ -32,7 +47,7 @@ describe("SetlistService.findManyLight", () => {
   // year's first day) so it works with the string-shaped date column.
   test("applies gte/lt date filter when year is provided", async () => {
     const db = makeMockDb();
-    const service = new SetlistService(db as never);
+    const service = new SetlistService(db as never, makeRockOperaStub());
 
     await service.findManyLight({
       filters: { year: 2024 },
@@ -45,7 +60,7 @@ describe("SetlistService.findManyLight", () => {
   // No date filter when neither year nor monthDay is provided
   test("omits date filter when no year or monthDay provided", async () => {
     const db = makeMockDb();
-    const service = new SetlistService(db as never);
+    const service = new SetlistService(db as never, makeRockOperaStub());
 
     await service.findManyLight({ filters: {} });
 
@@ -57,7 +72,7 @@ describe("SetlistService.findManyLight", () => {
   // but targets the denormalized YouTube count on the Show model.
   test("applies showYoutubesCount > 0 when hasYoutube is true", async () => {
     const db = makeMockDb();
-    const service = new SetlistService(db as never);
+    const service = new SetlistService(db as never, makeRockOperaStub());
 
     await service.findManyLight({
       filters: { year: 2024, hasYoutube: true },
@@ -72,7 +87,7 @@ describe("SetlistService.findManyLight", () => {
   // rather than skipping the filter (which is the `undefined` case).
   test("applies showYoutubesCount = 0 when hasYoutube is false", async () => {
     const db = makeMockDb();
-    const service = new SetlistService(db as never);
+    const service = new SetlistService(db as never, makeRockOperaStub());
 
     await service.findManyLight({
       filters: { year: 2024, hasYoutube: false },
@@ -86,7 +101,7 @@ describe("SetlistService.findManyLight", () => {
   // "shows without photos" filter from the year-page UI.
   test("applies showPhotosCount = 0 when hasPhotos is false", async () => {
     const db = makeMockDb();
-    const service = new SetlistService(db as never);
+    const service = new SetlistService(db as never, makeRockOperaStub());
 
     await service.findManyLight({
       filters: { year: 2024, hasPhotos: false },
@@ -100,7 +115,7 @@ describe("SetlistService.findManyLight", () => {
   // either count column so all shows remain in the results.
   test("omits photos/youtube filters when hasPhotos and hasYoutube are undefined", async () => {
     const db = makeMockDb();
-    const service = new SetlistService(db as never);
+    const service = new SetlistService(db as never, makeRockOperaStub());
 
     await service.findManyLight({ filters: { year: 2024 } });
 
@@ -114,7 +129,7 @@ describe("SetlistService.findManyLight", () => {
   // and negative mix to cover the cross-product.
   test("stacks hasPhotos=true with hasYoutube=false", async () => {
     const db = makeMockDb();
-    const service = new SetlistService(db as never);
+    const service = new SetlistService(db as never, makeRockOperaStub());
 
     await service.findManyLight({
       filters: { year: 2024, hasPhotos: true, hasYoutube: false },
@@ -132,7 +147,7 @@ describe("SetlistService.findManyLight", () => {
   // see NON_STUB_SHOWS_WHERE.
   test("excludes orphan stub shows (no venue) from year listings", async () => {
     const db = makeMockDb();
-    const service = new SetlistService(db as never);
+    const service = new SetlistService(db as never, makeRockOperaStub());
 
     await service.findManyLight({ filters: { year: 2024 } });
 
@@ -236,7 +251,7 @@ describe("SetlistService.findByShowSlug", () => {
   // payload — keeps the response compact).
   test("includes previousPerformanceShow date+slug on tracks", async () => {
     const db = makeMockDb();
-    const service = new SetlistService(db as never);
+    const service = new SetlistService(db as never, makeRockOperaStub());
 
     await service.findByShowSlug("2024-07-26-red-rocks-amphitheatre-morrison-co");
 
@@ -251,7 +266,7 @@ describe("SetlistService.findByShowSlug", () => {
   // from Prisma with the denormalized `gap` field already populated.
   test("returns averageSongGap derived from tracks", async () => {
     const db = makeMockDb();
-    const service = new SetlistService(db as never);
+    const service = new SetlistService(db as never, makeRockOperaStub());
     db.show.findUnique.mockResolvedValue({
       id: "show-1",
       slug: "2024-07-26",
@@ -364,7 +379,7 @@ describe("SetlistService.findManyLight", () => {
   // toggle on those pages needs the same prior-show pointer + averageSongGap.
   test("includes previousPerformanceShow date+slug on tracks", async () => {
     const db = makeMockDb();
-    const service = new SetlistService(db as never);
+    const service = new SetlistService(db as never, makeRockOperaStub());
 
     await service.findManyLight({ filters: { year: 2024 } });
 
@@ -384,7 +399,7 @@ describe("SetlistService.countByMonthDay", () => {
   test("calls db.show.count with endsWith date filter scoped to stats shows", async () => {
     const db = makeMockDb();
     db.show.count.mockResolvedValue(7);
-    const service = new SetlistService(db as never);
+    const service = new SetlistService(db as never, makeRockOperaStub());
 
     const result = await service.countByMonthDay("04-08");
 

--- a/packages/core/src/setlists/setlist-service.ts
+++ b/packages/core/src/setlists/setlist-service.ts
@@ -18,6 +18,7 @@ import {
   SHOW_ORDER_DESC,
   STATS_SHOWS_WHERE,
 } from "../_shared/show-ordering";
+import type { RockOperaService } from "../rock-operas/rock-opera-service";
 
 /**
  * Filter options for setlist queries. The `hasPhotos` / `hasYoutube` flags
@@ -265,6 +266,7 @@ function mapSetlistToDomainEntity(
     averageSongGap: average(eligible),
     medianSongGap: median(eligible),
     debutCount: computeDebutCount(tracks),
+    rockOperaPerformances: [],
   };
 }
 
@@ -328,11 +330,33 @@ function mapSetlistLightToDomainEntity(
     averageSongGap: average(eligible),
     medianSongGap: median(eligible),
     debutCount: computeDebutCount(tracks),
+    rockOperaPerformances: [],
   };
 }
 
 export class SetlistService {
-  constructor(private readonly db: DbClient) {}
+  constructor(
+    private readonly db: DbClient,
+    /**
+     * Used by `overlayRockOperaAnnotations` so every Setlist this
+     * service returns carries its rock opera annotations. Centralizing
+     * the lookup here means SetlistCard renders the
+     * "Nth full performance of <name>" line wherever a Setlist is read,
+     * without each caller having to know to ask for annotations.
+     */
+    private readonly rockOperas: RockOperaService,
+  ) {}
+
+  private async overlayRockOperaAnnotations<T extends Setlist | SetlistLight>(setlists: T[]): Promise<T[]> {
+    if (setlists.length === 0) return setlists;
+    const annotations = await this.rockOperas.findPerformancesForShows(setlists.map((s) => s.show.id));
+    if (annotations.size === 0) return setlists;
+    for (const setlist of setlists) {
+      const forShow = annotations.get(setlist.show.id);
+      if (forShow) setlist.rockOperaPerformances = forShow;
+    }
+    return setlists;
+  }
 
   async findByShowId(id: string): Promise<Setlist | null> {
     const show = await this.db.show.findUnique({
@@ -352,10 +376,12 @@ export class SetlistService {
 
     if (!show || !show.venue) return null;
 
-    return mapSetlistToDomainEntity({
+    const setlist = mapSetlistToDomainEntity({
       ...show,
       venue: show.venue,
     });
+    await this.overlayRockOperaAnnotations([setlist]);
+    return setlist;
   }
 
   async findByShowSlug(slug: string): Promise<Setlist | null> {
@@ -376,10 +402,12 @@ export class SetlistService {
 
     if (!result || !result.venue) return null;
 
-    return mapSetlistToDomainEntity({
+    const setlist = mapSetlistToDomainEntity({
       ...result,
       venue: result.venue,
     });
+    await this.overlayRockOperaAnnotations([setlist]);
+    return setlist;
   }
 
   /**
@@ -429,7 +457,7 @@ export class SetlistService {
       },
     });
 
-    return results
+    const setlists = results
       .filter((show) => show.venue !== null)
       .map((show) =>
         mapSetlistToDomainEntity({
@@ -441,6 +469,7 @@ export class SetlistService {
           })),
         }),
       );
+    return this.overlayRockOperaAnnotations(setlists);
   }
 
   async findMany(options?: {
@@ -491,7 +520,7 @@ export class SetlistService {
       },
     });
 
-    return results
+    const setlists = results
       .filter((result): result is typeof result & { venue: NonNullable<typeof result.venue> } => result.venue !== null)
       .map((show) =>
         mapSetlistToDomainEntity({
@@ -503,6 +532,7 @@ export class SetlistService {
           })),
         }),
       );
+    return this.overlayRockOperaAnnotations(setlists);
   }
 
   /**
@@ -579,7 +609,7 @@ export class SetlistService {
       },
     });
 
-    return results
+    const setlists = results
       .filter((result): result is typeof result & { venue: NonNullable<typeof result.venue> } => result.venue !== null)
       .map((show) =>
         mapSetlistLightToDomainEntity({
@@ -591,6 +621,7 @@ export class SetlistService {
           })),
         }),
       );
+    return this.overlayRockOperaAnnotations(setlists);
   }
 
   async countByMonthDay(monthDay: string): Promise<number> {

--- a/packages/core/src/shows/show-service.test.ts
+++ b/packages/core/src/shows/show-service.test.ts
@@ -9,14 +9,17 @@ const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } 
 // Cache invalidation stub — write-path tests don't reach into it but the
 // constructor requires a real-shaped service. Cast at the boundary so we
 // don't have to enumerate every method.
-function makeCacheInvalidationStub(): CacheInvalidationService {
+function makeCacheInvalidationStub(): CacheInvalidationService & {
+  invalidateRockOperaAssignment: Mock;
+} {
   return {
     invalidateShow: vi.fn(),
     invalidateShowListings: vi.fn(),
     invalidateShowComprehensive: vi.fn(),
     invalidateSongCaches: vi.fn(),
     invalidateAllTimers: vi.fn(),
-  } as unknown as CacheInvalidationService;
+    invalidateRockOperaAssignment: vi.fn(),
+  } as unknown as CacheInvalidationService & { invalidateRockOperaAssignment: Mock };
 }
 
 // Stats stub — preserves the Mock type on `rebuildGapsAndSongStatsSince`
@@ -29,7 +32,11 @@ function makeStatsStub(): StatsService & { rebuildGapsAndSongStatsSince: Mock } 
 }
 
 function makeMockDb() {
-  return {
+  // Bound to a single object so $transaction(callback) passes the same
+  // mock through, letting tests assert on `db.rockOperaPerformance.*.mock.calls`
+  // for calls made inside the transaction.
+  // biome-ignore lint/suspicious/noExplicitAny: test mock
+  const db: any = {
     show: {
       findMany: vi.fn().mockResolvedValue([]),
       findUnique: vi.fn(),
@@ -61,11 +68,26 @@ function makeMockDb() {
     venue: {
       findUnique: vi.fn().mockResolvedValue(null),
     },
-    $transaction: vi.fn(async (ops: unknown[]) => {
-      // Mirror Prisma's array-form $transaction: resolve each pre-built call.
-      return Promise.all(ops as Array<Promise<unknown>>);
-    }),
+    rockOpera: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    rockOperaPerformance: {
+      findMany: vi.fn().mockResolvedValue([]),
+      deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      createMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
   };
+  db.$transaction = vi.fn(async (input: unknown) => {
+    // Two forms: an array of pre-built calls, or a callback that receives
+    // the tx client. Mirror both — the rock-opera diff uses the callback
+    // form so it can sequence findMany → deleteMany → createMany against
+    // the same tx handle.
+    if (typeof input === "function") {
+      return (input as (tx: unknown) => Promise<unknown>)(db);
+    }
+    return Promise.all(input as Array<Promise<unknown>>);
+  });
+  return db;
 }
 
 describe("ShowService.getShowDatesWithFlags", () => {
@@ -230,6 +252,142 @@ describe("ShowService.update countForStats", () => {
 
     const updateArgs = db.show.update.mock.calls[0][0];
     expect(updateArgs.data.countForStats).toBe(false);
+  });
+});
+
+describe("ShowService.update — rock opera assignments", () => {
+  // Helper: stock a show.update mock that returns a valid show row so the
+  // outer update flow completes. The rock opera diff runs after this.
+  function setupShowUpdate(db: ReturnType<typeof makeMockDb>) {
+    db.show.findUnique.mockResolvedValueOnce({ id: "show-id", date: "2024-03-29", venueId: "venue-1" });
+    db.show.update.mockResolvedValue({
+      id: "show-id",
+      slug: "2024-03-29-test",
+      date: "2024-03-29",
+      venueId: "venue-1",
+      bandId: "band-1",
+      notes: null,
+      relistenUrl: null,
+      legacyId: null,
+      likesCount: 0,
+      averageRating: 0,
+      ratingsCount: 0,
+      showPhotosCount: 0,
+      showYoutubesCount: 0,
+      reviewsCount: 0,
+      countForStats: true,
+      dayOrder: null,
+      searchText: null,
+      searchVector: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  }
+
+  // Admin toggles rock opera tags from {A, B} to {B, C}. Expect a transactional
+  // diff: A is deleted, C is inserted, B is untouched. Drives the admin form
+  // "set me to exactly this list" semantics.
+  test("diffs {A,B} -> {B,C} as delete A + insert C, leaves B untouched", async () => {
+    const db = makeMockDb();
+    setupShowUpdate(db);
+    // Current rock opera tags for the show
+    db.rockOperaPerformance.findMany.mockResolvedValueOnce([
+      { rockOperaId: "ro-A", rockOpera: { slug: "opera-A" } },
+      { rockOperaId: "ro-B", rockOpera: { slug: "opera-B" } },
+    ]);
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), makeStatsStub());
+
+    await service.update("2024-03-29-test", {
+      date: "2024-03-29",
+      rockOperaIds: ["ro-B", "ro-C"],
+    });
+
+    expect(db.rockOperaPerformance.deleteMany).toHaveBeenCalledWith({
+      where: { showId: "show-id", rockOperaId: { in: ["ro-A"] } },
+    });
+    expect(db.rockOperaPerformance.createMany).toHaveBeenCalledWith({
+      data: [{ showId: "show-id", rockOperaId: "ro-C" }],
+    });
+  });
+
+  // No rock opera change → no diff queries fired. Untouched edits (notes
+  // only, etc.) shouldn't read or write the join table.
+  test("does not touch rock opera tables when rockOperaIds is omitted", async () => {
+    const db = makeMockDb();
+    setupShowUpdate(db);
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), makeStatsStub());
+
+    await service.update("2024-03-29-test", { date: "2024-03-29", notes: "edited" });
+
+    expect(db.rockOperaPerformance.findMany).not.toHaveBeenCalled();
+    expect(db.rockOperaPerformance.deleteMany).not.toHaveBeenCalled();
+    expect(db.rockOperaPerformance.createMany).not.toHaveBeenCalled();
+  });
+
+  // Empty array semantics: caller is saying "this show has no rock opera
+  // tags". Delete every existing row for the show, insert nothing.
+  test("clears all tags when rockOperaIds is an empty array", async () => {
+    const db = makeMockDb();
+    setupShowUpdate(db);
+    db.rockOperaPerformance.findMany.mockResolvedValueOnce([
+      { rockOperaId: "ro-A", rockOpera: { slug: "opera-A" } },
+      { rockOperaId: "ro-B", rockOpera: { slug: "opera-B" } },
+    ]);
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), makeStatsStub());
+
+    await service.update("2024-03-29-test", { date: "2024-03-29", rockOperaIds: [] });
+
+    expect(db.rockOperaPerformance.deleteMany).toHaveBeenCalledWith({
+      where: { showId: "show-id", rockOperaId: { in: ["ro-A", "ro-B"] } },
+    });
+    expect(db.rockOperaPerformance.createMany).not.toHaveBeenCalled();
+  });
+
+  // No-op diff (current set === new set): no writes, no cache invalidation
+  // for rock operas. The outer show comprehensive invalidation still fires.
+  test("no DB writes or rock opera cache invalidation when tags are unchanged", async () => {
+    const db = makeMockDb();
+    setupShowUpdate(db);
+    db.rockOperaPerformance.findMany.mockResolvedValueOnce([
+      { rockOperaId: "ro-A", rockOpera: { slug: "opera-A" } },
+      { rockOperaId: "ro-B", rockOpera: { slug: "opera-B" } },
+    ]);
+    const cacheStub = makeCacheInvalidationStub();
+    const service = new ShowService(db as never, logger, cacheStub, makeStatsStub());
+
+    await service.update("2024-03-29-test", { date: "2024-03-29", rockOperaIds: ["ro-A", "ro-B"] });
+
+    expect(db.rockOperaPerformance.deleteMany).not.toHaveBeenCalled();
+    expect(db.rockOperaPerformance.createMany).not.toHaveBeenCalled();
+    expect(cacheStub.invalidateRockOperaAssignment).not.toHaveBeenCalled();
+  });
+
+  // Cache invalidation fires for the union of removed + added slugs (so
+  // both opera-A's resource page list and opera-C's are refreshed).
+  // Neighbor-show invalidation (every other tagged show's annotation
+  // rank shifting) is handled at the broader invalidateShowListings
+  // layer via the show.data:* pattern delete — see
+  // cache-invalidation-service.test.ts.
+  test("invalidates rock opera caches for the union of removed + added slugs", async () => {
+    const db = makeMockDb();
+    setupShowUpdate(db);
+    db.rockOperaPerformance.findMany.mockResolvedValueOnce([
+      { rockOperaId: "ro-A", rockOpera: { slug: "opera-A" } },
+      { rockOperaId: "ro-B", rockOpera: { slug: "opera-B" } },
+    ]);
+    // Resolve newly-added opera-C's slug for cache invalidation
+    db.rockOpera.findMany.mockResolvedValueOnce([{ id: "ro-C", slug: "opera-C" }]);
+    const cacheStub = makeCacheInvalidationStub();
+    const service = new ShowService(db as never, logger, cacheStub, makeStatsStub());
+
+    await service.update("2024-03-29-test", { date: "2024-03-29", rockOperaIds: ["ro-B", "ro-C"] });
+
+    expect(cacheStub.invalidateRockOperaAssignment).toHaveBeenCalledWith(
+      expect.arrayContaining(["opera-A", "opera-C"]),
+    );
+    // opera-B is untouched (in both sets) — should not appear in invalidation list.
+    const invalidatedSlugs = (cacheStub.invalidateRockOperaAssignment as Mock).mock.calls[0][0] as string[];
+    expect(invalidatedSlugs).not.toContain("opera-B");
   });
 });
 

--- a/packages/core/src/shows/show-service.ts
+++ b/packages/core/src/shows/show-service.ts
@@ -35,6 +35,13 @@ export interface ShowServiceCreateInput {
   notes?: string | null;
   relistenUrl?: string | null;
   countForStats?: boolean;
+  /**
+   * Full-set semantics: the show ends up tagged with exactly these rock
+   * opera ids. Caller passes the complete list (including unchanged ones);
+   * update() diffs against current rows. Omit to leave tags untouched;
+   * pass `[]` to clear all tags.
+   */
+  rockOperaIds?: string[];
 }
 
 export type ShowCreateInput = Prisma.ShowCreateInput;
@@ -416,6 +423,10 @@ export class ShowService {
       await this.cacheInvalidation.invalidateShowComprehensive(currentShow.id, slug);
     }
 
+    if (data.rockOperaIds !== undefined) {
+      await this.syncRockOperaAssignments(currentShow.id, data.rockOperaIds);
+    }
+
     // Show edits that move the show in time (or later: count_for_stats /
     // day_order toggles) can change the gap denominator. Rebuild from the
     // earlier of the old and new dates so chains spanning either side are
@@ -427,6 +438,54 @@ export class ShowService {
     }
 
     return show;
+  }
+
+  /**
+   * Apply full-set rock opera assignments to a show. Reads current tags,
+   * computes the diff against `nextRockOperaIds`, and runs delete + insert
+   * in one transaction. Targets the resource-page cache for every opera
+   * whose performance list changed; neighbor invalidation (show.data
+   * entries whose annotations shifted) is handled by the broader
+   * invalidateShowListings called from the outer update path.
+   */
+  private async syncRockOperaAssignments(showId: string, nextRockOperaIds: string[]): Promise<void> {
+    const current = await this.db.rockOperaPerformance.findMany({
+      where: { showId },
+      include: { rockOpera: { select: { id: true, slug: true } } },
+    });
+    const currentIds = new Set(current.map((row) => row.rockOperaId));
+    const nextIds = new Set(nextRockOperaIds);
+
+    const toRemove = current.filter((row) => !nextIds.has(row.rockOperaId));
+    const toAdd = nextRockOperaIds.filter((id) => !currentIds.has(id));
+
+    if (toRemove.length === 0 && toAdd.length === 0) return;
+
+    await this.db.$transaction(async (tx) => {
+      if (toRemove.length > 0) {
+        await tx.rockOperaPerformance.deleteMany({
+          where: { showId, rockOperaId: { in: toRemove.map((row) => row.rockOperaId) } },
+        });
+      }
+      if (toAdd.length > 0) {
+        await tx.rockOperaPerformance.createMany({
+          data: toAdd.map((rockOperaId) => ({ showId, rockOperaId })),
+        });
+      }
+    });
+
+    // Resolve added-id slugs (we already have removed-id slugs from `current`)
+    // so cache invalidation can target the affected resource pages.
+    const addedSlugs =
+      toAdd.length === 0
+        ? []
+        : (await this.db.rockOpera.findMany({ where: { id: { in: toAdd } }, select: { slug: true } })).map(
+            (r) => r.slug,
+          );
+    const removedSlugs = toRemove.map((row) => row.rockOpera.slug);
+    const affectedSlugs = Array.from(new Set([...removedSlugs, ...addedSlugs]));
+
+    await this.cacheInvalidation.invalidateRockOperaAssignment(affectedSlugs);
   }
 
   /**

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -12,12 +12,16 @@ export const CacheKeys = {
    */
   show: {
     /** Complete show + setlist data for show page */
-    data: (slug: string) => `show:${slug}:data:v3`,
+    data: (slug: string) => `show:${slug}:data:v5`,
 
     // Note: Reviews are loaded fresh from DB, not cached
 
     /** All cache keys for a show (for pattern deletion) */
     all: (slug: string) => `show:${slug}:*`,
+    /** Every show.data entry across all slugs (for invalidations on
+     *  mutations that ripple beyond a single show — e.g. a date shift
+     *  on a tagged show changes neighbors' rock opera annotations). */
+    allData: () => "show:*:data:*",
   },
 
   /**
@@ -27,7 +31,7 @@ export const CacheKeys = {
     /** Paginated show listings with filters */
     list: (filters: CacheFilters) => {
       const filterHash = hashFilters(filters);
-      return `shows:list:${filterHash}:v3`;
+      return `shows:list:${filterHash}:v5`;
     },
 
     /** All show listing caches (for pattern deletion) */
@@ -42,7 +46,7 @@ export const CacheKeys = {
    */
   setlist: {
     /** Complete setlist data with tracks and annotations */
-    data: (slug: string) => `setlist:${slug}:data:v3`,
+    data: (slug: string) => `setlist:${slug}:data:v5`,
   },
 
   /**
@@ -98,7 +102,7 @@ export const CacheKeys = {
      * have 400+ attended shows and the un-paginated payload is large enough
      * to be slow to deserialize/transport even from Redis.
      */
-    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}:v3`,
+    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}:v5`,
     /** All pages of a single user's attended-setlists caches (for per-user invalidation). */
     allAttendedSetlistsForUser: (userId: string) => `user:${userId}:attended-setlists:*`,
     /** All per-user attended-setlists caches (for pattern deletion on broad show mutations). */
@@ -115,11 +119,25 @@ export const CacheKeys = {
   },
 
   /**
+   * Rock opera cache keys. `performances` payloads back the resource-page
+   * lists (Hot Air Balloon / CWB / RIM). Per-show annotation data is no
+   * longer cached separately — SetlistService overlays it onto every
+   * returned setlist, so it rides inside the existing show.data /
+   * shows.list / users.attendedSetlists payloads.
+   */
+  rockOperas: {
+    /** Resource-page list payload: setlists + external sources for one rock opera. */
+    performances: (slug: string) => `rock-operas:performances:${slug}:v3`,
+    /** Pattern for invalidating every performances cache (broad mutations). */
+    allPerformances: () => "rock-operas:performances:*",
+  },
+
+  /**
    * Home page cache keys
    */
   home: {
     /** Recent setlists for home page (limit + sort direction) */
-    recentSetlists: (limit: number) => `home:recent-setlists:${limit}:v3`,
+    recentSetlists: (limit: number) => `home:recent-setlists:${limit}:v5`,
   },
 
   /**

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -11,6 +11,7 @@ export * from "./models/file";
 export * from "./models/logger";
 export * from "./models/rating";
 export * from "./models/review";
+export * from "./models/rock-opera";
 export * from "./models/search-history";
 export * from "./models/setlist";
 export * from "./models/show";

--- a/packages/domain/src/models/rock-opera.ts
+++ b/packages/domain/src/models/rock-opera.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+export const rockOperaSchema = z.object({
+  id: z.string().uuid(),
+  slug: z.string(),
+  name: z.string(),
+  shortName: z.string(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type RockOpera = z.infer<typeof rockOperaSchema>;
+
+/**
+ * Pointer to the chronologically adjacent performance of the same rock
+ * opera. `gap` is the count of `count_for_stats=true` shows strictly
+ * between the two performance dates (matches Track.gap semantics).
+ */
+export type AdjacentRockOperaPerformance = {
+  date: string;
+  slug: string | null;
+  gap: number;
+};
+
+/**
+ * One rock opera annotation on a show, including the show's 1-based rank
+ * among all full performances of that rock opera (chronological order).
+ * `previousPerformance` is absent on the 1st full performance ever;
+ * `nextPerformance` is absent on the most recent one. Surfaced by
+ * setlist composers for show-page rendering.
+ */
+export type RockOperaPerformanceAnnotation = {
+  rockOpera: Pick<RockOpera, "slug" | "name" | "shortName">;
+  performanceNumber: number;
+  previousPerformance: AdjacentRockOperaPerformance | null;
+  nextPerformance: AdjacentRockOperaPerformance | null;
+};

--- a/packages/domain/src/models/setlist.ts
+++ b/packages/domain/src/models/setlist.ts
@@ -1,4 +1,5 @@
 import type { Annotation } from "./annotation";
+import type { RockOperaPerformanceAnnotation } from "./rock-opera";
 import type { Show } from "./show";
 import type { Track, TrackLight } from "./track";
 import type { Venue } from "./venue";
@@ -22,6 +23,12 @@ export type Setlist = {
    * because debuts are excluded from those numbers but still signal rarity.
    */
   debutCount: number;
+  /**
+   * Rock opera annotations for this show. Populated only by single-show
+   * fetches (services.setlists.findByShowSlug); list-page composers leave
+   * this empty so list pages pay no lookup cost.
+   */
+  rockOperaPerformances: RockOperaPerformanceAnnotation[];
 };
 
 export type SetLight = {
@@ -43,4 +50,10 @@ export type SetlistLight = {
    * because debuts are excluded from those numbers but still signal rarity.
    */
   debutCount: number;
+  /**
+   * Rock opera annotations for this show. Populated only by single-show
+   * fetches (services.setlists.findByShowSlug); list-page composers leave
+   * this empty so list pages pay no lookup cost.
+   */
+  rockOperaPerformances: RockOperaPerformanceAnnotation[];
 };


### PR DESCRIPTION
## Summary

- Tag any show as a full performance of one of the three rock operas (Hot Air Balloon, Chemical Warfare Brigade, Revolution In Motion) from the show edit form.
- Tagged shows display a "Nth full performance of <name>" callout above the setlist, with linked previous/next performance dates and the show gap to each. The callout renders on every SetlistCard: show page, year listings, top-rated, search, attended shows.
- Each rock opera resource page (`/resources/hot-air-balloon`, `/resources/chemical-warfare-brigade`, `/resources/revolution-in-motion`) gains a numbered, collapsible Full Performances section in chronological order, plus an in-page table of contents.
- Revolution in Motion's Listen & Watch panel now links Spotify + Apple Music + YouTube + a multi-service chooser directly, instead of routing every Spotify link through song.link (Odesli can't pair these albums' Spotify and Apple Music releases, so the chooser silently dropped one or the other). Podcast episodes link to pod.link.
- The 16 known historical performances are seeded by the migration.

## Test plan

- [ ] `/shows/2007-10-31-orpheum-theater-boston-ma` shows "★ This was the 8th full performance of The Hot Air Balloon" with linked previous (10/31/04 era) and next (12/31/18) dates and gap counts.
- [ ] `/resources/hot-air-balloon` lists 9 numbered performances (oldest first), each card expandable to its setlist with the same annotation.
- [ ] `/resources/chemical-warfare-brigade` lists 6 performances, `/resources/revolution-in-motion` lists 1.
- [ ] Year page (`/shows/year/1998`) and top-rated page show the annotation on tagged shows when their setlist card expands.
- [ ] Admin edit form on any show has a "Full rock opera performances" checkbox group between Band and Notes; toggling and saving updates the annotation and resource page on next request.
- [ ] Revolution in Motion's Listen & Watch panel shows Spotify + Apple Music + YouTube (Studio Album only) + multi-service icons per album; podcast episodes use the podcast icon and pair up two-per-row on mobile.
- [ ] Mobile viewport (375px) renders the Listen & Watch panel without truncation; album rows aren't cut off and podcast rows stack 2 wide.

## Implementation notes

- `RockOperaService.findPerformancesForShows(showIds)` is the batched lookup. `SetlistService` injects it and overlays annotations on every `Setlist` it returns, so every UI surface gets annotations without each caller knowing to ask.
- Cached Setlist payloads (`show.data`, `shows.list`, `setlist.data`, `users.attendedSetlists`, `home.recentSetlists`) embed `rockOperaPerformances`, so all those cache keys are bumped to `:v5`. `rockOperas.performances:slug:v3` caches the resource-page payload.
- `invalidateShowListings` adds two pattern wipes (`rockOperas.allPerformances`, `show.allData`) so any show-affecting mutation (notes, tracks, ratings, date shifts, rock opera assignment changes) clears neighbor caches whose annotations may have shifted.
- The sync script (`packages/core/scripts/sync-missing-shows.ts`) mirrors the `rock_operas` table and per-show assignments from prod via two new MCP fields (`get_rock_operas`, `rockOperaSlugs` on `get_shows`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
