### PR TITLE
Sync prod ratings, attendances, and stub users into local DBs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ db-restore:
 	@echo "Production data restored successfully."
 
 db-sync-missing-shows:
-	cd packages/core && doppler run -- bun run scripts/sync-missing-shows.ts $(if $(HELP),--help) $(if $(YEARS),--years=$(YEARS)) $(if $(DRY_RUN),--dry-run) $(if $(PRUNE_GHOST_SHOWS),--prune-ghost-shows)
+	cd packages/core && doppler run -- bun run scripts/sync-missing-shows.ts $(if $(HELP),--help) $(if $(YEARS),--years=$(YEARS)) $(if $(DRY_RUN),--dry-run) $(if $(PRUNE_GHOST_SHOWS),--prune-ghost-shows) $(if $(NO_USERS),--no-users) $(if $(FULL_USERS),--full-users)
 
 db-load-data-dump:
 	psql "$$(doppler secrets get DATABASE_URL --plain | sed 's|postgresql://postgres:|postgresql://supabase_admin:|')" -f $(PROD_DATA_PATH)

--- a/apps/web/app/routes/mcp/index.tsx
+++ b/apps/web/app/routes/mcp/index.tsx
@@ -220,7 +220,95 @@ const tools = [
       required: [],
     },
   },
+  // Sync tools — for the local sync-missing-shows script. Strictly PII-free:
+  // user rows return only id/username/avatar/timestamps; ratings + attendance
+  // carry no user PII on the model itself.
+  {
+    name: "list_users_since",
+    description:
+      "Paginated listing of non-PII user fields (id, username, avatar, timestamps) for users updated after a given time. Used by the local sync script.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        since: { type: "string", description: "ISO-8601 timestamp; rows with updatedAt > since are returned" },
+        cursor: { type: "string", description: "Opaque cursor from a prior page (base64 of updatedAt|id)" },
+        limit: { type: "number", description: "Max rows per page (default 2000, max 5000)" },
+      },
+      required: ["since"],
+    },
+  },
+  {
+    name: "list_ratings_since",
+    description:
+      "Paginated listing of ratings (id, userId, value, rateableType, rateableId, timestamps) updated after a given time. Used by the local sync script.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        since: { type: "string", description: "ISO-8601 timestamp; rows with updatedAt > since are returned" },
+        cursor: { type: "string", description: "Opaque cursor from a prior page (base64 of updatedAt|id)" },
+        limit: { type: "number", description: "Max rows per page (default 2000, max 5000)" },
+      },
+      required: ["since"],
+    },
+  },
+  {
+    name: "list_attendances_since",
+    description:
+      "Paginated listing of attendance rows (id, userId, showId, timestamps) updated after a given time. Used by the local sync script.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        since: { type: "string", description: "ISO-8601 timestamp; rows with updatedAt > since are returned" },
+        cursor: { type: "string", description: "Opaque cursor from a prior page (base64 of updatedAt|id)" },
+        limit: { type: "number", description: "Max rows per page (default 2000, max 5000)" },
+      },
+      required: ["since"],
+    },
+  },
+  {
+    name: "list_all_user_ids",
+    description: "Every user id on prod. Used by the local sync script's --full-users reconciliation pass.",
+    inputSchema: { type: "object", properties: {}, required: [] },
+  },
+  {
+    name: "list_all_rating_ids",
+    description: "Every rating id on prod. Used by the local sync script's --full-users reconciliation pass.",
+    inputSchema: { type: "object", properties: {}, required: [] },
+  },
+  {
+    name: "list_all_attendance_ids",
+    description: "Every attendance id on prod. Used by the local sync script's --full-users reconciliation pass.",
+    inputSchema: { type: "object", properties: {}, required: [] },
+  },
 ];
+
+const DEFAULT_SYNC_LIMIT = 2000;
+const MAX_SYNC_LIMIT = 5000;
+
+// Opaque cursor for the sync list endpoints. Encodes the last-seen
+// (updatedAt, id) so the next page starts after that boundary regardless of
+// rows landing at the same timestamp.
+function encodeSyncCursor(updatedAt: Date, id: string): string {
+  return Buffer.from(`${updatedAt.toISOString()}|${id}`, "utf8").toString("base64");
+}
+
+function decodeSyncCursor(cursor: string | undefined): { updatedAt: Date; id: string } | null {
+  if (!cursor) return null;
+  try {
+    const decoded = Buffer.from(cursor, "base64").toString("utf8");
+    const [iso, id] = decoded.split("|");
+    if (!iso || !id) return null;
+    return { updatedAt: new Date(iso), id };
+  } catch {
+    return null;
+  }
+}
+
+function clampSyncLimit(raw: unknown): number {
+  const n = typeof raw === "number" ? raw : DEFAULT_SYNC_LIMIT;
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_SYNC_LIMIT;
+  return Math.min(Math.floor(n), MAX_SYNC_LIMIT);
+}
 
 async function handleToolCall(name: string, args: Record<string, unknown>): Promise<unknown> {
   switch (name) {
@@ -658,6 +746,73 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
       }
 
       return { venues, ...(errors.length > 0 && { errors }) };
+    }
+
+    // Sync tools. The service's `select` allowlist already enforces the
+    // PII-free shape — see UserService.listForSync. We pass through directly
+    // here (no re-mapping) so any future widening of the projection has to
+    // happen in one place, with the test guarding it.
+    case "list_users_since": {
+      const since = new Date(args.since as string);
+      const cursor = decodeSyncCursor(args.cursor as string | undefined);
+      const limit = clampSyncLimit(args.limit);
+      const rows = await services.users.listForSync({
+        since,
+        cursorId: cursor?.id,
+        cursorUpdatedAt: cursor?.updatedAt,
+        limit,
+      });
+      const last = rows[rows.length - 1];
+      return {
+        users: rows,
+        nextCursor: rows.length === limit && last ? encodeSyncCursor(last.updatedAt, last.id) : null,
+      };
+    }
+
+    case "list_ratings_since": {
+      const since = new Date(args.since as string);
+      const cursor = decodeSyncCursor(args.cursor as string | undefined);
+      const limit = clampSyncLimit(args.limit);
+      const rows = await services.ratings.listForSync({
+        since,
+        cursorId: cursor?.id,
+        cursorUpdatedAt: cursor?.updatedAt,
+        limit,
+      });
+      const last = rows[rows.length - 1];
+      return {
+        ratings: rows,
+        nextCursor: rows.length === limit && last ? encodeSyncCursor(last.updatedAt, last.id) : null,
+      };
+    }
+
+    case "list_attendances_since": {
+      const since = new Date(args.since as string);
+      const cursor = decodeSyncCursor(args.cursor as string | undefined);
+      const limit = clampSyncLimit(args.limit);
+      const rows = await services.attendances.listForSync({
+        since,
+        cursorId: cursor?.id,
+        cursorUpdatedAt: cursor?.updatedAt,
+        limit,
+      });
+      const last = rows[rows.length - 1];
+      return {
+        attendances: rows,
+        nextCursor: rows.length === limit && last ? encodeSyncCursor(last.updatedAt, last.id) : null,
+      };
+    }
+
+    case "list_all_user_ids": {
+      return { ids: await services.users.listAllIdsForSync() };
+    }
+
+    case "list_all_rating_ids": {
+      return { ids: await services.ratings.listAllIdsForSync() };
+    }
+
+    case "list_all_attendance_ids": {
+      return { ids: await services.attendances.listAllIdsForSync() };
     }
 
     default:

--- a/packages/core/scripts/sync-missing-shows.test.ts
+++ b/packages/core/scripts/sync-missing-shows.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import {
   buildRockOperaAssignmentDiff,
   buildSetlistReconciliation,
@@ -15,6 +15,9 @@ import {
   matchVenue,
   parseYearsArg,
   showNeedsUpdate,
+  stubUserEmail,
+  STUB_USER_PASSWORD_DIGEST,
+  syncUserActivity,
   type LocalTrackForReconcile,
   type McpSearchVenueResult,
   type McpSetlist,
@@ -1591,5 +1594,545 @@ describe("buildSongDriftUpdate", () => {
     expect(patch).not.toHaveProperty("timesPlayed");
     expect(patch).not.toHaveProperty("dateFirstPlayed");
     expect(patch).not.toHaveProperty("dateLastPlayed");
+  });
+});
+
+describe("stubUserEmail / STUB_USER_PASSWORD_DIGEST", () => {
+  // Stub users' email and passwordDigest satisfy NOT NULL constraints
+  // without leaking real PII. The shape is asserted here as a regression
+  // guard — production sync output uses these values and changing them
+  // breaks existing local DBs.
+  test("stubUserEmail is deterministic and prefixed with stub-", () => {
+    expect(stubUserEmail("a1b2c3d4-e5f6-7890-abcd-ef1234567890")).toBe(
+      "stub-a1b2c3d4-e5f6-7890-abcd-ef1234567890@local.invalid",
+    );
+  });
+
+  test("STUB_USER_PASSWORD_DIGEST is a static placeholder, not a real digest", () => {
+    expect(STUB_USER_PASSWORD_DIGEST).toBe("STUB");
+  });
+});
+
+/**
+ * Build a stub prisma client that responds to the calls syncUserActivity
+ * makes. Each table is seeded with an array; lookups, upserts, and deletes
+ * mutate the array directly so assertions can read the final state.
+ */
+type StubUserRow = {
+  id: string;
+  email: string;
+  passwordDigest: string;
+  username: string | null;
+  avatarFileId: string | null;
+  avatarFileUrl: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  _refs?: { ratings: number; attendances: number; reviews: number; blogPosts: number };
+};
+type StubRatingRow = {
+  id: string;
+  userId: string;
+  value: number;
+  rateableType: string;
+  rateableId: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+type StubAttendanceRow = {
+  id: string;
+  userId: string;
+  showId: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function makeStubDb(seed: {
+  users?: StubUserRow[];
+  ratings?: StubRatingRow[];
+  attendances?: StubAttendanceRow[];
+  shows?: Array<{ id: string; slug: string }>;
+  tracks?: Array<{ id: string; showId: string }>;
+}) {
+  const users = seed.users ?? [];
+  const ratings = seed.ratings ?? [];
+  const attendances = seed.attendances ?? [];
+  const shows = seed.shows ?? [];
+  const tracks = seed.tracks ?? [];
+
+  const findFirstByMaxUpdatedAt = <T extends { updatedAt: Date }>(rows: T[]) => {
+    if (rows.length === 0) return null;
+    return rows.slice().sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0];
+  };
+
+  const db = {
+    user: {
+      findFirst: vi.fn(async () => findFirstByMaxUpdatedAt(users)),
+      findMany: vi.fn(async (args?: { where?: { id?: { in?: string[] } }; select?: Record<string, unknown> }) => {
+        const matching = args?.where?.id?.in
+          ? users.filter((u) => args.where?.id?.in?.includes(u.id))
+          : users;
+        if (args?.select && (args.select as Record<string, unknown>)._count) {
+          return matching.map((u) => ({
+            id: u.id,
+            _count: u._refs ?? { ratings: 0, attendances: 0, reviews: 0, blogPosts: 0 },
+          }));
+        }
+        return matching.map((u) => ({ id: u.id }));
+      }),
+      upsert: vi.fn(
+        async (args: {
+          where: { id: string };
+          create: StubUserRow;
+          update: Partial<StubUserRow>;
+        }) => {
+          const existing = users.find((u) => u.id === args.where.id);
+          if (existing) {
+            Object.assign(existing, args.update);
+            return existing;
+          }
+          users.push(args.create);
+          return args.create;
+        },
+      ),
+      deleteMany: vi.fn(async (args: { where: { id: { in: string[] } } }) => {
+        const ids = new Set(args.where.id.in);
+        for (let i = users.length - 1; i >= 0; i--) {
+          if (ids.has(users[i].id)) users.splice(i, 1);
+        }
+        return { count: ids.size };
+      }),
+    },
+    rating: {
+      findFirst: vi.fn(async () => findFirstByMaxUpdatedAt(ratings)),
+      findMany: vi.fn(async () => ratings.map((r) => ({ id: r.id, rateableId: r.rateableId, rateableType: r.rateableType }))),
+      upsert: vi.fn(async (args: { where: { id: string }; create: StubRatingRow; update: Partial<StubRatingRow> }) => {
+        const existing = ratings.find((r) => r.id === args.where.id);
+        if (existing) {
+          Object.assign(existing, args.update);
+          return existing;
+        }
+        ratings.push(args.create);
+        return args.create;
+      }),
+      deleteMany: vi.fn(async (args: { where: { id: { in: string[] } } }) => {
+        const ids = new Set(args.where.id.in);
+        for (let i = ratings.length - 1; i >= 0; i--) {
+          if (ids.has(ratings[i].id)) ratings.splice(i, 1);
+        }
+        return { count: ids.size };
+      }),
+    },
+    attendance: {
+      findFirst: vi.fn(async () => findFirstByMaxUpdatedAt(attendances)),
+      findMany: vi.fn(async () => attendances.map((a) => ({ id: a.id, showId: a.showId }))),
+      upsert: vi.fn(async (args: { where: { id: string }; create: StubAttendanceRow; update: Partial<StubAttendanceRow> }) => {
+        const existing = attendances.find((a) => a.id === args.where.id);
+        if (existing) {
+          Object.assign(existing, args.update);
+          return existing;
+        }
+        attendances.push(args.create);
+        return args.create;
+      }),
+      deleteMany: vi.fn(async (args: { where: { id: { in: string[] } } }) => {
+        const ids = new Set(args.where.id.in);
+        for (let i = attendances.length - 1; i >= 0; i--) {
+          if (ids.has(attendances[i].id)) attendances.splice(i, 1);
+        }
+        return { count: ids.size };
+      }),
+    },
+    show: {
+      findUnique: vi.fn(async (args: { where: { id: string } }) => {
+        const s = shows.find((row) => row.id === args.where.id);
+        return s ? { id: s.id, slug: s.slug } : null;
+      }),
+      findMany: vi.fn(async (args: { where: { id: { in: string[] } } }) => {
+        const ids = new Set(args.where.id.in);
+        return shows.filter((s) => ids.has(s.id)).map((s) => ({ slug: s.slug, id: s.id }));
+      }),
+    },
+    track: {
+      findUnique: vi.fn(async (args: { where: { id: string } }) => {
+        const t = tracks.find((row) => row.id === args.where.id);
+        return t ? { id: t.id } : null;
+      }),
+      findMany: vi.fn(async (args: { where: { id: { in: string[] } } }) => {
+        const ids = new Set(args.where.id.in);
+        return tracks
+          .filter((t) => ids.has(t.id))
+          .map((t) => {
+            const show = shows.find((s) => s.id === t.showId);
+            return { show: { slug: show?.slug ?? null } };
+          });
+      }),
+    },
+  };
+
+  return { db, state: { users, ratings, attendances } };
+}
+
+/**
+ * Build a stub mcp() callback that returns the prepared responses for each
+ * (toolName, callIndex). Helps tests assemble fully-paginated mock streams.
+ */
+function makeStubMcp(responses: Record<string, unknown[]>) {
+  const indexes: Record<string, number> = {};
+  return async <T>(toolName: string, _args: Record<string, unknown>): Promise<T> => {
+    const queue = responses[toolName];
+    if (!queue) throw new Error(`No stub response for ${toolName}`);
+    const i = indexes[toolName] ?? 0;
+    indexes[toolName] = i + 1;
+    return queue[i] as T;
+  };
+}
+
+const stubRatingService = () => ({
+  rebuildAggregatesFor: vi.fn(async () => {}),
+}) as never;
+
+describe("syncUserActivity — incremental mode", () => {
+  // Stub user insert path: synthetic email + STUB digest, real id +
+  // username + avatar + timestamps from prod. Guards against future
+  // refactors leaking real email or names into the local DB.
+  test("inserts a new stub user with synthetic email/passwordDigest and prod username/avatar", async () => {
+    const { db, state } = makeStubDb({});
+    const mcp = makeStubMcp({
+      list_users_since: [
+        {
+          users: [
+            {
+              id: "u-marc",
+              username: "trance-marc",
+              avatarFileId: null,
+              avatarFileUrl: "https://cdn.example/marc.jpg",
+              createdAt: "2024-08-12T00:00:00Z",
+              updatedAt: "2024-08-12T00:00:00Z",
+            },
+          ],
+          nextCursor: null,
+        },
+      ],
+      list_ratings_since: [{ ratings: [], nextCursor: null }],
+      list_attendances_since: [{ attendances: [], nextCursor: null }],
+    });
+
+    await syncUserActivity(db as never, {
+      isDryRun: false,
+      fullMode: false,
+      ratingService: stubRatingService(),
+      cacheInvalidation: null,
+      changedSlugs: new Set(),
+      now: new Date(),
+      mcp,
+    });
+
+    expect(state.users).toHaveLength(1);
+    const created = state.users[0];
+    expect(created).toMatchObject({
+      id: "u-marc",
+      email: "stub-u-marc@local.invalid",
+      passwordDigest: "STUB",
+      username: "trance-marc",
+      avatarFileUrl: "https://cdn.example/marc.jpg",
+    });
+  });
+
+  // Rating insert path: upsert by id, then collect the (Show, showId) pair
+  // so the aggregate rebuild runs once at the end. The show's slug lands
+  // in changedSlugs so the outer cache-invalidation pass clears the cached
+  // show.data payload that embeds Show.averageRating.
+  test("upserts a Show rating and triggers aggregate rebuild + cache invalidation", async () => {
+    const ratingService = stubRatingService();
+    const changedSlugs = new Set<string>();
+    const { db, state } = makeStubDb({
+      users: [
+        {
+          id: "u-marc",
+          email: "stub-u-marc@local.invalid",
+          passwordDigest: "STUB",
+          username: "trance-marc",
+          avatarFileId: null,
+          avatarFileUrl: null,
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-01-01T00:00:00Z"),
+        },
+      ],
+      shows: [{ id: "show-1", slug: "2024-08-12-cap-theatre" }],
+    });
+    const mcp = makeStubMcp({
+      list_users_since: [{ users: [], nextCursor: null }],
+      list_ratings_since: [
+        {
+          ratings: [
+            {
+              id: "r-1",
+              userId: "u-marc",
+              value: 5,
+              rateableType: "Show",
+              rateableId: "show-1",
+              createdAt: "2024-08-12T00:00:00Z",
+              updatedAt: "2024-08-12T00:00:00Z",
+            },
+          ],
+          nextCursor: null,
+        },
+      ],
+      list_attendances_since: [{ attendances: [], nextCursor: null }],
+    });
+
+    await syncUserActivity(db as never, {
+      isDryRun: false,
+      fullMode: false,
+      ratingService,
+      cacheInvalidation: null,
+      changedSlugs,
+      now: new Date(),
+      mcp,
+    });
+
+    expect(state.ratings).toHaveLength(1);
+    expect(state.ratings[0]).toMatchObject({ id: "r-1", userId: "u-marc", value: 5 });
+    expect(ratingService.rebuildAggregatesFor).toHaveBeenCalledWith([
+      { rateableId: "show-1", rateableType: "Show" },
+    ]);
+    expect(changedSlugs.has("2024-08-12-cap-theatre")).toBe(true);
+  });
+
+  // FK guard: ratings whose user / show / track isn't local must be
+  // warned-and-skipped, not crashed. Sync narrows the year window for the
+  // shows pass, so old shows referenced by ratings legitimately may not be
+  // local — silently dropping would be wrong, but raising would block the
+  // whole pass.
+  test("skips a Track rating whose track isn't local", async () => {
+    const ratingService = stubRatingService();
+    const { db, state } = makeStubDb({
+      users: [
+        {
+          id: "u-marc",
+          email: "stub-u-marc@local.invalid",
+          passwordDigest: "STUB",
+          username: "trance-marc",
+          avatarFileId: null,
+          avatarFileUrl: null,
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-01-01T00:00:00Z"),
+        },
+      ],
+      tracks: [], // No local tracks — the rating's rateableId can't resolve
+    });
+    const mcp = makeStubMcp({
+      list_users_since: [{ users: [], nextCursor: null }],
+      list_ratings_since: [
+        {
+          ratings: [
+            {
+              id: "r-orphan",
+              userId: "u-marc",
+              value: 4,
+              rateableType: "Track",
+              rateableId: "track-missing",
+              createdAt: "2024-08-12T00:00:00Z",
+              updatedAt: "2024-08-12T00:00:00Z",
+            },
+          ],
+          nextCursor: null,
+        },
+      ],
+      list_attendances_since: [{ attendances: [], nextCursor: null }],
+    });
+
+    const result = await syncUserActivity(db as never, {
+      isDryRun: false,
+      fullMode: false,
+      ratingService,
+      cacheInvalidation: null,
+      changedSlugs: new Set(),
+      now: new Date(),
+      mcp,
+    });
+
+    expect(state.ratings).toHaveLength(0);
+    expect(result.ratingsFkSkipped).toBe(1);
+    expect(ratingService.rebuildAggregatesFor).not.toHaveBeenCalled();
+  });
+
+  // Attendance insert path: same upsert-by-id shape as ratings; show.slug
+  // lands in changedSlugs so the outer cache-invalidation pass clears the
+  // affected show's listing payload.
+  test("upserts an attendance and stamps the show slug into changedSlugs", async () => {
+    const changedSlugs = new Set<string>();
+    const { db, state } = makeStubDb({
+      users: [
+        {
+          id: "u-marc",
+          email: "stub-u-marc@local.invalid",
+          passwordDigest: "STUB",
+          username: "trance-marc",
+          avatarFileId: null,
+          avatarFileUrl: null,
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-01-01T00:00:00Z"),
+        },
+      ],
+      shows: [{ id: "show-1", slug: "2024-08-12-cap-theatre" }],
+    });
+    const mcp = makeStubMcp({
+      list_users_since: [{ users: [], nextCursor: null }],
+      list_ratings_since: [{ ratings: [], nextCursor: null }],
+      list_attendances_since: [
+        {
+          attendances: [
+            {
+              id: "a-1",
+              userId: "u-marc",
+              showId: "show-1",
+              createdAt: "2024-08-12T00:00:00Z",
+              updatedAt: "2024-08-12T00:00:00Z",
+            },
+          ],
+          nextCursor: null,
+        },
+      ],
+    });
+
+    await syncUserActivity(db as never, {
+      isDryRun: false,
+      fullMode: false,
+      ratingService: stubRatingService(),
+      cacheInvalidation: null,
+      changedSlugs,
+      now: new Date(),
+      mcp,
+    });
+
+    expect(state.attendances).toHaveLength(1);
+    expect(state.attendances[0]).toMatchObject({ id: "a-1", userId: "u-marc", showId: "show-1" });
+    expect(changedSlugs.has("2024-08-12-cap-theatre")).toBe(true);
+  });
+
+  // Cursor: MAX(updatedAt) on the local table is the implicit checkpoint.
+  // Repeated runs ask prod for rows newer than that — the first run pulls
+  // everything (cursor=epoch), the second pulls only the delta.
+  test("uses local MAX(updatedAt) as the incremental cursor", async () => {
+    const { db } = makeStubDb({
+      users: [
+        {
+          id: "u-1",
+          email: "stub-u-1@local.invalid",
+          passwordDigest: "STUB",
+          username: "user-1",
+          avatarFileId: null,
+          avatarFileUrl: null,
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-08-12T00:00:00Z"),
+        },
+      ],
+    });
+    const calls: Array<{ tool: string; args: Record<string, unknown> }> = [];
+    const mcp = async <T>(toolName: string, args: Record<string, unknown>): Promise<T> => {
+      calls.push({ tool: toolName, args });
+      if (toolName === "list_users_since") return { users: [], nextCursor: null } as T;
+      if (toolName === "list_ratings_since") return { ratings: [], nextCursor: null } as T;
+      if (toolName === "list_attendances_since") return { attendances: [], nextCursor: null } as T;
+      throw new Error(`unexpected tool ${toolName}`);
+    };
+
+    await syncUserActivity(db as never, {
+      isDryRun: false,
+      fullMode: false,
+      ratingService: stubRatingService(),
+      cacheInvalidation: null,
+      changedSlugs: new Set(),
+      now: new Date(),
+      mcp,
+    });
+
+    const usersCall = calls.find((c) => c.tool === "list_users_since");
+    expect(usersCall?.args.since).toBe("2024-08-12T00:00:00.000Z");
+  });
+});
+
+describe("syncUserActivity — full-users mode", () => {
+  // Full mode reconciliation: ratings present locally but not on prod get
+  // deleted, and the affected rateable lands in the aggregate-rebuild set so
+  // its Show.averageRating / ratingsCount gets recomputed to zero.
+  test("deletes a local rating that's not on prod and triggers aggregate rebuild", async () => {
+    const ratingService = stubRatingService();
+    const { db, state } = makeStubDb({
+      users: [],
+      ratings: [
+        {
+          id: "r-stale",
+          userId: "u-marc",
+          value: 5,
+          rateableType: "Show",
+          rateableId: "show-1",
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-01-01T00:00:00Z"),
+        },
+      ],
+      shows: [{ id: "show-1", slug: "2024-08-12-cap-theatre" }],
+    });
+    const mcp = makeStubMcp({
+      list_users_since: [{ users: [], nextCursor: null }],
+      list_ratings_since: [{ ratings: [], nextCursor: null }],
+      list_attendances_since: [{ attendances: [], nextCursor: null }],
+      list_all_attendance_ids: [{ ids: [] }],
+      list_all_rating_ids: [{ ids: [] }],
+      list_all_user_ids: [{ ids: [] }],
+    });
+
+    const result = await syncUserActivity(db as never, {
+      isDryRun: false,
+      fullMode: true,
+      ratingService,
+      cacheInvalidation: null,
+      changedSlugs: new Set(),
+      now: new Date(),
+      mcp,
+    });
+
+    expect(state.ratings).toHaveLength(0);
+    expect(result.ratingsDeleted).toBe(1);
+    expect(ratingService.rebuildAggregatesFor).toHaveBeenCalledWith([
+      { rateableId: "show-1", rateableType: "Show" },
+    ]);
+  });
+
+  // Default (non-full) mode never deletes — additive sync is the safe
+  // default so locally-created test data isn't wiped on every run.
+  test("does NOT delete missing local rows in default incremental mode", async () => {
+    const { db, state } = makeStubDb({
+      ratings: [
+        {
+          id: "r-stale",
+          userId: "u-marc",
+          value: 5,
+          rateableType: "Show",
+          rateableId: "show-1",
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-01-01T00:00:00Z"),
+        },
+      ],
+    });
+    const mcp = makeStubMcp({
+      list_users_since: [{ users: [], nextCursor: null }],
+      list_ratings_since: [{ ratings: [], nextCursor: null }],
+      list_attendances_since: [{ attendances: [], nextCursor: null }],
+    });
+
+    const result = await syncUserActivity(db as never, {
+      isDryRun: false,
+      fullMode: false,
+      ratingService: stubRatingService(),
+      cacheInvalidation: null,
+      changedSlugs: new Set(),
+      now: new Date(),
+      mcp,
+    });
+
+    expect(state.ratings).toHaveLength(1);
+    expect(result.ratingsDeleted).toBe(0);
   });
 });

--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -20,6 +20,7 @@ import { Prisma } from "@prisma/client";
 import { CacheInvalidationService, CacheService } from "../src/_shared/cache";
 import prisma from "../src/_shared/prisma/client";
 import { RedisService } from "../src/_shared/redis";
+import { RatingService } from "../src/ratings/rating-service";
 import { SegueRunGeneratorService } from "../src/segue-run/segue-run-generator-service";
 import { StatsService } from "../src/stats/stats-service";
 import { createTestLogger } from "../src/_shared/test-logger";
@@ -139,6 +140,67 @@ export interface McpSearchVenueResult {
   city: string | null;
   state: string | null;
 }
+
+// User-activity sync shapes. Match apps/web/app/routes/mcp/index.tsx
+// list_users_since / list_ratings_since / list_attendances_since. Strictly
+// non-PII: no email, no real name, no auth secrets. The owning user row is
+// inserted locally as a stub (synthetic email + placeholder digest) so the
+// real ratings/attendance rows have a valid FK.
+export interface McpSyncUser {
+  id: string;
+  username: string | null;
+  avatarFileId: string | null;
+  avatarFileUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface McpSyncRating {
+  id: string;
+  userId: string;
+  value: number;
+  rateableType: string;
+  rateableId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface McpSyncAttendance {
+  id: string;
+  userId: string;
+  showId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const SYNC_PAGE_LIMIT = 2000;
+
+/**
+ * No-op CacheInvalidationService used when the script runs without REDIS.
+ * RatingService.rebuildAggregatesFor doesn't call any of these methods, but
+ * the constructor still requires the dependency.
+ */
+function createNoopCacheInvalidation(): Record<string, () => Promise<void>> {
+  const noop = async () => {};
+  return new Proxy({}, { get: () => noop }) as Record<string, () => Promise<void>>;
+}
+
+/**
+ * Synthetic email used for every stub user mirrored from prod. The real
+ * email never leaves prod, but User.email is NOT NULL UNIQUE, so we
+ * generate a deterministic placeholder from the prod uuid. Tests assert
+ * this shape — change with care.
+ */
+export function stubUserEmail(userId: string): string {
+  return `stub-${userId}@local.invalid`;
+}
+
+/**
+ * Placeholder for User.passwordDigest (NOT NULL). Matches the convention
+ * used by sync-supabase-users.ts which sets a literal placeholder for
+ * auth-provider-managed users.
+ */
+export const STUB_USER_PASSWORD_DIGEST = "STUB";
 
 // --- Pure helpers (unit-tested) ---
 
@@ -769,6 +831,410 @@ async function mcpCall<T>(toolName: string, args: Record<string, unknown>): Prom
   return JSON.parse(text) as T;
 }
 
+// --- User activity sync (users + ratings + attendances) ---
+
+interface UserActivityStats {
+  usersCreated: number;
+  usersUpdated: number;
+  ratingsUpserted: number;
+  ratingsFkSkipped: number;
+  attendancesUpserted: number;
+  attendancesFkSkipped: number;
+  usersDeleted: number;
+  ratingsDeleted: number;
+  attendancesDeleted: number;
+  aggregatesRebuilt: number;
+}
+
+interface SyncUserActivityOptions {
+  isDryRun: boolean;
+  fullMode: boolean;
+  ratingService: RatingService;
+  cacheInvalidation: CacheInvalidationService | null;
+  changedSlugs: Set<string>;
+  now: Date;
+  // Injected to keep the function unit-testable without mocking globals.
+  // Defaults to the real mcpCall in the production wiring below.
+  mcp?: <T>(toolName: string, args: Record<string, unknown>) => Promise<T>;
+}
+
+/**
+ * Pull users / ratings / attendances from prod and reconcile locally.
+ *
+ * Default mode is incremental: cursor = MAX(updatedAt) on each local table,
+ * pull rows newer than that, upsert by id. Stateless — no `.sync-state.json`,
+ * no cursor table. Skips deletes.
+ *
+ * --full-users adds a reconciliation pass: pull every prod id, delete the
+ * local rows missing from prod. Run occasionally for a true mirror.
+ *
+ * Rating aggregates (Show.averageRating / Track.averageRating + ratingsCount)
+ * are recomputed at the end via RatingService.rebuildAggregatesFor for every
+ * (rateableType, rateableId) the sync touched. Affected show slugs are added
+ * to changedSlugs so the outer cache-invalidation pass clears them.
+ *
+ * Ratings/attendances that reference a missing local user, show, or track
+ * are warned and skipped — the shows pass should have already brought in
+ * every show, but a fresh DB synced for a narrow year window may genuinely
+ * lack older ones.
+ */
+export async function syncUserActivity(
+  db: typeof prisma,
+  options: SyncUserActivityOptions,
+): Promise<UserActivityStats> {
+  const { isDryRun, fullMode, ratingService, now, changedSlugs } = options;
+  const mcp = options.mcp ?? mcpCall;
+  const stats: UserActivityStats = {
+    usersCreated: 0,
+    usersUpdated: 0,
+    ratingsUpserted: 0,
+    ratingsFkSkipped: 0,
+    attendancesUpserted: 0,
+    attendancesFkSkipped: 0,
+    usersDeleted: 0,
+    ratingsDeleted: 0,
+    attendancesDeleted: 0,
+    aggregatesRebuilt: 0,
+  };
+
+  // Cursor = local MAX(updatedAt). First run on a fresh table yields null;
+  // fall back to epoch so the first page pulls everything.
+  async function localMaxUpdatedAt(table: "user" | "rating" | "attendance"): Promise<Date> {
+    let row: { updatedAt: Date } | null;
+    if (table === "user") row = await db.user.findFirst({ orderBy: { updatedAt: "desc" }, select: { updatedAt: true } });
+    else if (table === "rating") row = await db.rating.findFirst({ orderBy: { updatedAt: "desc" }, select: { updatedAt: true } });
+    else row = await db.attendance.findFirst({ orderBy: { updatedAt: "desc" }, select: { updatedAt: true } });
+    return row?.updatedAt ?? new Date(0);
+  }
+
+  // --- Users ---
+  const userCursor = await localMaxUpdatedAt("user");
+  console.log(`👤 Users: incremental since ${userCursor.toISOString()}`);
+  let pageCursor: string | null = null;
+  do {
+    const args: Record<string, unknown> = { since: userCursor.toISOString(), limit: SYNC_PAGE_LIMIT };
+    if (pageCursor) args.cursor = pageCursor;
+    const { users, nextCursor } = await mcp<{ users: McpSyncUser[]; nextCursor: string | null }>(
+      "list_users_since",
+      args,
+    );
+    // Batched existence pre-check just to keep the +created vs ~updated
+    // counters honest. The upsert below would do the right thing either
+    // way, but we want the summary to distinguish first-time inserts.
+    const incomingUserIds = users.map((u) => u.id);
+    const existingUserRows = incomingUserIds.length > 0
+      ? await db.user.findMany({ where: { id: { in: incomingUserIds } }, select: { id: true } })
+      : [];
+    const existingUserIdSet = new Set(existingUserRows.map((row) => row.id));
+
+    for (const u of users) {
+      if (isDryRun) {
+        if (existingUserIdSet.has(u.id)) stats.usersUpdated++;
+        else stats.usersCreated++;
+        continue;
+      }
+      try {
+        await db.user.upsert({
+          where: { id: u.id },
+          update: {
+            username: u.username,
+            avatarFileId: u.avatarFileId,
+            avatarFileUrl: u.avatarFileUrl,
+            updatedAt: new Date(u.updatedAt),
+          },
+          create: {
+            id: u.id,
+            email: stubUserEmail(u.id),
+            passwordDigest: STUB_USER_PASSWORD_DIGEST,
+            username: u.username,
+            avatarFileId: u.avatarFileId,
+            avatarFileUrl: u.avatarFileUrl,
+            createdAt: new Date(u.createdAt),
+            updatedAt: new Date(u.updatedAt),
+          },
+        });
+        if (existingUserIdSet.has(u.id)) stats.usersUpdated++;
+        else stats.usersCreated++;
+      } catch (err) {
+        console.error(`  ❌ user ${u.id} sync failed:`, err);
+      }
+    }
+    pageCursor = nextCursor;
+  } while (pageCursor !== null);
+  console.log(`👤 Users: +${stats.usersCreated} ~${stats.usersUpdated}`);
+
+  // --- Ratings ---
+  // Affected (rateableType, rateableId) pairs — used after the loop to
+  // rebuild Show.averageRating / Track.averageRating + ratingsCount and to
+  // resolve cache-invalidation slugs.
+  const touchedRateables = new Map<string, { rateableId: string; rateableType: string }>();
+  const ratingCursor = await localMaxUpdatedAt("rating");
+  console.log(`⭐ Ratings: incremental since ${ratingCursor.toISOString()}`);
+  pageCursor = null;
+  do {
+    const args: Record<string, unknown> = { since: ratingCursor.toISOString(), limit: SYNC_PAGE_LIMIT };
+    if (pageCursor) args.cursor = pageCursor;
+    const { ratings, nextCursor } = await mcp<{ ratings: McpSyncRating[]; nextCursor: string | null }>(
+      "list_ratings_since",
+      args,
+    );
+    // Batched FK existence check per page. The user pass just ran above, so
+    // a missing user is rare (race against a prod insert mid-sync). The
+    // realistic miss is show/track: a dev DB synced for a narrow --years
+    // window legitimately lacks older shows that older ratings reference.
+    const ratingUserIds = Array.from(new Set(ratings.map((r) => r.userId)));
+    const ratingShowIds = Array.from(
+      new Set(ratings.filter((r) => r.rateableType === "Show").map((r) => r.rateableId)),
+    );
+    const ratingTrackIds = Array.from(
+      new Set(ratings.filter((r) => r.rateableType === "Track").map((r) => r.rateableId)),
+    );
+    const [existingRatingUsers, existingRatingShows, existingRatingTracks] = await Promise.all([
+      ratingUserIds.length > 0
+        ? db.user.findMany({ where: { id: { in: ratingUserIds } }, select: { id: true } })
+        : Promise.resolve([]),
+      ratingShowIds.length > 0
+        ? db.show.findMany({ where: { id: { in: ratingShowIds } }, select: { id: true } })
+        : Promise.resolve([]),
+      ratingTrackIds.length > 0
+        ? db.track.findMany({ where: { id: { in: ratingTrackIds } }, select: { id: true } })
+        : Promise.resolve([]),
+    ]);
+    const localRatingUserSet = new Set(existingRatingUsers.map((u) => u.id));
+    const localRatingShowSet = new Set(existingRatingShows.map((s) => s.id));
+    const localRatingTrackSet = new Set(existingRatingTracks.map((t) => t.id));
+
+    for (const r of ratings) {
+      if (!localRatingUserSet.has(r.userId)) {
+        stats.ratingsFkSkipped++;
+        console.warn(`  ⚠️  rating ${r.id}: skipping — user ${r.userId} not local`);
+        continue;
+      }
+      if (r.rateableType === "Show" && !localRatingShowSet.has(r.rateableId)) {
+        stats.ratingsFkSkipped++;
+        console.warn(`  ⚠️  rating ${r.id}: skipping — show ${r.rateableId} not local`);
+        continue;
+      }
+      if (r.rateableType === "Track" && !localRatingTrackSet.has(r.rateableId)) {
+        stats.ratingsFkSkipped++;
+        console.warn(`  ⚠️  rating ${r.id}: skipping — track ${r.rateableId} not local`);
+        continue;
+      }
+      if (isDryRun) {
+        stats.ratingsUpserted++;
+        touchedRateables.set(`${r.rateableType}|${r.rateableId}`, { rateableId: r.rateableId, rateableType: r.rateableType });
+        continue;
+      }
+      try {
+        await db.rating.upsert({
+          where: { id: r.id },
+          update: {
+            value: r.value,
+            updatedAt: new Date(r.updatedAt),
+          },
+          create: {
+            id: r.id,
+            userId: r.userId,
+            value: r.value,
+            rateableType: r.rateableType,
+            rateableId: r.rateableId,
+            createdAt: new Date(r.createdAt),
+            updatedAt: new Date(r.updatedAt),
+          },
+        });
+        stats.ratingsUpserted++;
+        touchedRateables.set(`${r.rateableType}|${r.rateableId}`, {
+          rateableId: r.rateableId,
+          rateableType: r.rateableType,
+        });
+      } catch (err) {
+        console.error(`  ❌ rating ${r.id} upsert failed:`, err);
+      }
+    }
+    pageCursor = nextCursor;
+  } while (pageCursor !== null);
+  console.log(`⭐ Ratings: +${stats.ratingsUpserted} (skipped ${stats.ratingsFkSkipped} on missing FK)`);
+
+  // --- Attendances ---
+  const attCursor = await localMaxUpdatedAt("attendance");
+  console.log(`🎫 Attendances: incremental since ${attCursor.toISOString()}`);
+  pageCursor = null;
+  do {
+    const args: Record<string, unknown> = { since: attCursor.toISOString(), limit: SYNC_PAGE_LIMIT };
+    if (pageCursor) args.cursor = pageCursor;
+    const { attendances, nextCursor } = await mcp<{ attendances: McpSyncAttendance[]; nextCursor: string | null }>(
+      "list_attendances_since",
+      args,
+    );
+    // Same batched FK check as the ratings loop.
+    const attUserIds = Array.from(new Set(attendances.map((a) => a.userId)));
+    const attShowIds = Array.from(new Set(attendances.map((a) => a.showId)));
+    const [existingAttUsers, existingAttShows] = await Promise.all([
+      attUserIds.length > 0
+        ? db.user.findMany({ where: { id: { in: attUserIds } }, select: { id: true } })
+        : Promise.resolve([]),
+      attShowIds.length > 0
+        ? db.show.findMany({ where: { id: { in: attShowIds } }, select: { id: true, slug: true } })
+        : Promise.resolve([]),
+    ]);
+    const localAttUserSet = new Set(existingAttUsers.map((u) => u.id));
+    const localAttShowBySlug = new Map(existingAttShows.map((s) => [s.id, s.slug]));
+
+    for (const a of attendances) {
+      if (!localAttUserSet.has(a.userId)) {
+        stats.attendancesFkSkipped++;
+        console.warn(`  ⚠️  attendance ${a.id}: skipping — user ${a.userId} not local`);
+        continue;
+      }
+      if (!localAttShowBySlug.has(a.showId)) {
+        stats.attendancesFkSkipped++;
+        console.warn(`  ⚠️  attendance ${a.id}: skipping — show ${a.showId} not local`);
+        continue;
+      }
+      const showSlug = localAttShowBySlug.get(a.showId) ?? null;
+      if (isDryRun) {
+        stats.attendancesUpserted++;
+        if (showSlug) changedSlugs.add(showSlug);
+        continue;
+      }
+      try {
+        await db.attendance.upsert({
+          where: { id: a.id },
+          update: { updatedAt: new Date(a.updatedAt) },
+          create: {
+            id: a.id,
+            userId: a.userId,
+            showId: a.showId,
+            createdAt: new Date(a.createdAt),
+            updatedAt: new Date(a.updatedAt),
+          },
+        });
+        stats.attendancesUpserted++;
+        if (showSlug) changedSlugs.add(showSlug);
+      } catch (err) {
+        console.error(`  ❌ attendance ${a.id} upsert failed:`, err);
+      }
+    }
+    pageCursor = nextCursor;
+  } while (pageCursor !== null);
+  console.log(`🎫 Attendances: +${stats.attendancesUpserted} (skipped ${stats.attendancesFkSkipped} on missing FK)`);
+
+  // --- Full-mode reconciliation: delete local rows not on prod ---
+  if (fullMode) {
+    console.log("🧹 Full mode: reconciling deletions");
+
+    // Attendances first (no FK back to users/ratings, but we want a stable
+    // order anyway).
+    const { ids: prodAttIds } = await mcp<{ ids: string[] }>("list_all_attendance_ids", {});
+    const prodAttSet = new Set(prodAttIds);
+    const localAtt = await db.attendance.findMany({ select: { id: true, showId: true } });
+    const localShowIdsForAtt = new Set<string>();
+    const attToDelete: string[] = [];
+    for (const a of localAtt) {
+      if (!prodAttSet.has(a.id)) {
+        attToDelete.push(a.id);
+        localShowIdsForAtt.add(a.showId);
+      }
+    }
+    if (attToDelete.length > 0) {
+      if (!isDryRun) {
+        await db.attendance.deleteMany({ where: { id: { in: attToDelete } } });
+      }
+      stats.attendancesDeleted = attToDelete.length;
+      const showsForDeleted = await db.show.findMany({
+        where: { id: { in: Array.from(localShowIdsForAtt) } },
+        select: { slug: true },
+      });
+      for (const s of showsForDeleted) if (s.slug) changedSlugs.add(s.slug);
+    }
+    console.log(`🎫 Attendances: -${stats.attendancesDeleted}`);
+
+    // Ratings — same pattern. Mark the rateables touched so the aggregate
+    // rebuild zeros them out if the last rating was deleted.
+    const { ids: prodRatingIds } = await mcp<{ ids: string[] }>("list_all_rating_ids", {});
+    const prodRatingSet = new Set(prodRatingIds);
+    const localRatings = await db.rating.findMany({
+      select: { id: true, rateableId: true, rateableType: true },
+    });
+    const ratingsToDelete: string[] = [];
+    for (const r of localRatings) {
+      if (!prodRatingSet.has(r.id)) {
+        ratingsToDelete.push(r.id);
+        touchedRateables.set(`${r.rateableType}|${r.rateableId}`, {
+          rateableId: r.rateableId,
+          rateableType: r.rateableType,
+        });
+      }
+    }
+    if (ratingsToDelete.length > 0) {
+      if (!isDryRun) {
+        await db.rating.deleteMany({ where: { id: { in: ratingsToDelete } } });
+      }
+      stats.ratingsDeleted = ratingsToDelete.length;
+    }
+    console.log(`⭐ Ratings: -${stats.ratingsDeleted}`);
+
+    // Users last. Two FKs (ratings, attendances) — we've already deleted any
+    // we're going to delete above, so a delete here for a user whose data
+    // is still local would FK-fail. In practice users on prod aren't deleted,
+    // but to be safe we only delete users with no remaining local refs.
+    const { ids: prodUserIds } = await mcp<{ ids: string[] }>("list_all_user_ids", {});
+    const prodUserSet = new Set(prodUserIds);
+    const localUsers = await db.user.findMany({
+      select: { id: true, _count: { select: { ratings: true, attendances: true, reviews: true, blogPosts: true } } },
+    });
+    const usersToDelete: string[] = [];
+    for (const u of localUsers) {
+      if (prodUserSet.has(u.id)) continue;
+      const hasRefs = u._count.ratings + u._count.attendances + u._count.reviews + u._count.blogPosts > 0;
+      if (hasRefs) {
+        console.warn(`  ⚠️  user ${u.id} not on prod but has local refs; skipping`);
+        continue;
+      }
+      usersToDelete.push(u.id);
+    }
+    if (usersToDelete.length > 0) {
+      if (!isDryRun) {
+        await db.user.deleteMany({ where: { id: { in: usersToDelete } } });
+      }
+      stats.usersDeleted = usersToDelete.length;
+    }
+    console.log(`👤 Users: -${stats.usersDeleted}`);
+  }
+
+  // --- Rating aggregate rebuild ---
+  if (touchedRateables.size > 0) {
+    const pairs = Array.from(touchedRateables.values());
+    console.log(`📐 Rebuilding rating aggregates for ${pairs.length} rateable(s)`);
+    if (!isDryRun) {
+      try {
+        await ratingService.rebuildAggregatesFor(pairs);
+        stats.aggregatesRebuilt = pairs.length;
+      } catch (err) {
+        console.error("  ❌ rating aggregate rebuild failed:", err);
+      }
+    }
+
+    // Add affected show slugs to changedSlugs so the outer cache-invalidation
+    // pass clears show.data + setlist.data (which embed Track.averageRating).
+    const showIds = pairs.filter((p) => p.rateableType === "Show").map((p) => p.rateableId);
+    const trackIds = pairs.filter((p) => p.rateableType === "Track").map((p) => p.rateableId);
+    if (showIds.length > 0) {
+      const shows = await db.show.findMany({ where: { id: { in: showIds } }, select: { slug: true } });
+      for (const s of shows) if (s.slug) changedSlugs.add(s.slug);
+    }
+    if (trackIds.length > 0) {
+      const tracks = await db.track.findMany({
+        where: { id: { in: trackIds } },
+        select: { show: { select: { slug: true } } },
+      });
+      for (const t of tracks) if (t.show.slug) changedSlugs.add(t.show.slug);
+    }
+  }
+
+  return stats;
+}
+
 // --- Main ---
 
 interface SyncStats {
@@ -800,6 +1266,7 @@ interface SyncStats {
   rockOperasUpserted: number;
   rockOperaAssignmentsAdded: number;
   rockOperaAssignmentsRemoved: number;
+  userActivity: UserActivityStats | null;
   errors: number;
 }
 
@@ -827,12 +1294,20 @@ Options:
                            shows on prod under the new slug still carry them).
                            Without this flag, ghost shows with user data are
                            logged and skipped.
+  --no-users               Skip the user-activity pass (users, ratings,
+                           attendances). The default pulls incrementally,
+                           keyed on local MAX(updatedAt) per table.
+  --full-users             After the incremental user-activity pass, fetch all
+                           prod user / rating / attendance ids and delete any
+                           local rows missing from prod. Use occasionally for
+                           a true mirror; default skips deletes.
   --help, -h               Show this message and exit.
 
 Examples:
   bun run scripts/sync-missing-shows.ts --years=2025
   bun run scripts/sync-missing-shows.ts --years=2010-2026 --dry-run
   bun run scripts/sync-missing-shows.ts --years=2010-2026 --prune-ghost-shows
+  bun run scripts/sync-missing-shows.ts --full-users
 `);
 }
 
@@ -848,6 +1323,8 @@ async function syncMissingShows(): Promise<void> {
   // DBs but blocks cleanup on dev DBs seeded from a prod dump (every old
   // show carries prod's user data, which then prevents rename cleanup).
   const pruneGhostShows = process.argv.includes("--prune-ghost-shows");
+  const skipUsers = process.argv.includes("--no-users");
+  const fullUsers = process.argv.includes("--full-users");
   const years = parseYearsArg(process.argv.slice(2), new Date());
   const now = new Date();
   const db = prisma;
@@ -865,6 +1342,17 @@ async function syncMissingShows(): Promise<void> {
   // StatsService is wired without a cache here — the script never reads
   // cached aggregates, only triggers the post-batch gap rebuild.
   const statsService = new StatsService(prisma, cache ?? undefined);
+  // RatingService.rebuildAggregatesFor is the bulk version of the per-row
+  // recompute used by the live mutation path. The user-activity pass calls
+  // it once at the end for every (rateableType, rateableId) it touched.
+  // cacheInvalidation is only used by the per-row mutation methods (upsert /
+  // clearForUser), not by rebuildAggregatesFor — the script does its own
+  // outer invalidation pass on changedSlugs — so a no-op stub is sufficient
+  // in REDIS-less local runs.
+  const ratingService = new RatingService(
+    prisma,
+    cacheInvalidation ?? (createNoopCacheInvalidation() as CacheInvalidationService),
+  );
   // SegueRun rows reference Track ids in a non-FK String[] array. When the
   // setlist reconcile inserts or deletes a track, those arrays go stale; we
   // call generateSegueRunsForShow per structurally-changed show to rebuild.
@@ -910,6 +1398,7 @@ async function syncMissingShows(): Promise<void> {
     rockOperasUpserted: 0,
     rockOperaAssignmentsAdded: 0,
     rockOperaAssignmentsRemoved: 0,
+    userActivity: null,
     errors: 0,
   };
 
@@ -1763,6 +2252,31 @@ async function syncMissingShows(): Promise<void> {
       }
     }
 
+    // Step 9: user-activity sync (users + ratings + attendances). Runs
+    // after the show/song/venue/track passes so FK lookups can resolve
+    // (every show/track a rating or attendance might reference is already
+    // local). The pass updates changedSlugs with the affected show slugs so
+    // the outer cache invalidation below clears the show.data + setlist.data
+    // payloads that embed Show.averageRating + Track.averageRating.
+    if (!skipUsers) {
+      try {
+        const userActivityStats = await syncUserActivity(db, {
+          isDryRun,
+          fullMode: fullUsers,
+          ratingService,
+          cacheInvalidation,
+          changedSlugs,
+          now,
+        });
+        stats.userActivity = userActivityStats;
+      } catch (err) {
+        console.error("💥 User activity sync failed:", err);
+        stats.errors++;
+      }
+    } else {
+      console.log("👤 Skipping user-activity pass (--no-users)");
+    }
+
     // Cache invalidation: mirrors what ShowService.create + TrackService.create
     // call on the canonical app paths. Per-slug `invalidateShow` clears
     // show.data + setlist.data; `invalidateShowListings` covers shows:list:* +
@@ -1828,6 +2342,15 @@ function printSummary(stats: SyncStats, isDryRun: boolean): void {
   console.log(`Unresolved song slugs: ${stats.unresolvedSongSlugs}`);
   console.log(`Rock operas upserted: ${stats.rockOperasUpserted}`);
   console.log(`Rock opera assignments added / removed: ${stats.rockOperaAssignmentsAdded} / ${stats.rockOperaAssignmentsRemoved}`);
+  if (stats.userActivity) {
+    const ua = stats.userActivity;
+    console.log(`Users (created / updated / deleted): ${ua.usersCreated} / ${ua.usersUpdated} / ${ua.usersDeleted}`);
+    console.log(`Ratings (upserted / deleted / FK skipped): ${ua.ratingsUpserted} / ${ua.ratingsDeleted} / ${ua.ratingsFkSkipped}`);
+    console.log(`Attendances (upserted / deleted / FK skipped): ${ua.attendancesUpserted} / ${ua.attendancesDeleted} / ${ua.attendancesFkSkipped}`);
+    console.log(`Rating aggregates rebuilt: ${ua.aggregatesRebuilt}`);
+  } else {
+    console.log(`User activity sync: skipped`);
+  }
   console.log(`Errors: ${stats.errors}`);
 }
 

--- a/packages/core/src/attendances/attendance-service.ts
+++ b/packages/core/src/attendances/attendance-service.ts
@@ -165,4 +165,44 @@ export class AttendanceService {
       return false;
     }
   }
+
+  /**
+   * Sync export: page through attendances for the local sync script. No PII
+   * on the Attendance model itself — just user/show foreign keys. Stable
+   * cursor over (updatedAt, id); see RatingService.listForSync.
+   */
+  async listForSync(opts: {
+    since: Date;
+    cursorId?: string;
+    cursorUpdatedAt?: Date;
+    limit: number;
+  }): Promise<Array<Pick<Attendance, "id" | "userId" | "showId" | "createdAt" | "updatedAt">>> {
+    const { since, cursorId, cursorUpdatedAt, limit } = opts;
+    const where = cursorUpdatedAt
+      ? {
+          OR: [
+            { updatedAt: { gt: cursorUpdatedAt } },
+            { AND: [{ updatedAt: cursorUpdatedAt }, { id: { gt: cursorId ?? "" } }] },
+          ],
+        }
+      : { updatedAt: { gt: since } };
+    const rows = await this.db.attendance.findMany({
+      where,
+      orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+      take: limit,
+      select: {
+        id: true,
+        userId: true,
+        showId: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    return rows;
+  }
+
+  async listAllIdsForSync(): Promise<string[]> {
+    const rows = await this.db.attendance.findMany({ select: { id: true } });
+    return rows.map((r) => r.id);
+  }
 }

--- a/packages/core/src/ratings/rating-service.test.ts
+++ b/packages/core/src/ratings/rating-service.test.ts
@@ -448,6 +448,184 @@ describe("RatingService.clearForUser", () => {
   });
 });
 
+describe("RatingService.rebuildAggregatesFor", () => {
+  // Bulk version of updateRateableAverageRating used by the sync script after
+  // importing many ratings at once. Single groupBy per rateableType collapses
+  // N rateables to one query each; per-rateable .update writes the resulting
+  // averageRating / ratingsCount onto Show or Track.
+  test("recomputes Show.averageRating + ratingsCount in one groupBy per type", async () => {
+    const showGroupBy = vi.fn().mockResolvedValue([
+      { rateableId: "show-1", _avg: { value: 4.5 }, _count: { id: 2 } },
+      { rateableId: "show-2", _avg: { value: 3.0 }, _count: { id: 1 } },
+    ]);
+    const showUpdate = vi.fn().mockResolvedValue(undefined);
+    const trackUpdate = vi.fn();
+    const trackGroupBy = vi.fn();
+    const db = {
+      rating: {
+        groupBy: vi
+          .fn()
+          .mockImplementation((args: { where: { rateableType: string } }) =>
+            args.where.rateableType === "Show" ? showGroupBy(args) : trackGroupBy(args),
+          ),
+      },
+      show: { update: showUpdate },
+      track: { update: trackUpdate },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    await service.rebuildAggregatesFor([
+      { rateableId: "show-1", rateableType: "Show" },
+      { rateableId: "show-2", rateableType: "Show" },
+    ]);
+
+    expect(showUpdate).toHaveBeenCalledTimes(2);
+    expect(showUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "show-1" },
+        data: expect.objectContaining({ averageRating: 4.5, ratingsCount: 2 }),
+      }),
+    );
+    expect(showUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "show-2" },
+        data: expect.objectContaining({ averageRating: 3.0, ratingsCount: 1 }),
+      }),
+    );
+    expect(trackUpdate).not.toHaveBeenCalled();
+    expect(trackGroupBy).not.toHaveBeenCalled();
+  });
+
+  // Rateables whose ratings dropped to zero (deleted last rating in full
+  // mode) don't appear in the groupBy result. The bulk method must zero
+  // them out anyway, matching what updateRateableAverageRating does for the
+  // single-row delete path.
+  test("zeroes out rateables that no longer have any ratings", async () => {
+    const showUpdate = vi.fn();
+    const db = {
+      rating: {
+        groupBy: vi.fn().mockResolvedValue([]),
+      },
+      show: { update: showUpdate },
+      track: { update: vi.fn() },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    await service.rebuildAggregatesFor([{ rateableId: "show-abandoned", rateableType: "Show" }]);
+
+    expect(showUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "show-abandoned" },
+        data: expect.objectContaining({ averageRating: 0, ratingsCount: 0 }),
+      }),
+    );
+  });
+
+  // Mixed types in one call: one groupBy hits the Show table, one hits the
+  // Track table. Per-rateable updates land on the matching denormalized row.
+  test("dispatches Show + Track rateables to the right tables", async () => {
+    const showUpdate = vi.fn();
+    const trackUpdate = vi.fn();
+    const db = {
+      rating: {
+        groupBy: vi
+          .fn()
+          .mockImplementation(async (args: { where: { rateableType: string } }) =>
+            args.where.rateableType === "Show"
+              ? [{ rateableId: "show-1", _avg: { value: 5.0 }, _count: { id: 3 } }]
+              : [{ rateableId: "track-1", _avg: { value: 3.5 }, _count: { id: 2 } }],
+          ),
+      },
+      show: { update: showUpdate },
+      track: { update: trackUpdate },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    await service.rebuildAggregatesFor([
+      { rateableId: "show-1", rateableType: "Show" },
+      { rateableId: "track-1", rateableType: "Track" },
+    ]);
+
+    expect(showUpdate).toHaveBeenCalledWith(expect.objectContaining({ where: { id: "show-1" } }));
+    expect(trackUpdate).toHaveBeenCalledWith(expect.objectContaining({ where: { id: "track-1" } }));
+  });
+
+  test("no-ops on an empty pair list", async () => {
+    const groupBy = vi.fn();
+    const db = {
+      rating: { groupBy },
+      show: { update: vi.fn() },
+      track: { update: vi.fn() },
+    } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    await service.rebuildAggregatesFor([]);
+
+    expect(groupBy).not.toHaveBeenCalled();
+  });
+});
+
+describe("RatingService.listForSync", () => {
+  // Stable cursor over (updatedAt, id). First page uses since-only; subsequent
+  // pages use the (updatedAt, id) tuple so rows landing at the same timestamp
+  // don't get re-fetched or skipped.
+  test("first page filters by updatedAt > since", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const db = { rating: { findMany } } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    const since = new Date("2024-01-01T00:00:00Z");
+    await service.listForSync({ since, limit: 100 });
+
+    expect(findMany.mock.calls[0][0]).toMatchObject({
+      where: { updatedAt: { gt: since } },
+      orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+      take: 100,
+    });
+  });
+
+  test("subsequent page uses (updatedAt, id) tuple as exclusive cursor", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const db = { rating: { findMany } } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    const cursorUpdatedAt = new Date("2024-05-01T00:00:00Z");
+    await service.listForSync({
+      since: new Date(0),
+      cursorUpdatedAt,
+      cursorId: "rating-uuid",
+      limit: 100,
+    });
+
+    expect(findMany.mock.calls[0][0].where).toEqual({
+      OR: [
+        { updatedAt: { gt: cursorUpdatedAt } },
+        { AND: [{ updatedAt: cursorUpdatedAt }, { id: { gt: "rating-uuid" } }] },
+      ],
+    });
+  });
+
+  // Narrow projection — no rating field is PII, but the select-narrow guards
+  // against accidentally widening the shape in future refactors.
+  test("selects only the wire-safe columns", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const db = { rating: { findMany } } as never;
+
+    const service = new RatingService(db, cacheInvalidation);
+    await service.listForSync({ since: new Date(0), limit: 100 });
+
+    expect(findMany.mock.calls[0][0].select).toEqual({
+      id: true,
+      userId: true,
+      value: true,
+      rateableType: true,
+      rateableId: true,
+      createdAt: true,
+      updatedAt: true,
+    });
+  });
+});
+
 describe("RatingService.upsert", () => {
   // Same motivation as the Track-clear case in clearForUser: the show's
   // cached setlist embeds Track.averageRating/ratingsCount, so the upsert

--- a/packages/core/src/ratings/rating-service.ts
+++ b/packages/core/src/ratings/rating-service.ts
@@ -105,6 +105,108 @@ export class RatingService {
     return { averageRating, ratingsCount };
   }
 
+  /**
+   * Bulk-recompute denormalized averageRating/ratingsCount for a set of
+   * rateables in one pass. Used by the sync script after importing or
+   * deleting many ratings at once — single-row callers (upsert, clearForUser)
+   * keep using updateRateableAverageRating. Pairs whose ratings dropped to
+   * zero are zeroed out on the rateable row.
+   */
+  async rebuildAggregatesFor(pairs: Array<{ rateableId: string; rateableType: string }>): Promise<void> {
+    if (pairs.length === 0) return;
+    const showIds = new Set<string>();
+    const trackIds = new Set<string>();
+    for (const { rateableId, rateableType } of pairs) {
+      if (rateableType === "Show") showIds.add(rateableId);
+      else if (rateableType === "Track") trackIds.add(rateableId);
+    }
+
+    const now = new Date();
+
+    if (showIds.size > 0) {
+      const rows = await this.db.rating.groupBy({
+        by: ["rateableId"],
+        where: { rateableType: "Show", rateableId: { in: Array.from(showIds) } },
+        _avg: { value: true },
+        _count: { id: true },
+      });
+      const statsById = new Map(rows.map((r) => [r.rateableId, r]));
+      for (const id of showIds) {
+        const stats = statsById.get(id);
+        const averageRating = stats?._avg.value ?? 0;
+        const ratingsCount = stats?._count.id ?? 0;
+        await this.db.show.update({
+          where: { id },
+          data: { averageRating, ratingsCount, updatedAt: now },
+        });
+      }
+    }
+
+    if (trackIds.size > 0) {
+      const rows = await this.db.rating.groupBy({
+        by: ["rateableId"],
+        where: { rateableType: "Track", rateableId: { in: Array.from(trackIds) } },
+        _avg: { value: true },
+        _count: { id: true },
+      });
+      const statsById = new Map(rows.map((r) => [r.rateableId, r]));
+      for (const id of trackIds) {
+        const stats = statsById.get(id);
+        const averageRating = stats?._avg.value ?? 0;
+        const ratingsCount = stats?._count.id ?? 0;
+        await this.db.track.update({
+          where: { id },
+          data: { averageRating, ratingsCount, updatedAt: now },
+        });
+      }
+    }
+  }
+
+  /**
+   * Sync export: page through ratings for the local sync script. PII-free
+   * by construction — no user PII is on the Rating model itself. Order by
+   * (updatedAt ASC, id ASC) so the cursor is stable. `since` is exclusive
+   * on the (updatedAt, id) tuple to prevent re-fetching the boundary row.
+   */
+  async listForSync(opts: {
+    since: Date;
+    cursorId?: string;
+    cursorUpdatedAt?: Date;
+    limit: number;
+  }): Promise<
+    Array<Pick<Rating, "id" | "userId" | "value" | "rateableType" | "rateableId" | "createdAt" | "updatedAt">>
+  > {
+    const { since, cursorId, cursorUpdatedAt, limit } = opts;
+    const where = cursorUpdatedAt
+      ? {
+          OR: [
+            { updatedAt: { gt: cursorUpdatedAt } },
+            { AND: [{ updatedAt: cursorUpdatedAt }, { id: { gt: cursorId ?? "" } }] },
+          ],
+        }
+      : { updatedAt: { gt: since } };
+    const rows = await this.db.rating.findMany({
+      where,
+      orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+      take: limit,
+      select: {
+        id: true,
+        userId: true,
+        value: true,
+        rateableType: true,
+        rateableId: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    return rows;
+  }
+
+  async listAllIdsForSync(): Promise<string[]> {
+    const rows = await this.db.rating.findMany({ select: { id: true } });
+    return rows.map((r) => r.id);
+  }
+
   async findManyByUserIdAndRateableIds(userId: string, rateableIds: string[], rateableType: string): Promise<Rating[]> {
     const results = await this.db.rating.findMany({
       where: { userId, rateableId: { in: rateableIds }, rateableType },

--- a/packages/core/src/users/user-service.test.ts
+++ b/packages/core/src/users/user-service.test.ts
@@ -147,3 +147,55 @@ describe("UserService.getUserProfileHeader", () => {
     expect(findFirst.mock.calls[1][0].orderBy).toMatchObject({ show: { date: "desc" } });
   });
 });
+
+describe("UserService.listForSync", () => {
+  // PII allowlist: the sync export MUST select only id/username/avatar/
+  // timestamps. Email, names, password digest, and auth tokens never leave
+  // prod. This test guards against a future refactor accidentally widening
+  // the projection.
+  test("selects only non-PII columns — never email, names, or auth fields", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const db = { user: { findMany } } as never;
+
+    const service = new UserService(db, logger);
+    await service.listForSync({ since: new Date(0), limit: 100 });
+
+    const select = findMany.mock.calls[0][0].select;
+    expect(select).toEqual({
+      id: true,
+      username: true,
+      avatarFileId: true,
+      avatarFileUrl: true,
+      createdAt: true,
+      updatedAt: true,
+    });
+    expect(select).not.toHaveProperty("email");
+    expect(select).not.toHaveProperty("firstName");
+    expect(select).not.toHaveProperty("lastName");
+    expect(select).not.toHaveProperty("passwordDigest");
+    expect(select).not.toHaveProperty("resetPasswordToken");
+    expect(select).not.toHaveProperty("confirmationToken");
+  });
+
+  // Same stable-cursor semantics as RatingService.listForSync: first page
+  // uses since-only, subsequent pages use the (updatedAt, id) tuple to avoid
+  // re-fetching or skipping rows landing at identical timestamps.
+  test("subsequent page uses (updatedAt, id) tuple as exclusive cursor", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const db = { user: { findMany } } as never;
+
+    const service = new UserService(db, logger);
+    const cursorUpdatedAt = new Date("2024-05-01T00:00:00Z");
+    await service.listForSync({
+      since: new Date(0),
+      cursorUpdatedAt,
+      cursorId: "u-uuid",
+      limit: 100,
+    });
+
+    expect(findMany.mock.calls[0][0].where).toEqual({
+      OR: [{ updatedAt: { gt: cursorUpdatedAt } }, { AND: [{ updatedAt: cursorUpdatedAt }, { id: { gt: "u-uuid" } }] }],
+    });
+    expect(findMany.mock.calls[0][0].orderBy).toEqual([{ updatedAt: "asc" }, { id: "asc" }]);
+  });
+});

--- a/packages/core/src/users/user-service.ts
+++ b/packages/core/src/users/user-service.ts
@@ -465,6 +465,51 @@ export class UserService {
     return sortedStats.slice(0, limit);
   }
 
+  /**
+   * Sync export: page through users for the local sync script. Selects only
+   * the non-PII columns (id, username, avatar, timestamps). Email, names,
+   * password digest, and auth tokens are deliberately excluded — they must
+   * never leave prod. Stable cursor over (updatedAt, id).
+   */
+  async listForSync(opts: { since: Date; cursorId?: string; cursorUpdatedAt?: Date; limit: number }): Promise<
+    Array<{
+      id: string;
+      username: string | null;
+      avatarFileId: string | null;
+      avatarFileUrl: string | null;
+      createdAt: Date;
+      updatedAt: Date;
+    }>
+  > {
+    const { since, cursorId, cursorUpdatedAt, limit } = opts;
+    const where = cursorUpdatedAt
+      ? {
+          OR: [
+            { updatedAt: { gt: cursorUpdatedAt } },
+            { AND: [{ updatedAt: cursorUpdatedAt }, { id: { gt: cursorId ?? "" } }] },
+          ],
+        }
+      : { updatedAt: { gt: since } };
+    return this.db.user.findMany({
+      where,
+      orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+      take: limit,
+      select: {
+        id: true,
+        username: true,
+        avatarFileId: true,
+        avatarFileUrl: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  }
+
+  async listAllIdsForSync(): Promise<string[]> {
+    const rows = await this.db.user.findMany({ select: { id: true } });
+    return rows.map((r) => r.id);
+  }
+
   async getCommunityTotals(): Promise<{
     totalUsers: number;
     totalReviews: number;


### PR DESCRIPTION
## Summary

`make db-sync-missing-shows` now syncs prod user activity into the local
DB alongside shows / songs / venues.

- **Ratings** (Show + Track) and **attendances** are pulled from prod and
  upserted by id.
- **Minimal stub user rows** are created so the foreign keys resolve.
  Stubs carry the real prod `id`, `username`, avatar fields, and
  timestamps; never email, names, password digest, or auth tokens.
- Rating aggregates (`Show.averageRating`, `Track.averageRating`,
  `ratingsCount`) are recomputed at the end for every rateable the sync
  touched, and the affected show slugs feed the outer cache-invalidation
  pass so `show.data` / `setlist.data` / listings refresh.

## Flags

- `make db-sync-missing-shows` (default): incremental pull, no deletes.
  Cursor is local `MAX(updatedAt)` per table; first run on an empty
  table pulls everything.
- `make db-sync-missing-shows FULL_USERS=1`: incremental, then fetch
  every prod id and delete locally-only rows. Run occasionally for a
  true mirror.
- `make db-sync-missing-shows NO_USERS=1`: skip the user-activity pass.
- Combinable with the existing `YEARS=`, `DRY_RUN=1`,
  `PRUNE_GHOST_SHOWS=1` flags.

## Privacy contract

Six new MCP tools in `apps/web/app/routes/mcp/index.tsx`:
`list_users_since`, `list_ratings_since`, `list_attendances_since`, and
the three `list_all_*_ids` reconciliation tools. Each uses an
allowlisted Prisma `select` so no PII column can be returned. A
regression test on `UserService.listForSync` asserts the allowlist
shape.

Stub users use:

```
email          = `stub-${id}@local.invalid`
passwordDigest = "STUB"
firstName / lastName = null
```

## Technical notes

- **Stateless cursor.** No `.sync-state.json`, no new Prisma table.
  `MAX(updatedAt)` on each local table is the implicit checkpoint;
  re-runs converge.
- **Batched FK guards.** Ratings whose user / show / track aren't local
  are warned and skipped (realistic on dev DBs synced for a narrow
  `--years` window). Lookups are batched per MCP page via one
  `findMany({ where: { id: { in: [...] } } })`, then in-memory `Set`
  checks, so the inner loop stays O(N) without per-row round-trips.
- **Bulk rating aggregate rebuild.** `RatingService.rebuildAggregatesFor`
  collapses N rateables to one `groupBy` per type plus per-rateable
  updates. Rateables whose ratings dropped to zero (deleted last rating
  in `FULL_USERS` mode) get zeroed out, matching the single-row delete
  semantics. The existing per-row recompute used by `upsert` /
  `clearForUser` stays in place.
- **Cursor pagination.** MCP tools accept an opaque base64 cursor
  encoding `(updatedAt, id)`, order by `updatedAt ASC, id ASC`, default
  limit 2000 / max 5000. Stable across rows landing at the same
  timestamp.

## Test plan

- [ ] `make tc` passes
- [ ] `make test` passes (1,217 tests)
- [ ] `make db-sync-missing-shows DRY_RUN=1` shows pending user / rating
      / attendance counts
- [ ] `make db-sync-missing-shows` lands new ratings + attendances; spot
      a synced show in `make db-studio` and confirm
      `Show.averageRating` matches the recomputed average of its
      ratings
- [ ] `make db-sync-missing-shows FULL_USERS=1` after deleting a rating
      on prod removes it locally
- [ ] `curl -X POST $MCP_URL ... list_users_since` returns only
      id/username/avatar/timestamps (no email, no names, no digest)
