### PR TITLE
Pin deploy SSH host key scan to ed25519

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Set up SSH known hosts
-        run: ssh-keyscan -H 5.161.124.129 >> ~/.ssh/known_hosts
+        run: ssh-keyscan -t ed25519 5.161.124.129 >> ~/.ssh/known_hosts
 
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@v3


### PR DESCRIPTION
Deploys to production no longer flake with `Net::SSH::HostKeyMismatch`.

## Background

Recent deploys have been failing roughly half the time with:

```
ERROR (Net::SSH::HostKeyMismatch): Exception while executing on host 5.161.124.129:
fingerprint SHA256:zWmBceNKfEr+kszZ1EnTYfUT47jokoTkm72J5jhCP6A does not match for "5.161.124.129"
```

The server hasn't been re-keyed. `ssh-keyscan` returns the same banner and key set on every run, and every failure rejects the same fingerprint. The flake came from `ssh-keyscan -H` writing all five of the host's keys into `known_hosts` as hashed entries, and Net::SSH (via Kamal/SSHKit) sometimes negotiating a key type whose hashed lookup it couldn't resolve, then raising `HostKeyMismatch` instead of finding a matching entry.

## Change

Scan only the `ed25519` key, unhashed. One key type in, one key type negotiated, deterministic match.
