### PR TITLE
Make user-profile rating tabs sortable tables

### DIFF
--- a/apps/web/app/components/rating/rating.tsx
+++ b/apps/web/app/components/rating/rating.tsx
@@ -16,7 +16,7 @@ interface RatingProps {
  * Formats a rating using whole numbers + ½ glyph since the rating UI only
  * supports whole and half increments. 4.5 → "4½", 5 → "5", 0.5 → "½".
  */
-function formatHalfStep(value: number): string {
+export function formatHalfStep(value: number): string {
   const whole = Math.floor(value);
   const hasHalf = value - whole >= 0.25; // tolerate float drift
   if (hasHalf) return whole === 0 ? "½" : `${whole}½`;

--- a/apps/web/app/components/setlist/set-label.test.ts
+++ b/apps/web/app/components/setlist/set-label.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "vitest";
-import { compareBySetThenPosition, countDistinctEncores, formatSetLabel, setSortKey } from "./set-label";
+import {
+  compareBySetThenPosition,
+  countDistinctEncores,
+  countSetlistEncores,
+  formatSetLabel,
+  setSortKey,
+} from "./set-label";
 
 describe("formatSetLabel", () => {
   // S-prefixed regular sets drop the "S" because the column header (or
@@ -49,26 +55,13 @@ describe("countDistinctEncores", () => {
   // Counts unique encore labels regardless of how many tracks share each
   // encore. Two tracks both labeled E1 still report "1 distinct encore".
   test("counts unique encore labels, not encore tracks", () => {
-    expect(
-      countDistinctEncores([
-        { set: "E1" },
-        { set: "E1" },
-        { set: "E1" },
-      ]),
-    ).toBe(1);
+    expect(countDistinctEncores([{ set: "E1" }, { set: "E1" }, { set: "E1" }])).toBe(1);
   });
 
   // Mixed-set rows: only encores contribute. Regular sets are ignored so
   // the result is safe to feed straight into `formatSetLabel({encoresInSet})`.
   test("ignores non-encore rows", () => {
-    expect(
-      countDistinctEncores([
-        { set: "S1" },
-        { set: "S2" },
-        { set: "E1" },
-        { set: "E2" },
-      ]),
-    ).toBe(2);
+    expect(countDistinctEncores([{ set: "S1" }, { set: "S2" }, { set: "E1" }, { set: "E2" }])).toBe(2);
   });
 
   // Empty list = 0 distinct encores. The collapse branch in formatSetLabel
@@ -82,6 +75,21 @@ describe("countDistinctEncores", () => {
   // don't have to pre-normalize input.
   test("normalizes lowercase encore labels for de-duplication", () => {
     expect(countDistinctEncores([{ set: "e1" }, { set: "E1" }])).toBe(1);
+  });
+});
+
+describe("countSetlistEncores", () => {
+  // Adapts set-grouped input (sets carry the label, not individual tracks)
+  // to the same distinct-encore count — one encore set yields 1.
+  test("counts distinct encores from set labels", () => {
+    expect(countSetlistEncores([{ label: "S1" }, { label: "S2" }, { label: "E1" }])).toBe(1);
+    expect(countSetlistEncores([{ label: "S1" }, { label: "E1" }, { label: "E2" }])).toBe(2);
+  });
+
+  // No encore set → 0, so formatSetLabel never collapses a non-existent
+  // encore.
+  test("returns 0 when there is no encore set", () => {
+    expect(countSetlistEncores([{ label: "S1" }, { label: "S2" }])).toBe(0);
   });
 });
 

--- a/apps/web/app/components/setlist/set-label.ts
+++ b/apps/web/app/components/setlist/set-label.ts
@@ -34,6 +34,17 @@ export function countDistinctEncores(rows: ReadonlyArray<{ set: string }>): numb
 }
 
 /**
+ * Distinct-encore count from a setlist's set groupings, where the set value
+ * lives on each group's `label` rather than on individual tracks. Adapts to
+ * {@link countDistinctEncores} so callers holding a `Setlist`-shaped object
+ * (sets with labels) get the `encoresInSet` value without re-deriving the
+ * set→`{ set }` mapping at the call site.
+ */
+export function countSetlistEncores(sets: ReadonlyArray<{ label: string }>): number {
+  return countDistinctEncores(sets.map((s) => ({ set: s.label })));
+}
+
+/**
  * Numeric sort key for a set label so callers can sort tracks by canonical
  * narrative order: soundcheck first, then S1..S4, then E1..E3, unknowns
  * last. Pairs with {@link compareBySetThenPosition} for full row ordering.

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -11,6 +11,7 @@ import { useAttendanceMutation } from "~/hooks/use-show-user-data";
 import { cn } from "~/lib/utils";
 import { AnniversaryBadge } from "./anniversary-badge";
 import { RockOperaAnnotations } from "./rock-opera-annotations";
+import { countSetlistEncores, formatSetLabel } from "./set-label";
 import { SetlistTable } from "./setlist-table";
 import { SetlistTablePersonal } from "./setlist-table-personal";
 import { SetlistViewControl, type SetlistViewSummary } from "./setlist-view-control";
@@ -193,6 +194,10 @@ function SetlistCardComponent({
   // Sort by index to maintain the order they were encountered
   const orderedAnnotations = Array.from(uniqueAnnotations.values()).sort((a, b) => a.index - b.index);
 
+  // Encore label collapse ("E1" → "E") fires only when the show has a
+  // single encore.
+  const encoresInSet = countSetlistEncores(setlist.sets);
+
   return (
     <Card className="card-premium relative overflow-hidden">
       <CardHeader
@@ -347,7 +352,9 @@ function SetlistCardComponent({
                       key={setlist.show.id + set.label}
                       className="inline-block w-full md:flex md:gap-4 md:items-baseline"
                     >
-                      <span className="inline text-base font-medium text-content-text-tertiary">{set.label}</span>
+                      <span className="inline text-base font-medium text-content-text-tertiary">
+                        {formatSetLabel(set.label, { encoresInSet })}
+                      </span>
                       <span className="inline ml-2 md:ml-0 md:flex-1">
                         {set.tracks.map((track, i) => (
                           <span key={track.id} className="inline">

--- a/apps/web/app/components/ui/url-sortable-header.test.tsx
+++ b/apps/web/app/components/ui/url-sortable-header.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+import { UrlSortableHeader } from "./url-sortable-header";
+
+type Sort = "date" | "rating";
+
+function setup(props: Partial<React.ComponentProps<typeof UrlSortableHeader<Sort>>> = {}) {
+  const onSortChange = vi.fn();
+  const utils = render(
+    <UrlSortableHeader<Sort>
+      sortKey="date"
+      label="Show"
+      currentSort={props.currentSort ?? "rating"}
+      currentDirection={props.currentDirection ?? "desc"}
+      defaultDirection={props.defaultDirection}
+      onSortChange={onSortChange}
+    />,
+  );
+  return { user: userEvent.setup(), onSortChange, ...utils };
+}
+
+describe("UrlSortableHeader", () => {
+  test("renders the label inside a button", () => {
+    setup();
+    expect(screen.getByRole("button", { name: /Show/ })).toBeInTheDocument();
+  });
+
+  // The active column (currentSort === sortKey) gets the emphasized label;
+  // an idle column does not. The bold class is the structural signal the
+  // rest of the table's styling keys off.
+  test("emphasizes the label only when its column is the active sort", () => {
+    const { rerender } = setup({ currentSort: "rating" });
+    expect(screen.getByText("Show").className).not.toContain("font-semibold");
+
+    rerender(
+      <UrlSortableHeader<Sort>
+        sortKey="date"
+        label="Show"
+        currentSort="date"
+        currentDirection="desc"
+        onSortChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Show").className).toContain("font-semibold");
+  });
+
+  // Clicking an idle column applies the default direction (desc) so a fresh
+  // sort lands "biggest/newest first" like the rest of the site.
+  test("clicking an idle column requests the default desc direction", async () => {
+    const { user, onSortChange } = setup({ currentSort: "rating", currentDirection: "asc" });
+    await user.click(screen.getByRole("button", { name: /Show/ }));
+    expect(onSortChange).toHaveBeenCalledWith("date", "desc");
+  });
+
+  // A column can opt into asc-first (e.g. Set/Track/Song columns) via
+  // defaultDirection.
+  test("clicking an idle column honors an asc defaultDirection", async () => {
+    const { user, onSortChange } = setup({ currentSort: "rating", defaultDirection: "asc" });
+    await user.click(screen.getByRole("button", { name: /Show/ }));
+    expect(onSortChange).toHaveBeenCalledWith("date", "asc");
+  });
+
+  // Re-clicking the active column flips its direction rather than resetting
+  // to the default — asc → desc and desc → asc.
+  test("clicking the active ascending column flips to descending", async () => {
+    const { user, onSortChange } = setup({ currentSort: "date", currentDirection: "asc" });
+    await user.click(screen.getByRole("button", { name: /Show/ }));
+    expect(onSortChange).toHaveBeenCalledWith("date", "desc");
+  });
+
+  test("clicking the active descending column flips to ascending", async () => {
+    const { user, onSortChange } = setup({ currentSort: "date", currentDirection: "desc" });
+    await user.click(screen.getByRole("button", { name: /Show/ }));
+    expect(onSortChange).toHaveBeenCalledWith("date", "asc");
+  });
+});

--- a/apps/web/app/components/ui/url-sortable-header.tsx
+++ b/apps/web/app/components/ui/url-sortable-header.tsx
@@ -1,0 +1,53 @@
+import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface UrlSortableHeaderProps<S extends string> {
+  sortKey: S;
+  label: ReactNode;
+  currentSort: S;
+  currentDirection: "asc" | "desc";
+  defaultDirection?: "asc" | "desc";
+  onSortChange: (sort: S, direction: "asc" | "desc") => void;
+}
+
+/**
+ * Sortable header for tables whose ordering lives in the URL rather than
+ * TanStack column state. Mirrors the visual treatment of
+ * [SortableHeader](./sortable-header.tsx) — active column gets a bold
+ * label + accent arrow, idle columns get a neutral chevron pair — but
+ * clicks invoke a callback so the route can navigate with the new sort.
+ *
+ * Click semantics: first click on an idle column applies
+ * `defaultDirection` (defaults to desc, matching the rest of the site).
+ * Re-clicking the active column flips between asc and desc.
+ */
+export function UrlSortableHeader<S extends string>({
+  sortKey,
+  label,
+  currentSort,
+  currentDirection,
+  defaultDirection = "desc",
+  onSortChange,
+}: UrlSortableHeaderProps<S>) {
+  const isActive = currentSort === sortKey;
+  const nextDirection: "asc" | "desc" = isActive ? (currentDirection === "asc" ? "desc" : "asc") : defaultDirection;
+
+  return (
+    <button
+      type="button"
+      className="cursor-pointer select-none hover:text-content-text-primary text-left flex flex-wrap items-start gap-x-1"
+      onClick={() => onSortChange(sortKey, nextDirection)}
+    >
+      <span className={isActive ? "text-content-text-primary font-semibold" : ""}>{label}</span>
+      <span className={isActive ? "text-brand-primary" : ""}>
+        {isActive && currentDirection === "asc" ? (
+          <ArrowUpIcon className="h-3 w-3 sm:h-4 sm:w-4 inline" />
+        ) : isActive ? (
+          <ArrowDownIcon className="h-3 w-3 sm:h-4 sm:w-4 inline" />
+        ) : (
+          <ArrowUpDown className="h-3 w-3 sm:h-4 sm:w-4 inline" />
+        )}
+      </span>
+    </button>
+  );
+}

--- a/apps/web/app/routes/users/$username.tsx
+++ b/apps/web/app/routes/users/$username.tsx
@@ -1,8 +1,11 @@
+import type { RatingWithShow, RatingWithTrack, ShowRatingsSort, TrackRatingsSort } from "@bip/core";
 import { CacheKeys, compareByShowDate } from "@bip/domain";
 import { dehydrate } from "@tanstack/react-query";
 import { CalendarDays, Edit, MessageSquare, Star, Users } from "lucide-react";
 import type { LoaderFunctionArgs, MetaFunction } from "react-router-dom";
 import { Link, useNavigate } from "react-router-dom";
+import { formatHalfStep } from "~/components/rating/rating";
+import { formatSetLabel } from "~/components/setlist/set-label";
 import { SetlistList } from "~/components/setlist/setlist-list";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
 import { Badge } from "~/components/ui/badge";
@@ -10,14 +13,37 @@ import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { PaginationControls } from "~/components/ui/pagination-controls";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
+import { UrlSortableHeader } from "~/components/ui/url-sortable-header";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { type PublicContext, publicLoader } from "~/lib/base-loaders";
 import { showUserDataQueryKey } from "~/lib/query-keys";
 import { createPrefetchClient } from "~/lib/query-prefetch";
-import { formatDateLong } from "~/lib/utils";
+import { formatDateLong, formatDateShort, formatDateShortMobile } from "~/lib/utils";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
 import { computeShowUserData } from "~/server/show-user-data";
+
+const SHOW_RATINGS_SORTS = ["date", "rating", "modified"] as const satisfies readonly ShowRatingsSort[];
+const TRACK_RATINGS_SORTS = [
+  "date",
+  "set",
+  "track",
+  "song",
+  "rating",
+  "modified",
+] as const satisfies readonly TrackRatingsSort[];
+
+function parseShowRatingsSort(raw: string | null): ShowRatingsSort {
+  return (SHOW_RATINGS_SORTS as readonly string[]).includes(raw ?? "") ? (raw as ShowRatingsSort) : "date";
+}
+
+function parseTrackRatingsSort(raw: string | null): TrackRatingsSort {
+  return (TRACK_RATINGS_SORTS as readonly string[]).includes(raw ?? "") ? (raw as TrackRatingsSort) : "date";
+}
+
+function parseDirection(raw: string | null): "asc" | "desc" {
+  return raw === "asc" ? "asc" : "desc";
+}
 
 const ATTENDED_SHOWS_PAGE_SIZE = 50;
 const RATINGS_PAGE_SIZE = 100;
@@ -39,6 +65,9 @@ async function loadUserProfile({ params, request, context }: LoaderFunctionArgs 
   const rawPage = Number.parseInt(url.searchParams.get("page") ?? "1", 10);
   const pageParam = Number.isFinite(rawPage) && rawPage > 0 ? rawPage : 1;
   const activeTab = parseTab(url.searchParams.get("tab"));
+  const showRatingsSort = parseShowRatingsSort(url.searchParams.get("sort"));
+  const trackRatingsSort = parseTrackRatingsSort(url.searchParams.get("sort"));
+  const ratingsDirection = parseDirection(url.searchParams.get("dir"));
 
   const sessionUser = context.currentUser ?? null;
 
@@ -84,11 +113,21 @@ async function loadUserProfile({ params, request, context }: LoaderFunctionArgs 
 
   const showRatings =
     activeTab === "show-ratings"
-      ? await services.ratings.findShowRatingsByUserId(user.id, { skip: ratingsSkip, take: RATINGS_PAGE_SIZE })
+      ? await services.ratings.findShowRatingsByUserId(user.id, {
+          skip: ratingsSkip,
+          take: RATINGS_PAGE_SIZE,
+          sort: showRatingsSort,
+          direction: ratingsDirection,
+        })
       : [];
   const trackRatings =
     activeTab === "track-ratings"
-      ? await services.ratings.findTrackRatingsByUserId(user.id, { skip: ratingsSkip, take: RATINGS_PAGE_SIZE })
+      ? await services.ratings.findTrackRatingsByUserId(user.id, {
+          skip: ratingsSkip,
+          take: RATINGS_PAGE_SIZE,
+          sort: trackRatingsSort,
+          direction: ratingsDirection,
+        })
       : [];
 
   const totalRatings = tabCounts.showRatingsCount + tabCounts.trackRatingsCount;
@@ -156,6 +195,9 @@ async function loadUserProfile({ params, request, context }: LoaderFunctionArgs 
       totalPages: ratingsTotalPages,
       total: ratingsTotal,
     },
+    showRatingsSort,
+    trackRatingsSort,
+    ratingsDirection,
     activeTab,
     attendanceCount,
     reviewCount: tabCounts.reviewCount,
@@ -199,6 +241,9 @@ export default function UserProfile() {
     showRatings,
     trackRatings,
     ratingsPagination,
+    showRatingsSort,
+    trackRatingsSort,
+    ratingsDirection,
     activeTab,
     attendanceCount,
     reviewCount,
@@ -219,7 +264,22 @@ export default function UserProfile() {
   // the user clicked Next/Prev — otherwise React Router yanks them back
   // to the top of the page on every pagination click.
   const handlePageChange = (nextPage: number) => {
-    navigate(`?tab=${activeTab}&page=${nextPage}`, { preventScrollReset: true });
+    const sortSuffix =
+      activeTab === "show-ratings" || activeTab === "track-ratings"
+        ? `&sort=${activeTab === "show-ratings" ? showRatingsSort : trackRatingsSort}&dir=${ratingsDirection}`
+        : "";
+    navigate(`?tab=${activeTab}&page=${nextPage}${sortSuffix}`, { preventScrollReset: true });
+  };
+
+  // Sort changes drop the page back to 1: a sort against page 2 lands the
+  // user in the middle of the freshly-ordered list, which is rarely what
+  // they want. Both tabs share the handler shape; only the URL fragment
+  // changes per tab.
+  const handleShowRatingsSortChange = (sort: ShowRatingsSort, direction: "asc" | "desc") => {
+    navigate(`?tab=show-ratings&sort=${sort}&dir=${direction}`, { preventScrollReset: true });
+  };
+  const handleTrackRatingsSortChange = (sort: TrackRatingsSort, direction: "asc" | "desc") => {
+    navigate(`?tab=track-ratings&sort=${sort}&dir=${direction}`, { preventScrollReset: true });
   };
 
   return (
@@ -478,45 +538,13 @@ export default function UserProfile() {
             />
           )}
           {showRatings.length > 0 ? (
-            <div className="space-y-4">
-              {showRatings.map((rating) => (
-                <Card key={rating.id} className="card-premium">
-                  <CardHeader>
-                    <div className="flex items-center justify-between">
-                      <CardTitle className="text-lg">
-                        {rating.show.slug ? (
-                          <Link
-                            to={`/shows/${rating.show.slug}`}
-                            className="text-brand-primary hover:text-brand-secondary transition-colors hover:underline"
-                          >
-                            {rating.show.venue?.name || "Unknown Venue"}
-                          </Link>
-                        ) : (
-                          <span className="text-brand-primary">{rating.show.venue?.name || "Unknown Venue"}</span>
-                        )}
-                      </CardTitle>
-                      <div className="flex items-center gap-2">
-                        <div className="flex items-center gap-1">
-                          <Star className="w-4 h-4 text-rating-gold fill-rating-gold" />
-                          <span className="font-bold text-rating-gold">{rating.value}</span>
-                        </div>
-                        <span className="text-sm text-content-text-tertiary">
-                          {formatDateLong(rating.createdAt.toISOString())}
-                        </span>
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-2 text-sm text-content-text-secondary mt-1">
-                      <CalendarDays className="w-4 h-4" />
-                      <span>{formatDateLong(rating.show.date)}</span>
-                      {rating.show.venue?.city && rating.show.venue?.state && (
-                        <span>
-                          • {rating.show.venue.city}, {rating.show.venue.state}
-                        </span>
-                      )}
-                    </div>
-                  </CardHeader>
-                </Card>
-              ))}
+            <div className="w-fit max-w-full mx-auto">
+              <ShowRatingsTable
+                rows={showRatings}
+                sort={showRatingsSort}
+                direction={ratingsDirection}
+                onSort={handleShowRatingsSortChange}
+              />
             </div>
           ) : (
             <Card className="card-premium">
@@ -554,55 +582,13 @@ export default function UserProfile() {
             />
           )}
           {trackRatings.length > 0 ? (
-            <div className="space-y-4">
-              {trackRatings.map((rating) => (
-                <Card key={rating.id} className="card-premium">
-                  <CardHeader>
-                    <div className="flex items-center justify-between">
-                      <CardTitle className="text-lg">
-                        {rating.track.slug ? (
-                          <Link
-                            to={`/tracks/${rating.track.slug}`}
-                            className="text-brand-primary hover:text-brand-secondary transition-colors hover:underline"
-                          >
-                            {rating.track.song.title}
-                          </Link>
-                        ) : (
-                          <Link
-                            to={`/songs/${rating.track.song.slug}`}
-                            className="text-brand-primary hover:text-brand-secondary transition-colors hover:underline"
-                          >
-                            {rating.track.song.title}
-                          </Link>
-                        )}
-                      </CardTitle>
-                      <div className="flex items-center gap-2">
-                        <div className="flex items-center gap-1">
-                          <Star className="w-4 h-4 text-rating-gold fill-rating-gold" />
-                          <span className="font-bold text-rating-gold">{rating.value}</span>
-                        </div>
-                        <span className="text-sm text-content-text-tertiary">
-                          {formatDateLong(rating.createdAt.toISOString())}
-                        </span>
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-2 text-sm text-content-text-secondary mt-1">
-                      <span className="bg-content-bg px-2 py-1 rounded text-xs font-medium">
-                        Set {rating.track.set} • #{rating.track.position}
-                      </span>
-                      {rating.track.show.slug ? (
-                        <Link to={`/shows/${rating.track.show.slug}`} className="hover:underline">
-                          {rating.track.show.venue?.name || "Unknown Venue"} • {formatDateLong(rating.track.show.date)}
-                        </Link>
-                      ) : (
-                        <span>
-                          {rating.track.show.venue?.name || "Unknown Venue"} • {formatDateLong(rating.track.show.date)}
-                        </span>
-                      )}
-                    </div>
-                  </CardHeader>
-                </Card>
-              ))}
+            <div className="w-fit max-w-full mx-auto">
+              <TrackRatingsTable
+                rows={trackRatings}
+                sort={trackRatingsSort}
+                direction={ratingsDirection}
+                onSort={handleTrackRatingsSortChange}
+              />
             </div>
           ) : (
             <Card className="card-premium">
@@ -720,6 +706,178 @@ export default function UserProfile() {
           )}
         </TabsContent>
       </Tabs>
+    </div>
+  );
+}
+
+// Modified-date cell: compact M/D/YY on mobile so it fits beside the other
+// columns, full "Month D, YYYY" once there's room at sm+.
+function ModifiedDate({ createdAt }: { createdAt: Date | string }) {
+  const iso = createdAt instanceof Date ? createdAt.toISOString() : createdAt;
+  return (
+    <>
+      <span className="sm:hidden">{formatDateShortMobile(iso)}</span>
+      <span className="hidden sm:inline">{formatDateLong(iso)}</span>
+    </>
+  );
+}
+
+function StarValue({ value }: { value: number }) {
+  return (
+    <span className="inline-flex items-center gap-1 whitespace-nowrap">
+      <Star className="h-3 w-3 sm:h-4 sm:w-4 text-rating-gold" />
+      <span className="font-medium text-xs sm:text-sm text-content-text-primary">{formatHalfStep(value)}</span>
+    </span>
+  );
+}
+
+// Show date cell with venue line below on sm+ viewports. Uses plain media
+// queries (not the @container/datecell variant in ShowDate) so the column
+// width and the date-format swap don't fight each other inside a table
+// with table-layout: auto.
+function DateVenueLink({ date, slug, venueLine }: { date: string; slug: string | null; venueLine: string | null }) {
+  const body = (
+    <>
+      <div className="font-medium text-base whitespace-nowrap">
+        <span className="sm:hidden">{formatDateShortMobile(date)}</span>
+        <span className="hidden sm:inline">{formatDateShort(date)}</span>
+      </div>
+      {venueLine && (
+        <div className="text-xs text-content-text-tertiary mt-0.5 hidden sm:block whitespace-nowrap">{venueLine}</div>
+      )}
+    </>
+  );
+  if (!slug) {
+    return <div className="text-content-text-secondary">{body}</div>;
+  }
+  return (
+    <Link to={`/shows/${slug}`} className="block text-brand-primary hover:text-brand-secondary">
+      {body}
+    </Link>
+  );
+}
+
+const tableCellClass = "px-2 py-2 sm:px-3 sm:py-2.5 align-top border-t border-glass-border/30";
+const tableHeadClass = "px-2 py-2 sm:px-3 sm:py-2.5 text-xs sm:text-sm text-content-text-secondary text-left align-top";
+
+interface ShowRatingsTableProps {
+  rows: RatingWithShow[];
+  sort: ShowRatingsSort;
+  direction: "asc" | "desc";
+  onSort: (sort: ShowRatingsSort, direction: "asc" | "desc") => void;
+}
+
+function ShowRatingsTable({ rows, sort, direction, onSort }: ShowRatingsTableProps) {
+  const header = (sortKey: ShowRatingsSort, label: string, defaultDirection?: "asc" | "desc") => (
+    <UrlSortableHeader<ShowRatingsSort>
+      sortKey={sortKey}
+      label={label}
+      currentSort={sort}
+      currentDirection={direction}
+      defaultDirection={defaultDirection}
+      onSortChange={onSort}
+    />
+  );
+  return (
+    <div className="w-fit max-w-full overflow-x-auto">
+      <table className="table-auto border-collapse text-sm">
+        <thead>
+          <tr>
+            <th className={tableHeadClass}>{header("date", "Show")}</th>
+            <th className={tableHeadClass}>{header("rating", "Rating")}</th>
+            <th className={tableHeadClass}>{header("modified", "Modified")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const venueLine = row.show.venue?.name
+              ? [row.show.venue.name, row.show.venue.city, row.show.venue.state].filter(Boolean).join(", ")
+              : null;
+            return (
+              <tr key={row.id} className="hover:bg-hover-glass">
+                <td className={tableCellClass}>
+                  <DateVenueLink date={row.show.date} slug={row.show.slug} venueLine={venueLine} />
+                </td>
+                <td className={tableCellClass}>
+                  <StarValue value={row.value} />
+                </td>
+                <td className={`${tableCellClass} text-content-text-tertiary whitespace-nowrap`}>
+                  <ModifiedDate createdAt={row.createdAt} />
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+interface TrackRatingsTableProps {
+  rows: RatingWithTrack[];
+  sort: TrackRatingsSort;
+  direction: "asc" | "desc";
+  onSort: (sort: TrackRatingsSort, direction: "asc" | "desc") => void;
+}
+
+function TrackRatingsTable({ rows, sort, direction, onSort }: TrackRatingsTableProps) {
+  const header = (sortKey: TrackRatingsSort, label: string, defaultDirection?: "asc" | "desc") => (
+    <UrlSortableHeader<TrackRatingsSort>
+      sortKey={sortKey}
+      label={label}
+      currentSort={sort}
+      currentDirection={direction}
+      defaultDirection={defaultDirection}
+      onSortChange={onSort}
+    />
+  );
+  return (
+    <div className="w-fit max-w-full overflow-x-auto">
+      <table className="table-auto border-collapse text-sm">
+        <thead>
+          <tr>
+            <th className={tableHeadClass}>{header("date", "Show")}</th>
+            <th className={`${tableHeadClass} hidden sm:table-cell`}>{header("set", "Set", "asc")}</th>
+            <th className={`${tableHeadClass} hidden sm:table-cell`}>{header("track", "#", "asc")}</th>
+            <th className={tableHeadClass}>{header("song", "Song", "asc")}</th>
+            <th className={tableHeadClass}>{header("rating", "Rating")}</th>
+            <th className={tableHeadClass}>{header("modified", "Modified")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.id} className="hover:bg-hover-glass">
+              <td className={tableCellClass}>
+                <DateVenueLink
+                  date={row.track.show.date}
+                  slug={row.track.show.slug}
+                  venueLine={row.track.show.venue?.name ?? null}
+                />
+              </td>
+              <td className={`${tableCellClass} hidden sm:table-cell text-content-text-secondary tabular-nums`}>
+                {formatSetLabel(row.track.set, { encoresInSet: row.track.encoresInSet })}
+              </td>
+              <td className={`${tableCellClass} hidden sm:table-cell text-content-text-secondary tabular-nums`}>
+                {row.track.position}
+              </td>
+              <td className={tableCellClass}>
+                <Link
+                  to={`/songs/${row.track.song.slug}`}
+                  className="text-brand-primary hover:text-brand-secondary font-medium block max-w-[6.5rem] sm:max-w-[14rem] break-words"
+                >
+                  {row.track.song.title}
+                </Link>
+              </td>
+              <td className={tableCellClass}>
+                <StarValue value={row.value} />
+              </td>
+              <td className={`${tableCellClass} text-content-text-tertiary whitespace-nowrap`}>
+                <ModifiedDate createdAt={row.createdAt} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/packages/core/src/_shared/show-ordering.test.ts
+++ b/packages/core/src/_shared/show-ordering.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+import { setSortKeySql, showOrderBySql } from "./show-ordering";
+
+function renderSql(fragment: { strings: readonly string[]; values: unknown[] }): string {
+  const parts: string[] = [];
+  for (let i = 0; i < fragment.strings.length; i++) {
+    parts.push(fragment.strings[i]);
+    if (i < fragment.values.length) {
+      const v = fragment.values[i];
+      if (v && typeof v === "object" && Array.isArray((v as { strings?: unknown[] }).strings)) {
+        parts.push(renderSql(v as { strings: readonly string[]; values: unknown[] }));
+      } else {
+        parts.push(String(v));
+      }
+    }
+  }
+  return parts.join("");
+}
+
+describe("showOrderBySql", () => {
+  // Smoke test — the existing helper. Confirms the rendering harness works
+  // for the nested Prisma.Sql case the rest of the suite depends on.
+  test("emits date + day_order COALESCE + id triplet for DESC", () => {
+    const sql = renderSql(showOrderBySql("s", "DESC") as never);
+    expect(sql).toMatch(/s\.date\s+DESC/);
+    expect(sql).toMatch(/COALESCE\(s\.day_order,\s*2147483647\)\s+DESC/);
+    expect(sql).toMatch(/s\.id::text\s+DESC/);
+  });
+});
+
+describe("setSortKeySql", () => {
+  // Mirrors apps/web/app/components/setlist/set-label.ts:setSortKey so
+  // SQL ORDER BY and the in-memory comparator agree on canonical order:
+  // Soundcheck → S1..S4 → E1..E3 → unknown. The numeric arms have to
+  // line up with the TS function — drift means table rows sort one way
+  // server-side and another client-side on a re-sort.
+  test("renders a CASE expression keyed by the alias's set column", () => {
+    const sql = renderSql(setSortKeySql("t") as never);
+    expect(sql).toMatch(/CASE/);
+    expect(sql).toMatch(/t\.set/);
+    expect(sql).toMatch(/END/);
+  });
+
+  test("ordinals match the TS setSortKey (Soundcheck=0, S1=10, S2=20, S3=30, S4=40, E1=50, E2=60, E3=70)", () => {
+    const sql = renderSql(setSortKeySql("t") as never);
+    // SQL inlines LOWER(set) so the CASE arms are lowercase literals.
+    expect(sql).toMatch(/'soundcheck'.*0/i);
+    expect(sql).toMatch(/'s1'.*10/i);
+    expect(sql).toMatch(/'s2'.*20/i);
+    expect(sql).toMatch(/'s3'.*30/i);
+    expect(sql).toMatch(/'s4'.*40/i);
+    expect(sql).toMatch(/'e1'.*50/i);
+    expect(sql).toMatch(/'e2'.*60/i);
+    expect(sql).toMatch(/'e3'.*70/i);
+  });
+
+  test("unknown labels collapse to 999 (the fallback in the TS implementation)", () => {
+    const sql = renderSql(setSortKeySql("t") as never);
+    expect(sql).toMatch(/ELSE\s+999/);
+  });
+});

--- a/packages/core/src/_shared/show-ordering.ts
+++ b/packages/core/src/_shared/show-ordering.ts
@@ -53,7 +53,35 @@ export const TRACK_BY_SHOW_ORDER_ASC: Prisma.TrackOrderByWithRelationInput[] = [
  * `day_order`, `id` (no renaming) so the helper output lines up.
  */
 type ShowAlias = "s" | "s2" | "shows";
+type TrackAlias = "t" | "tracks";
 type SortDirection = "ASC" | "DESC";
+
+/**
+ * Raw-SQL CASE expression mirroring `setSortKey` from
+ * apps/web/app/components/setlist/set-label.ts. Use in $queryRaw ORDER BY
+ * clauses so SQL-side ordering by set matches the in-memory
+ * `compareBySetThenPosition` comparator: Soundcheck → S1..S4 → E1..E3 →
+ * unknown. Pass the alias your tracks table has in the query (`t` or
+ * `tracks`).
+ *
+ * Keep the ordinals in sync with the TS function; drift produces
+ * inconsistent ordering between paginated server fetches and any
+ * client-side re-sort sharing the same rows.
+ */
+export function setSortKeySql(alias: TrackAlias): Prisma.Sql {
+  const a = Prisma.raw(alias);
+  return Prisma.sql`CASE LOWER(${a}.set)
+    WHEN 'soundcheck' THEN 0
+    WHEN 's1' THEN 10
+    WHEN 's2' THEN 20
+    WHEN 's3' THEN 30
+    WHEN 's4' THEN 40
+    WHEN 'e1' THEN 50
+    WHEN 'e2' THEN 60
+    WHEN 'e3' THEN 70
+    ELSE 999
+  END`;
+}
 
 /**
  * Raw-SQL `ORDER BY` fragment matching SHOW_ORDER_ASC/DESC, for use in

--- a/packages/core/src/ratings/rating-service.test.ts
+++ b/packages/core/src/ratings/rating-service.test.ts
@@ -9,298 +9,397 @@ const cacheInvalidation = {
   invalidateShowComprehensive: vi.fn(),
 } as never;
 
-type MockRating = {
+// Flattens a $queryRaw mock call (TemplateStringsArray + Prisma.Sql
+// interpolations) into a single SQL string so tests can assert on the
+// composed ORDER BY clause. Prisma.Sql exposes its template parts under
+// `.strings`; nested Prisma.sql fragments are spliced in. Cribs the same
+// pattern used by song-page-composer.test.ts.
+function flattenSqlFromMockCall(call: unknown[]): string {
+  const [templateStrings, ...interpolations] = call as [readonly string[], ...unknown[]];
+  const parts: string[] = [];
+  for (let i = 0; i < templateStrings.length; i++) {
+    parts.push(templateStrings[i]);
+    if (i < interpolations.length) {
+      const v = interpolations[i];
+      if (v && typeof v === "object" && Array.isArray((v as { strings?: unknown[] }).strings)) {
+        parts.push((v as { strings: string[] }).strings.join(" ? "));
+      } else {
+        parts.push("?");
+      }
+    }
+  }
+  return parts.join("");
+}
+
+type ShowRatingRow = {
   id: string;
-  userId: string;
-  rateableId: string;
-  rateableType: string;
   value: number;
-  createdAt: Date;
-  updatedAt: Date;
+  created_at: Date;
+  show_slug: string;
+  show_date: string;
+  venue_name: string | null;
+  venue_city: string | null;
+  venue_state: string | null;
 };
 
-function rating(overrides: Partial<MockRating>): MockRating {
+function showRatingRow(overrides: Partial<ShowRatingRow> = {}): ShowRatingRow {
   return {
     id: "r1",
-    userId: "u1",
-    rateableId: "x1",
-    rateableType: "Show",
     value: 5,
-    createdAt: new Date("2024-01-01T00:00:00Z"),
-    updatedAt: new Date("2024-01-01T00:00:00Z"),
+    created_at: new Date("2024-01-01T00:00:00Z"),
+    show_slug: "2024-08-12-cap-theatre",
+    show_date: "2024-08-12",
+    venue_name: "The Capitol Theatre",
+    venue_city: "Port Chester",
+    venue_state: "NY",
     ...overrides,
   };
 }
 
 describe("RatingService.findShowRatingsByUserId", () => {
-  // The user-profile show-ratings list only displays id/value/createdAt +
-  // nested slug/date/venue trio. Returning a Rating-extending shape with
-  // userId/rateableId/etc. forces ~1.7 MB of unused JSON onto heavy users
-  // (the heaviest user has ~1,700 show ratings). The slim shape strips those.
-  test("returns slim shape without userId, rateableId, rateableType, or updatedAt", async () => {
-    const db = {
-      rating: {
-        findMany: vi.fn().mockResolvedValue([rating({ id: "r1", rateableId: "show-1" })]),
-      },
-      show: {
-        findMany: vi.fn().mockResolvedValue([
-          {
-            id: "show-1",
-            slug: "2024-08-12-cap-theatre",
-            date: "2024-08-12",
-            venue: { name: "The Capitol Theatre", city: "Port Chester", state: "NY" },
-          },
-        ]),
-      },
-    } as never;
-
+  // Default ordering is `date` desc, and same-day rows must break ties on
+  // `day_order` (NULLS FIRST under DESC) then `id` — the standard show
+  // ordering. Asserting `showOrderBySql` is wired in (not a hand-rolled
+  // `s.date DESC`) keeps same-day rated shows in canonical order across
+  // pages.
+  test("default sort=date desc orders via showOrderBySql with createdAt tiebreaker", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const db = { $queryRaw: queryRaw } as never;
     const service = new RatingService(db, cacheInvalidation);
-    const result = await service.findShowRatingsByUserId("u1");
 
-    expect(result).toHaveLength(1);
-    const row = result[0];
-    expect(row).toEqual({
-      id: "r1",
-      value: 5,
-      createdAt: new Date("2024-01-01T00:00:00Z"),
-      show: {
-        slug: "2024-08-12-cap-theatre",
-        date: "2024-08-12",
-        venue: { name: "The Capitol Theatre", city: "Port Chester", state: "NY" },
-      },
-    });
-    // Explicit negative assertions — these fields drove the bloat.
-    expect(row).not.toHaveProperty("userId");
-    expect(row).not.toHaveProperty("rateableId");
-    expect(row).not.toHaveProperty("rateableType");
-    expect(row).not.toHaveProperty("updatedAt");
+    await service.findShowRatingsByUserId("u1");
+
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    const sql = flattenSqlFromMockCall(queryRaw.mock.calls[0]);
+    expect(sql).toMatch(/s\.date\s+DESC/);
+    expect(sql).toMatch(/COALESCE\(s\.day_order/);
+    expect(sql).toMatch(/r\.created_at\s+DESC/);
   });
 
-  // If the underlying show was deleted while the rating remained (data
-  // drift), we drop the orphan rather than crash. Mirrors the original
-  // .filter() behavior; protects the user profile from white-screening on
-  // dangling ratings.
-  test("skips ratings whose related show is missing", async () => {
-    const db = {
-      rating: {
-        findMany: vi
-          .fn()
-          .mockResolvedValue([rating({ id: "r1", rateableId: "missing" }), rating({ id: "r2", rateableId: "show-1" })]),
-      },
-      show: {
-        findMany: vi.fn().mockResolvedValue([
-          {
-            id: "show-1",
-            slug: "show-slug",
-            date: "2024-08-12",
-            venue: null,
-          },
-        ]),
-      },
-    } as never;
-
+  // The slim shape — id/value/createdAt + nested slug/date/venue trio —
+  // is what the user-profile route renders. Anything wider re-bloats the
+  // heaviest users' page payload.
+  test("maps rows into the slim shape (no userId/rateableId/updatedAt)", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([showRatingRow()]);
+    const db = { $queryRaw: queryRaw } as never;
     const service = new RatingService(db, cacheInvalidation);
+
     const result = await service.findShowRatingsByUserId("u1");
 
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe("r2");
+    expect(result).toEqual([
+      {
+        id: "r1",
+        value: 5,
+        createdAt: new Date("2024-01-01T00:00:00Z"),
+        show: {
+          slug: "2024-08-12-cap-theatre",
+          date: "2024-08-12",
+          venue: { name: "The Capitol Theatre", city: "Port Chester", state: "NY" },
+        },
+      },
+    ]);
+    expect(result[0]).not.toHaveProperty("userId");
+    expect(result[0]).not.toHaveProperty("rateableId");
+    expect(result[0]).not.toHaveProperty("rateableType");
+    expect(result[0]).not.toHaveProperty("updatedAt");
+  });
+
+  // A null venue (rating against a show that's been venue-scrubbed)
+  // surfaces as `show.venue: null`, mirroring the previous two-query
+  // implementation. The route renders "Unknown Venue" against null.
+  test("returns show.venue = null when venue_name is null", async () => {
+    const queryRaw = vi
+      .fn()
+      .mockResolvedValue([showRatingRow({ venue_name: null, venue_city: null, venue_state: null })]);
+    const db = { $queryRaw: queryRaw } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    const result = await service.findShowRatingsByUserId("u1");
+
     expect(result[0].show.venue).toBeNull();
   });
 
   // Heavy users (~1,700 show ratings) need server-side pagination —
   // shipping all rows on every load costs hundreds of KB. The service
-  // accepts skip/take and the caller is expected to combine with
-  // getUserTabCounts() for the total. Verifies the slice is applied at the
-  // DB level, not in JS.
-  test("supports skip/take pagination at the DB layer", async () => {
-    const ratingFindMany = vi.fn().mockResolvedValue([rating({ id: "r-page-3", rateableId: "show-page-3" })]);
-    const db = {
-      rating: { findMany: ratingFindMany },
-      show: {
-        findMany: vi.fn().mockResolvedValue([
-          {
-            id: "show-page-3",
-            slug: "s",
-            date: "2024-01-01",
-            venue: null,
-          },
-        ]),
-      },
-    } as never;
-
+  // accepts skip/take and inlines them into LIMIT/OFFSET so the slice is
+  // applied at the DB level, not in JS.
+  test("supports skip/take pagination via LIMIT/OFFSET", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const db = { $queryRaw: queryRaw } as never;
     const service = new RatingService(db, cacheInvalidation);
-    const result = await service.findShowRatingsByUserId("u1", { skip: 200, take: 100 });
 
-    expect(ratingFindMany.mock.calls[0][0]).toMatchObject({ skip: 200, take: 100 });
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe("r-page-3");
+    await service.findShowRatingsByUserId("u1", { skip: 200, take: 100 });
+
+    const call = queryRaw.mock.calls[0];
+    const sql = flattenSqlFromMockCall(call);
+    expect(sql).toMatch(/LIMIT\s+\$?\?/);
+    expect(sql).toMatch(/OFFSET\s+\$?\?/);
+    // 200 (skip) and 100 (take) bound as parameters; the user id is
+    // also bound, so we don't pin a specific index.
+    const interpolations = call.slice(1);
+    expect(interpolations).toContain(200);
+    expect(interpolations).toContain(100);
   });
 
-  // Narrowed Prisma projection: only select the columns the slim shape
-  // surfaces. Regression guard — accidentally going back to `include` re-bloats
-  // every load.
-  test("queries the DB with a narrow `select` (no full row projection)", async () => {
-    const showFindMany = vi.fn().mockResolvedValue([]);
-    const db = {
-      rating: { findMany: vi.fn().mockResolvedValue([rating({ rateableId: "show-1" })]) },
-      show: { findMany: showFindMany },
-    } as never;
-
+  // INNER JOIN against shows means orphaned ratings (show deleted but
+  // rating row remains) silently drop at the SQL layer rather than
+  // crashing the user profile.
+  test("uses INNER JOIN against shows so orphaned ratings drop", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const db = { $queryRaw: queryRaw } as never;
     const service = new RatingService(db, cacheInvalidation);
+
     await service.findShowRatingsByUserId("u1");
 
-    const args = showFindMany.mock.calls[0][0];
-    expect(args).toHaveProperty("select");
-    expect(args).not.toHaveProperty("include");
-    expect(args.select).toMatchObject({
-      id: true,
-      slug: true,
-      date: true,
-      venue: { select: { name: true, city: true, state: true } },
-    });
+    const sql = flattenSqlFromMockCall(queryRaw.mock.calls[0]);
+    expect(sql).toMatch(/INNER\s+JOIN\s+shows\s+s\b/i);
+  });
+
+  // sort=rating desc: rating.value primary, show order DESC tiebreaker,
+  // rating.createdAt DESC as the final stability key. Spec lives in the
+  // plan file.
+  test("sort=rating desc orders by r.value then showOrderBySql DESC then createdAt", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const db = { $queryRaw: queryRaw } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    await service.findShowRatingsByUserId("u1", { sort: "rating", direction: "desc" });
+
+    const sql = flattenSqlFromMockCall(queryRaw.mock.calls[0]);
+    expect(sql).toMatch(/ORDER\s+BY[\s\S]*r\.value\s+DESC[\s\S]*s\.date\s+DESC[\s\S]*r\.created_at\s+DESC/i);
+  });
+
+  // Tiebreakers follow the primary direction — sort=modified asc means the
+  // showOrderBySql tiebreaker is ASC as well, so a "reverse sort" reverses
+  // the whole ordering top-to-bottom rather than mixing directions.
+  test("sort=modified asc orders by r.created_at then showOrderBySql ASC", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const db = { $queryRaw: queryRaw } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    await service.findShowRatingsByUserId("u1", { sort: "modified", direction: "asc" });
+
+    const sql = flattenSqlFromMockCall(queryRaw.mock.calls[0]);
+    expect(sql).toMatch(/ORDER\s+BY[\s\S]*r\.created_at\s+ASC[\s\S]*s\.date\s+ASC/i);
   });
 });
 
+type TrackRatingRow = {
+  id: string;
+  value: number;
+  created_at: Date;
+  track_slug: string | null;
+  track_position: number;
+  track_set: string;
+  encores_in_set: number | bigint;
+  show_slug: string | null;
+  show_date: string;
+  venue_name: string | null;
+  song_slug: string;
+  song_title: string;
+};
+
+function trackRatingRow(overrides: Partial<TrackRatingRow> = {}): TrackRatingRow {
+  return {
+    id: "r1",
+    value: 5,
+    created_at: new Date("2024-01-01T00:00:00Z"),
+    track_slug: "basis-for-a-day-2024-08-12",
+    track_position: 3,
+    track_set: "S1",
+    encores_in_set: 1,
+    show_slug: "2024-08-12-cap-theatre",
+    show_date: "2024-08-12",
+    venue_name: "The Capitol Theatre",
+    song_slug: "basis-for-a-day",
+    song_title: "Basis for a Day",
+    ...overrides,
+  };
+}
+
 describe("RatingService.findTrackRatingsByUserId", () => {
-  // The user-profile track-ratings list is the worst offender — 7,784 rows
-  // for the heaviest user. The slim shape drops every unused field, including venue
-  // city/state (which the track-rating row doesn't display, unlike the
-  // show-rating row above).
-  test("returns slim shape with no venue.city/state and no UUIDs", async () => {
-    const db = {
-      rating: {
-        findMany: vi.fn().mockResolvedValue([rating({ id: "r1", rateableId: "track-1", rateableType: "Track" })]),
-      },
-      track: {
-        findMany: vi.fn().mockResolvedValue([
-          {
-            id: "track-1",
-            slug: "basis-for-a-day-2024-08-12",
-            position: 3,
-            set: "S1",
-            show: {
-              slug: "2024-08-12-cap-theatre",
-              date: "2024-08-12",
-              venue: { name: "The Capitol Theatre" },
-            },
-            song: { slug: "basis-for-a-day", title: "Basis for a Day" },
-          },
-        ]),
-      },
-    } as never;
-
+  // Default sort=date desc: show date primary via showOrderBySql, then
+  // set ordinal + track position as tiebreakers — and tiebreakers share
+  // the primary direction (DESC), so within a show the row order is
+  // encore-first / late-set-first when reading top-down.
+  test("default sort=date desc orders by showOrderBySql DESC then set + position DESC", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const db = { $queryRaw: queryRaw } as never;
     const service = new RatingService(db, cacheInvalidation);
-    const result = await service.findTrackRatingsByUserId("u1");
 
-    expect(result).toHaveLength(1);
-    expect(result[0]).toEqual({
-      id: "r1",
-      value: 5,
-      createdAt: new Date("2024-01-01T00:00:00Z"),
-      track: {
-        slug: "basis-for-a-day-2024-08-12",
-        position: 3,
-        set: "S1",
-        show: {
-          slug: "2024-08-12-cap-theatre",
-          date: "2024-08-12",
-          venue: { name: "The Capitol Theatre" },
-        },
-        song: { slug: "basis-for-a-day", title: "Basis for a Day" },
-      },
-    });
-    expect(result[0]).not.toHaveProperty("userId");
-    expect(result[0]).not.toHaveProperty("rateableType");
-    expect(result[0].track).not.toHaveProperty("id");
-    expect(result[0].track.show).not.toHaveProperty("id");
-    expect(result[0].track.show.venue).not.toHaveProperty("city");
-    expect(result[0].track.show.venue).not.toHaveProperty("state");
-    expect(result[0].track.song).not.toHaveProperty("id");
-  });
-
-  // Same orphan-protection as show ratings — if the joined track is gone we
-  // drop the row instead of crashing the user profile.
-  test("skips ratings whose related track is missing", async () => {
-    const db = {
-      rating: {
-        findMany: vi
-          .fn()
-          .mockResolvedValue([
-            rating({ id: "r1", rateableId: "missing-track", rateableType: "Track" }),
-            rating({ id: "r2", rateableId: "track-1", rateableType: "Track" }),
-          ]),
-      },
-      track: {
-        findMany: vi.fn().mockResolvedValue([
-          {
-            id: "track-1",
-            slug: "above-the-waves",
-            position: 1,
-            set: "S2",
-            show: { slug: "show-slug", date: "2024-01-01", venue: { name: "Some Venue" } },
-            song: { slug: "above-the-waves", title: "Above The Waves" },
-          },
-        ]),
-      },
-    } as never;
-
-    const service = new RatingService(db, cacheInvalidation);
-    const result = await service.findTrackRatingsByUserId("u1");
-
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe("r2");
-  });
-
-  // Same pagination requirement as show ratings — the heaviest user has ~7,800 track
-  // ratings and a single full payload is ~4 MB. skip/take must reach the
-  // DB so we never marshal rows we don't render.
-  test("supports skip/take pagination at the DB layer", async () => {
-    const ratingFindMany = vi
-      .fn()
-      .mockResolvedValue([rating({ id: "r-tracks-page-2", rateableId: "track-page-2", rateableType: "Track" })]);
-    const db = {
-      rating: { findMany: ratingFindMany },
-      track: {
-        findMany: vi.fn().mockResolvedValue([
-          {
-            id: "track-page-2",
-            slug: "basis-for-a-day",
-            position: 1,
-            set: "S1",
-            show: { slug: "s", date: "2024-01-01", venue: { name: "v" } },
-            song: { slug: "basis-for-a-day", title: "Basis for a Day" },
-          },
-        ]),
-      },
-    } as never;
-
-    const service = new RatingService(db, cacheInvalidation);
-    const result = await service.findTrackRatingsByUserId("u1", { skip: 100, take: 100 });
-
-    expect(ratingFindMany.mock.calls[0][0]).toMatchObject({ skip: 100, take: 100 });
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe("r-tracks-page-2");
-  });
-
-  // Same Prisma narrowing regression guard as show ratings — the track
-  // method must use `select` (not `include`) and limit nested venue/song.
-  test("queries the DB with a narrow `select`", async () => {
-    const trackFindMany = vi.fn().mockResolvedValue([]);
-    const db = {
-      rating: { findMany: vi.fn().mockResolvedValue([rating({ rateableType: "Track", rateableId: "track-1" })]) },
-      track: { findMany: trackFindMany },
-    } as never;
-
-    const service = new RatingService(db, cacheInvalidation);
     await service.findTrackRatingsByUserId("u1");
 
-    const args = trackFindMany.mock.calls[0][0];
-    expect(args).toHaveProperty("select");
-    expect(args).not.toHaveProperty("include");
-    // Venue should expose only `name` — city/state would re-introduce bloat.
-    expect(args.select.show.select.venue.select).toEqual({ name: true });
-    // Song should expose only slug/title — no UUID.
-    expect(args.select.song.select).toEqual({ slug: true, title: true });
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    const sql = flattenSqlFromMockCall(queryRaw.mock.calls[0]);
+    expect(sql).toMatch(/s\.date\s+DESC/);
+    expect(sql).toMatch(/COALESCE\(s\.day_order/);
+    expect(sql).toMatch(/CASE\s+LOWER\(t\.set\)[\s\S]*DESC/);
+    expect(sql).toMatch(/t\.position\s+DESC/);
+  });
+
+  // Slim shape: id/value/createdAt + nested track {slug, position, set,
+  // show {slug, date, venue {name}}, song {slug, title}}. Anything wider
+  // re-bloats the heaviest users' payload (~7,800 rows).
+  test("maps rows into the slim shape", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([trackRatingRow()]);
+    const db = { $queryRaw: queryRaw } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    const result = await service.findTrackRatingsByUserId("u1");
+
+    expect(result).toEqual([
+      {
+        id: "r1",
+        value: 5,
+        createdAt: new Date("2024-01-01T00:00:00Z"),
+        track: {
+          slug: "basis-for-a-day-2024-08-12",
+          position: 3,
+          set: "S1",
+          encoresInSet: 1,
+          show: {
+            slug: "2024-08-12-cap-theatre",
+            date: "2024-08-12",
+            venue: { name: "The Capitol Theatre" },
+          },
+          song: { slug: "basis-for-a-day", title: "Basis for a Day" },
+        },
+      },
+    ]);
+    expect(result[0]).not.toHaveProperty("userId");
+    expect(result[0].track).not.toHaveProperty("id");
+    expect(result[0].track.show.venue).not.toHaveProperty("city");
+    expect(result[0].track.show.venue).not.toHaveProperty("state");
+  });
+
+  test("returns track.show.venue = null when venue_name is null", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([trackRatingRow({ venue_name: null })]);
+    const db = { $queryRaw: queryRaw } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    const result = await service.findTrackRatingsByUserId("u1");
+
+    expect(result[0].track.show.venue).toBeNull();
+  });
+
+  test("supports skip/take pagination via LIMIT/OFFSET", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const db = { $queryRaw: queryRaw } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    await service.findTrackRatingsByUserId("u1", { skip: 100, take: 100 });
+
+    const interpolations = queryRaw.mock.calls[0].slice(1);
+    expect(interpolations).toContain(100);
+  });
+
+  // sort=set asc: set ordinal primary, position next, show order last —
+  // all share ASC so reversing the sort reverses the entire reading.
+  test("sort=set asc orders by setSortKeySql ASC then position ASC then showOrderBySql ASC", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const db = { $queryRaw: queryRaw } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    await service.findTrackRatingsByUserId("u1", { sort: "set", direction: "asc" });
+
+    const sql = flattenSqlFromMockCall(queryRaw.mock.calls[0]);
+    expect(sql).toMatch(
+      /ORDER\s+BY[\s\S]*CASE\s+LOWER\(t\.set\)[\s\S]*ASC[\s\S]*t\.position\s+ASC[\s\S]*s\.date\s+ASC/i,
+    );
+  });
+
+  // sort=track asc: position primary, set ordinal next, all ASC.
+  test("sort=track asc orders by position ASC then setSortKeySql ASC then showOrderBySql ASC", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const db = { $queryRaw: queryRaw } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    await service.findTrackRatingsByUserId("u1", { sort: "track", direction: "asc" });
+
+    const sql = flattenSqlFromMockCall(queryRaw.mock.calls[0]);
+    expect(sql).toMatch(
+      /ORDER\s+BY[\s\S]*t\.position\s+ASC[\s\S]*CASE\s+LOWER\(t\.set\)[\s\S]*ASC[\s\S]*s\.date\s+ASC/i,
+    );
+  });
+
+  // sort=song asc: case-insensitive title alphabetic.
+  test("sort=song asc orders by LOWER(song.title)", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const db = { $queryRaw: queryRaw } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    await service.findTrackRatingsByUserId("u1", { sort: "song", direction: "asc" });
+
+    const sql = flattenSqlFromMockCall(queryRaw.mock.calls[0]);
+    expect(sql).toMatch(/ORDER\s+BY[\s\S]*LOWER\(sg\.title\)\s+ASC/i);
+  });
+
+  // sort=rating desc: value primary, show order DESC, set/position tiebreakers.
+  test("sort=rating desc orders by r.value then showOrderBySql then set/position", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const db = { $queryRaw: queryRaw } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    await service.findTrackRatingsByUserId("u1", { sort: "rating", direction: "desc" });
+
+    const sql = flattenSqlFromMockCall(queryRaw.mock.calls[0]);
+    expect(sql).toMatch(
+      /ORDER\s+BY[\s\S]*r\.value\s+DESC[\s\S]*s\.date\s+DESC[\s\S]*CASE\s+LOWER\(t\.set\)[\s\S]*t\.position/i,
+    );
+  });
+
+  test("sort=modified asc orders by r.created_at then showOrderBySql ASC", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const db = { $queryRaw: queryRaw } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    await service.findTrackRatingsByUserId("u1", { sort: "modified", direction: "asc" });
+
+    const sql = flattenSqlFromMockCall(queryRaw.mock.calls[0]);
+    expect(sql).toMatch(/ORDER\s+BY[\s\S]*r\.created_at\s+ASC[\s\S]*s\.date\s+ASC/i);
+  });
+
+  // The cell renderer needs to know how many distinct encores the show
+  // has so it can collapse "E1" → "E" on single-encore shows. The query
+  // computes that via a per-row scalar subquery counting distinct
+  // /^E\d+$/ set labels on the row's show.
+  test("projects encores_in_set via a per-row tracks subquery", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const db = { $queryRaw: queryRaw } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    await service.findTrackRatingsByUserId("u1");
+
+    const sql = flattenSqlFromMockCall(queryRaw.mock.calls[0]);
+    expect(sql).toMatch(/COUNT\(DISTINCT\s+t2\.set\)/i);
+    expect(sql).toMatch(/t2\.show_id\s*=\s*t\.show_id/i);
+    expect(sql).toMatch(/'\^E\[0-9\]\+\$'/);
+    expect(sql).toMatch(/AS\s+encores_in_set/i);
+  });
+
+  // Verify the projected count actually threads through to track.encoresInSet
+  // on the returned row shape, so the cell can pass it to formatSetLabel.
+  test("exposes encoresInSet on the returned track shape", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([trackRatingRow({ track_set: "E1", encores_in_set: 1 })]);
+    const db = { $queryRaw: queryRaw } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    const result = await service.findTrackRatingsByUserId("u1");
+
+    expect(result[0].track.encoresInSet).toBe(1);
+  });
+
+  test("INNER JOINs tracks/shows/songs so orphan ratings drop", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const db = { $queryRaw: queryRaw } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    await service.findTrackRatingsByUserId("u1");
+
+    const sql = flattenSqlFromMockCall(queryRaw.mock.calls[0]);
+    expect(sql).toMatch(/INNER\s+JOIN\s+tracks\s+t\b/i);
+    expect(sql).toMatch(/INNER\s+JOIN\s+shows\s+s\b/i);
+    expect(sql).toMatch(/INNER\s+JOIN\s+songs\s+sg\b/i);
   });
 });
 

--- a/packages/core/src/ratings/rating-service.ts
+++ b/packages/core/src/ratings/rating-service.ts
@@ -1,6 +1,53 @@
 import type { Rating } from "@bip/domain";
+import { Prisma } from "@prisma/client";
 import { type CacheInvalidationService, yearFromShowSlug } from "../_shared/cache";
 import type { DbClient, DbRating } from "../_shared/database/models";
+import { setSortKeySql, showOrderBySql } from "../_shared/show-ordering";
+
+export type ShowRatingsSort = "date" | "rating" | "modified";
+export type TrackRatingsSort = "date" | "set" | "track" | "song" | "rating" | "modified";
+export type SortDirection = "asc" | "desc";
+
+function sqlDirection(direction: SortDirection): Prisma.Sql {
+  return direction === "asc" ? Prisma.raw("ASC") : Prisma.raw("DESC");
+}
+
+// Tiebreakers always share the primary sort's direction. Asking for date
+// DESC means same-day rows further sort set DESC + position DESC, so an
+// "encore-first" reading within each show. Asking for date ASC reverses
+// it (set/position ASC) so the typical chronological top-down reading.
+function showRatingsOrderBy(sort: ShowRatingsSort, direction: SortDirection): Prisma.Sql {
+  const dir = sqlDirection(direction);
+  const showOrder = showOrderBySql("s", direction === "asc" ? "ASC" : "DESC");
+  switch (sort) {
+    case "rating":
+      return Prisma.sql`r.value ${dir}, ${showOrder}, r.created_at ${dir}`;
+    case "modified":
+      return Prisma.sql`r.created_at ${dir}, ${showOrder}`;
+    default:
+      return Prisma.sql`${showOrder}, r.created_at ${dir}`;
+  }
+}
+
+function trackRatingsOrderBy(sort: TrackRatingsSort, direction: SortDirection): Prisma.Sql {
+  const dir = sqlDirection(direction);
+  const setKey = setSortKeySql("t");
+  const showOrder = showOrderBySql("s", direction === "asc" ? "ASC" : "DESC");
+  switch (sort) {
+    case "set":
+      return Prisma.sql`${setKey} ${dir}, t.position ${dir}, ${showOrder}`;
+    case "track":
+      return Prisma.sql`t.position ${dir}, ${setKey} ${dir}, ${showOrder}`;
+    case "song":
+      return Prisma.sql`LOWER(sg.title) ${dir}, ${showOrder}, ${setKey} ${dir}, t.position ${dir}`;
+    case "rating":
+      return Prisma.sql`r.value ${dir}, ${showOrder}, ${setKey} ${dir}, t.position ${dir}`;
+    case "modified":
+      return Prisma.sql`r.created_at ${dir}, ${showOrder}`;
+    default:
+      return Prisma.sql`${showOrder}, ${setKey} ${dir}, t.position ${dir}`;
+  }
+}
 
 /**
  * Slim show-rating row for list views — only fields the user-profile page
@@ -36,6 +83,13 @@ export interface RatingWithTrack {
     slug: string | null;
     position: number;
     set: string;
+    /**
+     * Number of distinct encore labels (E1, E2, ...) in the same show.
+     * Surfaced so the cell renderer can collapse "E1" → "E" via
+     * `formatSetLabel({ encoresInSet })` when the show has only one
+     * encore — the rest of the time, the numeral disambiguates.
+     */
+    encoresInSet: number;
     show: {
       slug: string | null;
       date: string;
@@ -312,123 +366,132 @@ export class RatingService {
     return result ? mapRatingToDomainEntity(result) : null;
   }
 
-  async findShowRatingsByUserId(userId: string, options?: { skip?: number; take?: number }): Promise<RatingWithShow[]> {
-    const results = await this.db.rating.findMany({
-      where: {
-        userId,
-        rateableType: "Show",
-        value: { gte: 1, lte: 5 }, // Only valid ratings
+  async findShowRatingsByUserId(
+    userId: string,
+    options?: { skip?: number; take?: number; sort?: ShowRatingsSort; direction?: SortDirection },
+  ): Promise<RatingWithShow[]> {
+    const sort = options?.sort ?? "date";
+    const direction = options?.direction ?? "desc";
+    const take = options?.take ?? 100;
+    const skip = options?.skip ?? 0;
+    const orderBy = showRatingsOrderBy(sort, direction);
+
+    const rows = await this.db.$queryRaw<
+      Array<{
+        id: string;
+        value: number;
+        created_at: Date;
+        show_slug: string | null;
+        show_date: string;
+        venue_name: string | null;
+        venue_city: string | null;
+        venue_state: string | null;
+      }>
+    >`
+      SELECT
+        r.id AS id,
+        r.value AS value,
+        r.created_at AS created_at,
+        s.slug AS show_slug,
+        s.date AS show_date,
+        v.name AS venue_name,
+        v.city AS venue_city,
+        v.state AS venue_state
+      FROM ratings r
+      INNER JOIN shows s ON s.id = r.rateable_id
+      LEFT JOIN venues v ON v.id = s.venue_id
+      WHERE r.user_id = ${userId}::uuid
+        AND r.rateable_type = 'Show'
+        AND r.value BETWEEN 1 AND 5
+      ORDER BY ${orderBy}
+      LIMIT ${take} OFFSET ${skip}
+    `;
+
+    return rows.map((row) => ({
+      id: row.id,
+      value: row.value,
+      createdAt: row.created_at,
+      show: {
+        slug: row.show_slug,
+        date: row.show_date,
+        venue: row.venue_name === null ? null : { name: row.venue_name, city: row.venue_city, state: row.venue_state },
       },
-      orderBy: { createdAt: "desc" },
-      skip: options?.skip,
-      take: options?.take,
-    });
-
-    // Get show data for all ratings — narrow projection (slug/date/venue
-    // trio) since the user-profile list cards don't use any other field.
-    const showIds = results.map((r) => r.rateableId);
-    const shows = await this.db.show.findMany({
-      where: { id: { in: showIds } },
-      select: {
-        id: true,
-        slug: true,
-        date: true,
-        venue: { select: { name: true, city: true, state: true } },
-      },
-    });
-
-    const showMap = new Map(shows.map((show) => [show.id, show]));
-
-    return results
-      .map((rating): RatingWithShow | null => {
-        const show = showMap.get(rating.rateableId);
-        if (!show) return null;
-
-        return {
-          id: rating.id,
-          value: rating.value,
-          createdAt: rating.createdAt,
-          show: {
-            slug: show.slug,
-            date: show.date,
-            venue: show.venue
-              ? {
-                  name: show.venue.name,
-                  city: show.venue.city,
-                  state: show.venue.state,
-                }
-              : null,
-          },
-        };
-      })
-      .filter((rating): rating is RatingWithShow => rating !== null);
+    }));
   }
 
   async findTrackRatingsByUserId(
     userId: string,
-    options?: { skip?: number; take?: number },
+    options?: { skip?: number; take?: number; sort?: TrackRatingsSort; direction?: SortDirection },
   ): Promise<RatingWithTrack[]> {
-    const results = await this.db.rating.findMany({
-      where: {
-        userId,
-        rateableType: "Track",
-        value: { gte: 1, lte: 5 }, // Only valid ratings
-      },
-      orderBy: { createdAt: "desc" },
-      skip: options?.skip,
-      take: options?.take,
-    });
+    const sort = options?.sort ?? "date";
+    const direction = options?.direction ?? "desc";
+    const take = options?.take ?? 100;
+    const skip = options?.skip ?? 0;
+    const orderBy = trackRatingsOrderBy(sort, direction);
 
-    // Get track data with show and song info — narrow projection: the
-    // user-profile track-rating cards only display set/position + nested
-    // slug/date/venue.name + song.slug/title.
-    const trackIds = results.map((r) => r.rateableId);
-    const tracks = await this.db.track.findMany({
-      where: { id: { in: trackIds } },
-      select: {
-        id: true,
-        slug: true,
-        position: true,
-        set: true,
+    const rows = await this.db.$queryRaw<
+      Array<{
+        id: string;
+        value: number;
+        created_at: Date;
+        track_slug: string | null;
+        track_position: number;
+        track_set: string;
+        encores_in_set: bigint | number;
+        show_slug: string | null;
+        show_date: string;
+        venue_name: string | null;
+        song_slug: string;
+        song_title: string;
+      }>
+    >`
+      SELECT
+        r.id AS id,
+        r.value AS value,
+        r.created_at AS created_at,
+        t.slug AS track_slug,
+        t.position AS track_position,
+        t.set AS track_set,
+        (
+          SELECT COUNT(DISTINCT t2.set)
+          FROM tracks t2
+          WHERE t2.show_id = t.show_id
+            AND t2.set ~* '^E[0-9]+$'
+        ) AS encores_in_set,
+        s.slug AS show_slug,
+        s.date AS show_date,
+        v.name AS venue_name,
+        sg.slug AS song_slug,
+        sg.title AS song_title
+      FROM ratings r
+      INNER JOIN tracks t ON t.id = r.rateable_id
+      INNER JOIN shows s ON s.id = t.show_id
+      LEFT JOIN venues v ON v.id = s.venue_id
+      INNER JOIN songs sg ON sg.id = t.song_id
+      WHERE r.user_id = ${userId}::uuid
+        AND r.rateable_type = 'Track'
+        AND r.value BETWEEN 1 AND 5
+      ORDER BY ${orderBy}
+      LIMIT ${take} OFFSET ${skip}
+    `;
+
+    return rows.map((row) => ({
+      id: row.id,
+      value: row.value,
+      createdAt: row.created_at,
+      track: {
+        slug: row.track_slug,
+        position: row.track_position,
+        set: row.track_set,
+        encoresInSet: Number(row.encores_in_set),
         show: {
-          select: {
-            slug: true,
-            date: true,
-            venue: { select: { name: true } },
-          },
+          slug: row.show_slug,
+          date: row.show_date,
+          venue: row.venue_name === null ? null : { name: row.venue_name },
         },
-        song: { select: { slug: true, title: true } },
+        song: { slug: row.song_slug, title: row.song_title },
       },
-    });
-
-    const trackMap = new Map(tracks.map((track) => [track.id, track]));
-
-    return results
-      .map((rating): RatingWithTrack | null => {
-        const track = trackMap.get(rating.rateableId);
-        if (!track) return null;
-
-        return {
-          id: rating.id,
-          value: rating.value,
-          createdAt: rating.createdAt,
-          track: {
-            slug: track.slug,
-            position: track.position,
-            set: track.set,
-            show: {
-              slug: track.show.slug,
-              date: track.show.date,
-              venue: track.show.venue ? { name: track.show.venue.name } : null,
-            },
-            song: {
-              slug: track.song.slug,
-              title: track.song.title,
-            },
-          },
-        };
-      })
-      .filter((rating): rating is RatingWithTrack => rating !== null);
+    }));
   }
 
   async deleteByRateableId(rateableId: string, rateableType: string): Promise<void> {


### PR DESCRIPTION
## Summary

The **Show Ratings** and **Song Version Ratings** tabs on a user profile
(`/users/:username`) are now sortable tables instead of stacked cards.

- Click any column header to sort; the URL carries `?sort=&dir=` so the view
  is shareable and survives a refresh. Default is most-recently-rated first.
- Sorting is **server-side across all rows**, so paging stays consistent —
  page 2 continues the same order rather than re-sorting only what's visible.
- Tables size to their content and center on the page; columns thin out on
  mobile (Set/# drop on Song Version Ratings, dates compact to `M/D/YY`,
  Modified stays visible).
- Set labels render consistently via `formatSetLabel`: the show-page inline
  setlist now shows `1` / `2` / `E` instead of `S1` / `S2` / `E1`, and a show
  with a single encore collapses `E1` to `E`.

## Columns

| Tab | Columns |
| --- | --- |
| Show Ratings | Show (date + venue), Rating, Modified |
| Song Version Ratings | Show, Set, #, Song, Rating, Modified |

## Implementation notes

- Ordering is composed in raw SQL through the shared helpers in
  `packages/core/src/_shared/show-ordering.ts`. Added `setSortKeySql`
  next to `showOrderBySql` so the SQL `ORDER BY` for sets matches the
  in-memory `compareBySetThenPosition` comparator (Soundcheck → S1..S4 →
  E1..E3 → unknown). Tiebreakers share the primary sort direction so a
  reverse sort reverses the entire reading top-to-bottom.
- `findShowRatingsByUserId` / `findTrackRatingsByUserId` now run a single
  joined `$queryRaw` (the old two-query `findMany` + `IN` lookup couldn't
  sort by joined columns) and accept `sort` + `direction`. The track query
  also projects an `encores_in_set` count per row so the cell can collapse
  the encore label without a second fetch.
- Sort headers use a new URL-driven `UrlSortableHeader` (the rest of the app
  sorts via TanStack column state, which doesn't fit server-side ordering).

## Test plan

- [x] `make tc` — full-repo typecheck
- [x] `make test` — 353 core + 887 web tests pass
- [x] Show Ratings + Song Version Ratings: default order, each header sort,
      mobile column layout, verified in browser
- [x] Show page inline setlist renders `1` / `2` / `E`; single-encore show
      collapses `E1` → `E`
