### PR TITLE
Add Played Before column to gap-chart view

### DIFF
--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -19,6 +19,11 @@ vi.mock("~/hooks/use-show-user-data", () => ({
 vi.mock("~/hooks/use-track-user-ratings", () => ({
   useTrackUserRatings: vi.fn(() => ({ userRatingMap: new Map<string, number>(), isLoading: false })),
 }));
+// SetlistTable also fetches the catalog play-dates blob for the Played
+// Before column; stub it so the gap-chart view renders without React Query.
+vi.mock("~/hooks/use-song-play-dates", () => ({
+  useSongPlayDates: vi.fn(() => ({ data: {} as Record<string, string[]>, isLoading: false })),
+}));
 
 // Stub heavy child components
 vi.mock("./track-rating-overlay", () => ({

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -323,7 +323,11 @@ function SetlistCardComponent({
                   summary={catalogSummary}
                   showPersonal={Boolean(user)}
                 />
-                <SetlistTable showSlug={setlist.show.slug ?? ""} tracks={setlist.sets.flatMap((s) => s.tracks)} />
+                <SetlistTable
+                  showSlug={setlist.show.slug ?? ""}
+                  showDate={setlist.show.date}
+                  tracks={setlist.sets.flatMap((s) => s.tracks)}
+                />
               </div>
             ) : view === "personal" && user ? (
               <div className="space-y-2">

--- a/apps/web/app/components/setlist/setlist-columns-personal.tsx
+++ b/apps/web/app/components/setlist/setlist-columns-personal.tsx
@@ -1,8 +1,8 @@
 import type { TrackLight } from "@bip/domain";
-import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
-import { SortableHeader } from "~/components/ui/sortable-header";
+import type { ColumnDef } from "@tanstack/react-table";
 import type { PersonalSetlistRow } from "~/lib/personal-setlist-columns";
 import {
+  createCountColumn,
   createGapColumn,
   createRatingColumn,
   createSetlistCommonColumns,
@@ -46,37 +46,15 @@ export function createPersonalSetlistColumns(
       fixedWidth: "7.5rem",
       hideOnMobile: true,
     }),
-    createSeenCountColumn(),
+    // "Seen Before" — attended performances strictly before this show.
+    // Mobile-visible (it's been there since the personal view shipped);
+    // the catalog peer "Played Before" hides on mobile instead.
+    createCountColumn<PersonalSetlistTableRow>({
+      id: "totalTimesSeen",
+      accessor: (row) => row.personal.totalTimesSeen,
+      label: ["Seen", "Before"],
+      mobileFixedWidth: "3rem",
+    }),
     createRatingColumn<PersonalSetlistTableRow>(ratingCtx),
   ];
-}
-
-/**
- * "Seen Before" column — count of attended performances strictly before
- * this show. Inline factory because no other column shares this shape.
- */
-function createSeenCountColumn(): ColumnDef<PersonalSetlistTableRow, unknown> {
-  const columnHelper = createColumnHelper<PersonalSetlistTableRow>();
-  return columnHelper.accessor((row) => row.personal.totalTimesSeen, {
-    id: "totalTimesSeen",
-    header: ({ column }) => (
-      <SortableHeader
-        column={column}
-        label={
-          <span className="flex flex-col items-start leading-tight">
-            <span>Seen</span>
-            <span>Before</span>
-          </span>
-        }
-      />
-    ),
-    // Bounded content (1-3 digit count). Desktop fixedWidth holds the
-    // stacked "Seen / Before" header + sort arrow on its own line below
-    // without leaving any extra slack.
-    meta: { fixedWidth: "4.5rem", mobileFixedWidth: "3rem" },
-    enableSorting: true,
-    sortingFn: "basic",
-    sortDescFirst: false,
-    cell: (info) => <span className="text-content-text-secondary tabular-nums">{info.getValue() as number}</span>,
-  }) as ColumnDef<PersonalSetlistTableRow, unknown>;
 }

--- a/apps/web/app/components/setlist/setlist-columns.test.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.test.tsx
@@ -14,9 +14,11 @@ vi.mock("~/components/performance/track-rating-cell", () => ({
 }));
 
 const { createSetlistColumns } = await import("./setlist-columns");
-type SetlistTableRow = TrackLight;
+type SetlistTableRow = TrackLight & { priorPerformanceCount: number | null };
 
-function makeTrack(overrides: Partial<TrackLight> & { songId: string; position: number }): SetlistTableRow {
+function makeTrack(
+  overrides: Partial<TrackLight> & { songId: string; position: number; priorPerformanceCount?: number | null },
+): SetlistTableRow {
   return {
     id: `t-${overrides.position}`,
     showId: "show-1",
@@ -33,6 +35,7 @@ function makeTrack(overrides: Partial<TrackLight> & { songId: string; position: 
     previousPerformanceShowId: overrides.previousPerformanceShowId ?? null,
     previousPerformanceShow: overrides.previousPerformanceShow ?? null,
     song: overrides.song ?? { id: overrides.songId, title: "Basis for a Day", slug: "basis-for-a-day" },
+    priorPerformanceCount: overrides.priorPerformanceCount ?? 0,
   };
 }
 
@@ -73,23 +76,28 @@ async function renderTable(rows: SetlistTableRow[], factoryArgs?: Parameters<typ
 }
 
 describe("createSetlistColumns", () => {
-  // Column order: Set, Track #, Song, Gap, Last Played, Rating. Track sits
-  // between Set and Song; Gap sits next to Song so the rarity number reads
-  // as "Song / Gap" before the user's eye jumps to the older Last Played
-  // date. Rating anchors the right edge — it's the action column (click to
-  // rate) so it lives where the eye lands at the end of the row scan.
-  test("returns columns in order [Set, Track, All-timer, Song, Gap, Last Played, Rating]", () => {
+  // Column order: Set, Track #, Song, Gap, Last Played, Played Before,
+  // Rating. Track sits between Set and Song; Gap sits next to Song so the
+  // rarity number reads as "Song / Gap" before the user's eye jumps to the
+  // older Last Played date and prior-play count. Rating anchors the right
+  // edge — it's the action column (click to rate) so it lives where the
+  // eye lands at the end of the row scan.
+  test("returns columns in order [Set, Track, All-timer, Song, Gap, Last Played, Played Before, Rating]", () => {
     const columns = createSetlistColumns();
-    expect(columns.map((c) => c.id)).toEqual(["set", "track", "allTimer", "song", "gap", "lastPlayed", "rating"]);
+    expect(columns.map((c) => c.id)).toEqual([
+      "set",
+      "track",
+      "allTimer",
+      "song",
+      "gap",
+      "lastPlayed",
+      "priorPerformanceCount",
+      "rating",
+    ]);
   });
 
-  // Every column is sortable. Set and Track # share the canonical
-  // "set order then position" comparator (sorting either way produces the
-  // same render); Song sorts alphabetically; Gap sorts numerically with
-  // debuts/repeats kept at the extremes; Last Played sorts by previous-show
-  // date; Rating sorts by community average (unrated tracks cluster at the
-  // bottom on desc).
-  test("Set, Track, Song, Gap, Last Played, and Rating are all sortable", () => {
+  // Every column is sortable.
+  test("Set, Track, Song, Gap, Last Played, Played Before, and Rating are all sortable", () => {
     const columns = createSetlistColumns();
     const sortable = new Map(columns.map((c) => [c.id, c.enableSorting]));
     expect(sortable.get("set")).toBe(true);
@@ -97,6 +105,7 @@ describe("createSetlistColumns", () => {
     expect(sortable.get("song")).toBe(true);
     expect(sortable.get("gap")).toBe(true);
     expect(sortable.get("lastPlayed")).toBe(true);
+    expect(sortable.get("priorPerformanceCount")).toBe(true);
     expect(sortable.get("rating")).toBe(true);
   });
 
@@ -115,7 +124,7 @@ describe("createSetlistColumns", () => {
     // the Set header puts the table into "sorted by set" mode.
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /^Set$/i }));
-    const setCells = screen.getAllByRole("cell").filter((_, i) => i % 7 === 0);
+    const setCells = screen.getAllByRole("cell").filter((_, i) => i % 8 === 0);
     expect(setCells.map((c) => c.textContent)).toEqual(["1", "", "2", ""]);
   });
 
@@ -142,7 +151,7 @@ describe("createSetlistColumns", () => {
       makeTrack({ songId: "c", position: 3, set: "S2", gap: 20, song: { id: "c", title: "Confrontation", slug: "z" } }),
     ]);
     await user.click(screen.getByRole("button", { name: /Gap/i }));
-    const setCells = screen.getAllByRole("cell").filter((_, i) => i % 7 === 0);
+    const setCells = screen.getAllByRole("cell").filter((_, i) => i % 8 === 0);
     // After asc-by-gap: gap=5 (S1), gap=10 (S1), gap=20 (S2). Every row
     // displays its set label.
     expect(setCells.map((c) => c.textContent)).toEqual(["1", "1", "2"]);
@@ -178,7 +187,7 @@ describe("createSetlistColumns", () => {
     ]);
     // Label is split into stacked spans; accessible name is "LastPlayed".
     await user.click(screen.getByRole("button", { name: /LastPlayed/i }));
-    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 7 === 3);
+    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 8 === 3);
     expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
       "Basis for a Day",
       "Above the Waves",
@@ -209,7 +218,7 @@ describe("createSetlistColumns", () => {
       }),
     ]);
     await user.click(screen.getByRole("button", { name: /Gap/i }));
-    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 7 === 3);
+    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 8 === 3);
     expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
       "Basis for a Day",
       "Above the Waves",
@@ -254,7 +263,7 @@ describe("createSetlistColumns", () => {
     ]);
     // First click on Rating sorts descending ("best first" via sortDescFirst).
     await user.click(screen.getByRole("button", { name: /Rating/i }));
-    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 7 === 3);
+    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 8 === 3);
     // 4.5/50 (Confrontation) > 4.5/3 (Crickets) > 3.0 (Above the Waves).
     expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
       "Confrontation",
@@ -298,7 +307,7 @@ describe("createSetlistColumns", () => {
       }),
     ]);
     await user.click(screen.getByRole("button", { name: /Rating/i }));
-    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 7 === 3);
+    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 8 === 3);
     // All three tied → set+position takes over, inverted by desc → 3, 2, 1.
     expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
       "Crickets",
@@ -317,11 +326,11 @@ describe("createSetlistColumns", () => {
       makeTrack({ songId: "d", position: 4, set: "E1", song: { id: "d", title: "Crickets", slug: "w" } }),
     ]);
     const cells = screen.getAllByRole("cell");
-    // Each row produces 7 cells; cells[1], cells[8], cells[15], cells[22] are Track #.
+    // Each row produces 8 cells; cells[1], cells[9], cells[17], cells[25] are Track #.
     expect(cells[1].textContent).toBe("1");
-    expect(cells[8].textContent).toBe("2");
-    expect(cells[15].textContent).toBe("1");
-    expect(cells[22].textContent).toBe("1");
+    expect(cells[9].textContent).toBe("2");
+    expect(cells[17].textContent).toBe("1");
+    expect(cells[25].textContent).toBe("1");
   });
 
   // Set column drops the "S" prefix (S1 → 1, S2 → 2, etc.) — the column
@@ -334,9 +343,9 @@ describe("createSetlistColumns", () => {
       makeTrack({ songId: "b", position: 2, set: "S2", song: { id: "b", title: "Tempest", slug: "t" } }),
     ]);
     const cells = screen.getAllByRole("cell");
-    // 7 cells per row; cells[0] = Set of row 0, cells[7] = Set of row 1.
+    // 8 cells per row; cells[0] = Set of row 0, cells[8] = Set of row 1.
     expect(cells[0].textContent).toBe("1");
-    expect(cells[7].textContent).toBe("2");
+    expect(cells[8].textContent).toBe("2");
   });
 
   // Single encore collapses E1 → E because there's no second encore to
@@ -348,9 +357,9 @@ describe("createSetlistColumns", () => {
       makeTrack({ songId: "b", position: 2, set: "E1", song: { id: "b", title: "Crickets", slug: "c" } }),
     ]);
     const singleCells = screen.getAllByRole("cell");
-    // 7 cells per row; cells[0] = Set row 0, cells[7] = Set row 1.
+    // 8 cells per row; cells[0] = Set row 0, cells[8] = Set row 1.
     expect(singleCells[0].textContent).toBe("1");
-    expect(singleCells[7].textContent).toBe("E");
+    expect(singleCells[8].textContent).toBe("E");
 
     // Re-render with two encores to confirm we keep the numbering.
     document.body.innerHTML = "";
@@ -360,7 +369,7 @@ describe("createSetlistColumns", () => {
     ]);
     const multiCells = screen.getAllByRole("cell");
     expect(multiCells[0].textContent).toBe("E1");
-    expect(multiCells[7].textContent).toBe("E2");
+    expect(multiCells[8].textContent).toBe("E2");
   });
 
   // Normal row: gap renders as the integer; Last Played renders the prior
@@ -467,6 +476,41 @@ describe("createSetlistColumns", () => {
     ]);
     const link = screen.getByRole("link", { name: "Confrontation" });
     expect(link).toHaveAttribute("href", "/songs/confrontation");
+  });
+
+  // Played Before renders the prior-count integer for normal rows and an
+  // em-dash placeholder while the catalog play-dates blob is still loading
+  // (null) — keeps the column from flashing "0" then settling to the real
+  // count on first paint.
+  test("renders priorPerformanceCount integer and em-dash for null", async () => {
+    await renderTable([
+      makeTrack({
+        songId: "song-known",
+        position: 1,
+        priorPerformanceCount: 47,
+        song: { id: "song-known", title: "Basis for a Day", slug: "basis-for-a-day" },
+      }),
+      makeTrack({
+        songId: "song-loading",
+        position: 2,
+        priorPerformanceCount: null,
+        song: { id: "song-loading", title: "Crickets", slug: "crickets" },
+      }),
+    ]);
+    expect(screen.getByText("47")).toBeInTheDocument();
+    // Loading row plus the Last Played em-dash on the same row both render
+    // "—", so we assert presence rather than count.
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+
+  // Played Before is hidden on mobile to keep the dense gap-chart row
+  // readable on narrow screens; the personal view's Seen Before stays
+  // visible on its own table.
+  test("Played Before column hides on mobile", () => {
+    const columns = createSetlistColumns();
+    const playedBefore = columns.find((c) => c.id === "priorPerformanceCount");
+    const meta = playedBefore?.meta as { hideOnMobile?: boolean } | undefined;
+    expect(meta?.hideOnMobile).toBe(true);
   });
 
   // Rating stays visible on phones too — the rating button is the

--- a/apps/web/app/components/setlist/setlist-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.tsx
@@ -2,6 +2,7 @@ import type { TrackLight } from "@bip/domain";
 import type { ColumnDef } from "@tanstack/react-table";
 import { buildGapCellState, isWithinShowRepeat } from "./gap-cell";
 import {
+  createCountColumn,
   createGapColumn,
   createRatingColumn,
   createSetlistCommonColumns,
@@ -11,18 +12,19 @@ import {
 
 /**
  * Row shape consumed by the gap-chart table. Narrowed from the full Setlist
- * tree so the column factory doesn't depend on Set/Show/Venue context —
- * just a TrackLight with the denormalized gap + previous-performance fields.
+ * tree so the column factory doesn't depend on Set/Show/Venue context.
+ * `priorPerformanceCount` is computed in the table component from the lazy
+ * catalog play-dates blob; null while the blob is still loading.
  */
-export type SetlistTableRow = TrackLight;
+export type SetlistTableRow = TrackLight & { priorPerformanceCount: number | null };
 
 /**
  * Columns for the SetlistCard "gap chart" view. Order is locked at
- * [Set, Track #, Song, Gap, Last Played, Rating]. The first three come
- * from the shared `createSetlistCommonColumns` helper; this factory adds
- * the gap-chart-specific Gap, Last Played, and the shared interactive
- * Rating column on the right edge. Args default to anonymous + empty so
- * isolated column tests stay terse.
+ * [Set, Track #, Song, Gap, Last Played, Played Before, Rating]. The first
+ * three come from the shared `createSetlistCommonColumns` helper; this
+ * factory adds the gap-chart-specific Gap, Last Played, Played Before, and
+ * the shared interactive Rating column on the right edge. Args default to
+ * anonymous + empty so isolated column tests stay terse.
  */
 export function createSetlistColumns(ctx?: Partial<SetlistRatingContext>): ColumnDef<SetlistTableRow, unknown>[] {
   const ratingCtx: SetlistRatingContext = {
@@ -45,6 +47,15 @@ export function createSetlistColumns(ctx?: Partial<SetlistRatingContext>): Colum
       label: "Last Played",
       accessor: (row) => row.previousPerformanceShow,
       fixedWidth: "7.5rem",
+    }),
+    // Desktop-only "Played Before" — the personal view's Seen Before peer
+    // stays visible on mobile because that's its existing layout; the
+    // catalog version is additive and was asked to leave mobile untouched.
+    createCountColumn<SetlistTableRow>({
+      id: "priorPerformanceCount",
+      accessor: (row) => row.priorPerformanceCount,
+      label: ["Played", "Before"],
+      hideOnMobile: true,
     }),
     createRatingColumn<SetlistTableRow>(ratingCtx),
   ];

--- a/apps/web/app/components/setlist/setlist-common-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-common-columns.tsx
@@ -87,6 +87,62 @@ export function createRatingColumn<T extends TrackLight>(ctx: SetlistRatingConte
 }
 
 /**
+ * Stacked-label count column used by both gap-chart views: catalog "Played
+ * Before" and personal "Seen Before". The two columns share header shape,
+ * sort config, and cell rendering — only the accessor, label words, and
+ * mobile presentation differ. Centralizing here avoids drift between the
+ * two factories.
+ *
+ * The accessor returns `null` to indicate "not loaded yet" (the catalog
+ * variant fetches its data asynchronously); rendered as an em-dash so the
+ * column doesn't flash a misleading "0" before settling on the real count.
+ * Synchronous callers (personal view) can return `0` directly and never
+ * see the placeholder.
+ */
+export function createCountColumn<T extends TrackLight>(opts: {
+  id: string;
+  accessor: (row: T) => number | null;
+  /**
+   * Two-word header rendered as stacked spans so the column can stay
+   * narrow on phones (e.g., `["Played", "Before"]`, `["Seen", "Before"]`).
+   */
+  label: [string, string];
+  hideOnMobile?: boolean;
+  mobileFixedWidth?: string;
+}): ColumnDef<T, unknown> {
+  const columnHelper = createColumnHelper<T>();
+  return columnHelper.accessor((row) => opts.accessor(row) ?? Number.NEGATIVE_INFINITY, {
+    id: opts.id,
+    header: ({ column }) => (
+      <SortableHeader
+        column={column}
+        label={
+          <span className="flex flex-col items-start leading-tight">
+            <span>{opts.label[0]}</span>
+            <span>{opts.label[1]}</span>
+          </span>
+        }
+      />
+    ),
+    // 4-digit max content (catalog's most-played songs land in the high
+    // hundreds), so 4.5rem fits the stacked header + sort arrow on its
+    // own row below without slack.
+    meta: {
+      fixedWidth: "4.5rem",
+      ...(opts.hideOnMobile ? { hideOnMobile: true } : {}),
+      ...(opts.mobileFixedWidth ? { mobileFixedWidth: opts.mobileFixedWidth } : {}),
+    },
+    enableSorting: true,
+    sortingFn: "basic",
+    sortDescFirst: false,
+    cell: (info) => {
+      const value = opts.accessor(info.row.original);
+      return <span className="text-content-text-secondary tabular-nums">{value === null ? "—" : value}</span>;
+    },
+  }) as ColumnDef<T, unknown>;
+}
+
+/**
  * Set, Track, and Song columns are identical across every SetlistCard
  * table view (gap chart, personal gap chart, and anything we add later).
  * Centralize them here so the per-view column factories can focus on

--- a/apps/web/app/components/setlist/setlist-table.test.tsx
+++ b/apps/web/app/components/setlist/setlist-table.test.tsx
@@ -12,6 +12,9 @@ vi.mock("~/hooks/use-session", () => ({
 vi.mock("~/hooks/use-track-user-ratings", () => ({
   useTrackUserRatings: vi.fn(() => ({ userRatingMap: new Map<string, number>(), isLoading: false })),
 }));
+vi.mock("~/hooks/use-song-play-dates", () => ({
+  useSongPlayDates: vi.fn(() => ({ data: {} as Record<string, string[]>, isLoading: false })),
+}));
 // Stub TrackRatingCell so the rating column emits a deterministic, prop-
 // dumping node — the rating cell internals are covered elsewhere.
 vi.mock("~/components/performance/track-rating-cell", () => ({
@@ -20,6 +23,7 @@ vi.mock("~/components/performance/track-rating-cell", () => ({
 
 const { useSession } = await import("~/hooks/use-session");
 const { useTrackUserRatings } = await import("~/hooks/use-track-user-ratings");
+const { useSongPlayDates } = await import("~/hooks/use-song-play-dates");
 const { SetlistTable } = await import("./setlist-table");
 
 function makeTrack(overrides: Partial<TrackLight> & { songId: string; position: number }): TrackLight {
@@ -52,6 +56,7 @@ describe("SetlistTable", () => {
     await setupWithRouter(
       <SetlistTable
         showSlug="2024-07-19-camden"
+        showDate="2024-07-19"
         tracks={[
           makeTrack({
             songId: "c",
@@ -80,7 +85,7 @@ describe("SetlistTable", () => {
         ]}
       />,
     );
-    const cells = screen.getAllByRole("cell").filter((_, i) => i % 7 === 3);
+    const cells = screen.getAllByRole("cell").filter((_, i) => i % 8 === 3);
     expect(cells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
       "Basis for a Day",
       "Above the Waves",
@@ -95,6 +100,7 @@ describe("SetlistTable", () => {
     await setupWithRouter(
       <SetlistTable
         showSlug="2024-07-19-camden"
+        showDate="2024-07-19"
         tracks={[
           makeTrack({
             songId: "a",
@@ -134,6 +140,7 @@ describe("SetlistTable", () => {
     await setupWithRouter(
       <SetlistTable
         showSlug="2024-07-19-camden"
+        showDate="2024-07-19"
         tracks={[
           makeTrack({
             songId: "song-basis",
@@ -151,5 +158,47 @@ describe("SetlistTable", () => {
     expect(screen.getByTestId("TrackRatingCell").textContent).toContain('"showSlug":"2024-07-19-camden"');
     expect(screen.getByTestId("TrackRatingCell").textContent).toContain('"userRating":5');
     expect(screen.getByTestId("TrackRatingCell").textContent).toContain('"isAuthenticated":true');
+  });
+
+  // Wiring: SetlistTable threads each row's songId into the catalog blob,
+  // counts dates strictly before `showDate`, and surfaces that count in the
+  // Played Before cell. Stubs return a non-empty blob so the augmentation
+  // path actually runs (loading state already covered in setlist-columns
+  // tests via the em-dash rendering).
+  test("renders the prior-performance count derived from the catalog blob", async () => {
+    vi.mocked(useSongPlayDates).mockReturnValue({
+      data: {
+        // Three plays strictly before 2024-07-19 → cell renders "3".
+        "song-tractorbeam": ["2018-12-31", "2020-06-10", "2022-04-14", "2024-07-19", "2025-01-01"],
+        // No prior plays → "0" (a personal debut from the catalog's view).
+        "song-debut": ["2024-07-19"],
+      },
+      isLoading: false,
+    });
+
+    await setupWithRouter(
+      <SetlistTable
+        showSlug="2024-07-19-camden"
+        showDate="2024-07-19"
+        tracks={[
+          makeTrack({
+            songId: "song-tractorbeam",
+            position: 1,
+            song: { id: "song-tractorbeam", title: "Tractorbeam", slug: "tractorbeam" },
+          }),
+          makeTrack({
+            songId: "song-debut",
+            position: 2,
+            song: { id: "song-debut", title: "Munchkin Invasion", slug: "munchkin-invasion" },
+          }),
+        ]}
+      />,
+    );
+
+    // Each row has 8 cells; Played Before is index 6. Cells 6 + 14 are the
+    // Played Before cells for the two rows respectively.
+    const cells = screen.getAllByRole("cell");
+    expect(cells[6].textContent).toBe("3");
+    expect(cells[14].textContent).toBe("0");
   });
 });

--- a/apps/web/app/components/setlist/setlist-table.tsx
+++ b/apps/web/app/components/setlist/setlist-table.tsx
@@ -1,9 +1,10 @@
-import type { TrackLight } from "@bip/domain";
+import { countSortedBefore, type TrackLight } from "@bip/domain";
 import { useMemo } from "react";
 import { DataTable } from "~/components/ui/data-table";
 import { useSession } from "~/hooks/use-session";
+import { useSongPlayDates } from "~/hooks/use-song-play-dates";
 import { useTrackUserRatings } from "~/hooks/use-track-user-ratings";
-import { createSetlistColumns } from "./setlist-columns";
+import { createSetlistColumns, type SetlistTableRow } from "./setlist-columns";
 
 interface SetlistTableProps {
   tracks: TrackLight[];
@@ -12,6 +13,11 @@ interface SetlistTableProps {
    * cells. Threaded down to RatingBadgeButton.
    */
   showSlug: string;
+  /**
+   * Show date in `YYYY-MM-DD`. Drives the Played Before column — for each
+   * row we count stats performances of the song strictly before this date.
+   */
+  showDate: string;
 }
 
 /**
@@ -20,15 +26,25 @@ interface SetlistTableProps {
  * SetlistViewControl (rendered by SetlistCard above and below the table)
  * so it can sit on the same row as the setlist/gap-chart toggle.
  *
- * Calls `useTrackUserRatings` lazily — this component only mounts when the
- * card is in `view="gap-chart"`, so list pages don't fetch viewer ratings
- * until a user actually opens the chart view.
+ * Calls `useTrackUserRatings` and `useSongPlayDates` lazily — this component
+ * only mounts when the card is in `view="gap-chart"`, so list pages don't
+ * fetch either dataset until a user actually opens the chart view. The
+ * catalog play-dates blob is one fetch per session that powers Played
+ * Before for every gap-chart toggle thereafter.
  */
-export function SetlistTable({ tracks, showSlug }: SetlistTableProps) {
+export function SetlistTable({ tracks, showSlug, showDate }: SetlistTableProps) {
   const { user } = useSession();
   const isAuthenticated = !!user;
   const trackIds = useMemo(() => tracks.map((t) => t.id), [tracks]);
   const { userRatingMap } = useTrackUserRatings(trackIds);
+  const { data: songPlayDates, isLoading: isPlayDatesLoading } = useSongPlayDates();
+
+  const rows: SetlistTableRow[] = useMemo(() => {
+    return tracks.map((track) => ({
+      ...track,
+      priorPerformanceCount: isPlayDatesLoading ? null : countSortedBefore(songPlayDates[track.songId] ?? [], showDate),
+    }));
+  }, [tracks, songPlayDates, isPlayDatesLoading, showDate]);
 
   const columns = useMemo(
     () => createSetlistColumns({ showSlug, userRatingMap, isAuthenticated }),
@@ -37,7 +53,7 @@ export function SetlistTable({ tracks, showSlug }: SetlistTableProps) {
   return (
     <DataTable
       columns={columns}
-      data={tracks}
+      data={rows}
       hideSearch
       hidePagination
       hidePaginationText

--- a/apps/web/app/hooks/use-song-play-dates.ts
+++ b/apps/web/app/hooks/use-song-play-dates.ts
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+
+export type SongPlayDates = Record<string, string[]>;
+
+const EMPTY: SongPlayDates = {};
+
+/**
+ * Lazy fetcher for the catalog play-history blob (`{songId: [date, ...]}`).
+ * Backs the SetlistCard gap-chart "Played Before" column — the lazy gate
+ * is structural: this hook only mounts when SetlistTable mounts, which
+ * only happens when the user opens gap-chart. After that one fetch, every
+ * gap-chart toggle across the session reads from React Query in memory.
+ *
+ * Public payload (no auth needed). 5-minute staleTime mirrors the personal
+ * history hook; the server-side cache is Redis-backed with a 24h TTL and
+ * invalidates on show mutations.
+ */
+export function useSongPlayDates(): { data: SongPlayDates; isLoading: boolean } {
+  const { data, isLoading } = useQuery({
+    queryKey: ["stats", "song-play-dates"],
+    queryFn: async (): Promise<SongPlayDates> => {
+      const response = await fetch("/api/stats/song-play-dates");
+      if (!response.ok) throw new Error("Failed to load song play dates");
+      return response.json();
+    },
+    staleTime: 5 * 60_000,
+  });
+
+  return { data: data ?? EMPTY, isLoading };
+}

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -133,6 +133,7 @@ export default [
     route("users", "routes/api/users.tsx"),
     route("users/avatar", "routes/api/users/avatar.tsx"),
     route("users/song-history", "routes/api/users/song-history.tsx"),
+    route("stats/song-play-dates", "routes/api/stats/song-play-dates.tsx"),
     route("contact", "routes/api/contact.tsx"),
     route("cron/:action", "routes/api/cron/$action.tsx"),
     route("images/upload", "routes/api/images/upload.tsx"),

--- a/apps/web/app/routes/api/stats/song-play-dates.test.ts
+++ b/apps/web/app/routes/api/stats/song-play-dates.test.ts
@@ -1,0 +1,58 @@
+import type { LoaderFunctionArgs } from "react-router-dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// publicLoader normally wraps the inner function with optional auth; bypass
+// it so the loader can be driven directly with synthetic args.
+vi.mock("~/lib/base-loaders", () => ({
+  publicLoader: <T>(fn: (args: LoaderFunctionArgs & { context: unknown }) => Promise<T>) => fn,
+}));
+
+const getSongPlayDates = vi.fn();
+vi.mock("~/server/services", () => ({
+  services: { stats: { getSongPlayDates } },
+}));
+
+vi.mock("~/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { loader } = await import("./song-play-dates");
+
+function makeArgs(): LoaderFunctionArgs & { context: unknown } {
+  return {
+    request: new Request("http://localhost/api/stats/song-play-dates"),
+    params: {},
+    context: {},
+  } as unknown as LoaderFunctionArgs & { context: unknown };
+}
+
+describe("GET /api/stats/song-play-dates", () => {
+  beforeEach(() => {
+    getSongPlayDates.mockReset();
+  });
+
+  // Happy path: pass through the catalog play-history blob the service
+  // returns. No auth gating — the catalog isn't user-scoped.
+  test("returns the play-dates blob from the service", async () => {
+    const payload = {
+      "song-tractorbeam": ["2020-06-10", "2021-04-14"],
+      "song-confrontation": ["2018-12-31"],
+    };
+    getSongPlayDates.mockResolvedValue(payload);
+
+    const response = (await loader(makeArgs())) as Response;
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(payload);
+    expect(getSongPlayDates).toHaveBeenCalledTimes(1);
+  });
+
+  // Service failure: surface a 500 instead of a stack trace. The hook
+  // throws on non-ok so React Query can transition to error state.
+  test("returns 500 when the service throws", async () => {
+    getSongPlayDates.mockRejectedValue(new Error("redis down"));
+
+    const response = (await loader(makeArgs())) as Response;
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "Failed to fetch song play dates" });
+  });
+});

--- a/apps/web/app/routes/api/stats/song-play-dates.tsx
+++ b/apps/web/app/routes/api/stats/song-play-dates.tsx
@@ -1,0 +1,24 @@
+import { publicLoader } from "~/lib/base-loaders";
+import { logger } from "~/lib/logger";
+import { services } from "~/server/services";
+
+/**
+ * Backs the gap-chart "Played Before" column. Returns the global
+ * `{songId: [date, ...]}` map of stats-eligible performances so the
+ * client can binary-search prior counts for any show without paying
+ * a per-show server query. Public — the catalog is not user-scoped.
+ * Browsers fetch this once per session via React Query (lazy on the
+ * first gap-chart open); Redis serves repeat callers.
+ */
+export const loader = publicLoader(async () => {
+  try {
+    const blob = await services.stats.getSongPlayDates();
+    return Response.json(blob);
+  } catch (error) {
+    logger.error("Error fetching song play dates", { error });
+    return new Response(JSON.stringify({ error: "Failed to fetch song play dates" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+});

--- a/packages/core/src/_shared/cache/cache-invalidation-service.test.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.test.ts
@@ -68,6 +68,7 @@ describe("CacheInvalidationService.invalidateShowListings", () => {
     expect(cache.delPattern).toHaveBeenCalledWith("home:*");
     expect(cache.del).toHaveBeenCalledWith(CacheKeys.stats.showsByYear());
     expect(cache.del).toHaveBeenCalledWith(CacheKeys.stats.showDates());
+    expect(cache.del).toHaveBeenCalledWith(CacheKeys.stats.songPlayDates());
   });
 
   // Per-user song-history embeds track-level data from every attended show,

--- a/packages/core/src/_shared/cache/cache-invalidation-service.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.ts
@@ -76,6 +76,7 @@ export class CacheInvalidationService {
       this.cache.delPattern("home:*"), // Invalidate all home page caches
       this.cache.del(CacheKeys.stats.showsByYear()), // shows-per-year aggregate is tied to the show catalog
       this.cache.del(CacheKeys.stats.showDates()), // sorted stats-show-dates array backs Gap to Now on /songs
+      this.cache.del(CacheKeys.stats.songPlayDates()), // catalog play-history blob backs gap-chart Played Before column
       // Per-user attended-setlists caches include each show's setlist + venue;
       // wipe them all when any show metadata moves.
       this.cache.delPattern(CacheKeys.users.allAttendedSetlists()),
@@ -101,8 +102,12 @@ export class CacheInvalidationService {
    * for callers that mutate shows without going through the listing flow.
    */
   async invalidateStatsShowsByYear(): Promise<void> {
-    this.logger.info("Invalidating stats:shows-by-year + stats:show-dates");
-    await Promise.all([this.cache.del(CacheKeys.stats.showsByYear()), this.cache.del(CacheKeys.stats.showDates())]);
+    this.logger.info("Invalidating stats:shows-by-year + stats:show-dates + stats:song-play-dates");
+    await Promise.all([
+      this.cache.del(CacheKeys.stats.showsByYear()),
+      this.cache.del(CacheKeys.stats.showDates()),
+      this.cache.del(CacheKeys.stats.songPlayDates()),
+    ]);
   }
 
   /**

--- a/packages/core/src/page-composers/song-page-composer.ts
+++ b/packages/core/src/page-composers/song-page-composer.ts
@@ -1,10 +1,18 @@
-import type { AllTimersPageView, Annotation, SongPagePerformance, SongPageView } from "@bip/domain";
+import {
+  type AllTimersPageView,
+  type Annotation,
+  countSortedAfter,
+  countSortedBetween,
+  countSortedOnOrAfter,
+  type SongPagePerformance,
+  type SongPageView,
+} from "@bip/domain";
 import { Prisma } from "@prisma/client";
 import type { DbClient } from "../_shared/database/models";
 import { showOrderBySql, statsShowsSql } from "../_shared/show-ordering";
 import { computeTrackGaps, sortTracksForGapWalk, type TrackForGapWalk } from "../_shared/track-gap";
 import type { SongService } from "../songs/song-service";
-import { countShowsAfter, countShowsBetween, countShowsOnOrAfter, type StatsService } from "../stats/stats-service";
+import type { StatsService } from "../stats/stats-service";
 
 /**
  * Filters for querying performances. All fields are optional — only
@@ -380,8 +388,8 @@ export class SongPageComposer {
     const out = new Map<string, FilteredSongRarity>();
     for (const row of rows) {
       const filteredTimesPlayed = Number.parseInt(row.show_count, 10);
-      const filteredShowsSinceLastPlayed = countShowsAfter(matchingShowDates, row.last_date);
-      const showsOnOrAfterDebut = countShowsOnOrAfter(matchingShowDates, row.first_date);
+      const filteredShowsSinceLastPlayed = countSortedAfter(matchingShowDates, row.last_date);
+      const showsOnOrAfterDebut = countSortedOnOrAfter(matchingShowDates, row.first_date);
       const filteredPercentSinceDebut = showsOnOrAfterDebut === 0 ? null : filteredTimesPlayed / showsOnOrAfterDebut;
       // Mean closed gap within the filter scope. Numerator counts only
       // matching shows strictly BETWEEN the first and last filtered plays,
@@ -392,7 +400,7 @@ export class SongPageComposer {
       const filteredAverageGapShows =
         filteredTimesPlayed < 2
           ? null
-          : countShowsBetween(matchingShowDates, row.first_date, row.last_date) / (filteredTimesPlayed - 1);
+          : countSortedBetween(matchingShowDates, row.first_date, row.last_date) / (filteredTimesPlayed - 1);
       out.set(row.song_id, {
         filteredShowsSinceLastPlayed,
         filteredPercentSinceDebut,

--- a/packages/core/src/rock-operas/rock-opera-service.ts
+++ b/packages/core/src/rock-operas/rock-opera-service.ts
@@ -1,7 +1,13 @@
-import type { AdjacentRockOperaPerformance, Logger, RockOpera, RockOperaPerformanceAnnotation } from "@bip/domain";
+import {
+  type AdjacentRockOperaPerformance,
+  countSortedBetween,
+  type Logger,
+  type RockOpera,
+  type RockOperaPerformanceAnnotation,
+} from "@bip/domain";
 import type { DbClient } from "../_shared/database/models";
 import { SHOW_ORDER_ASC } from "../_shared/show-ordering";
-import { countShowsBetween, type StatsService } from "../stats/stats-service";
+import type { StatsService } from "../stats/stats-service";
 
 type DbRockOpera = {
   id: string;
@@ -101,10 +107,10 @@ export class RockOperaService {
       const next = index < operaShows.length - 1 ? operaShows[index + 1] : null;
 
       const previousPerformance: AdjacentRockOperaPerformance | null = prev
-        ? { date: prev.date, slug: prev.slug, gap: countShowsBetween(statsShowDates, prev.date, current.date) }
+        ? { date: prev.date, slug: prev.slug, gap: countSortedBetween(statsShowDates, prev.date, current.date) }
         : null;
       const nextPerformance: AdjacentRockOperaPerformance | null = next
-        ? { date: next.date, slug: next.slug, gap: countShowsBetween(statsShowDates, current.date, next.date) }
+        ? { date: next.date, slug: next.slug, gap: countSortedBetween(statsShowDates, current.date, next.date) }
         : null;
 
       const annotation: RockOperaPerformanceAnnotation = {

--- a/packages/core/src/stats/stats-service.test.ts
+++ b/packages/core/src/stats/stats-service.test.ts
@@ -1,12 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 import type { CacheService } from "../_shared/cache";
-import {
-  countShowsAfter,
-  countShowsBetween,
-  countShowsOnOrAfter,
-  StatsService,
-  songStatsChanged,
-} from "./stats-service";
+import { StatsService, songStatsChanged } from "./stats-service";
 
 const baseFresh = {
   timesPlayed: 3,
@@ -110,127 +104,24 @@ describe("songStatsChanged", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// countShowsAfter — pure binary-search count of dates strictly after a target
-// ---------------------------------------------------------------------------
+// Behavior of the sorted-string binary-search counters lives in
+// packages/domain/src/sorted-dates.test.ts now that the primitives moved
+// to @bip/domain. No behavior to retest at this layer.
 
-describe("countShowsAfter", () => {
-  // Drives the songs-list Gap to Now column (number of stats-eligible shows
-  // since a song's dateLastPlayed) and the song-detail page's "X shows ago"
-  // sublabel. Backed by a single cached date array so the binary search
-  // runs in O(log n) per song.
-
-  // Empty catalogue → no shows after any date.
-  test("returns 0 for empty input regardless of target", () => {
-    expect(countShowsAfter([], "2024-01-01")).toBe(0);
-  });
-
-  // Target older than every show → every show counts as "after".
-  test("returns full length when target precedes all dates", () => {
-    expect(countShowsAfter(["2010-01-01", "2015-06-15", "2020-12-31"], "2000-01-01")).toBe(3);
-  });
-
-  // Target equal to a date → strictly-greater semantics excludes the match
-  // itself. Matches the song-detail composer's existing SQL (`> date`, not
-  // `>=`), so a song played on the most recent show reads "0 shows ago".
-  test("strictly-greater: target equal to a date does not count that date", () => {
-    expect(countShowsAfter(["2020-01-01", "2021-01-01", "2022-01-01"], "2021-01-01")).toBe(1);
-  });
-
-  // Target equal to multiple repeated dates → still strictly greater, so
-  // all repeated entries are excluded.
-  test("strictly-greater with duplicates: all matching entries are excluded", () => {
-    expect(countShowsAfter(["2020-01-01", "2020-01-01", "2021-01-01"], "2020-01-01")).toBe(1);
-  });
-
-  // Target later than the latest date → no shows after.
-  test("returns 0 when target follows every date", () => {
-    expect(countShowsAfter(["2010-01-01", "2015-06-15", "2020-12-31"], "2025-01-01")).toBe(0);
-  });
-
-  // Target between two dates → counts everything strictly greater.
-  test("counts dates strictly greater than a target falling between two entries", () => {
-    expect(countShowsAfter(["2010-01-01", "2015-06-15", "2020-12-31", "2024-07-04"], "2018-01-01")).toBe(2);
-  });
-
-  // Large array sanity — binary search handles 480 entries (40 years × 12
-  // months) without churn, and the result still matches the linear answer.
-  test("matches a linear scan on a 480-element array", () => {
-    const dates: string[] = [];
-    for (let year = 1990; year < 2030; year++) {
-      for (let month = 1; month <= 12; month++) {
-        dates.push(`${year}-${String(month).padStart(2, "0")}-15`);
-      }
-    }
-    dates.sort();
-    const target = "2010-06-15";
-    const binary = countShowsAfter(dates, target);
-    const linear = dates.filter((d) => d > target).length;
-    expect(binary).toBe(linear);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// countShowsOnOrAfter — inclusive variant for the filtered-debut denominator
-// ---------------------------------------------------------------------------
-
-describe("countShowsOnOrAfter", () => {
-  // Drives Filtered Since Debut / Filtered Avg Gap on /songs: the denominator
-  // is "matching-universe shows from the song's first filtered play onward",
-  // which must include the debut show itself — so this is `>=`, not `>`.
-
-  // Empty catalogue → nothing on or after anything.
-  test("returns 0 for empty input regardless of target", () => {
-    expect(countShowsOnOrAfter([], "2024-01-01")).toBe(0);
-  });
-
-  // Target before every date → every entry counts.
-  test("returns full length when target precedes all dates", () => {
-    expect(countShowsOnOrAfter(["2010-01-01", "2015-06-15", "2020-12-31"], "2000-01-01")).toBe(3);
-  });
-
-  // Target equal to a date → that date counts (this is the on-or-after
-  // variant). Distinguishes this helper from `countShowsAfter`.
-  test("inclusive: target equal to a date includes that date", () => {
-    expect(countShowsOnOrAfter(["2020-01-01", "2021-01-01", "2022-01-01"], "2021-01-01")).toBe(2);
-  });
-
-  // Target later than the latest date → nothing remains.
-  test("returns 0 when target follows every date", () => {
-    expect(countShowsOnOrAfter(["2010-01-01", "2015-06-15"], "2030-01-01")).toBe(0);
-  });
-});
-
-describe("countShowsBetween", () => {
-  // Drives the mean-closed-gap numerator for filteredAverageGapShows:
-  // matching-universe shows strictly between the first and last filtered
-  // plays. Both endpoints are exclusive — the play dates themselves are
-  // performances, not gaps.
-
-  // Empty array short-circuits regardless of bounds.
-  test("returns 0 for empty input", () => {
-    expect(countShowsBetween([], "2024-01-01", "2024-12-31")).toBe(0);
-  });
-
-  // Strict between: dates equal to either endpoint are excluded.
-  test("excludes both endpoints", () => {
-    const dates = ["2024-01-01", "2024-02-01", "2024-03-01", "2024-04-01", "2024-05-01"];
-    expect(countShowsBetween(dates, "2024-01-01", "2024-05-01")).toBe(3);
-  });
-
-  // No shows fall in a degenerate or inverted interval — never negative.
-  test("returns 0 when low >= high", () => {
-    const dates = ["2024-01-01", "2024-02-01", "2024-03-01"];
-    expect(countShowsBetween(dates, "2024-03-01", "2024-01-01")).toBe(0);
-    expect(countShowsBetween(dates, "2024-02-01", "2024-02-01")).toBe(0);
-  });
-
-  // Bounds outside the array range count nothing past the endpoints.
-  test("returns 0 when no dates fall in range", () => {
-    const dates = ["2024-01-01", "2024-02-01"];
-    expect(countShowsBetween(dates, "2025-01-01", "2025-12-31")).toBe(0);
-  });
-});
+/**
+ * Build a StatsService wrapping a vitest-mocked `$queryRaw` and a
+ * pass-through cache that always invokes the producer. Tests can read
+ * `queryRaw.mock.calls[0]` to assert on the SQL the service issued or
+ * pre-seed `mockResolvedValue` to drive the row-shape branches.
+ */
+function makeStubbedService(rows: unknown[] = []) {
+  const queryRaw = vi.fn().mockResolvedValue(rows);
+  const db = { $queryRaw: queryRaw } as unknown as ConstructorParameters<typeof StatsService>[0];
+  const cache = {
+    getOrSet: async <T>(_key: unknown, producer: () => Promise<T>) => producer(),
+  } as unknown as CacheService;
+  return { service: new StatsService(db, cache), queryRaw };
+}
 
 // Both getShowsByYear and getStatsShowDates feed denominators for rarity
 // stats — % since debut, shows since last played. Prod's per-date "stub"
@@ -239,16 +130,6 @@ describe("countShowsBetween", () => {
 // the SQL: every show-counting predicate must add `venue_id IS NOT NULL`
 // so the rarity math only counts real shows.
 describe("StatsService stub filtering in raw SQL", () => {
-  function makeStubbedService() {
-    const queryRaw = vi.fn().mockResolvedValue([]);
-    const db = { $queryRaw: queryRaw } as unknown as ConstructorParameters<typeof StatsService>[0];
-    // Cache: pass through to the producer so we can intercept the SQL it issues.
-    const cache = {
-      getOrSet: async <T>(_key: unknown, producer: () => Promise<T>) => producer(),
-    } as unknown as CacheService;
-    return { service: new StatsService(db, cache), queryRaw };
-  }
-
   // `$queryRaw` is called as a tag template. Prisma passes the cooked
   // template-string chunks as the first arg and every interpolated
   // `Prisma.Sql` fragment as the rest. Concatenate both so the assertion
@@ -274,5 +155,39 @@ describe("StatsService stub filtering in raw SQL", () => {
     await service.getStatsShowDates();
     expect(queryRaw).toHaveBeenCalledTimes(1);
     expect(joinSqlFromCall(queryRaw.mock.calls[0])).toContain("venue_id IS NOT NULL");
+  });
+
+  // The catalog play-dates blob backs the gap-chart "Played Before" column.
+  // Stubs would over-count a song's prior plays for any show after the stub
+  // date, so the same filter must be applied here too.
+  test("getSongPlayDates's SQL excludes orphan stub shows (venue_id IS NOT NULL)", async () => {
+    const { service, queryRaw } = makeStubbedService();
+    await service.getSongPlayDates();
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    expect(joinSqlFromCall(queryRaw.mock.calls[0])).toContain("venue_id IS NOT NULL");
+  });
+});
+
+describe("StatsService.getSongPlayDates", () => {
+  // Groups raw `{song_id, date}` rows into `{songId: [date, date, ...]}`.
+  // Per-song arrays must come out sorted ascending so clients can binary-
+  // search for "strictly before" without re-sorting.
+  test("groups rows by songId and preserves ascending order per song", async () => {
+    const { service } = makeStubbedService([
+      { song_id: "song-A", d: "2010-01-01" },
+      { song_id: "song-B", d: "2010-02-01" },
+      { song_id: "song-A", d: "2012-06-15" },
+      { song_id: "song-A", d: "2015-03-20" },
+      { song_id: "song-B", d: "2018-08-08" },
+    ]);
+    expect(await service.getSongPlayDates()).toEqual({
+      "song-A": ["2010-01-01", "2012-06-15", "2015-03-20"],
+      "song-B": ["2010-02-01", "2018-08-08"],
+    });
+  });
+
+  test("returns an empty object when there are no plays", async () => {
+    const { service } = makeStubbedService();
+    expect(await service.getSongPlayDates()).toEqual({});
   });
 });

--- a/packages/core/src/stats/stats-service.ts
+++ b/packages/core/src/stats/stats-service.ts
@@ -1,4 +1,4 @@
-import { CacheKeys } from "@bip/domain";
+import { CacheKeys, countSortedAfter } from "@bip/domain";
 import type { CacheService } from "../_shared/cache/cache-service";
 import type { DbClient } from "../_shared/database/models";
 import { nonStubShowsSql, STATS_SHOWS_WHERE, statsShowsSql, TRACK_BY_SHOW_ORDER_ASC } from "../_shared/show-ordering";
@@ -98,13 +98,50 @@ export class StatsService {
   }
 
   /**
+   * Returns `{songId: [date, ...]}` covering every stats-eligible
+   * performance of every song, each per-song array sorted ascending.
+   * Backs the gap-chart "Played Before" column: clients fetch this
+   * once per session and binary-search prior counts client-side, so
+   * year/top-rated pages don't pay a per-show query when users open
+   * the gap-chart view. Sort happens in SQL so the JS group step is
+   * O(n) — preserving insertion order is enough to keep arrays sorted.
+   */
+  async getSongPlayDates(): Promise<Record<string, string[]>> {
+    if (!this.cache) {
+      throw new Error("StatsService.getSongPlayDates() requires a cache; constructed without one");
+    }
+    return this.cache.getOrSet(
+      CacheKeys.stats.songPlayDates(),
+      async () => {
+        const rows = await this.db.$queryRaw<Array<{ song_id: string; d: string }>>`
+          SELECT tracks.song_id, to_char(shows.date::date, 'YYYY-MM-DD') AS d
+          FROM tracks
+          JOIN shows ON tracks.show_id = shows.id
+          WHERE shows.date IS NOT NULL
+            AND ${statsShowsSql("shows")}
+            AND ${nonStubShowsSql("shows")}
+          ORDER BY shows.date ASC
+        `;
+        const out: Record<string, string[]> = {};
+        for (const row of rows) {
+          const arr = out[row.song_id];
+          if (arr) arr.push(row.d);
+          else out[row.song_id] = [row.d];
+        }
+        return out;
+      },
+      { ttl: ONE_DAY_SECONDS },
+    );
+  }
+
+  /**
    * Number of stats-eligible shows strictly after a song's `dateLastPlayed`
    * — drives the "X shows ago" reading on the song detail page and the
    * Gap to Now column on /songs.
    */
   async getShowsSinceLastPlayed(dateLastPlayed: Date | string): Promise<number> {
     const dates = await this.getStatsShowDates();
-    return countShowsAfter(dates, toIsoDate(dateLastPlayed));
+    return countSortedAfter(dates, toIsoDate(dateLastPlayed));
   }
 
   /**
@@ -129,7 +166,7 @@ export class StatsService {
     const out = new Map<string, number>();
     for (const song of songs) {
       if (!song.dateLastPlayed) continue;
-      out.set(song.id, countShowsAfter(dates, toIsoDate(song.dateLastPlayed)));
+      out.set(song.id, countSortedAfter(dates, toIsoDate(song.dateLastPlayed)));
     }
     return out;
   }
@@ -358,70 +395,6 @@ function dateMs(d: Date | null): number | null {
 function toIsoDate(d: Date | string): string {
   if (typeof d === "string") return d.length > 10 ? d.slice(0, 10) : d;
   return d.toISOString().slice(0, 10);
-}
-
-/**
- * Counts entries strictly greater than `target` in a sorted-ascending
- * string array via binary search. Strictly-greater (not `>=`) so a song
- * played at the most recent stats-eligible show reads "0 shows ago",
- * not "1 show ago".
- */
-export function countShowsAfter(sortedDates: string[], target: string): number {
-  if (sortedDates.length === 0) return 0;
-  // Find the index of the first element strictly greater than target.
-  let lo = 0;
-  let hi = sortedDates.length;
-  while (lo < hi) {
-    const mid = (lo + hi) >>> 1;
-    if (sortedDates[mid] <= target) lo = mid + 1;
-    else hi = mid;
-  }
-  return sortedDates.length - lo;
-}
-
-/**
- * Counts entries on or after `target` in a sorted-ascending string array.
- * Used as the denominator for Filtered Since Debut / Filtered Avg Gap on
- * /songs — "matching-universe shows from this song's first filtered play
- * onward", which includes the debut show itself.
- */
-export function countShowsOnOrAfter(sortedDates: string[], target: string): number {
-  if (sortedDates.length === 0) return 0;
-  let lo = 0;
-  let hi = sortedDates.length;
-  while (lo < hi) {
-    const mid = (lo + hi) >>> 1;
-    if (sortedDates[mid] < target) lo = mid + 1;
-    else hi = mid;
-  }
-  return sortedDates.length - lo;
-}
-
-/**
- * Counts entries strictly between `low` and `high` (both exclusive) in a
- * sorted-ascending string array. Drives the "shows that fell in gaps
- * between plays" denominator for filtered Avg Gap on /songs: we want the
- * mean closed gap, so the trailing dry spell after the last filtered play
- * and the period before the first filtered play must both be excluded.
- */
-export function countShowsBetween(sortedDates: string[], low: string, high: string): number {
-  if (sortedDates.length === 0 || low >= high) return 0;
-  let lo = 0;
-  let hi = sortedDates.length;
-  while (lo < hi) {
-    const mid = (lo + hi) >>> 1;
-    if (sortedDates[mid] <= low) lo = mid + 1;
-    else hi = mid;
-  }
-  const startIdx = lo;
-  lo = startIdx;
-  hi = sortedDates.length;
-  while (lo < hi) {
-    const mid = (lo + hi) >>> 1;
-    if (sortedDates[mid] < high) lo = mid + 1;
-    else hi = mid;
-  }
-  return lo - startIdx;
 }
 
 function stableYearlyJson(value: unknown): string {

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -156,6 +156,14 @@ export const CacheKeys = {
      * show. `:v2` bump: now excludes orphan stub shows (venue_id IS NULL).
      */
     showDates: () => "stats:show-dates:v2",
+    /**
+     * Catalog play-history blob: `{songId: [date, date, ...]}` with every
+     * stats-track performance per song, dates sorted ascending. Backs the
+     * gap-chart "Played Before" column — clients fetch this once per
+     * session (lazy on first gap-chart open), then binary-search prior
+     * counts client-side instead of paying a per-show server query.
+     */
+    songPlayDates: () => "stats:song-play-dates:v1",
   },
 } as const;
 

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -22,5 +22,6 @@ export * from "./models/venue";
 export * from "./search";
 export * from "./segue-run";
 export * from "./show-ordering";
+export * from "./sorted-dates";
 export * from "./views/blog-post";
 export * from "./views/song-page";

--- a/packages/domain/src/sorted-dates.test.ts
+++ b/packages/domain/src/sorted-dates.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "vitest";
+import { countSortedAfter, countSortedBefore, countSortedBetween, countSortedOnOrAfter } from "./sorted-dates";
+
+// ---------------------------------------------------------------------------
+// countSortedAfter — strictly-greater binary-search count
+// ---------------------------------------------------------------------------
+
+describe("countSortedAfter", () => {
+  // Drives the /songs Gap to Now column and song-detail "X shows ago"
+  // sublabel — number of stats-eligible shows since dateLastPlayed.
+
+  test("returns 0 for empty input regardless of target", () => {
+    expect(countSortedAfter([], "2024-01-01")).toBe(0);
+  });
+
+  test("returns full length when target precedes all dates", () => {
+    expect(countSortedAfter(["2010-01-01", "2015-06-15", "2020-12-31"], "2000-01-01")).toBe(3);
+  });
+
+  // Strictly-greater semantics excludes the match itself. Matches the
+  // song-detail composer's existing SQL (`> date`, not `>=`).
+  test("strictly-greater: target equal to a date does not count that date", () => {
+    expect(countSortedAfter(["2020-01-01", "2021-01-01", "2022-01-01"], "2021-01-01")).toBe(1);
+  });
+
+  test("strictly-greater with duplicates: all matching entries are excluded", () => {
+    expect(countSortedAfter(["2020-01-01", "2020-01-01", "2021-01-01"], "2020-01-01")).toBe(1);
+  });
+
+  test("returns 0 when target follows every date", () => {
+    expect(countSortedAfter(["2010-01-01", "2015-06-15", "2020-12-31"], "2025-01-01")).toBe(0);
+  });
+
+  test("counts dates strictly greater than a target falling between two entries", () => {
+    expect(countSortedAfter(["2010-01-01", "2015-06-15", "2020-12-31", "2024-07-04"], "2018-01-01")).toBe(2);
+  });
+
+  // Binary search must agree with a linear scan even on larger arrays.
+  test("matches a linear scan on a 480-element array", () => {
+    const dates: string[] = [];
+    for (let year = 1990; year < 2030; year++) {
+      for (let month = 1; month <= 12; month++) {
+        dates.push(`${year}-${String(month).padStart(2, "0")}-15`);
+      }
+    }
+    dates.sort();
+    const target = "2010-06-15";
+    expect(countSortedAfter(dates, target)).toBe(dates.filter((d) => d > target).length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countSortedOnOrAfter — inclusive variant for the filtered-debut denominator
+// ---------------------------------------------------------------------------
+
+describe("countSortedOnOrAfter", () => {
+  // Drives Filtered Since Debut / Filtered Avg Gap on /songs — the
+  // denominator must include the debut show itself.
+
+  test("returns 0 for empty input regardless of target", () => {
+    expect(countSortedOnOrAfter([], "2024-01-01")).toBe(0);
+  });
+
+  test("returns full length when target precedes all dates", () => {
+    expect(countSortedOnOrAfter(["2010-01-01", "2015-06-15", "2020-12-31"], "2000-01-01")).toBe(3);
+  });
+
+  // Distinguishes this helper from `countSortedAfter`.
+  test("inclusive: target equal to a date includes that date", () => {
+    expect(countSortedOnOrAfter(["2020-01-01", "2021-01-01", "2022-01-01"], "2021-01-01")).toBe(2);
+  });
+
+  test("returns 0 when target follows every date", () => {
+    expect(countSortedOnOrAfter(["2010-01-01", "2015-06-15"], "2030-01-01")).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countSortedBefore — strictly-less binary-search count
+// ---------------------------------------------------------------------------
+
+describe("countSortedBefore", () => {
+  // Drives the gap-chart Played Before column: number of stats-eligible
+  // performances of a song strictly before the current show's date.
+  // Mirrors the personal view's "Seen Before" semantic.
+
+  test("returns 0 for empty input", () => {
+    expect(countSortedBefore([], "2026-05-24")).toBe(0);
+  });
+
+  test("returns 0 when every date is on or after the target", () => {
+    expect(countSortedBefore(["2026-05-24", "2026-06-01"], "2026-05-24")).toBe(0);
+  });
+
+  // Strictly-less semantics excludes dates equal to the target — a play
+  // on the show date itself isn't a "prior" play.
+  test("strictly-less: target equal to a date does not count that date", () => {
+    expect(countSortedBefore(["2020-01-01", "2026-05-24", "2026-05-24"], "2026-05-24")).toBe(1);
+  });
+
+  test("counts plays strictly before a target falling between entries", () => {
+    const dates = ["2010-04-12", "2015-06-15", "2020-12-31", "2024-08-08"];
+    expect(countSortedBefore(dates, "2020-12-31")).toBe(2);
+    expect(countSortedBefore(dates, "2025-01-01")).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countSortedBetween — both endpoints exclusive
+// ---------------------------------------------------------------------------
+
+describe("countSortedBetween", () => {
+  // Drives the closed-gap numerator for filteredAverageGapShows: matching-
+  // universe shows strictly between the first and last filtered plays.
+  // Endpoints are performances, not gaps.
+
+  test("returns 0 for empty input", () => {
+    expect(countSortedBetween([], "2024-01-01", "2024-12-31")).toBe(0);
+  });
+
+  test("excludes both endpoints", () => {
+    const dates = ["2024-01-01", "2024-02-01", "2024-03-01", "2024-04-01", "2024-05-01"];
+    expect(countSortedBetween(dates, "2024-01-01", "2024-05-01")).toBe(3);
+  });
+
+  // Inverted or degenerate intervals return 0, never negative.
+  test("returns 0 when low >= high", () => {
+    const dates = ["2024-01-01", "2024-02-01", "2024-03-01"];
+    expect(countSortedBetween(dates, "2024-03-01", "2024-01-01")).toBe(0);
+    expect(countSortedBetween(dates, "2024-02-01", "2024-02-01")).toBe(0);
+  });
+
+  test("returns 0 when no dates fall in range", () => {
+    const dates = ["2024-01-01", "2024-02-01"];
+    expect(countSortedBetween(dates, "2025-01-01", "2025-12-31")).toBe(0);
+  });
+});

--- a/packages/domain/src/sorted-dates.ts
+++ b/packages/domain/src/sorted-dates.ts
@@ -1,0 +1,87 @@
+/**
+ * Pure binary-search counters over a sorted-ascending string array.
+ * Lives in `@bip/domain` so both the server (rarity stats, gap denominators)
+ * and the client (gap-chart Played Before column) can share one
+ * implementation — `@bip/core` imports leak Prisma into the web bundle, so
+ * the primitives needed to be hoisted somewhere universally importable.
+ *
+ * Designed for ISO `YYYY-MM-DD` strings — lexicographic compare matches
+ * chronological order so callers don't have to parse to `Date`. Works on
+ * any sorted-ascending string array even so; the "dates" naming reflects
+ * the dominant use case, not a hard requirement on the input.
+ *
+ * All four public counters are thin wrappers around the standard
+ * `lower_bound` / `upper_bound` pair (Python's `bisect_left` / `bisect_right`).
+ * Keeping the two binary searches in one place means there's exactly one
+ * `while (lo < hi) ...` loop to read, audit, and keep correct.
+ */
+
+/**
+ * Smallest index `i` such that `arr[i] >= target`. Equivalent to C++
+ * `std::lower_bound` / Python `bisect_left`. Returns `arr.length` when
+ * every element is strictly less than target.
+ */
+function lowerBound(arr: readonly string[], target: string): number {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (arr[mid] < target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/**
+ * Smallest index `i` such that `arr[i] > target`. Equivalent to C++
+ * `std::upper_bound` / Python `bisect_right`. Returns `arr.length` when
+ * every element is less than or equal to target.
+ */
+function upperBound(arr: readonly string[], target: string): number {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (arr[mid] <= target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/**
+ * Count of entries strictly greater than `target`. Strictly-greater
+ * (not `>=`) so a record at the most recent date reads "0 after itself",
+ * not "1".
+ */
+export function countSortedAfter(sortedDates: readonly string[], target: string): number {
+  return sortedDates.length - upperBound(sortedDates, target);
+}
+
+/**
+ * Count of entries greater than or equal to `target`. Inclusive variant —
+ * used as the denominator for "matching-universe shows from a debut date
+ * onward" calculations where the debut itself must count.
+ */
+export function countSortedOnOrAfter(sortedDates: readonly string[], target: string): number {
+  return sortedDates.length - lowerBound(sortedDates, target);
+}
+
+/**
+ * Count of entries strictly less than `target`. Mirrors the "Seen Before"
+ * semantic for catalog data: viewing a 2020 show shouldn't pull a 2024
+ * performance into the count.
+ */
+export function countSortedBefore(sortedDates: readonly string[], target: string): number {
+  return lowerBound(sortedDates, target);
+}
+
+/**
+ * Count of entries strictly between `low` and `high` (both exclusive).
+ * Drives the closed-gap denominator for average-gap calculations: the
+ * endpoints themselves are performances, not gaps. Inverted or degenerate
+ * intervals collapse to 0 rather than negative.
+ */
+export function countSortedBetween(sortedDates: readonly string[], low: string, high: string): number {
+  if (low >= high) return 0;
+  return lowerBound(sortedDates, high) - upperBound(sortedDates, low);
+}


### PR DESCRIPTION
## Summary

- Adds a **Played Before** column to the gap-chart view, sitting between Last Played and Rating. Each row shows how many times that song has been performed (in stats-eligible shows) strictly before the current show's date. It's the catalog analog of the personal view's Seen Before count.
- Desktop only. Mobile gap-chart and the personal view's mobile layout are unchanged.

## How the data gets there

A single lazy catalog blob (`{songId: [date, ...]}`, ~50 KB gzipped) is fetched once per session on the first gap-chart open via React Query, then the client binary-searches each track's date array against the current show's date to derive the count.

This avoids a per-show server query on heavy list pages (year, top-rated). Once the blob is in memory, every gap-chart toggle in the session is free. Mirrors the existing pattern used by the personal view's `usePersonalSongHistory` hook.

No Track schema migration. No setlist-payload cache key bumps. One new cache key (`stats:song-play-dates:v1`, invalidated alongside `stats:show-dates`).

## Test plan

- [ ] Open a show's gap-chart view (e.g. `/shows/2026-05-24-mishawaka-amphitheater-bellvue-co?view=gap-chart`). Played Before column appears between Last Played and Rating with real counts after the blob loads.
- [ ] On the same show, toggle to `?view=personal`. Seen Before column is unchanged.
- [ ] Open a heavy list page (`/shows/year/2025` or `/shows/top-rated`), toggle one card to gap-chart. Column renders with no perceptible delay after the first blob fetch.
- [ ] Resize to mobile width. Played Before column is hidden; Seen Before on personal mobile is unchanged.
- [ ] Sort by Played Before (asc then desc). Rows reorder by the count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
