### PR TITLE
Purge Cloudflare year tags for past-year show edits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ cd apps/web && bun run test:watch    # Watch mode
 
 Test files are colocated with source: `*.test.{ts,tsx}`. Shared test helpers live in `apps/web/test/test-utils.tsx` (import via `@test/*` alias, e.g. `import { setup } from "@test/test-utils"`).
 
+**Skip tests the typechecker covers.** Don't test helper signatures, argument counts, or type-enforced shapes. Add only wiring assertions where the typechecker can't verify a value gets pulled from the right source (e.g. the right field threads through a call chain).
+
 **Git Hooks:**
 Custom hooks live in `.githooks/`. Enable them once per clone:
 ```bash

--- a/apps/web/app/routes/on-this-day.$monthDay.tsx
+++ b/apps/web/app/routes/on-this-day.$monthDay.tsx
@@ -32,7 +32,10 @@ interface LoaderData {
 
 export function headers(): Headers {
   const headers = new Headers();
-  headers.set("Cache-Control", "public, max-age=300, s-maxage=86400, stale-while-revalidate=3600");
+  // max-age only, no `s-maxage`. This route has no Cache-Tag mapping any
+  // subset of shows, so the edge has no purge path for show mutations.
+  // Origin work is covered by Redis (setlists + all-timers caches).
+  headers.set("Cache-Control", "public, max-age=300");
   return headers;
 }
 

--- a/packages/core/src/_shared/cache/cache-invalidation-service.test.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.test.ts
@@ -50,7 +50,7 @@ describe("CacheInvalidationService.invalidateShowListings", () => {
     const cache = makeCache();
     const service = new CacheInvalidationService(cache as never, logger);
 
-    await service.invalidateShowListings();
+    await service.invalidateShowListings([2018]);
 
     expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.users.allAttendedSetlists());
   });
@@ -62,7 +62,7 @@ describe("CacheInvalidationService.invalidateShowListings", () => {
     const cache = makeCache();
     const service = new CacheInvalidationService(cache as never, logger);
 
-    await service.invalidateShowListings();
+    await service.invalidateShowListings([2018]);
 
     expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.shows.allLists());
     expect(cache.delPattern).toHaveBeenCalledWith("home:*");
@@ -77,7 +77,7 @@ describe("CacheInvalidationService.invalidateShowListings", () => {
     const cache = makeCache();
     const service = new CacheInvalidationService(cache as never, logger);
 
-    await service.invalidateShowListings();
+    await service.invalidateShowListings([2018]);
 
     expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.users.allSongHistory());
   });
@@ -91,7 +91,7 @@ describe("CacheInvalidationService.invalidateShowListings", () => {
     const cache = makeCache();
     const service = new CacheInvalidationService(cache as never, logger);
 
-    await service.invalidateShowListings();
+    await service.invalidateShowListings([2018]);
 
     expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.rockOperas.allPerformances());
   });
@@ -106,8 +106,48 @@ describe("CacheInvalidationService.invalidateShowListings", () => {
     const cache = makeCache();
     const service = new CacheInvalidationService(cache as never, logger);
 
-    await service.invalidateShowListings();
+    await service.invalidateShowListings([2018]);
 
     expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.show.allData());
+  });
+
+  // The `/shows/year/:year` route is edge-cached with a `year-YYYY`
+  // Cache-Tag (24h s-maxage past years, 5m current). Mutations on a show
+  // must purge exactly the year(s) tied to that show; otherwise the year
+  // listing stays stale at the edge even though Redis has been wiped.
+  test("purges Cloudflare year tags for the supplied years", async () => {
+    const cache = makeCache();
+    const cloudflareCache = { purgeYearListings: vi.fn().mockResolvedValue(undefined) };
+    const service = new CacheInvalidationService(cache as never, logger, cloudflareCache as never);
+
+    await service.invalidateShowListings([2018, 2024]);
+
+    expect(cloudflareCache.purgeYearListings).toHaveBeenCalledWith([2018, 2024]);
+  });
+
+  // An empty years array means "no edge entry to evict" — the API call
+  // is skipped entirely. The Redis layer is still wiped above. A silent
+  // fallback to a default year would hide caller bugs.
+  test("skips Cloudflare purge when years is empty", async () => {
+    const cache = makeCache();
+    const cloudflareCache = { purgeYearListings: vi.fn().mockResolvedValue(undefined) };
+    const service = new CacheInvalidationService(cache as never, logger, cloudflareCache as never);
+
+    await service.invalidateShowListings([]);
+
+    expect(cloudflareCache.purgeYearListings).not.toHaveBeenCalled();
+  });
+
+  // Date-move edits pass both the old and new year, which collapse to one
+  // year when the move stays within a calendar year. Dedupe lives in the
+  // service so callers can pass duplicates without spamming Cloudflare.
+  test("dedupes year tags before calling Cloudflare", async () => {
+    const cache = makeCache();
+    const cloudflareCache = { purgeYearListings: vi.fn().mockResolvedValue(undefined) };
+    const service = new CacheInvalidationService(cache as never, logger, cloudflareCache as never);
+
+    await service.invalidateShowListings([2018, 2018, 2019]);
+
+    expect(cloudflareCache.purgeYearListings).toHaveBeenCalledWith([2018, 2019]);
   });
 });

--- a/packages/core/src/_shared/cache/cache-invalidation-service.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.ts
@@ -2,6 +2,24 @@ import { CacheKeys, type Logger } from "@bip/domain";
 import type { CacheService } from "./cache-service";
 import type { CloudflareCacheService } from "./cloudflare-cache-service";
 
+/**
+ * Extract the year from a show slug. Show slugs start with `YYYY-MM-DD-`.
+ * Returns null when the leading four characters don't parse as a year.
+ */
+export function yearFromShowSlug(slug: string): number | null {
+  const year = Number.parseInt(slug.slice(0, 4), 10);
+  return Number.isFinite(year) ? year : null;
+}
+
+/**
+ * Extract the year from a Show.date. The Prisma column is `String` in the
+ * `YYYY-MM-DD` format, but accept Date for callers that hold one in memory.
+ */
+export function yearFromShowDate(date: string | Date): number {
+  if (typeof date === "string") return Number.parseInt(date.slice(0, 4), 10);
+  return date.getUTCFullYear();
+}
+
 export class CacheInvalidationService {
   constructor(
     private readonly cache: CacheService,
@@ -43,10 +61,16 @@ export class CacheInvalidationService {
   }
 
   /**
-   * Invalidate all show listing caches (for when show metadata changes)
+   * Invalidate all show listing caches (for when show metadata changes).
+   *
+   * `years` lists the calendar years whose `/shows/year/:year` Cloudflare
+   * edge entries need purging — typically the year(s) of the mutated show.
+   * Pass an empty array when no year tag is affected; the Redis layer is
+   * purged unconditionally.
    */
-  async invalidateShowListings(): Promise<void> {
-    this.logger.info("Invalidating all show listing caches and home page");
+  async invalidateShowListings(years: number[]): Promise<void> {
+    this.logger.info("Invalidating all show listing caches and home page", { years });
+    const dedupedYears = Array.from(new Set(years.filter(Number.isFinite)));
     await Promise.all([
       this.cache.delPattern(CacheKeys.shows.allLists()),
       this.cache.delPattern("home:*"), // Invalidate all home page caches
@@ -68,7 +92,7 @@ export class CacheInvalidationService {
       // changes, neighbors' annotations (rank/prev/next) shift — wipe
       // every show.data so the next request rebuilds with fresh data.
       this.cache.delPattern(CacheKeys.show.allData()),
-      this.cloudflareCache?.purgeYearListings(),
+      dedupedYears.length > 0 ? this.cloudflareCache?.purgeYearListings(dedupedYears) : Promise.resolve(),
     ]);
   }
 
@@ -90,15 +114,23 @@ export class CacheInvalidationService {
   }
 
   /**
-   * Comprehensive show invalidation - clears all caches related to a show
+   * Comprehensive show invalidation - clears all caches related to a show.
+   *
+   * `years` lists the calendar year(s) whose listing edge entries must be
+   * purged — both old and new on a date move so each year's edge entry
+   * gets evicted.
    */
-  async invalidateShowComprehensive(showId?: string, slug?: string): Promise<void> {
-    this.logger.info(`Comprehensive invalidation for show: ${showId}, slug: ${slug}`);
+  async invalidateShowComprehensive(
+    showId: string | undefined,
+    slug: string | undefined,
+    years: number[],
+  ): Promise<void> {
+    this.logger.info(`Comprehensive invalidation for show: ${showId}, slug: ${slug}`, { years });
 
     await Promise.all([
       slug ? this.invalidateShow(slug) : Promise.resolve(),
       showId ? this.invalidateShowReviews(showId) : Promise.resolve(),
-      this.invalidateShowListings(),
+      this.invalidateShowListings(years),
       this.invalidateSongCaches(),
     ]);
   }
@@ -139,13 +171,27 @@ export class CacheInvalidationService {
   }
 
   /**
-   * Bulk invalidation for multiple shows (useful for admin operations)
+   * Bulk invalidation for multiple shows (useful for admin operations).
+   *
+   * Each show carries a `date` (preferred — Show.date is `YYYY-MM-DD`) or
+   * a `slug` that starts with the date; both feed the Cloudflare year-tag
+   * purge so every affected year's listing is evicted.
    */
-  async invalidateShows(shows: Array<{ id: string; slug?: string }>): Promise<void> {
+  async invalidateShows(shows: Array<{ id: string; slug?: string; date?: string | Date }>): Promise<void> {
     this.logger.info(`Bulk invalidating ${shows.length} shows`);
+
+    const years: number[] = [];
+    for (const show of shows) {
+      if (show.date !== undefined) {
+        years.push(yearFromShowDate(show.date));
+      } else if (show.slug) {
+        const year = yearFromShowSlug(show.slug);
+        if (year !== null) years.push(year);
+      }
+    }
 
     const invalidations = shows.map((show) => this.invalidateShowByShowId(show.id, show.slug));
 
-    await Promise.all([...invalidations, this.invalidateShowListings()]);
+    await Promise.all([...invalidations, this.invalidateShowListings(years)]);
   }
 }

--- a/packages/core/src/annotations/annotation-service.test.ts
+++ b/packages/core/src/annotations/annotation-service.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, type Mock, test, vi } from "vitest";
+import type { CacheInvalidationService } from "../_shared/cache";
+import { AnnotationService } from "./annotation-service";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+
+function makeCacheInvalidationStub(): CacheInvalidationService & { invalidateShowComprehensive: Mock } {
+  return {
+    invalidateShowComprehensive: vi.fn().mockResolvedValue(undefined),
+  } as unknown as CacheInvalidationService & { invalidateShowComprehensive: Mock };
+}
+
+describe("AnnotationService — Cloudflare year-tag wiring", () => {
+  // Adding/editing notes on a past-year show has the same edge-cache shape
+  // as the track all-timer bug: per-show Redis clears but `/shows/year/YYYY`
+  // stays stale unless the year is purged. The cache path looks the show up
+  // via the track relation — pull date alongside slug and pass the year.
+  test("update() passes the show's year derived from the track's show.date", async () => {
+    const db = {
+      track: {
+        findUnique: vi.fn().mockResolvedValue({
+          showId: "show-id",
+          show: { slug: "2018-07-12-red-rocks", date: "2018-07-12" },
+        }),
+      },
+      annotation: {
+        findUnique: vi.fn().mockResolvedValue({ trackId: "track-id" }),
+        update: vi.fn().mockResolvedValue({
+          id: "annotation-id",
+          trackId: "track-id",
+          desc: "Big jam",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+      },
+    };
+    const cache = makeCacheInvalidationStub();
+    const service = new AnnotationService(db as never, logger, cache);
+
+    await service.update("annotation-id", { desc: "Big jam" });
+
+    expect(cache.invalidateShowComprehensive).toHaveBeenCalledWith("show-id", "2018-07-12-red-rocks", [2018]);
+  });
+});

--- a/packages/core/src/annotations/annotation-service.ts
+++ b/packages/core/src/annotations/annotation-service.ts
@@ -1,5 +1,5 @@
 import type { Annotation, Logger } from "@bip/domain";
-import type { CacheInvalidationService } from "../_shared/cache";
+import { type CacheInvalidationService, yearFromShowDate } from "../_shared/cache";
 import type { DbAnnotation, DbClient } from "../_shared/database/models";
 
 // Mapper functions
@@ -23,14 +23,16 @@ export class AnnotationService {
   private async invalidateShowCachesForTrack(trackId: string): Promise<void> {
     if (!this.cacheInvalidation) return;
 
-    // Get track's show ID for cache invalidation
+    // slug keys the per-show Redis entries; date keys the Cloudflare
+    // `year-YYYY` listing tag.
     const track = await this.db.track.findUnique({
       where: { id: trackId },
-      select: { showId: true, show: { select: { slug: true } } },
+      select: { showId: true, show: { select: { slug: true, date: true } } },
     });
 
     if (track?.showId && track.show?.slug) {
-      await this.cacheInvalidation.invalidateShowComprehensive(track.showId, track.show.slug);
+      const year = yearFromShowDate(track.show.date);
+      await this.cacheInvalidation.invalidateShowComprehensive(track.showId, track.show.slug, [year]);
     }
   }
 

--- a/packages/core/src/ratings/rating-service.test.ts
+++ b/packages/core/src/ratings/rating-service.test.ts
@@ -414,7 +414,7 @@ describe("RatingService.clearForUser", () => {
       showSlug: "2024-08-12-cap-theatre",
     });
 
-    expect(invalidate).toHaveBeenCalledWith(undefined, "2024-08-12-cap-theatre");
+    expect(invalidate).toHaveBeenCalledWith(undefined, "2024-08-12-cap-theatre", [2024]);
   });
 
   // Track-type clears must invalidate the show's setlist cache. The cached
@@ -486,5 +486,45 @@ describe("RatingService.upsert", () => {
     });
 
     expect(invalidateShow).toHaveBeenCalledWith("2024-08-12-cap-theatre");
+  });
+
+  // Show ratings go through invalidateShowComprehensive — the year is parsed
+  // from the slug's leading `YYYY-MM-DD-` so the past-year edge entry on
+  // `/shows/year/YYYY` gets purged. Without the right year, a 2018 rating
+  // would clear Redis but leave the 24h-cached year listing stale.
+  test("passes the slug's year to invalidateShowComprehensive on a Show rating", async () => {
+    const invalidateShowComprehensive = vi.fn();
+    const now = new Date("2018-07-12T00:00:00Z");
+    const db = {
+      rating: {
+        upsert: vi.fn().mockResolvedValue({
+          id: "r1",
+          userId: "u1",
+          rateableId: "show-1",
+          rateableType: "Show",
+          value: 5,
+          createdAt: now,
+          updatedAt: now,
+        }),
+        aggregate: vi.fn().mockResolvedValue({ _avg: { value: 5.0 }, _count: { id: 1 } }),
+      },
+      show: { update: vi.fn() },
+      track: { update: vi.fn() },
+    } as never;
+
+    const service = new RatingService(db, {
+      invalidateAttendanceCaches: vi.fn(),
+      invalidateShow: vi.fn(),
+      invalidateShowComprehensive,
+    } as never);
+    await service.upsert({
+      rateableId: "show-1",
+      rateableType: "Show",
+      userId: "u1",
+      value: 5,
+      showSlug: "2018-07-12-red-rocks",
+    });
+
+    expect(invalidateShowComprehensive).toHaveBeenCalledWith(undefined, "2018-07-12-red-rocks", [2018]);
   });
 });

--- a/packages/core/src/ratings/rating-service.ts
+++ b/packages/core/src/ratings/rating-service.ts
@@ -1,5 +1,5 @@
 import type { Rating } from "@bip/domain";
-import type { CacheInvalidationService } from "../_shared/cache";
+import { type CacheInvalidationService, yearFromShowSlug } from "../_shared/cache";
 import type { DbClient, DbRating } from "../_shared/database/models";
 
 /**
@@ -142,7 +142,8 @@ export class RatingService {
     });
 
     if (data.rateableType === "Show" && data.showSlug) {
-      await this.cacheInvalidation.invalidateShowComprehensive(undefined, data.showSlug);
+      const year = yearFromShowSlug(data.showSlug);
+      await this.cacheInvalidation.invalidateShowComprehensive(undefined, data.showSlug, year !== null ? [year] : []);
     } else if (data.rateableType === "Track" && data.showSlug) {
       // The show's cached setlist payload at CacheKeys.show.data(slug)
       // embeds Track.averageRating/ratingsCount on each track, so a rating
@@ -360,7 +361,8 @@ export class RatingService {
     const stats = await this.updateRateableAverageRating(data.rateableId, data.rateableType);
 
     if (data.rateableType === "Show" && data.showSlug) {
-      await this.cacheInvalidation.invalidateShowComprehensive(undefined, data.showSlug);
+      const year = yearFromShowSlug(data.showSlug);
+      await this.cacheInvalidation.invalidateShowComprehensive(undefined, data.showSlug, year !== null ? [year] : []);
     } else if (data.rateableType === "Track" && data.showSlug) {
       // Same reason as the upsert path: Track.averageRating/ratingsCount
       // live inside the cached setlist payload, so a recompute has to bust

--- a/packages/core/src/shows/show-service.test.ts
+++ b/packages/core/src/shows/show-service.test.ts
@@ -391,6 +391,113 @@ describe("ShowService.update — rock opera assignments", () => {
   });
 });
 
+describe("ShowService — Cloudflare year-tag wiring", () => {
+  // create() lacks a "current year" to fall back on, so the new show's date
+  // is the only source of the year tag. Admin-creating a past-year show
+  // (e.g. a missing late-90s show) must purge that year's listing tag, not
+  // the current calendar year.
+  test("create() passes the new show's year to invalidateShowListings", async () => {
+    const db = makeMockDb();
+    const cacheStub = makeCacheInvalidationStub();
+    const service = new ShowService(db as never, logger, cacheStub, makeStatsStub());
+
+    await service.create({ date: "1999-12-31" });
+
+    expect(cacheStub.invalidateShowListings).toHaveBeenCalledWith([1999]);
+  });
+
+  // delete() reads the show's date before removing the row (also used by
+  // the stats rebuild). The Cloudflare purge for the deleted show's year
+  // must use that captured date, not the current year — otherwise
+  // /shows/year/2018 keeps showing the deleted row at the edge.
+  test("delete() passes the deleted show's year to invalidateShowComprehensive", async () => {
+    const db = makeMockDb();
+    db.show.findUnique.mockResolvedValueOnce({ slug: "2018-07-12-red-rocks", date: "2018-07-12" });
+    const cacheStub = makeCacheInvalidationStub();
+    const service = new ShowService(db as never, logger, cacheStub, makeStatsStub());
+
+    await service.delete("show-id");
+
+    expect(cacheStub.invalidateShowComprehensive).toHaveBeenCalledWith("show-id", "2018-07-12-red-rocks", [2018]);
+  });
+
+  // The show's actual year (not the current calendar year) must reach
+  // invalidateShowComprehensive so the `year-YYYY` Cloudflare tag for
+  // `/shows/year/YYYY` gets purged. Without this wiring, a past-year edit
+  // would clear Redis but leave the edge entry stale until s-maxage
+  // (24h for past years).
+  test("update() without a date change passes the show's year to invalidateShowComprehensive", async () => {
+    const db = makeMockDb();
+    db.show.findUnique.mockResolvedValueOnce({ id: "show-id", date: "2018-07-12", venueId: "venue-1" });
+    db.show.update.mockResolvedValue({
+      id: "show-id",
+      slug: "2018-07-12-red-rocks",
+      date: "2018-07-12",
+      venueId: "venue-1",
+      bandId: null,
+      notes: "edited",
+      relistenUrl: null,
+      countForStats: true,
+      dayOrder: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      likesCount: 0,
+      averageRating: 0,
+      ratingsCount: 0,
+      showPhotosCount: 0,
+      showYoutubesCount: 0,
+      reviewsCount: 0,
+    });
+    const cacheStub = makeCacheInvalidationStub();
+    const service = new ShowService(db as never, logger, cacheStub, makeStatsStub());
+
+    await service.update("2018-07-12-red-rocks", { date: "", notes: "edited" });
+
+    expect(cacheStub.invalidateShowComprehensive).toHaveBeenCalledWith("show-id", "2018-07-12-red-rocks", [2018]);
+  });
+
+  // A date-move across calendar years (2018 -> 2019) has to purge BOTH year
+  // tags: the old year so its listing evicts the now-misplaced row, the new
+  // year so its listing picks up the row. The slug also changes in this
+  // case so the call path goes through invalidateShowListings, not
+  // invalidateShowComprehensive.
+  test("update() with cross-year date move passes both old and new years", async () => {
+    const db = makeMockDb();
+    db.show.findUnique
+      .mockResolvedValueOnce({ id: "show-id", date: "2018-07-12", venueId: "venue-1" })
+      // generateShowSlug looks for slug collisions
+      .mockResolvedValueOnce(null);
+    db.show.update.mockResolvedValue({
+      id: "show-id",
+      slug: "2019-07-12-red-rocks",
+      date: "2019-07-12",
+      venueId: "venue-1",
+      bandId: null,
+      notes: null,
+      relistenUrl: null,
+      countForStats: true,
+      dayOrder: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      likesCount: 0,
+      averageRating: 0,
+      ratingsCount: 0,
+      showPhotosCount: 0,
+      showYoutubesCount: 0,
+      reviewsCount: 0,
+    });
+    db.venue.findUnique.mockResolvedValue({ name: "Red Rocks", city: "Morrison", state: "CO" });
+    const cacheStub = makeCacheInvalidationStub();
+    const service = new ShowService(db as never, logger, cacheStub, makeStatsStub());
+
+    await service.update("2018-07-12-red-rocks", { date: "2019-07-12" });
+
+    const listingsCall = (cacheStub.invalidateShowListings as Mock).mock.calls[0][0] as number[];
+    expect(listingsCall).toEqual(expect.arrayContaining([2018, 2019]));
+    expect(listingsCall).toHaveLength(2);
+  });
+});
+
 describe("ShowService — gap rebuild on mutation", () => {
   // Adding a new show changes the universe of count_for_stats=true shows,
   // which ripples to gap chains for songs whose performances span the new

--- a/packages/core/src/shows/show-service.ts
+++ b/packages/core/src/shows/show-service.ts
@@ -1,6 +1,6 @@
 import type { Logger, Show, Venue } from "@bip/domain";
 import { Prisma } from "@prisma/client";
-import type { CacheInvalidationService } from "../_shared/cache";
+import { type CacheInvalidationService, yearFromShowDate } from "../_shared/cache";
 import type { DbClient, DbShow, DbVenue } from "../_shared/database/models";
 import { buildIncludeClause, buildWhereClause } from "../_shared/database/query-utils";
 import type { FilterCondition, QueryOptions } from "../_shared/database/types";
@@ -359,7 +359,7 @@ export class ShowService {
     const show = mapShowToDomainEntity(result);
 
     // Invalidate show listing caches (new show affects listings)
-    await this.cacheInvalidation.invalidateShowListings();
+    await this.cacheInvalidation.invalidateShowListings([yearFromShowDate(createInput.date)]);
 
     // Adding a count_for_stats=true show changes the "shows between"
     // denominator for songs whose chains span this date — rebuild gaps
@@ -412,15 +412,23 @@ export class ShowService {
 
     const show = mapShowToDomainEntity(result);
 
+    // Year-tag purges cover both the old date (so its listing evicts) and
+    // the new date (so its listing picks the row up). `||` not `??` so an
+    // empty-string date falls through to currentShow.date, matching the
+    // slug-regen guard above.
+    const affectedYears = Array.from(
+      new Set([yearFromShowDate(currentShow.date), yearFromShowDate(data.date || currentShow.date)]),
+    );
+
     if (newSlug && newSlug !== slug) {
       // Slug changed - invalidate both old and new
       await Promise.all([
         this.cacheInvalidation.invalidateShow(slug), // old slug
         this.cacheInvalidation.invalidateShow(newSlug), // new slug
-        this.cacheInvalidation.invalidateShowListings(),
+        this.cacheInvalidation.invalidateShowListings(affectedYears),
       ]);
     } else {
-      await this.cacheInvalidation.invalidateShowComprehensive(currentShow.id, slug);
+      await this.cacheInvalidation.invalidateShowComprehensive(currentShow.id, slug, affectedYears);
     }
 
     if (data.rockOperaIds !== undefined) {
@@ -525,7 +533,7 @@ export class ShowService {
       ),
     );
 
-    await this.cacheInvalidation.invalidateShowListings();
+    await this.cacheInvalidation.invalidateShowListings([yearFromShowDate(date)]);
   }
 
   async delete(id: string): Promise<boolean> {
@@ -542,7 +550,8 @@ export class ShowService {
       });
 
       if (show?.slug) {
-        await this.cacheInvalidation.invalidateShowComprehensive(id, show.slug);
+        const years = show.date ? [yearFromShowDate(show.date)] : [];
+        await this.cacheInvalidation.invalidateShowComprehensive(id, show.slug, years);
       }
 
       // Removing a stats-show shrinks the "shows between" denominator for

--- a/packages/core/src/shows/youtube-service.test.ts
+++ b/packages/core/src/shows/youtube-service.test.ts
@@ -126,7 +126,7 @@ describe("YoutubeService.createForShow", () => {
   test("persists the row, increments showYoutubesCount, and invalidates show caches", async () => {
     const db = makeMockDb();
     db.showYoutube.create.mockResolvedValue({ id: "row-new", videoId: "dQw4w9WgXcQ" });
-    db.show.findUnique.mockResolvedValue({ slug: "2001-09-01-wetlands" });
+    db.show.findUnique.mockResolvedValue({ slug: "2001-09-01-wetlands", date: "2001-09-01" });
     const cache = makeMockCacheInvalidation();
     const service = new YoutubeService(db as never, cache as never);
 
@@ -140,7 +140,7 @@ describe("YoutubeService.createForShow", () => {
       where: { id: "show-1" },
       data: { showYoutubesCount: { increment: 1 } },
     });
-    expect(cache.invalidateShowComprehensive).toHaveBeenCalledWith("show-1", "2001-09-01-wetlands");
+    expect(cache.invalidateShowComprehensive).toHaveBeenCalledWith("show-1", "2001-09-01-wetlands", [2001]);
     expect(result).toEqual({
       id: "row-new",
       videoId: "dQw4w9WgXcQ",
@@ -186,7 +186,7 @@ describe("YoutubeService.deleteEntry", () => {
   test("looks up the show, deletes the row, decrements count, invalidates caches", async () => {
     const db = makeMockDb();
     db.showYoutube.findUnique.mockResolvedValue({ showId: "show-1" });
-    db.show.findUnique.mockResolvedValue({ slug: "2001-09-01-wetlands" });
+    db.show.findUnique.mockResolvedValue({ slug: "2001-09-01-wetlands", date: "2001-09-01" });
     const cache = makeMockCacheInvalidation();
     const service = new YoutubeService(db as never, cache as never);
 
@@ -201,7 +201,7 @@ describe("YoutubeService.deleteEntry", () => {
       where: { id: "show-1" },
       data: { showYoutubesCount: { decrement: 1 } },
     });
-    expect(cache.invalidateShowComprehensive).toHaveBeenCalledWith("show-1", "2001-09-01-wetlands");
+    expect(cache.invalidateShowComprehensive).toHaveBeenCalledWith("show-1", "2001-09-01-wetlands", [2001]);
   });
 
   // Deleting a row that no longer exists is a no-op — no delete, no count

--- a/packages/core/src/shows/youtube-service.ts
+++ b/packages/core/src/shows/youtube-service.ts
@@ -1,4 +1,4 @@
-import type { CacheInvalidationService } from "../_shared/cache";
+import { type CacheInvalidationService, yearFromShowDate } from "../_shared/cache";
 import type { DbClient } from "../_shared/database/models";
 
 function videoUrl(videoId: string): string {
@@ -114,10 +114,11 @@ export class YoutubeService {
     if (!this.cacheInvalidation) return;
     const show = await this.db.show.findUnique({
       where: { id: showId },
-      select: { slug: true },
+      select: { slug: true, date: true },
     });
     if (show?.slug) {
-      await this.cacheInvalidation.invalidateShowComprehensive(showId, show.slug);
+      const year = yearFromShowDate(show.date);
+      await this.cacheInvalidation.invalidateShowComprehensive(showId, show.slug, [year]);
     }
   }
 }

--- a/packages/core/src/tracks/track-service.test.ts
+++ b/packages/core/src/tracks/track-service.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, type Mock, test, vi } from "vitest";
+import type { CacheInvalidationService } from "../_shared/cache";
+import { TrackService } from "./track-service";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+
+function makeCacheInvalidationStub(): CacheInvalidationService & {
+  invalidateShowComprehensive: Mock;
+  invalidateAllTimers: Mock;
+} {
+  return {
+    invalidateShowComprehensive: vi.fn().mockResolvedValue(undefined),
+    invalidateAllTimers: vi.fn().mockResolvedValue(undefined),
+  } as unknown as CacheInvalidationService & {
+    invalidateShowComprehensive: Mock;
+    invalidateAllTimers: Mock;
+  };
+}
+
+describe("TrackService — Cloudflare year-tag wiring", () => {
+  // The user-reported bug: an admin toggling all-timer on a 2018 track
+  // updated the show detail page immediately but left the /shows/year/2018
+  // listing stale at the edge. The fix wires the show's actual year into
+  // invalidateShowComprehensive. Pull the year from the show row the cache
+  // path already looks up (not from the current calendar year).
+  test("update() passes the show's year derived from show.date", async () => {
+    const db = {
+      track: {
+        findUnique: vi.fn().mockResolvedValue({ showId: "show-id" }),
+        update: vi.fn().mockResolvedValue({
+          id: "track-id",
+          slug: "track-slug",
+          showId: "show-id",
+          songId: "song-id",
+          position: 1,
+          set: "S1",
+          allTimer: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+      },
+      show: {
+        findUnique: vi.fn().mockResolvedValue({ slug: "2018-07-12-red-rocks", date: "2018-07-12" }),
+      },
+    };
+    const cache = makeCacheInvalidationStub();
+    const service = new TrackService(db as never, logger, cache);
+
+    await service.update("track-id", { allTimer: true });
+
+    expect(cache.invalidateShowComprehensive).toHaveBeenCalledWith("show-id", "2018-07-12-red-rocks", [2018]);
+  });
+
+  // Delete shares the same invalidation path (private invalidateShowCaches),
+  // so verify it also threads the show year through.
+  test("delete() passes the show's year derived from show.date", async () => {
+    const db = {
+      track: {
+        findUnique: vi.fn().mockResolvedValue({ showId: "show-id" }),
+        delete: vi.fn().mockResolvedValue(undefined),
+      },
+      show: {
+        findUnique: vi.fn().mockResolvedValue({ slug: "2018-07-12-red-rocks", date: "2018-07-12" }),
+      },
+    };
+    const cache = makeCacheInvalidationStub();
+    const service = new TrackService(db as never, logger, cache);
+
+    await service.delete("track-id");
+
+    expect(cache.invalidateShowComprehensive).toHaveBeenCalledWith("show-id", "2018-07-12-red-rocks", [2018]);
+  });
+});

--- a/packages/core/src/tracks/track-service.ts
+++ b/packages/core/src/tracks/track-service.ts
@@ -1,5 +1,5 @@
 import type { Annotation, Logger, Track } from "@bip/domain";
-import type { CacheInvalidationService } from "../_shared/cache";
+import { type CacheInvalidationService, yearFromShowDate } from "../_shared/cache";
 import type { DbAnnotation, DbClient, DbSong, DbTrack } from "../_shared/database/models";
 import { buildIncludeClause, buildOrderByClause, buildWhereClause } from "../_shared/database/query-utils";
 import type { QueryOptions } from "../_shared/database/types";
@@ -52,14 +52,16 @@ export class TrackService {
   private async invalidateShowCaches(showId: string): Promise<void> {
     if (!this.cacheInvalidation) return;
 
-    // Get show slug for invalidation
+    // slug keys the per-show Redis entries; date keys the Cloudflare
+    // `year-YYYY` listing tag.
     const show = await this.db.show.findUnique({
       where: { id: showId },
-      select: { slug: true },
+      select: { slug: true, date: true },
     });
 
     if (show?.slug) {
-      await this.cacheInvalidation.invalidateShowComprehensive(showId, show.slug);
+      const year = yearFromShowDate(show.date);
+      await this.cacheInvalidation.invalidateShowComprehensive(showId, show.slug, [year]);
     }
   }
 


### PR DESCRIPTION
## Summary

- Admin edits on past-year shows (all-timer toggle, ratings, notes, YouTube links, show metadata) now show up on `/shows/year/YYYY` on the next request instead of waiting up to 24 hours for the Cloudflare edge cache to expire.
- Date-move edits across calendar years purge both the old and new year, so each year's listing evicts correctly.
- `/on-this-day/:monthDay` no longer edge-cached on Cloudflare. Redis already covers origin work and there was no purge path for show mutations.

## Technical detail

`/shows/year/:year` is edge-cached with a `year-YYYY` `Cache-Tag` and `s-maxage` of 24h for past years (5m for current). `CacheInvalidationService.invalidateShowListings` was calling `purgeYearListings()` with no argument, which defaulted to the current calendar year only. Track / annotation / rating / show edits on a 2018 show cleared Redis but left the `year-2018` edge entry stale.

Every listing-invalidation entry point now takes a `years: number[]` argument, threaded all the way down to Cloudflare. Show service derives the year from `Show.date`; rating service derives it from the slug's leading `YYYY-MM-DD-`. `ShowService.update` passes both old and new years to handle cross-year date moves.

`/on-this-day/:monthDay` had the same edge-cache shape but no Cache-Tag, so there was no targeted purge path. Rather than thread per-month-day invalidation through every show-mutation path, the route drops `s-maxage` and lets Redis carry origin load.

## Test plan

- [ ] On prod, toggle all-timer on a past-year track and confirm `/shows/year/YYYY` updates on the next page load.
- [ ] On prod, edit notes on a past-year show and confirm the listing reflects it.
- [ ] On prod, move a show's date across calendar years and confirm both year listings update.
- [ ] On prod, confirm `/on-this-day/:monthDay` updates immediately after editing a show on that date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
