### PR TITLE
Add rating distribution charts to user profiles

### DIFF
--- a/apps/web/app/components/rating/rating-charts.tsx
+++ b/apps/web/app/components/rating/rating-charts.tsx
@@ -1,0 +1,248 @@
+import type { RatingYearBucket } from "@bip/core";
+import { useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { ChartTooltipCard } from "~/components/ui/chart-tooltip";
+import { SegmentButton } from "~/components/ui/segment-button";
+import { CHART_BAR_CURSOR, CHART_COLORS, chartSeriesColor } from "~/lib/chart-colors";
+import {
+  availableYears,
+  buildAverageMedianByYear,
+  buildHistogramData,
+  type HistogramMode,
+  histogramYAxisConfig,
+} from "~/lib/rating-charts";
+import { START_YEAR } from "~/lib/song-filters";
+import { cn } from "~/lib/utils";
+
+interface RatingChartsProps {
+  buckets: RatingYearBucket[];
+  kind: "show" | "track";
+}
+
+/**
+ * Charts view for a profile's rating tabs. Derives an all-time / per-year
+ * star-value histogram and an average-vs-median trend line from the
+ * aggregate bucket set, so the same component serves show and track ratings.
+ * Renders nothing when there are no ratings — the tab's existing empty-state
+ * card covers that case.
+ */
+export function RatingCharts({ buckets, kind }: RatingChartsProps) {
+  const [selectedYears, setSelectedYears] = useState<number[]>([]);
+  const [histogramMode, setHistogramMode] = useState<HistogramMode>("percent");
+  if (buckets.length === 0) return null;
+
+  const years = availableYears(buckets);
+  const { series, data, seriesTotals } = buildHistogramData(buckets, selectedYears, histogramMode);
+  // Always span the full band era so the trend's x-axis is consistent across
+  // users and years with no ratings read as genuine gaps, not skipped.
+  const trend = buildAverageMedianByYear(buckets, { start: START_YEAR, end: new Date().getFullYear() });
+  const noun = kind === "show" ? "Show" : "Song Version";
+  const isPercent = histogramMode === "percent";
+
+  function toggleYear(year: number) {
+    setSelectedYears((current) =>
+      current.includes(year) ? current.filter((value) => value !== year) : [...current, year],
+    );
+  }
+
+  const comparing = selectedYears.length > 0;
+
+  // Pin the y-axis to a tight scale sized to the tallest bar (percent
+  // fractions or integer counts), so columns fill the panel and a sparse
+  // year doesn't get a stranded or fractional axis.
+  const plottedMax = data.reduce((max, row) => series.reduce((m, key) => Math.max(m, row[key] as number), max), 0);
+  const yAxis = histogramYAxisConfig(isPercent, plottedMax);
+
+  return (
+    <div className="space-y-4">
+      <div className="glass-content rounded-lg p-6">
+        <div className="flex items-center justify-between mb-4 gap-3 flex-wrap">
+          <h3 className="text-lg font-semibold text-content-text-primary">{noun} Rating Distribution</h3>
+          <fieldset className="flex border-0 p-0 m-0">
+            <legend className="sr-only">Distribution units</legend>
+            <SegmentButton size="md" active={!isPercent} onClick={() => setHistogramMode("count")}>
+              Count
+            </SegmentButton>
+            <SegmentButton size="md" active={isPercent} onClick={() => setHistogramMode("percent")}>
+              Percent
+            </SegmentButton>
+          </fieldset>
+        </div>
+        <fieldset className="flex flex-wrap gap-2 mb-4 border-0 p-0 m-0">
+          <legend className="sr-only">Filter distribution by year</legend>
+          <YearChip active={!comparing} onClick={() => setSelectedYears([])}>
+            All Years
+          </YearChip>
+          {years.map((year) => (
+            <YearChip key={year} active={selectedYears.includes(year)} onClick={() => toggleYear(year)}>
+              {year}
+            </YearChip>
+          ))}
+        </fieldset>
+        <div className="h-80">
+          <ResponsiveContainer width="100%" height="100%">
+            {/* Key on the series set so adding/removing a year remounts the
+                bars: recharts dodges grouped bars by registration order, not
+                declaration order, so without a remount a year added later
+                lands on the right instead of its sorted slot. */}
+            <BarChart key={series.join("-")} data={data} margin={{ top: 20, right: 30, left: 0, bottom: 20 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke={CHART_COLORS.grid} opacity={0.3} />
+              <XAxis dataKey="label" stroke={CHART_COLORS.axis} fontSize={12} />
+              <YAxis
+                stroke={CHART_COLORS.axis}
+                fontSize={12}
+                allowDecimals={yAxis.allowDecimals}
+                domain={yAxis.domain}
+                ticks={yAxis.ticks}
+                tickFormatter={isPercent ? (value: number) => `${Math.round(value * 100)}%` : undefined}
+              />
+              <Tooltip
+                content={<HistogramTooltip comparing={comparing} isPercent={isPercent} seriesTotals={seriesTotals} />}
+                cursor={CHART_BAR_CURSOR}
+                isAnimationActive={false}
+              />
+              {comparing && <Legend />}
+              {series.map((key, index) => (
+                <Bar key={key} dataKey={key} name={key} fill={chartSeriesColor(index)} radius={[2, 2, 0, 0]} />
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      <div className="glass-content rounded-lg p-6">
+        <h3 className="text-lg font-semibold text-content-text-primary mb-4">Average &amp; Median by Year</h3>
+        <div className="h-80">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={trend} margin={{ top: 20, right: 30, left: 0, bottom: 20 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke={CHART_COLORS.grid} opacity={0.3} />
+              <XAxis dataKey="year" stroke={CHART_COLORS.axis} fontSize={12} />
+              <YAxis stroke={CHART_COLORS.axis} fontSize={12} domain={[0, 5]} ticks={[1, 2, 3, 4, 5]} />
+              <Tooltip content={<TrendTooltip />} isAnimationActive={false} />
+              <Legend />
+              <Line
+                type="monotone"
+                dataKey="average"
+                name="Average"
+                stroke={chartSeriesColor(0)}
+                strokeWidth={2}
+                dot={{ fill: chartSeriesColor(0), strokeWidth: 2, r: 3 }}
+                activeDot={{ r: 5 }}
+              />
+              <Line
+                type="monotone"
+                dataKey="median"
+                name="Median"
+                stroke={chartSeriesColor(1)}
+                strokeWidth={2}
+                strokeDasharray="5 4"
+                dot={{ fill: chartSeriesColor(1), strokeWidth: 2, r: 3 }}
+                activeDot={{ r: 5 }}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface YearChipProps {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+function YearChip({ active, onClick, children }: YearChipProps) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={cn(
+        "px-2.5 py-1 text-xs font-medium rounded-full border transition-colors cursor-pointer",
+        active
+          ? "border-brand-primary bg-brand-primary/15 text-content-text-primary"
+          : "border-content-glass-border text-content-text-tertiary hover:text-content-text-secondary",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+interface TooltipEntry {
+  name?: string;
+  value?: number;
+  color?: string;
+  dataKey?: string;
+}
+
+interface ChartTooltipProps {
+  active?: boolean;
+  payload?: TooltipEntry[];
+  label?: number | string;
+}
+
+/**
+ * Histogram tooltip: shows the hovered star value and, per series, both the
+ * rating count and its share of that series' total — so the user sees both
+ * dimensions regardless of which units the chart is currently drawing. When
+ * comparing years, each selected year gets its own line.
+ */
+function HistogramTooltip({
+  active,
+  payload,
+  label,
+  comparing,
+  isPercent,
+  seriesTotals,
+}: ChartTooltipProps & { comparing: boolean; isPercent: boolean; seriesTotals: Record<string, number> }) {
+  if (!active || !payload || payload.length === 0) return null;
+  return (
+    <ChartTooltipCard>
+      <div className="font-medium">{label} stars</div>
+      {payload.map((entry) => {
+        const key = entry.dataKey ?? "";
+        const total = seriesTotals[key] ?? 0;
+        const raw = entry.value ?? 0;
+        const count = isPercent ? Math.round(raw * total) : raw;
+        const fraction = total > 0 ? count / total : 0;
+        const ratingsLabel = count === 1 ? "rating" : "ratings";
+        return (
+          <div key={key || entry.name}>
+            {comparing ? <span style={{ color: entry.color }}>{entry.name}: </span> : null}
+            {count} {ratingsLabel}
+            <span className="text-content-text-tertiary"> · {(fraction * 100).toFixed(1)}%</span>
+          </div>
+        );
+      })}
+    </ChartTooltipCard>
+  );
+}
+
+/** Trend tooltip: average and median for the hovered concert year. */
+function TrendTooltip({ active, payload, label }: ChartTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  return (
+    <ChartTooltipCard>
+      <div className="font-medium">{label}</div>
+      {payload.map((entry) => (
+        <div key={entry.dataKey ?? entry.name} style={{ color: entry.color }}>
+          {entry.name}: {(entry.value ?? 0).toFixed(2)}
+        </div>
+      ))}
+    </ChartTooltipCard>
+  );
+}

--- a/apps/web/app/components/show/debut-year-chart.tsx
+++ b/apps/web/app/components/show/debut-year-chart.tsx
@@ -2,8 +2,9 @@ import { average, median } from "@bip/domain";
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { ChartTooltipCard } from "~/components/ui/chart-tooltip";
 import { SegmentButton } from "~/components/ui/segment-button";
-import { CHART_COLORS } from "~/lib/chart-colors";
+import { CHART_BAR_CURSOR, CHART_COLORS } from "~/lib/chart-colors";
 import { START_YEAR } from "~/lib/song-filters";
 
 type SongRef = { title: string; slug: string };
@@ -135,7 +136,7 @@ export function DebutYearChart({ setlist }: DebutYearChartProps) {
             <BarChart data={distribution} margin={{ top: 4, right: 4, left: -16, bottom: 4 }} barCategoryGap="10%">
               <XAxis dataKey="year" stroke={CHART_COLORS.axis} fontSize={10} interval={labelInterval} />
               <YAxis stroke={CHART_COLORS.axis} fontSize={10} allowDecimals={false} width={28} />
-              <Tooltip content={<DebutYearTooltip />} isAnimationActive={false} />
+              <Tooltip content={<DebutYearTooltip />} cursor={CHART_BAR_CURSOR} isAnimationActive={false} />
               <Bar dataKey="count" fill={CHART_COLORS.accent} />
             </BarChart>
           </ResponsiveContainer>
@@ -196,14 +197,7 @@ function DebutYearTooltip({ active, payload }: DebutYearTooltipProps) {
   if (count === 0) return null;
   const songsLabel = count === 1 ? "song" : "songs";
   return (
-    <div
-      className="rounded-md border px-3 py-2 text-sm"
-      style={{
-        backgroundColor: CHART_COLORS.tooltipBg,
-        borderColor: CHART_COLORS.tooltipBorder,
-        color: CHART_COLORS.tooltipText,
-      }}
-    >
+    <ChartTooltipCard>
       <div className="font-medium">{year}</div>
       <div className="text-content-text-tertiary">
         {count} {songsLabel}
@@ -213,6 +207,6 @@ function DebutYearTooltip({ active, payload }: DebutYearTooltipProps) {
           <li key={song.slug}>{song.title}</li>
         ))}
       </ul>
-    </div>
+    </ChartTooltipCard>
   );
 }

--- a/apps/web/app/components/song/yearly-play-chart.tsx
+++ b/apps/web/app/components/song/yearly-play-chart.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { ChartTooltipCard } from "~/components/ui/chart-tooltip";
+import { SegmentButton } from "~/components/ui/segment-button";
 import { CHART_COLORS } from "~/lib/chart-colors";
 import { START_YEAR } from "~/lib/song-filters";
-import { cn } from "~/lib/utils";
 import {
   buildYearlyChartData,
   expandPlayedYears,
@@ -40,22 +41,22 @@ export function YearlyPlayChart({ yearlyPlayData, showsByYear }: YearlyPlayChart
         <div className="flex items-center flex-wrap gap-y-2">
           <fieldset className="flex border-0 p-0 m-0">
             <legend className="sr-only">Chart units</legend>
-            <ToggleButton active={mode === "count"} onClick={() => setMode("count")}>
+            <SegmentButton size="md" active={mode === "count"} onClick={() => setMode("count")}>
               # Plays
-            </ToggleButton>
-            <ToggleButton active={isPercent} onClick={() => setMode("percent")}>
+            </SegmentButton>
+            <SegmentButton size="md" active={isPercent} onClick={() => setMode("percent")}>
               % of Shows
-            </ToggleButton>
+            </SegmentButton>
           </fieldset>
           <div className="mx-3 h-5 w-px bg-content-text-tertiary/30" aria-hidden="true" />
           <fieldset className="flex border-0 p-0 m-0">
             <legend className="sr-only">Year scope</legend>
-            <ToggleButton active={yearScope === "played"} onClick={() => setYearScope("played")}>
+            <SegmentButton size="md" active={yearScope === "played"} onClick={() => setYearScope("played")}>
               Years Played
-            </ToggleButton>
-            <ToggleButton active={yearScope === "all"} onClick={() => setYearScope("all")}>
+            </SegmentButton>
+            <SegmentButton size="md" active={yearScope === "all"} onClick={() => setYearScope("all")}>
               All Years
-            </ToggleButton>
+            </SegmentButton>
           </fieldset>
         </div>
       </div>
@@ -107,43 +108,12 @@ export function YearlyChartTooltip({ active, payload }: YearlyChartTooltipProps)
   const percentText = percent > 0 ? `${Math.round(percent * 100)}% of shows` : null;
 
   return (
-    <div
-      className="rounded-md border px-3 py-2 text-sm"
-      style={{
-        backgroundColor: CHART_COLORS.tooltipBg,
-        borderColor: CHART_COLORS.tooltipBorder,
-        color: CHART_COLORS.tooltipText,
-      }}
-    >
+    <ChartTooltipCard>
       <div className="font-medium">{year}</div>
       <div>
         {count} {playsLabel}
         {percentText ? <span className="text-content-text-tertiary"> · {percentText}</span> : null}
       </div>
-    </div>
-  );
-}
-
-interface ToggleButtonProps {
-  active: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}
-
-function ToggleButton({ active, onClick, children }: ToggleButtonProps) {
-  return (
-    <button
-      type="button"
-      aria-pressed={active}
-      onClick={onClick}
-      className={cn(
-        "px-3 py-1.5 text-sm font-medium border-b-2 transition-colors cursor-pointer",
-        active
-          ? "border-brand-primary text-content-text-primary"
-          : "border-transparent text-content-text-tertiary hover:text-content-text-secondary",
-      )}
-    >
-      {children}
-    </button>
+    </ChartTooltipCard>
   );
 }

--- a/apps/web/app/components/ui/chart-tooltip.tsx
+++ b/apps/web/app/components/ui/chart-tooltip.tsx
@@ -1,0 +1,22 @@
+import { CHART_COLORS } from "~/lib/chart-colors";
+
+/**
+ * The dark, bordered card shell every bespoke recharts tooltip in the app
+ * renders into (song play chart, debut-year chart, rating charts). Recharts
+ * elements take literal colors, not classNames, so the palette comes from
+ * CHART_COLORS via inline style. Pass the per-chart rows as children.
+ */
+export function ChartTooltipCard({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="rounded-md border px-3 py-2 text-sm"
+      style={{
+        backgroundColor: CHART_COLORS.tooltipBg,
+        borderColor: CHART_COLORS.tooltipBorder,
+        color: CHART_COLORS.tooltipText,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/app/components/ui/segment-button.tsx
+++ b/apps/web/app/components/ui/segment-button.tsx
@@ -6,24 +6,32 @@ interface SegmentButtonProps {
    *  the toggle state to screen readers. */
   active: boolean;
   onClick: () => void;
+  /**
+   * "sm" (default) is the compact rail size used by setlist/debut controls;
+   * "md" is the larger chart-header size (matches the in-chart unit/scope
+   * switches on the song and ratings charts).
+   */
+  size?: "sm" | "md";
   children: React.ReactNode;
 }
 
 /**
  * Bottom-border tab/segment button. Used by SetlistViewControl
- * (setlist/gap chart/personal) and DebutYearChart (chart/table). Lives in
- * `~/components/ui/` because the visual primitive is shared across
+ * (setlist/gap chart/personal), DebutYearChart (chart/table), and the
+ * chart-header unit/scope/view toggles on the song and ratings charts.
+ * Lives in `~/components/ui/` because the visual primitive is shared across
  * feature areas — wrap it in feature-specific renderers rather than
  * duplicating the className.
  */
-export function SegmentButton({ active, onClick, children }: SegmentButtonProps) {
+export function SegmentButton({ active, onClick, size = "sm", children }: SegmentButtonProps) {
   return (
     <button
       type="button"
       aria-pressed={active}
       onClick={onClick}
       className={cn(
-        "px-2 py-1 border-b-2 transition-colors cursor-pointer",
+        "border-b-2 transition-colors cursor-pointer",
+        size === "md" ? "px-3 py-1.5 text-sm font-medium" : "px-2 py-1",
         active
           ? "border-brand-primary text-content-text-primary"
           : "border-transparent text-content-text-tertiary hover:text-content-text-secondary",

--- a/apps/web/app/lib/chart-colors.ts
+++ b/apps/web/app/lib/chart-colors.ts
@@ -12,3 +12,22 @@ export const CHART_COLORS = {
   tooltipBorder: "#374151",
   tooltipText: "#F3F4F6",
 } as const;
+
+/**
+ * Distinct series colors for grouped/overlaid charts (e.g. comparing rating
+ * distributions across multiple years side by side). Literal hex equivalents
+ * of the --chart-primary/secondary/tertiary/quaternary/accent design tokens
+ * in styles.css. Cycles when a chart has more series than colors.
+ */
+export const CHART_SERIES_COLORS = ["#8B5CF6", "#30E87D", "#BC9FDF", "#8CD9AC", "#F7C42B"] as const;
+
+export function chartSeriesColor(index: number): string {
+  return CHART_SERIES_COLORS[index % CHART_SERIES_COLORS.length];
+}
+
+/**
+ * Recharts `cursor` for bar charts — the translucent highlight behind the
+ * hovered bar. Shared so every bar chart's hover background reads the same
+ * (a subtle grid-gray tint) rather than recharts' lighter default.
+ */
+export const CHART_BAR_CURSOR = { fill: CHART_COLORS.grid, opacity: 0.2 } as const;

--- a/apps/web/app/lib/rating-charts.test.ts
+++ b/apps/web/app/lib/rating-charts.test.ts
@@ -1,0 +1,194 @@
+import type { RatingYearBucket } from "@bip/core";
+import { describe, expect, it } from "vitest";
+import {
+  ALL_YEARS_SERIES,
+  availableYears,
+  buildAverageMedianByYear,
+  buildHistogramData,
+  countAxisTicks,
+  histogramYAxisConfig,
+  percentAxisTicks,
+} from "./rating-charts";
+
+describe("buildHistogramData", () => {
+  it("sums every year into one 'all' series when no years are selected", () => {
+    const buckets: RatingYearBucket[] = [
+      { year: 2017, value: 5, count: 3 },
+      { year: 2018, value: 5, count: 2 },
+      { year: 2018, value: 4, count: 1 },
+    ];
+    const { series, data } = buildHistogramData(buckets, []);
+
+    expect(series).toEqual([ALL_YEARS_SERIES]);
+    expect(data.find((row) => row.value === 5)?.[ALL_YEARS_SERIES]).toBe(5);
+    expect(data.find((row) => row.value === 4)?.[ALL_YEARS_SERIES]).toBe(1);
+    expect(data.find((row) => row.value === 0.5)?.[ALL_YEARS_SERIES]).toBe(0);
+  });
+
+  it("splits into one ascending series per selected year for side-by-side compare", () => {
+    const buckets: RatingYearBucket[] = [
+      { year: 2017, value: 5, count: 3 },
+      { year: 2018, value: 5, count: 2 },
+      { year: 2019, value: 5, count: 9 },
+    ];
+    const { series, data } = buildHistogramData(buckets, [2018, 2017]);
+
+    expect(series).toEqual(["2017", "2018"]);
+    const fiveStar = data.find((row) => row.value === 5);
+    expect(fiveStar?.["2017"]).toBe(3);
+    expect(fiveStar?.["2018"]).toBe(2);
+    expect(fiveStar).not.toHaveProperty("2019"); // unselected year is excluded
+  });
+
+  it("renders all ten 0.5-step buckets even when most are empty", () => {
+    const { data } = buildHistogramData([{ year: 2020, value: 3, count: 1 }], []);
+    expect(data.map((row) => row.value)).toEqual([0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5]);
+  });
+
+  it("expresses each series as a fraction of its own total in percent mode", () => {
+    // 2017 rated more often than 2018, but both are all-5s, so each should
+    // read 100% at the 5 bucket — percent normalizes away the volume gap.
+    const buckets: RatingYearBucket[] = [
+      { year: 2017, value: 5, count: 8 },
+      { year: 2017, value: 4, count: 2 },
+      { year: 2018, value: 5, count: 1 },
+    ];
+    const { data } = buildHistogramData(buckets, [2017, 2018], "percent");
+    const fiveStar = data.find((row) => row.value === 5);
+    const fourStar = data.find((row) => row.value === 4);
+    expect(fiveStar?.["2017"]).toBeCloseTo(0.8);
+    expect(fourStar?.["2017"]).toBeCloseTo(0.2);
+    expect(fiveStar?.["2018"]).toBeCloseTo(1);
+  });
+});
+
+describe("buildAverageMedianByYear", () => {
+  it("computes weighted average and median per year, ascending", () => {
+    const buckets: RatingYearBucket[] = [
+      { year: 2018, value: 4, count: 1 },
+      { year: 2017, value: 5, count: 1 },
+      { year: 2017, value: 3, count: 1 },
+      { year: 2017, value: 4, count: 1 },
+    ];
+    const points = buildAverageMedianByYear(buckets);
+
+    expect(points.map((point) => point.year)).toEqual([2017, 2018]);
+    // 2017: values 3,4,5 → mean 4, odd count → median is the middle value 4.
+    expect(points[0]).toMatchObject({ year: 2017, average: 4, median: 4 });
+    expect(points[1]).toMatchObject({ year: 2018, average: 4, median: 4 });
+  });
+
+  it("averages the two middle buckets when an even total straddles them", () => {
+    // Four ratings split evenly across 3 and 4 → median midpoint 3.5.
+    const points = buildAverageMedianByYear([
+      { year: 2021, value: 3, count: 2 },
+      { year: 2021, value: 4, count: 2 },
+    ]);
+    expect(points[0]).toMatchObject({ average: 3.5, median: 3.5 });
+  });
+
+  it("returns the single bucket's value for a year with one distinct rating", () => {
+    const points = buildAverageMedianByYear([{ year: 2022, value: 5, count: 7 }]);
+    expect(points[0]).toMatchObject({ average: 5, median: 5 });
+  });
+
+  it("fills the full requested year range, with nulls for years that have no ratings", () => {
+    const points = buildAverageMedianByYear([{ year: 2018, value: 4, count: 1 }], { start: 2016, end: 2019 });
+    expect(points.map((point) => point.year)).toEqual([2016, 2017, 2018, 2019]);
+    expect(points.find((point) => point.year === 2018)).toMatchObject({ average: 4, median: 4 });
+    expect(points.find((point) => point.year === 2017)).toMatchObject({ average: null, median: null });
+  });
+
+  it("widens the range to cover data years outside it so no rating is dropped", () => {
+    const points = buildAverageMedianByYear(
+      [
+        { year: 2010, value: 5, count: 1 },
+        { year: 2026, value: 4, count: 1 },
+      ],
+      { start: 2020, end: 2022 },
+    );
+    expect(points[0].year).toBe(2010);
+    expect(points[points.length - 1].year).toBe(2026);
+  });
+});
+
+describe("availableYears", () => {
+  it("returns distinct years earliest-first so chips read left-to-right", () => {
+    const buckets: RatingYearBucket[] = [
+      { year: 2017, value: 5, count: 1 },
+      { year: 2019, value: 4, count: 1 },
+      { year: 2017, value: 3, count: 1 },
+    ];
+    expect(availableYears(buckets)).toEqual([2017, 2019]);
+  });
+});
+
+describe("percentAxisTicks", () => {
+  it("sizes the scale to the tallest bar so columns nearly fill the panel", () => {
+    // 41% bar → 10% step, 50% ceiling: the bar fills ~82% of the height.
+    expect(percentAxisTicks(0.41)).toEqual([0, 0.1, 0.2, 0.3, 0.4, 0.5]);
+    // 13% bar → 5% step, 15% ceiling: a low max still gets a tight scale.
+    expect(percentAxisTicks(0.13)).toEqual([0, 0.05, 0.1, 0.15]);
+  });
+
+  it("keeps a sparse-year spike on the same 10% grid as the all-years view", () => {
+    // A year with 16 ratings peaking at 9 → 56%: 10% steps to 60%, not a
+    // coarse 20% jump, so it doesn't read as a different kind of axis.
+    expect(percentAxisTicks(0.5625)).toEqual([0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6]);
+  });
+
+  it("leaves headroom when the tallest bar lands exactly on a tick", () => {
+    // Two ratings split 50/50 → 50% bars. Ceiling goes to 60%, not 50%, so
+    // the bars don't clip the top edge.
+    expect(percentAxisTicks(0.5)).toEqual([0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6]);
+  });
+
+  it("widens the step for tall bars so labels don't crowd", () => {
+    expect(percentAxisTicks(0.9)).toEqual([0, 0.2, 0.4, 0.6, 0.8, 1]);
+  });
+
+  it("never exceeds 100%", () => {
+    expect(percentAxisTicks(1)).toEqual([0, 0.2, 0.4, 0.6, 0.8, 1]);
+  });
+
+  it("keeps a sane floor when the chart is empty or flat", () => {
+    expect(percentAxisTicks(0)).toEqual([0, 0.05]);
+  });
+});
+
+describe("countAxisTicks", () => {
+  it("draws a tight integer axis for a 1-rating year instead of inflating to fit 5 ticks", () => {
+    expect(countAxisTicks(1)).toEqual([0, 1]);
+  });
+
+  it("steps by 1 while the count is small", () => {
+    expect(countAxisTicks(4)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("widens to a 1-2-5 step so a big count stays under ~7 gridlines", () => {
+    expect(countAxisTicks(9)).toEqual([0, 2, 4, 6, 8, 10]);
+    expect(countAxisTicks(150)).toEqual([0, 50, 100, 150]);
+  });
+
+  it("never returns a degenerate axis for an empty chart", () => {
+    expect(countAxisTicks(0)).toEqual([0, 1]);
+  });
+});
+
+describe("histogramYAxisConfig", () => {
+  it("pins count mode to a tight integer axis (no fractional ticks, no inflated headroom)", () => {
+    expect(histogramYAxisConfig(false, 1)).toEqual({
+      allowDecimals: false,
+      domain: [0, 1],
+      ticks: [0, 1],
+    });
+  });
+
+  it("pins the percent axis to the nice-tick scale", () => {
+    expect(histogramYAxisConfig(true, 0.5)).toEqual({
+      allowDecimals: true,
+      domain: [0, 0.6],
+      ticks: [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
+    });
+  });
+});

--- a/apps/web/app/lib/rating-charts.ts
+++ b/apps/web/app/lib/rating-charts.ts
@@ -1,0 +1,249 @@
+import type { RatingYearBucket } from "@bip/core";
+import { formatHalfStep } from "~/components/rating/rating";
+
+/**
+ * The 0.5-step star values a rating can take, low to high. The histogram
+ * always renders all ten so empty buckets read as genuine gaps rather than
+ * a compressed axis. Includes 0.5, which the profile rating *tables* exclude
+ * (their query filters value BETWEEN 1 AND 5) — the charts show every rating.
+ */
+export const RATING_BUCKETS = [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5] as const;
+
+/** Series key used for the combined, all-years histogram. */
+export const ALL_YEARS_SERIES = "all";
+
+/** Histogram y-axis units: raw rating counts, or each series' share of its own total. */
+export type HistogramMode = "count" | "percent";
+
+export interface HistogramData {
+  /** Recharts series keys to draw: `["all"]` combined, else one per year. */
+  series: string[];
+  /**
+   * One row per bucket value; each series key maps to that bucket's count, or
+   * its fraction (0–1) of the series total when mode is "percent".
+   */
+  data: Array<{ value: number; label: string } & Record<string, number | string>>;
+  /**
+   * Total rating count per series key. Lets the tooltip recover the raw count
+   * from a percent bar (and the percent from a count bar) so it can always
+   * show both, regardless of the active units.
+   */
+  seriesTotals: Record<string, number>;
+}
+
+export interface AverageMedianPoint {
+  year: number;
+  /** null for a year in the spanned range that has no ratings (line breaks there). */
+  average: number | null;
+  median: number | null;
+}
+
+function inSelectedYears(bucket: RatingYearBucket, years: number[]): boolean {
+  return years.length === 0 || years.includes(bucket.year);
+}
+
+/**
+ * Build histogram rows for Recharts. With no years selected, one combined
+ * "all" series sums every year; with years selected, one series per year so
+ * the bars sit side by side for comparison. Every bucket value appears in
+ * every row (zero-filled) so the x-axis is stable as the selection changes.
+ *
+ * In "percent" mode each value is divided by its own series total, so a
+ * year that was rated more often doesn't dwarf a lighter year — the bars
+ * compare shape, not volume.
+ */
+export function buildHistogramData(
+  buckets: RatingYearBucket[],
+  selectedYears: number[],
+  mode: HistogramMode = "count",
+): HistogramData {
+  const series = selectedYears.length === 0 ? [ALL_YEARS_SERIES] : [...selectedYears].sort((a, b) => a - b).map(String);
+
+  const data = RATING_BUCKETS.map((value) => {
+    const row: { value: number; label: string } & Record<string, number | string> = {
+      value,
+      label: formatHalfStep(value),
+    };
+    for (const key of series) {
+      row[key] = 0;
+    }
+    return row;
+  });
+
+  const rowByValue = new Map(data.map((row) => [row.value, row]));
+  for (const bucket of buckets) {
+    if (!inSelectedYears(bucket, selectedYears)) continue;
+    const row = rowByValue.get(bucket.value);
+    if (!row) continue; // value outside the 0.5-step grid; ignore defensively
+    const key = selectedYears.length === 0 ? ALL_YEARS_SERIES : String(bucket.year);
+    row[key] = (row[key] as number) + bucket.count;
+  }
+
+  const seriesTotals: Record<string, number> = {};
+  for (const key of series) {
+    seriesTotals[key] = data.reduce((sum, row) => sum + (row[key] as number), 0);
+  }
+
+  if (mode === "percent") {
+    for (const key of series) {
+      const total = seriesTotals[key];
+      if (total === 0) continue;
+      for (const row of data) {
+        row[key] = (row[key] as number) / total;
+      }
+    }
+  }
+
+  return { series, data, seriesTotals };
+}
+
+// Round percentage gridline steps, finest first.
+const PERCENT_AXIS_STEPS = [0.05, 0.1, 0.2, 0.25, 0.5];
+const PERCENT_AXIS_MAX_TICKS = 7;
+
+function percentCeiling(maxFraction: number, step: number): number {
+  // Next step multiple strictly above the tallest bar, so a bar that lands
+  // exactly on a tick (e.g. two ratings split 50/50) still gets headroom
+  // instead of clipping the top edge. Capped at 100%; a flat/empty chart
+  // still draws one step.
+  return Math.min(1, (Math.floor(maxFraction / step + 1e-9) + 1) * step);
+}
+
+/**
+ * Y-axis ticks for the percent histogram: a "nice ticks" scale sized to the
+ * tallest bar so columns fill the panel (~80–98% height) with a little
+ * headroom, instead of hugging the floor under a fixed 100% axis or clipping
+ * the top edge. Picks the finest round step (5/10/20/25/50%) that keeps the
+ * gridline count sane, so the common range stays on 10% steps (a 56%-tall
+ * sparse-year bar reads on the same 10% grid as the all-years view) and only
+ * widens to 20%+ once a tall axis would otherwise crowd.
+ */
+export function percentAxisTicks(maxFraction: number): number[] {
+  const step =
+    PERCENT_AXIS_STEPS.find(
+      (candidate) => percentCeiling(maxFraction, candidate) / candidate <= PERCENT_AXIS_MAX_TICKS - 1 + 1e-9,
+    ) ?? PERCENT_AXIS_STEPS[PERCENT_AXIS_STEPS.length - 1];
+  const ceiling = percentCeiling(maxFraction, step);
+  const ticks: number[] = [];
+  for (let tick = 0; tick <= ceiling + 1e-9; tick += step) {
+    ticks.push(Math.round(tick * 100) / 100);
+  }
+  return ticks;
+}
+
+/**
+ * Integer y-axis ticks for the count histogram. Uses a 1-2-5 step sized to
+ * keep the gridline count under ~7, with the ceiling snapped tight to the
+ * tallest bar. Explicit ticks because recharts' own integer auto-scale
+ * inflates a small max (a 1-rating year would draw a 0–4 axis to fit five
+ * ticks, stranding the bar at a quarter height).
+ */
+export function countAxisTicks(maxCount: number): number[] {
+  if (maxCount <= 0) return [0, 1];
+  let step = 1;
+  for (let magnitude = 1; ; magnitude *= 10) {
+    const candidate = [1, 2, 5].map((base) => base * magnitude).find((s) => Math.ceil(maxCount / s) <= 6);
+    if (candidate) {
+      step = candidate;
+      break;
+    }
+  }
+  const ceiling = Math.ceil(maxCount / step) * step;
+  const ticks: number[] = [];
+  for (let tick = 0; tick <= ceiling; tick += step) {
+    ticks.push(tick);
+  }
+  return ticks;
+}
+
+export interface HistogramYAxisConfig {
+  allowDecimals: boolean;
+  domain: [number, number];
+  ticks: number[];
+}
+
+/**
+ * Y-axis props for the distribution histogram. Both modes pin an explicit
+ * tight scale so a sparse year reads cleanly: count mode uses integer
+ * gridlines (no fractional "0.5 rating" ticks, no inflated headroom), percent
+ * mode uses the nice-tick fraction scale from `percentAxisTicks`.
+ */
+export function histogramYAxisConfig(isPercent: boolean, plottedMax: number): HistogramYAxisConfig {
+  const ticks = isPercent ? percentAxisTicks(plottedMax) : countAxisTicks(plottedMax);
+  return { allowDecimals: isPercent, domain: [0, ticks[ticks.length - 1]], ticks };
+}
+
+/**
+ * Weighted median of discrete value/count pairs without materializing the
+ * underlying rows. Walks the sorted buckets to the two middle positions and
+ * averages them — so an even total straddling two buckets returns their
+ * midpoint (e.g. counts split evenly across 3 and 4 → 3.5).
+ */
+function weightedMedian(pairs: Array<{ value: number; count: number }>): number {
+  const total = pairs.reduce((sum, pair) => sum + pair.count, 0);
+  if (total === 0) return 0;
+  const sorted = [...pairs].sort((a, b) => a.value - b.value);
+  const lowerPosition = Math.floor((total + 1) / 2);
+  const upperPosition = Math.ceil((total + 1) / 2);
+
+  let cumulative = 0;
+  let lowerValue: number | null = null;
+  let upperValue: number | null = null;
+  for (const pair of sorted) {
+    cumulative += pair.count;
+    if (lowerValue === null && cumulative >= lowerPosition) lowerValue = pair.value;
+    if (upperValue === null && cumulative >= upperPosition) {
+      upperValue = pair.value;
+      break;
+    }
+  }
+  return ((lowerValue ?? 0) + (upperValue ?? 0)) / 2;
+}
+
+/**
+ * Per-concert-year average and weighted median rating for the trend line.
+ * Both summarize the same per-year buckets so a user can see mean vs. median
+ * drift apart when their ratings skew.
+ *
+ * Without a range, returns only the years that have ratings. With a range,
+ * emits one point per year across the whole span (widened if needed so no
+ * data year is dropped) — years with no ratings get null average/median, so
+ * the x-axis always covers the full era and the line breaks over empty years.
+ */
+export function buildAverageMedianByYear(
+  buckets: RatingYearBucket[],
+  range?: { start: number; end: number },
+): AverageMedianPoint[] {
+  const byYear = new Map<number, Array<{ value: number; count: number }>>();
+  for (const bucket of buckets) {
+    const list = byYear.get(bucket.year) ?? [];
+    list.push({ value: bucket.value, count: bucket.count });
+    byYear.set(bucket.year, list);
+  }
+
+  const statByYear = new Map<number, { average: number; median: number }>();
+  for (const [year, pairs] of byYear) {
+    const total = pairs.reduce((sum, pair) => sum + pair.count, 0);
+    const weightedSum = pairs.reduce((sum, pair) => sum + pair.value * pair.count, 0);
+    statByYear.set(year, { average: total === 0 ? 0 : weightedSum / total, median: weightedMedian(pairs) });
+  }
+
+  if (!range) {
+    return [...statByYear.entries()].sort(([a], [b]) => a - b).map(([year, stat]) => ({ year, ...stat }));
+  }
+
+  const dataYears = [...statByYear.keys()];
+  const start = Math.min(range.start, ...dataYears);
+  const end = Math.max(range.end, ...dataYears);
+  const points: AverageMedianPoint[] = [];
+  for (let year = start; year <= end; year++) {
+    const stat = statByYear.get(year);
+    points.push({ year, average: stat?.average ?? null, median: stat?.median ?? null });
+  }
+  return points;
+}
+
+/** Distinct concert years present in the buckets, earliest first (left-to-right chip order). */
+export function availableYears(buckets: RatingYearBucket[]): number[] {
+  return [...new Set(buckets.map((bucket) => bucket.year))].sort((a, b) => a - b);
+}

--- a/apps/web/app/routes/users/$username.test.tsx
+++ b/apps/web/app/routes/users/$username.test.tsx
@@ -1,5 +1,5 @@
 import { mockShallowComponent } from "@test/test-utils";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -83,8 +83,41 @@ vi.mock("~/components/setlist/setlist-list", () => ({
   },
 }));
 
+// Stub the charts view — it's the default on the rating tabs, but it renders
+// recharts (unreliable in jsdom) and these tests cover routing/table/pagination
+// wiring, not the chart internals (those are unit-tested in rating-charts.test.ts).
+vi.mock("~/components/rating/rating-charts", () => ({
+  RatingCharts: () => <div data-testid="RatingCharts" />,
+}));
+
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import UserProfile from "./$username";
+
+// Minimal rating rows so the rating tabs render their table (the tab is empty,
+// not paginated, when the list is empty). Disco Biscuits song per convention.
+const showRatingRow = {
+  id: "sr1",
+  value: 5,
+  createdAt: new Date("2024-01-02T00:00:00Z"),
+  show: {
+    slug: "2024-08-12-port-chester-ny",
+    date: "2024-08-12",
+    venue: { name: "The Cap", city: "Port Chester", state: "NY" },
+  },
+};
+const trackRatingRow = {
+  id: "tr1",
+  value: 4.5,
+  createdAt: new Date("2024-01-02T00:00:00Z"),
+  track: {
+    slug: "basis-for-a-day-t1",
+    position: 1,
+    set: "S1",
+    encoresInSet: 0,
+    show: { slug: "2024-08-12-port-chester-ny", date: "2024-08-12", venue: { name: "The Cap" } },
+    song: { slug: "basis-for-a-day", title: "Basis for a Day" },
+  },
+};
 
 function renderProfile(initialEntry = "/users/evan") {
   return render(
@@ -250,30 +283,36 @@ describe("UserProfile", () => {
   // rendered DOM small on heavy users (~7,800 track ratings at the top end). The
   // loader provides `ratingsPagination` whenever the active tab is one of
   // the rating tabs; component renders PaginationControls below the list.
-  test("renders rating-tab pagination when activeTab is show-ratings and totalPages > 1", () => {
+  test("shows show-ratings pagination in the table view when totalPages > 1", () => {
     vi.mocked(useSerializedLoaderData).mockReturnValue({
       ...baseLoaderData,
       activeTab: "show-ratings",
-      showRatings: [],
+      showRatings: [showRatingRow],
       ratingsPagination: { page: 1, pageSize: 100, totalPages: 18, total: 1739 },
     });
 
     renderProfile("/users/evan?tab=show-ratings");
-    // Pagination chrome renders both above and below the list.
+    // Charts is the default view, so pagination isn't shown until the user
+    // switches to the table.
+    expect(screen.queryByText(/Showing 1 to 100 of 1739 results/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^table$/i }));
+    // Pagination chrome renders both above and below the table.
     expect(screen.getAllByText(/Showing 1 to 100 of 1739 results/)).toHaveLength(2);
     expect(screen.getAllByRole("button", { name: /next/i })).toHaveLength(2);
   });
 
   // Same for track-ratings — pagination chrome is shared infrastructure.
-  test("renders rating-tab pagination when activeTab is track-ratings and totalPages > 1", () => {
+  test("shows track-ratings pagination in the table view when totalPages > 1", () => {
     vi.mocked(useSerializedLoaderData).mockReturnValue({
       ...baseLoaderData,
       activeTab: "track-ratings",
-      trackRatings: [],
+      trackRatings: [trackRatingRow],
       ratingsPagination: { page: 2, pageSize: 100, totalPages: 78, total: 7784 },
     });
 
     renderProfile("/users/evan?tab=track-ratings");
+    fireEvent.click(screen.getByRole("button", { name: /^table$/i }));
     expect(screen.getAllByText(/Showing 101 to 200 of 7784 results/)).toHaveLength(2);
   });
 
@@ -284,11 +323,12 @@ describe("UserProfile", () => {
     vi.mocked(useSerializedLoaderData).mockReturnValue({
       ...baseLoaderData,
       activeTab: "show-ratings",
-      showRatings: [],
+      showRatings: [showRatingRow],
       ratingsPagination: { page: 1, pageSize: 100, totalPages: 1, total: 5 },
     });
 
     renderProfile("/users/evan?tab=show-ratings");
+    fireEvent.click(screen.getByRole("button", { name: /^table$/i }));
     expect(screen.queryByRole("button", { name: /next/i })).not.toBeInTheDocument();
   });
 

--- a/apps/web/app/routes/users/$username.tsx
+++ b/apps/web/app/routes/users/$username.tsx
@@ -2,9 +2,11 @@ import type { RatingWithShow, RatingWithTrack, ShowRatingsSort, TrackRatingsSort
 import { CacheKeys, compareByShowDate } from "@bip/domain";
 import { dehydrate } from "@tanstack/react-query";
 import { CalendarDays, Edit, MessageSquare, Star, Users } from "lucide-react";
+import { useState } from "react";
 import type { LoaderFunctionArgs, MetaFunction } from "react-router-dom";
 import { Link, useNavigate } from "react-router-dom";
 import { formatHalfStep } from "~/components/rating/rating";
+import { RatingCharts } from "~/components/rating/rating-charts";
 import { formatSetLabel } from "~/components/setlist/set-label";
 import { SetlistList } from "~/components/setlist/setlist-list";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
@@ -12,6 +14,7 @@ import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { PaginationControls } from "~/components/ui/pagination-controls";
+import { SegmentButton } from "~/components/ui/segment-button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { UrlSortableHeader } from "~/components/ui/url-sortable-header";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
@@ -130,6 +133,14 @@ async function loadUserProfile({ params, request, context }: LoaderFunctionArgs 
         })
       : [];
 
+  // Aggregate distribution for the active ratings tab's Charts view. Tiny
+  // (~250 {year,value,count} rows) vs the paginated table rows, so it ships
+  // with the page rather than lazy-loading on toggle.
+  const showRatingBuckets =
+    activeTab === "show-ratings" ? await services.ratings.getShowRatingDistribution(user.id) : [];
+  const trackRatingBuckets =
+    activeTab === "track-ratings" ? await services.ratings.getTrackRatingDistribution(user.id) : [];
+
   const totalRatings = tabCounts.showRatingsCount + tabCounts.trackRatingsCount;
 
   // Total attended pages comes straight from the count — no full-list fetch
@@ -189,6 +200,8 @@ async function loadUserProfile({ params, request, context }: LoaderFunctionArgs 
     },
     showRatings,
     trackRatings,
+    showRatingBuckets,
+    trackRatingBuckets,
     ratingsPagination: {
       page: clampedRatingsPage,
       pageSize: RATINGS_PAGE_SIZE,
@@ -240,6 +253,8 @@ export default function UserProfile() {
     attendedPagination,
     showRatings,
     trackRatings,
+    showRatingBuckets,
+    trackRatingBuckets,
     ratingsPagination,
     showRatingsSort,
     trackRatingsSort,
@@ -281,6 +296,11 @@ export default function UserProfile() {
   const handleTrackRatingsSortChange = (sort: TrackRatingsSort, direction: "asc" | "desc") => {
     navigate(`?tab=track-ratings&sort=${sort}&dir=${direction}`, { preventScrollReset: true });
   };
+
+  // Table vs. Charts is a per-view client toggle, shared by both ratings
+  // tabs — it must not touch the URL or the loader would refetch the table
+  // rows on every switch.
+  const [ratingsView, setRatingsView] = useState<"table" | "charts">("charts");
 
   return (
     <div className="w-full space-y-6">
@@ -528,24 +548,42 @@ export default function UserProfile() {
 
         {/* Show Ratings Tab */}
         <TabsContent value="show-ratings" className="space-y-4">
-          {activeTab === "show-ratings" && ratingsPagination.totalPages > 1 && (
-            <PaginationControls
-              page={ratingsPagination.page}
-              totalPages={ratingsPagination.totalPages}
-              total={ratingsPagination.total}
-              pageSize={ratingsPagination.pageSize}
-              onPageChange={handlePageChange}
-            />
-          )}
           {showRatings.length > 0 ? (
-            <div className="w-fit max-w-full mx-auto">
-              <ShowRatingsTable
-                rows={showRatings}
-                sort={showRatingsSort}
-                direction={ratingsDirection}
-                onSort={handleShowRatingsSortChange}
-              />
-            </div>
+            <>
+              <RatingsViewToggle view={ratingsView} onChange={setRatingsView} label="Show ratings view" />
+              {ratingsView === "charts" ? (
+                <RatingCharts buckets={showRatingBuckets} kind="show" />
+              ) : (
+                <>
+                  {ratingsPagination.totalPages > 1 && (
+                    <PaginationControls
+                      page={ratingsPagination.page}
+                      totalPages={ratingsPagination.totalPages}
+                      total={ratingsPagination.total}
+                      pageSize={ratingsPagination.pageSize}
+                      onPageChange={handlePageChange}
+                    />
+                  )}
+                  <div className="w-fit max-w-full mx-auto">
+                    <ShowRatingsTable
+                      rows={showRatings}
+                      sort={showRatingsSort}
+                      direction={ratingsDirection}
+                      onSort={handleShowRatingsSortChange}
+                    />
+                  </div>
+                  {ratingsPagination.totalPages > 1 && (
+                    <PaginationControls
+                      page={ratingsPagination.page}
+                      totalPages={ratingsPagination.totalPages}
+                      total={ratingsPagination.total}
+                      pageSize={ratingsPagination.pageSize}
+                      onPageChange={handlePageChange}
+                    />
+                  )}
+                </>
+              )}
+            </>
           ) : (
             <Card className="card-premium">
               <CardContent className="py-12 text-center">
@@ -559,37 +597,46 @@ export default function UserProfile() {
               </CardContent>
             </Card>
           )}
-          {activeTab === "show-ratings" && ratingsPagination.totalPages > 1 && (
-            <PaginationControls
-              page={ratingsPagination.page}
-              totalPages={ratingsPagination.totalPages}
-              total={ratingsPagination.total}
-              pageSize={ratingsPagination.pageSize}
-              onPageChange={handlePageChange}
-            />
-          )}
         </TabsContent>
 
         {/* Song Version Ratings Tab */}
         <TabsContent value="track-ratings" className="space-y-4">
-          {activeTab === "track-ratings" && ratingsPagination.totalPages > 1 && (
-            <PaginationControls
-              page={ratingsPagination.page}
-              totalPages={ratingsPagination.totalPages}
-              total={ratingsPagination.total}
-              pageSize={ratingsPagination.pageSize}
-              onPageChange={handlePageChange}
-            />
-          )}
           {trackRatings.length > 0 ? (
-            <div className="w-fit max-w-full mx-auto">
-              <TrackRatingsTable
-                rows={trackRatings}
-                sort={trackRatingsSort}
-                direction={ratingsDirection}
-                onSort={handleTrackRatingsSortChange}
-              />
-            </div>
+            <>
+              <RatingsViewToggle view={ratingsView} onChange={setRatingsView} label="Song version ratings view" />
+              {ratingsView === "charts" ? (
+                <RatingCharts buckets={trackRatingBuckets} kind="track" />
+              ) : (
+                <>
+                  {ratingsPagination.totalPages > 1 && (
+                    <PaginationControls
+                      page={ratingsPagination.page}
+                      totalPages={ratingsPagination.totalPages}
+                      total={ratingsPagination.total}
+                      pageSize={ratingsPagination.pageSize}
+                      onPageChange={handlePageChange}
+                    />
+                  )}
+                  <div className="w-fit max-w-full mx-auto">
+                    <TrackRatingsTable
+                      rows={trackRatings}
+                      sort={trackRatingsSort}
+                      direction={ratingsDirection}
+                      onSort={handleTrackRatingsSortChange}
+                    />
+                  </div>
+                  {ratingsPagination.totalPages > 1 && (
+                    <PaginationControls
+                      page={ratingsPagination.page}
+                      totalPages={ratingsPagination.totalPages}
+                      total={ratingsPagination.total}
+                      pageSize={ratingsPagination.pageSize}
+                      onPageChange={handlePageChange}
+                    />
+                  )}
+                </>
+              )}
+            </>
           ) : (
             <Card className="card-premium">
               <CardContent className="py-12 text-center">
@@ -602,15 +649,6 @@ export default function UserProfile() {
                 </p>
               </CardContent>
             </Card>
-          )}
-          {activeTab === "track-ratings" && ratingsPagination.totalPages > 1 && (
-            <PaginationControls
-              page={ratingsPagination.page}
-              totalPages={ratingsPagination.totalPages}
-              total={ratingsPagination.total}
-              pageSize={ratingsPagination.pageSize}
-              onPageChange={handlePageChange}
-            />
           )}
         </TabsContent>
 
@@ -706,6 +744,32 @@ export default function UserProfile() {
           )}
         </TabsContent>
       </Tabs>
+    </div>
+  );
+}
+
+// Table/Charts switch shared by both ratings tabs. Centered above the
+// content so it reads as a view selector for the whole panel.
+function RatingsViewToggle({
+  view,
+  onChange,
+  label,
+}: {
+  view: "table" | "charts";
+  onChange: (view: "table" | "charts") => void;
+  label: string;
+}) {
+  return (
+    <div className="flex justify-center">
+      <fieldset className="flex border-0 p-0 m-0">
+        <legend className="sr-only">{label}</legend>
+        <SegmentButton size="md" active={view === "charts"} onClick={() => onChange("charts")}>
+          Charts
+        </SegmentButton>
+        <SegmentButton size="md" active={view === "table"} onClick={() => onChange("table")}>
+          Table
+        </SegmentButton>
+      </fieldset>
     </div>
   );
 }

--- a/packages/core/src/ratings/rating-service.ts
+++ b/packages/core/src/ratings/rating-service.ts
@@ -102,6 +102,19 @@ export interface RatingWithTrack {
   };
 }
 
+/**
+ * One cell of a user's rating distribution: how many ratings of a given
+ * star value land on shows from a given concert year. The user-profile
+ * charts derive every view (all-time histogram, per-year compare,
+ * average/median line) from this single grouped shape, so we never ship
+ * the thousands of individual rating rows the table query paginates.
+ */
+export interface RatingYearBucket {
+  year: number;
+  value: number;
+  count: number;
+}
+
 // Mapper functions
 function mapRatingToDomainEntity(dbRating: DbRating): Rating {
   return {
@@ -492,6 +505,45 @@ export class RatingService {
         song: { slug: row.song_slug, title: row.song_title },
       },
     }));
+  }
+
+  /**
+   * Distribution of a user's show ratings by concert year and star value,
+   * for the profile charts. Unlike the table queries this includes 0.5
+   * ratings (value >= 0.5, not BETWEEN 1 AND 5) so the histogram reflects
+   * every rating, and it aggregates server-side: ~250 bucket rows instead
+   * of the user's full (often thousands) rating set.
+   */
+  async getShowRatingDistribution(userId: string): Promise<RatingYearBucket[]> {
+    const rows = await this.db.$queryRaw<Array<{ year: number; value: number; count: number }>>`
+      SELECT LEFT(s.date, 4)::int AS year, r.value AS value, COUNT(*)::int AS count
+      FROM ratings r
+      INNER JOIN shows s ON s.id = r.rateable_id
+      WHERE r.user_id = ${userId}::uuid
+        AND r.rateable_type = 'Show'
+        AND r.value >= 0.5
+      GROUP BY LEFT(s.date, 4)::int, r.value
+    `;
+    return rows.map((row) => ({ year: row.year, value: row.value, count: Number(row.count) }));
+  }
+
+  /**
+   * Distribution of a user's track (song-version) ratings by concert year
+   * and star value. Same shape and motivation as getShowRatingDistribution;
+   * the concert year comes from the track's show.
+   */
+  async getTrackRatingDistribution(userId: string): Promise<RatingYearBucket[]> {
+    const rows = await this.db.$queryRaw<Array<{ year: number; value: number; count: number }>>`
+      SELECT LEFT(s.date, 4)::int AS year, r.value AS value, COUNT(*)::int AS count
+      FROM ratings r
+      INNER JOIN tracks t ON t.id = r.rateable_id
+      INNER JOIN shows s ON s.id = t.show_id
+      WHERE r.user_id = ${userId}::uuid
+        AND r.rateable_type = 'Track'
+        AND r.value >= 0.5
+      GROUP BY LEFT(s.date, 4)::int, r.value
+    `;
+    return rows.map((row) => ({ year: row.year, value: row.value, count: Number(row.count) }));
   }
 
   async deleteByRateableId(rateableId: string, rateableType: string): Promise<void> {


### PR DESCRIPTION
Users can now visualize their ratings on their profile. The **Show Ratings** and **Song Version Ratings** tabs gain a **Charts / Table** toggle (Charts is the default), and the Charts view shows two graphs:

- **Rating distribution histogram** — how their ratings spread across the ½–5 star buckets. Toggle **Count vs Percent**, filter to a single concert year, or select several years to compare side by side.
- **Average & Median by Year** — a trend line of their average and median rating per concert year, spanning the full band era.

The Table view is unchanged (paginated rows).

## How it works

Charts are driven by a new aggregate query (`getShowRatingDistribution` / `getTrackRatingDistribution`) that groups a user's ratings by concert year and star value — ~250 rows instead of the user's full set (10k+ for heavy users), fetched only for the active tab. The Table/Charts toggle and year selection are client state, so switching views never refetches.

The hover background, palette, tooltip card, and segment toggle are now shared (`CHART_BAR_CURSOR`, `chartSeriesColor`, `ChartTooltipCard`, `SegmentButton` with a `size` prop), and the song and debut-year charts were moved onto them.

## Notes for the reviewer

- **Charts include ½-star ratings** (`value >= 0.5`); the rating *tables* still exclude them (`BETWEEN 1 AND 5`), so a user with ½-star ratings sees a slightly higher chart total than table total. Intentional — the histogram should reflect every rating.
- **Axis scaling** is handled by pure, unit-tested helpers (`percentAxisTicks`, `countAxisTicks`, `histogramYAxisConfig`): percent uses a nice-tick scale with headroom; count forces integer ticks (recharts otherwise draws fractional "0.5 rating" gridlines or inflates a 1-rating year to a 0–4 axis).
- **Grouped bars are keyed by the selected-year set** (`<BarChart key=...>`) because recharts dodges grouped bars by mount order, not declaration order — without the remount, a year added later lands on the right instead of its sorted slot.

## Testing

`make tc`, `bun run test` (909 tests), and `make lint` all pass. Chart logic is unit-tested in `rating-charts.test.ts`; the charts were verified in-browser across the top rating-heavy profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
