### PR TITLE
Add Relisten streaming links across shows and setlists

### DIFF
--- a/apps/web/app/components/setlist/show-external-badges.test.tsx
+++ b/apps/web/app/components/setlist/show-external-badges.test.tsx
@@ -19,6 +19,7 @@ describe("ShowExternalBadges", () => {
       <ShowExternalBadges
         sources={{
           nugsUrls: ["https://play.nugs.net/release/1"],
+          relistenUrl: "https://relisten.net/disco-biscuits/2004/12/31",
           archiveUrl: "https://archive.org/details/db2004",
           youtubeUrl: "https://youtube.com/watch?v=aaa",
         }}
@@ -28,6 +29,10 @@ describe("ShowExternalBadges", () => {
     expect(screen.getByRole("link", { name: "Available on nugs.net" })).toHaveAttribute(
       "href",
       "https://play.nugs.net/release/1",
+    );
+    expect(screen.getByRole("link", { name: "Available on Relisten" })).toHaveAttribute(
+      "href",
+      "https://relisten.net/disco-biscuits/2004/12/31",
     );
     expect(screen.getByRole("link", { name: "Available on archive.org" })).toHaveAttribute(
       "href",
@@ -93,6 +98,7 @@ describe("ShowExternalBadges", () => {
     await setupWithRouter(<ShowExternalBadges sources={{ nugsUrls: ["https://play.nugs.net/release/1"] }} />);
 
     expect(screen.getByRole("link", { name: "Available on nugs.net" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Available on Relisten" })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Available on archive.org" })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Video on YouTube" })).not.toBeInTheDocument();
   });

--- a/apps/web/app/components/setlist/show-external-badges.tsx
+++ b/apps/web/app/components/setlist/show-external-badges.tsx
@@ -1,6 +1,6 @@
 import { Camera } from "lucide-react";
 import { Link } from "react-router-dom";
-import { EXTERNAL_SOURCE_DOMAINS, faviconSrc } from "~/lib/favicon";
+import { EXTERNAL_FAVICON_LINK_CLASS, EXTERNAL_SOURCE_DOMAINS, faviconSrc } from "~/lib/favicon";
 import { cn } from "~/lib/utils";
 
 /**
@@ -17,6 +17,8 @@ export interface ShowExternalSources {
    * release so users can tell a rare two-release night at a glance.
    */
   nugsUrls?: string[];
+  /** relisten.net link for the show date, or undefined when Relisten lacks it. */
+  relistenUrl?: string;
   archiveUrl?: string;
   youtubeUrl?: string;
 }
@@ -57,8 +59,6 @@ interface PhotosBadgeProps {
   count: number | undefined;
 }
 
-const BADGE_LINK_CLASS =
-  "inline-flex items-center transition-transform hover:scale-110 hover:-translate-y-0.5 hover:drop-shadow-[0_0_6px_rgba(167,139,250,0.55)]";
 const BADGE_ICON_CLASS = "h-5 w-5 shrink-0";
 
 /**
@@ -69,7 +69,7 @@ const BADGE_ICON_CLASS = "h-5 w-5 shrink-0";
 function FaviconLink({ domain, href, label }: FaviconLinkProps) {
   if (!href) return null;
   return (
-    <a href={href} target="_blank" rel="noopener noreferrer" title={label} className={BADGE_LINK_CLASS}>
+    <a href={href} target="_blank" rel="noopener noreferrer" title={label} className={EXTERNAL_FAVICON_LINK_CLASS}>
       <img src={faviconSrc(domain)} alt={label} className={BADGE_ICON_CLASS} />
     </a>
   );
@@ -82,7 +82,7 @@ function FaviconLink({ domain, href, label }: FaviconLinkProps) {
 function PhotosBadge({ href, count }: PhotosBadgeProps) {
   if (!href || !count || count <= 0) return null;
   return (
-    <Link to={href} title={`${count} photos`} className={cn(BADGE_LINK_CLASS, "gap-1")}>
+    <Link to={href} title={`${count} photos`} className={cn(EXTERNAL_FAVICON_LINK_CLASS, "gap-1")}>
       <Camera className={BADGE_ICON_CLASS} />
       <span className="text-sm">{count}</span>
     </Link>
@@ -98,7 +98,11 @@ function PhotosBadge({ href, count }: PhotosBadgeProps) {
 export function ShowExternalBadges({ sources, photosHref, photosCount }: ShowExternalBadgesProps) {
   const nugsUrls = sources.nugsUrls ?? [];
   const hasAny =
-    nugsUrls.length > 0 || sources.archiveUrl || sources.youtubeUrl || (photosHref && photosCount && photosCount > 0);
+    nugsUrls.length > 0 ||
+    sources.relistenUrl ||
+    sources.archiveUrl ||
+    sources.youtubeUrl ||
+    (photosHref && photosCount && photosCount > 0);
   if (!hasAny) return null;
 
   return (
@@ -121,6 +125,7 @@ export function ShowExternalBadges({ sources, photosHref, photosCount }: ShowExt
         href={sources.archiveUrl}
         label="Available on archive.org"
       />
+      <FaviconLink domain={EXTERNAL_SOURCE_DOMAINS.relisten} href={sources.relistenUrl} label="Available on Relisten" />
       <PhotosBadge href={photosHref} count={photosCount} />
     </div>
   );

--- a/apps/web/app/components/show/show-form.tsx
+++ b/apps/web/app/components/show/show-form.tsx
@@ -183,20 +183,6 @@ export function ShowForm({
 
         <FormField
           control={form.control}
-          name="relistenUrl"
-          render={({ field }: { field: ControllerRenderProps<ShowFormValues, "relistenUrl"> }) => (
-            <FormItem>
-              <FormLabel className="text-content-text-secondary">Relisten URL</FormLabel>
-              <FormControl>
-                <Input placeholder="Enter Relisten URL" {...field} className={formInputClass} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
           name="countForStats"
           render={({ field }: { field: ControllerRenderProps<ShowFormValues, "countForStats"> }) => (
             <FormItem className="flex items-center gap-3">

--- a/apps/web/app/lib/favicon.ts
+++ b/apps/web/app/lib/favicon.ts
@@ -20,6 +20,7 @@ export function faviconSrc(domain: string): string {
  */
 export const EXTERNAL_SOURCE_DOMAINS = {
   nugs: "nugs.net",
+  relisten: "relisten.net",
   youtube: "youtube.com",
   archive: "archive.org",
   spotify: "spotify.com",
@@ -28,3 +29,12 @@ export const EXTERNAL_SOURCE_DOMAINS = {
   // we link to when we want listeners on Tidal / Deezer / Amazon / etc.
   songLink: "song.link",
 } as const;
+
+/**
+ * Shared chrome for a favicon-as-link: the lift-and-glow hover used wherever
+ * an external source renders as a clickable icon (setlist badge strip,
+ * resource-page performance rows). Centralized so the hover treatment stays
+ * identical across surfaces.
+ */
+export const EXTERNAL_FAVICON_LINK_CLASS =
+  "inline-flex items-center transition-transform hover:scale-110 hover:-translate-y-0.5 hover:drop-shadow-[0_0_6px_rgba(167,139,250,0.55)]";

--- a/apps/web/app/routes/resources/chemical-warfare-brigade.tsx
+++ b/apps/web/app/routes/resources/chemical-warfare-brigade.tsx
@@ -4,7 +4,7 @@ import { SetlistList } from "~/components/setlist/setlist-list";
 import { Card, CardHeader } from "~/components/ui/card";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
-import { EXTERNAL_SOURCE_DOMAINS, faviconSrc } from "~/lib/favicon";
+import { EXTERNAL_FAVICON_LINK_CLASS, EXTERNAL_SOURCE_DOMAINS, faviconSrc } from "~/lib/favicon";
 import { ROCK_OPERA_SLUG, rockOperaPath } from "~/lib/rock-operas";
 import { slugifyAnchor } from "~/lib/utils";
 import { getRockOperaPerformances, type RockOperaPerformancesLoaderData } from "./rock-opera-performances";
@@ -459,6 +459,7 @@ const electronPerformances = [
     city: "Philadelphia",
     state: "PA",
     archiveUrl: "https://archive.org/details/etron2000-08-18.shnf",
+    relistenUrl: null,
   },
   {
     date: "5/11/2008",
@@ -466,6 +467,7 @@ const electronPerformances = [
     city: "Denver",
     state: "CO",
     archiveUrl: null,
+    relistenUrl: null,
   },
   {
     date: "5/11/2013",
@@ -473,6 +475,7 @@ const electronPerformances = [
     city: "New Haven",
     state: "CT",
     archiveUrl: null,
+    relistenUrl: null,
   },
   {
     date: "3/26/2017",
@@ -480,6 +483,7 @@ const electronPerformances = [
     city: "Frisco",
     state: "CO",
     archiveUrl: "https://archive.org/details/Electron2017-03-26.multitrack.flac",
+    relistenUrl: "https://relisten.net/electron/2017/03/26",
   },
   {
     date: "4/21/2017",
@@ -487,6 +491,7 @@ const electronPerformances = [
     city: "New York",
     state: "NY",
     archiveUrl: "https://archive.org/details/Electron2017-04-21.multitrack.flac",
+    relistenUrl: "https://relisten.net/electron/2017/04/21",
   },
 ];
 
@@ -757,21 +762,38 @@ const ChemicalWarfareBrigade: React.FC = () => {
                       <div className="text-base md:text-xl text-content-text-primary">
                         {perf.venue} - {perf.city}, {perf.state}
                       </div>
-                      {perf.archiveUrl && (
-                        <div className="pr-2 sm:pr-3">
-                          <a
-                            href={perf.archiveUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            title="Available on archive.org"
-                            className="inline-flex items-center transition-transform hover:scale-110 hover:-translate-y-0.5 hover:drop-shadow-[0_0_6px_rgba(167,139,250,0.55)]"
-                          >
-                            <img
-                              src={faviconSrc(EXTERNAL_SOURCE_DOMAINS.archive)}
-                              alt="Available on archive.org"
-                              className="h-5 w-5 shrink-0"
-                            />
-                          </a>
+                      {(perf.archiveUrl || perf.relistenUrl) && (
+                        <div className="flex items-center gap-2 pr-2 sm:pr-3">
+                          {perf.archiveUrl && (
+                            <a
+                              href={perf.archiveUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              title="Available on archive.org"
+                              className={EXTERNAL_FAVICON_LINK_CLASS}
+                            >
+                              <img
+                                src={faviconSrc(EXTERNAL_SOURCE_DOMAINS.archive)}
+                                alt="Available on archive.org"
+                                className="h-5 w-5 shrink-0"
+                              />
+                            </a>
+                          )}
+                          {perf.relistenUrl && (
+                            <a
+                              href={perf.relistenUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              title="Available on Relisten"
+                              className={EXTERNAL_FAVICON_LINK_CLASS}
+                            >
+                              <img
+                                src={faviconSrc(EXTERNAL_SOURCE_DOMAINS.relisten)}
+                                alt="Available on Relisten"
+                                className="h-5 w-5 shrink-0"
+                              />
+                            </a>
+                          )}
                         </div>
                       )}
                     </div>

--- a/apps/web/app/routes/shows/$slug.tsx
+++ b/apps/web/app/routes/shows/$slug.tsx
@@ -37,6 +37,7 @@ interface ShowLoaderData {
   reviews: ReviewMinimal[];
   archiveRecordings: ArchiveDotOrgRecording[];
   nugsLinks: ExternalLink[];
+  relistenLinks: ExternalLink[];
   youtubeLinks: ExternalLink[];
   externalSources: ShowExternalSources;
   photos: ShowFile[];
@@ -80,9 +81,10 @@ export const loader = publicLoader(async ({ params, context }): Promise<ShowLoad
 
   logger.info(`Show data loaded for ${slug} - setlist cached, reviews fresh`);
 
-  const [archiveRecordings, nugsReleases, youtubeVideoUrls, externalSourcesMap] = await Promise.all([
+  const [archiveRecordings, nugsReleases, relistenUrl, youtubeVideoUrls, externalSourcesMap] = await Promise.all([
     services.archiveDotOrg.findRecordingsForDate(setlist.show.date),
     services.nugs.findReleasesForDate(setlist.show.date),
+    services.relisten.findUrlForDate(setlist.show.date),
     services.youtube.getVideoUrlsForShow(setlist.show.id),
     computeShowExternalSources([setlist.show]),
   ]);
@@ -101,6 +103,7 @@ export const loader = publicLoader(async ({ params, context }): Promise<ShowLoad
     url: release.url,
     label: `Listen on nugs.net${release.artistName === "Tractorbeam" ? " (Tractorbeam)" : ""}`,
   }));
+  const relistenLinks: ExternalLink[] = relistenUrl ? [{ url: relistenUrl, label: "Listen on Relisten" }] : [];
   const youtubeLinks: ExternalLink[] = youtubeVideoUrls.map((url, i) => ({
     url,
     label: `Watch on YouTube${youtubeVideoUrls.length > 1 ? ` (${i + 1})` : ""}`,
@@ -111,6 +114,7 @@ export const loader = publicLoader(async ({ params, context }): Promise<ShowLoad
     reviews,
     archiveRecordings,
     nugsLinks,
+    relistenLinks,
     youtubeLinks,
     externalSources: externalSourcesMap[setlist.show.id] ?? {},
     photos,
@@ -124,8 +128,17 @@ export function meta({ data }: { data: ShowLoaderData }) {
 }
 
 export default function Show() {
-  const { setlist, reviews, archiveRecordings, nugsLinks, youtubeLinks, externalSources, photos, adjacentShows } =
-    useSerializedLoaderData<ShowLoaderData>();
+  const {
+    setlist,
+    reviews,
+    archiveRecordings,
+    nugsLinks,
+    relistenLinks,
+    youtubeLinks,
+    externalSources,
+    photos,
+    adjacentShows,
+  } = useSerializedLoaderData<ShowLoaderData>();
   const { user } = useSession();
   const revalidator = useRevalidator();
   const [setlistView, setSetlistView] = useSetlistView();
@@ -320,6 +333,7 @@ export default function Show() {
             <ExternalLinkCard faviconDomain={EXTERNAL_SOURCE_DOMAINS.nugs} title="Official release" items={nugsLinks} />
             <ExternalLinkCard faviconDomain={EXTERNAL_SOURCE_DOMAINS.youtube} title="Video" items={youtubeLinks} />
             <ArchiveRecordingsCard items={archiveRecordings} />
+            <ExternalLinkCard faviconDomain={EXTERNAL_SOURCE_DOMAINS.relisten} title="Relisten" items={relistenLinks} />
 
             {/* Highlights panel */}
             <SetlistHighlights setlist={setlist} />

--- a/apps/web/app/server/show-external-sources.test.ts
+++ b/apps/web/app/server/show-external-sources.test.ts
@@ -4,10 +4,12 @@ import { computeShowExternalSources } from "./show-external-sources";
 const getReleaseUrlsByDate = vi.fn();
 const getPrimaryUrlsByDate = vi.fn();
 const getFirstVideoUrlByShowIds = vi.fn();
+const getRelistenUrlsByDate = vi.fn();
 
 vi.mock("~/server/services", () => ({
   services: {
     nugs: { getReleaseUrlsByDate: () => getReleaseUrlsByDate() },
+    relisten: { getUrlsByDate: () => getRelistenUrlsByDate() },
     archiveDotOrg: { getPrimaryUrlsByDate: () => getPrimaryUrlsByDate() },
     youtube: { getFirstVideoUrlByShowIds: (ids: string[]) => getFirstVideoUrlByShowIds(ids) },
   },
@@ -19,6 +21,7 @@ describe("computeShowExternalSources", () => {
     getReleaseUrlsByDate.mockResolvedValue({});
     getPrimaryUrlsByDate.mockResolvedValue({});
     getFirstVideoUrlByShowIds.mockResolvedValue({});
+    getRelistenUrlsByDate.mockResolvedValue({});
   });
 
   // Empty input short-circuits so loaders can pass whatever list they have
@@ -30,6 +33,7 @@ describe("computeShowExternalSources", () => {
     expect(getReleaseUrlsByDate).not.toHaveBeenCalled();
     expect(getPrimaryUrlsByDate).not.toHaveBeenCalled();
     expect(getFirstVideoUrlByShowIds).not.toHaveBeenCalled();
+    expect(getRelistenUrlsByDate).not.toHaveBeenCalled();
   });
 
   // Shows are keyed by id in the result; nugs/archive URLs lookup by date,
@@ -38,12 +42,14 @@ describe("computeShowExternalSources", () => {
     getReleaseUrlsByDate.mockResolvedValue({ "2004-12-31": ["https://play.nugs.net/release/1"] });
     getPrimaryUrlsByDate.mockResolvedValue({ "2004-12-31": "https://archive.org/details/db2004" });
     getFirstVideoUrlByShowIds.mockResolvedValue({ "show-nye04": "https://youtube.com/watch?v=aaa" });
+    getRelistenUrlsByDate.mockResolvedValue({ "2004-12-31": "https://relisten.net/disco-biscuits/2004/12/31" });
 
     const result = await computeShowExternalSources([{ id: "show-nye04", date: "2004-12-31" }]);
 
     expect(result).toEqual({
       "show-nye04": {
         nugsUrls: ["https://play.nugs.net/release/1"],
+        relistenUrl: "https://relisten.net/disco-biscuits/2004/12/31",
         archiveUrl: "https://archive.org/details/db2004",
         youtubeUrl: "https://youtube.com/watch?v=aaa",
       },
@@ -62,6 +68,7 @@ describe("computeShowExternalSources", () => {
 
     expect(result["show-lockn"]).toEqual({
       nugsUrls: undefined,
+      relistenUrl: undefined,
       archiveUrl: "https://archive.org/details/db2019",
       youtubeUrl: undefined,
     });

--- a/apps/web/app/server/show-external-sources.ts
+++ b/apps/web/app/server/show-external-sources.ts
@@ -26,8 +26,9 @@ export async function computeShowExternalSources(shows: ShowLike[]): Promise<Rec
   if (shows.length === 0) return result;
 
   const showIds = shows.map((s) => s.id);
-  const [nugsUrlsByDate, archiveUrlsByDate, youtubeUrlsByShowId] = await Promise.all([
+  const [nugsUrlsByDate, relistenUrlsByDate, archiveUrlsByDate, youtubeUrlsByShowId] = await Promise.all([
     services.nugs.getReleaseUrlsByDate(),
+    services.relisten.getUrlsByDate(),
     services.archiveDotOrg.getPrimaryUrlsByDate(),
     services.youtube.getFirstVideoUrlByShowIds(showIds),
   ]);
@@ -35,6 +36,7 @@ export async function computeShowExternalSources(shows: ShowLike[]): Promise<Rec
   for (const show of shows) {
     result[show.id] = {
       nugsUrls: nugsUrlsByDate[show.date],
+      relistenUrl: relistenUrlsByDate[show.date],
       archiveUrl: archiveUrlsByDate[show.date],
       youtubeUrl: youtubeUrlsByShowId[show.id],
     };

--- a/packages/core/src/_shared/services.ts
+++ b/packages/core/src/_shared/services.ts
@@ -13,6 +13,7 @@ import { SearchHistoryService } from "../search/search-history-service";
 import { SetlistService } from "../setlists/setlist-service";
 import { ArchiveDotOrgService } from "../shows/archive-dot-org-service";
 import { NugsService } from "../shows/nugs-service";
+import { RelistenService } from "../shows/relisten-service";
 import { ShowService } from "../shows/show-service";
 import { TourDatesService } from "../shows/tour-dates-service";
 import { YoutubeService } from "../shows/youtube-service";
@@ -46,6 +47,7 @@ export interface Services {
   songPageComposer: SongPageComposer;
   tourDatesService: TourDatesService;
   nugs: NugsService;
+  relisten: RelistenService;
   archiveDotOrg: ArchiveDotOrgService;
   youtube: YoutubeService;
   files: FileService;
@@ -92,6 +94,7 @@ export function createServices(container: ServiceContainer): Services {
     songPageComposer: new SongPageComposer(container.db, songService, statsService),
     tourDatesService: new TourDatesService(container.redis),
     nugs: new NugsService(container.redis, container.logger),
+    relisten: new RelistenService(container.redis, container.logger),
     archiveDotOrg: new ArchiveDotOrgService(container.redis, container.logger),
     youtube: new YoutubeService(container.db, container.cacheInvalidation),
     files: new FileService(container.db, container.logger, {

--- a/packages/core/src/shows/relisten-service.test.ts
+++ b/packages/core/src/shows/relisten-service.test.ts
@@ -1,0 +1,171 @@
+import { CacheKeys } from "@bip/domain";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { RedisService } from "../_shared/redis";
+import { RELISTEN_ARTIST_SLUG, RelistenService } from "./relisten-service";
+
+function makeRedisMock() {
+  const store = new Map<string, unknown>();
+  return {
+    get: vi.fn(async <T>(key: string): Promise<T | null> => (store.has(key) ? (store.get(key) as T) : null)),
+    set: vi.fn(async <T>(key: string, value: T): Promise<void> => {
+      store.set(key, value);
+    }),
+    __store: store,
+  } as unknown as RedisService & { __store: Map<string, unknown> };
+}
+
+interface YearShow {
+  display_date: string;
+  source_count: number;
+}
+
+/**
+ * Drives the mock the way the real fetcher hits the API: one request to the
+ * `/years` list, then one request per year. Switches on the URL (not call
+ * order) because the per-year requests fire concurrently. Years named in
+ * `failYears` respond non-ok so tests can exercise partial-failure handling.
+ */
+function makeFetchByUrl(yearsToShows: Record<string, YearShow[]>, failYears: string[] = []) {
+  return vi.fn(async (input: string | URL): Promise<Response> => {
+    const url = input.toString();
+    const yearMatch = url.match(/\/years\/(\d{4})$/);
+    if (yearMatch) {
+      const year = yearMatch[1];
+      if (failYears.includes(year)) {
+        return { ok: false, status: 500 } as unknown as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({ shows: yearsToShows[year] ?? [] }),
+      } as unknown as Response;
+    }
+    if (url.endsWith("/years")) {
+      return {
+        ok: true,
+        json: async () => Object.keys(yearsToShows).map((year) => ({ year })),
+      } as unknown as Response;
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+}
+
+const CATALOG = {
+  "1998": [
+    { display_date: "1998-04-17", source_count: 2 },
+    { display_date: "1998-12-31", source_count: 1 },
+  ],
+  "2017": [{ display_date: "2017-04-21", source_count: 3 }],
+};
+
+describe("RelistenService", () => {
+  let redis: ReturnType<typeof makeRedisMock>;
+  let service: RelistenService;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    redis = makeRedisMock();
+    service = new RelistenService(redis);
+    fetchMock = makeFetchByUrl(CATALOG);
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Cold cache: fetch the years list, then each year, index by ISO date, and
+  // return a relisten.net/{slug}/YYYY/MM/DD link derived from display_date.
+  test("cache miss: fetches years then each year and returns the date's relisten.net URL", async () => {
+    const url = await service.findUrlForDate("1998-04-17");
+
+    expect(url).toBe(`https://relisten.net/${RELISTEN_ARTIST_SLUG}/1998/04/17`);
+    expect(fetchMock.mock.calls[0][0]).toContain(`/artists/${RELISTEN_ARTIST_SLUG}/years`);
+  });
+
+  // Second lookup for any date must come from Redis with no re-fetch.
+  test("cache hit: does not re-fetch when the catalog is already cached", async () => {
+    await service.findUrlForDate("1998-04-17");
+    fetchMock.mockClear();
+
+    const url = await service.findUrlForDate("2017-04-21");
+
+    expect(url).toBe(`https://relisten.net/${RELISTEN_ARTIST_SLUG}/2017/04/21`);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // Dates Relisten doesn't have return undefined so the UI skips the link.
+  test("returns undefined when no show matches the date", async () => {
+    expect(await service.findUrlForDate("1999-04-09")).toBeUndefined();
+  });
+
+  // Shows with no streamable sources must not produce a (dead) link.
+  test("skips shows with a falsy source_count", async () => {
+    fetchMock = makeFetchByUrl({ "2020": [{ display_date: "2020-01-01", source_count: 0 }] });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    service = new RelistenService(redis);
+
+    expect(await service.findUrlForDate("2020-01-01")).toBeUndefined();
+  });
+
+  // External downtime must not break the show page.
+  test("returns undefined and does not crash when fetch throws", async () => {
+    fetchMock = vi.fn(async () => {
+      throw new Error("relisten api unreachable");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    service = new RelistenService(redis);
+
+    expect(await service.findUrlForDate("1998-04-17")).toBeUndefined();
+  });
+
+  // One bad year must not wipe the whole catalog — the years that loaded
+  // still produce links. Relisten fires ~30 concurrent year requests on a
+  // cold cache, so a single rate-limited/flaky year is the likely failure,
+  // and an all-or-nothing fetch would make every Relisten link vanish.
+  test("keeps shows from years that loaded when one year request fails", async () => {
+    fetchMock = makeFetchByUrl(CATALOG, ["2017"]);
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    service = new RelistenService(redis);
+
+    expect(await service.findUrlForDate("1998-04-17")).toBe(`https://relisten.net/${RELISTEN_ARTIST_SLUG}/1998/04/17`);
+    expect(await service.findUrlForDate("2017-04-21")).toBeUndefined();
+  });
+
+  // A transient empty result must not be cached, or a glitch locks the map
+  // empty for the full TTL.
+  test("does not cache an empty catalog result (retries next call)", async () => {
+    fetchMock = makeFetchByUrl({});
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    service = new RelistenService(redis);
+    await service.findUrlForDate("1998-04-17");
+
+    fetchMock = makeFetchByUrl(CATALOG);
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const url = await service.findUrlForDate("1998-04-17");
+
+    expect(url).toBe(`https://relisten.net/${RELISTEN_ARTIST_SLUG}/1998/04/17`);
+  });
+
+  // getUrlsByDate returns the full date->URL map for listing-page badges.
+  test("getUrlsByDate returns every show date mapped to its relisten.net URL", async () => {
+    const map = await service.getUrlsByDate();
+
+    expect(map).toEqual({
+      "1998-04-17": `https://relisten.net/${RELISTEN_ARTIST_SLUG}/1998/04/17`,
+      "1998-12-31": `https://relisten.net/${RELISTEN_ARTIST_SLUG}/1998/12/31`,
+      "2017-04-21": `https://relisten.net/${RELISTEN_ARTIST_SLUG}/2017/04/21`,
+    });
+  });
+
+  // Persist under the domain cache key with the shared 24h catalog TTL.
+  test("persists catalog under CacheKeys.relisten.catalog with a 24h TTL", async () => {
+    await service.findUrlForDate("1998-04-17");
+
+    const setCalls = (redis.set as ReturnType<typeof vi.fn>).mock.calls;
+    const keys = setCalls.map((c) => c[0]);
+    expect(keys).toContain(CacheKeys.relisten.catalog());
+    for (const call of setCalls) {
+      expect(call[2]).toEqual({ EX: 60 * 60 * 24 });
+    }
+  });
+});

--- a/packages/core/src/shows/relisten-service.ts
+++ b/packages/core/src/shows/relisten-service.ts
@@ -1,0 +1,113 @@
+import type { Logger } from "@bip/domain";
+import { CacheKeys } from "@bip/domain";
+import { DateIndexedCatalog } from "../_shared/catalog/date-indexed-catalog";
+import type { RedisService } from "../_shared/redis";
+
+/** Relisten files Disco Biscuits shows under this artist slug. */
+export const RELISTEN_ARTIST_SLUG = "disco-biscuits";
+
+const API_BASE = `https://api.relisten.net/api/v2/artists/${RELISTEN_ARTIST_SLUG}`;
+
+/** One entry from Relisten's `/years` list endpoint. */
+interface RelistenYear {
+  year?: string;
+}
+
+/** A single show inside a `/years/{year}` response. */
+interface RelistenShow {
+  display_date?: string;
+  source_count?: number;
+}
+
+/** Envelope shape from Relisten's `/years/{year}` endpoint. */
+interface RelistenYearResponse {
+  shows?: RelistenShow[];
+}
+
+/**
+ * Web link for a show date. Relisten's player URL is purely date-derived, so
+ * the catalog only exists to tell us which dates Relisten actually has — we
+ * never want to render a link to a date with no recordings.
+ */
+function buildShowUrl(isoDate: string): string {
+  const [year, month, day] = isoDate.split("-");
+  return `https://relisten.net/${RELISTEN_ARTIST_SLUG}/${year}/${month}/${day}`;
+}
+
+function buildFetcher(logger?: Logger) {
+  return async (): Promise<Record<string, string>> => {
+    logger?.info("Fetching Relisten catalog", { slug: RELISTEN_ARTIST_SLUG });
+    const yearsResponse = await fetch(`${API_BASE}/years`);
+    if (!yearsResponse.ok) {
+      throw new Error(`Failed to fetch Relisten years: ${yearsResponse.status}`);
+    }
+    const years: RelistenYear[] = await yearsResponse.json();
+
+    // ~30 concurrent year requests. Use allSettled (not all) so one flaky or
+    // rate-limited year doesn't reject the batch and wipe the entire catalog —
+    // the years that loaded still produce links; the rest are logged and
+    // retried on the next refresh (empty maps aren't cached).
+    const settled = await Promise.allSettled(
+      years
+        .map((y) => y.year)
+        .filter((year): year is string => Boolean(year))
+        .map(async (year) => {
+          const response = await fetch(`${API_BASE}/years/${year}`);
+          if (!response.ok) {
+            throw new Error(`Failed to fetch Relisten year ${year}: ${response.status}`);
+          }
+          const data: RelistenYearResponse = await response.json();
+          return data.shows ?? [];
+        }),
+    );
+
+    const map: Record<string, string> = {};
+    for (const result of settled) {
+      if (result.status === "rejected") {
+        logger?.error("Relisten year fetch failed, skipping", { error: result.reason });
+        continue;
+      }
+      for (const show of result.value) {
+        if (!show.display_date || !show.source_count) continue;
+        map[show.display_date] = buildShowUrl(show.display_date);
+      }
+    }
+    return map;
+  };
+}
+
+/**
+ * Wraps Relisten's public REST API for Disco Biscuits shows. Relisten streams
+ * fan recordings; this service learns which show dates Relisten has so the UI
+ * can render a "Listen on Relisten" link without ever pointing at a date that
+ * has no recordings. The link target itself is derived from the date. Backs
+ * the show-page Relisten card and the listing-page favicon badge.
+ */
+export class RelistenService {
+  private readonly catalog: DateIndexedCatalog<string>;
+
+  /**
+   * @param redis Shared Redis client for the underlying catalog cache.
+   * @param logger Optional logger; fetch failures are swallowed so a show page
+   *   never breaks on Relisten downtime.
+   */
+  constructor(redis: RedisService, logger?: Logger) {
+    this.catalog = new DateIndexedCatalog<string>(redis, CacheKeys.relisten.catalog(), buildFetcher(logger), logger);
+  }
+
+  /**
+   * Relisten link for a single show date, or undefined when Relisten has no
+   * recordings for it.
+   */
+  async findUrlForDate(date: string): Promise<string | undefined> {
+    return this.catalog.findByDate(date);
+  }
+
+  /**
+   * Full date → Relisten-URL map for listing pages that need O(1) per-row
+   * lookups across many shows via a single Redis read.
+   */
+  async getUrlsByDate(): Promise<Record<string, string>> {
+    return this.catalog.getAll();
+  }
+}

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -64,6 +64,13 @@ export const CacheKeys = {
   },
 
   /**
+   * Relisten full-catalog cache (date-indexed map of all Disco Biscuits shows)
+   */
+  relisten: {
+    catalog: () => "relisten-catalog-disco-biscuits",
+  },
+
+  /**
    * Song-related cache keys
    */
   songs: {
@@ -102,7 +109,7 @@ export const CacheKeys = {
      * have 400+ attended shows and the un-paginated payload is large enough
      * to be slow to deserialize/transport even from Redis.
      */
-    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}:v5`,
+    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}:v6`,
     /** All pages of a single user's attended-setlists caches (for per-user invalidation). */
     allAttendedSetlistsForUser: (userId: string) => `user:${userId}:attended-setlists:*`,
     /** All per-user attended-setlists caches (for pattern deletion on broad show mutations). */
@@ -127,7 +134,7 @@ export const CacheKeys = {
    */
   rockOperas: {
     /** Resource-page list payload: setlists + external sources for one rock opera. */
-    performances: (slug: string) => `rock-operas:performances:${slug}:v3`,
+    performances: (slug: string) => `rock-operas:performances:${slug}:v4`,
     /** Pattern for invalidating every performances cache (broad mutations). */
     allPerformances: () => "rock-operas:performances:*",
   },


### PR DESCRIPTION
## What changed

You can now jump straight to a show's Relisten recording. Relisten links appear:

- On **show pages**, as a "Relisten" card in the right rail (below the Archive card).
- On **setlist listing cards**, as a Relisten favicon in the badge strip (to the right of the Archive badge).
- On the **Chemical Warfare Brigade** resource page, next to the existing archive.org badges on the Electron performance rows.

They sit alongside the existing nugs.net / archive.org / YouTube links.

## How it works

A new `RelistenService` pulls the Disco Biscuits catalog from the Relisten REST API (`/years`, then per-year shows), indexes it by date, and caches it in Redis for 24h via `DateIndexedCatalog`, the same read-through pattern the nugs and archive integrations use. The link target is purely date-derived (`relisten.net/disco-biscuits/YYYY/MM/DD`), so the catalog only exists to confirm which dates Relisten carries; links never point at an empty date.

The admin show form's "Relisten URL" field is removed (links are now sourced live), while the `relistenUrl` key stays in the form schema so existing saves don't wipe the stored column.

## Reviewer notes

- **Resilience:** the catalog fetches ~30 years concurrently. It uses `Promise.allSettled`, so a single flaky/rate-limited year is logged and skipped rather than blanking the whole catalog. Empty results aren't cached, so a fully-failed fetch retries on the next request.
- **Cache versioning:** two cached payloads embed external-source URLs, so their keys are bumped to avoid serving pre-Relisten shapes: `rock-operas:performances` (v3 to v4) and `user:*:attended-setlists` (v5 to v6). Other surfaces compute external sources fresh per request.
- **CWB coverage:** Electron is on Relisten under its own slug, but only 3/26/2017 and 4/21/2017 of the five listed performances exist there; the other three link archive.org only.

## Tests
- `RelistenService`: catalog fetch/index/cache, date miss, zero-source skip, partial-year failure, error to empty, TTL.
- `computeShowExternalSources`: `relistenUrl` threads by date.
- `ShowExternalBadges`: Relisten favicon renders / omits with the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
