### PR TITLE
Add per-track durations and show/set lengths to setlists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ cd apps/web && bun run test:watch    # Watch mode
 
 Test files are colocated with source: `*.test.{ts,tsx}`. Shared test helpers live in `apps/web/test/test-utils.tsx` (import via `@test/*` alias, e.g. `import { setup } from "@test/test-utils"`).
 
-**Skip tests the typechecker covers.** Don't test helper signatures, argument counts, or type-enforced shapes. Add only wiring assertions where the typechecker can't verify a value gets pulled from the right source (e.g. the right field threads through a call chain).
+**Skip tests the typechecker covers — but "type-covered" means the shape is checkable, not the behavior.** Don't test helper signatures, argument counts, or type-enforced shapes. DO test behavior the typechecker can't see: conditional rendering (what appears under which props/state), formatting and derivation branches (e.g. em-dash vs value), edge cases, and user interactions — plus wiring assertions where a value must thread from the right source. A component that renders differently by props, or a function with a branch, still needs a test even though its types check. Don't let "skip type-covered" bleed into "skip behavioral."
 
 **Git Hooks:**
 Custom hooks live in `.githooks/`. Enable them once per clone:

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ doppler:
 migrate:
 	cd packages/core && bun prisma:migrate:dev
 
+migrate-deploy:
+	cd packages/core && bun prisma:migrate:deploy
+
 migrate-create:
 	@if [ -z "$(NAME)" ]; then echo "Usage: make migrate-create NAME=add_foo_index" && exit 1; fi
 	cd packages/core && bun prisma:migrate:create -- --name $(NAME)

--- a/apps/web/app/components/author/author-columns.tsx
+++ b/apps/web/app/components/author/author-columns.tsx
@@ -3,6 +3,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import { Link } from "react-router-dom";
 import { Button } from "~/components/ui/button";
+import { NumberCell } from "~/components/ui/number-cell";
 
 const formatDate = (date: Date) => {
   return new Date(date).toLocaleDateString("en-US", {
@@ -66,7 +67,11 @@ export const authorColumns: ColumnDef<AuthorWithSongCount>[] = [
     },
     cell: ({ row }) => {
       const count = row.original.songCount ?? 0;
-      return <span className="text-content-text-primary font-semibold">{count}</span>;
+      return (
+        <NumberCell width="4ch" className="text-content-text-primary font-semibold">
+          {count}
+        </NumberCell>
+      );
     },
   },
   {

--- a/apps/web/app/components/gap-icon.tsx
+++ b/apps/web/app/components/gap-icon.tsx
@@ -11,7 +11,11 @@ export function GapIcon({ icon, label }: { icon: ReactElement; label: string }) 
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <span role="img" aria-label={label}>
+          {/* inline-block so the icon honors its NumberCell's text-align —
+              Tailwind's preflight makes the inner <svg> display:block, which
+              would otherwise ignore the right-aligned slot and float left,
+              out of line with the numeric gap rows. */}
+          <span role="img" aria-label={label} className="inline-block">
             {icon}
           </span>
         </TooltipTrigger>

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -6,6 +6,8 @@ import { formatSetLabel } from "~/components/setlist/set-label";
 import { ShowDate } from "~/components/show-date";
 import { ShowDateLink } from "~/components/show-date-link";
 import { AllTimerCell, allTimerColumnMeta } from "~/components/track/all-timer-cell";
+import { DurationValue } from "~/components/track/duration-cell";
+import { NumberCell } from "~/components/ui/number-cell";
 import { CombinedNotes } from "./combined-notes";
 import { DateVenueCell } from "./date-venue-cell";
 import { TrackRatingCell } from "./track-rating-cell";
@@ -126,12 +128,24 @@ export const songAfterSortingFn = makeAdjacentSongSortingFn(
  */
 function renderGapCell({ value, isRepeat }: { value: number | null | undefined; isRepeat: boolean }) {
   if (isRepeat) {
-    return <GapIcon icon={<RotateCcw className="h-4 w-4 text-content-text-secondary" />} label="Same Show" />;
+    return (
+      <NumberCell width="3ch">
+        <GapIcon icon={<RotateCcw className="h-4 w-4 text-content-text-secondary" />} label="Same Show" />
+      </NumberCell>
+    );
   }
   if (value == null) {
-    return <GapIcon icon={<Star className="h-4 w-4 text-content-text-secondary" />} label="Debut" />;
+    return (
+      <NumberCell width="3ch">
+        <GapIcon icon={<Star className="h-4 w-4 text-content-text-secondary" />} label="Debut" />
+      </NumberCell>
+    );
   }
-  return <span className="text-content-text-secondary tabular-nums">{value}</span>;
+  return (
+    <NumberCell width="3ch" className="text-content-text-secondary">
+      {value}
+    </NumberCell>
+  );
 }
 
 /**
@@ -297,6 +311,30 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
     }) as ColumnDef<SongPagePerformance, unknown>,
   );
 
+  // Track length, sitting between Date and Gap. Hidden on mobile — the row is
+  // already dense. Always present (incl. cross-song surfaces like all-timers /
+  // on-this-day); rows without a resolved duration render an em-dash.
+  columns.push(
+    columnHelper.accessor((row) => row.duration ?? Number.NEGATIVE_INFINITY, {
+      id: "duration",
+      meta: { fixedWidth: "4.5rem", hideOnMobile: true },
+      header: ({ column }) => <SortableHeader column={column} label="Time" />,
+      enableSorting: true,
+      sortingFn: (a, b) => {
+        const av = a.original.duration ?? -1;
+        const bv = b.original.duration ?? -1;
+        if (av !== bv) return av - bv;
+        return compareByShowDate(a.original, b.original);
+      },
+      sortDescFirst: true,
+      cell: (info) => (
+        <NumberCell width="5ch">
+          <DurationValue seconds={info.row.original.duration} />
+        </NumberCell>
+      ),
+    }) as ColumnDef<SongPagePerformance, unknown>,
+  );
+
   if (includeGapColumns) {
     columns.push(
       columnHelper.accessor((row) => row.gap ?? Number.NEGATIVE_INFINITY, {
@@ -369,8 +407,11 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
         enableSorting: false,
         cell: (info) => {
           const set = info.getValue();
-          if (!set) return <span className="text-content-text-tertiary">—</span>;
-          return <span className="text-content-text-secondary">{formatSetLabel(set)}</span>;
+          return (
+            <NumberCell width="2ch" className={set ? "text-content-text-secondary" : "text-content-text-tertiary"}>
+              {set ? formatSetLabel(set) : "—"}
+            </NumberCell>
+          );
         },
       }) as ColumnDef<SongPagePerformance, unknown>,
     );

--- a/apps/web/app/components/setlist/gap-cell.tsx
+++ b/apps/web/app/components/setlist/gap-cell.tsx
@@ -1,5 +1,6 @@
 import { RotateCcw, Star } from "lucide-react";
 import { GapIcon } from "~/components/gap-icon";
+import { NumberCell } from "~/components/ui/number-cell";
 
 /**
  * Discriminated union for the three possible states of a Gap or Your-Gap
@@ -52,10 +53,22 @@ export function GapCell({
   thisShowLabel: string;
 }) {
   if (state.kind === "debut") {
-    return <GapIcon icon={<Star className="h-4 w-4 text-content-text-secondary" />} label={debutLabel} />;
+    return (
+      <NumberCell width="3ch">
+        <GapIcon icon={<Star className="h-4 w-4 text-content-text-secondary" />} label={debutLabel} />
+      </NumberCell>
+    );
   }
   if (state.kind === "this-show") {
-    return <GapIcon icon={<RotateCcw className="h-4 w-4 text-content-text-secondary" />} label={thisShowLabel} />;
+    return (
+      <NumberCell width="3ch">
+        <GapIcon icon={<RotateCcw className="h-4 w-4 text-content-text-secondary" />} label={thisShowLabel} />
+      </NumberCell>
+    );
   }
-  return <span className="text-content-text-secondary tabular-nums">{state.value}</span>;
+  return (
+    <NumberCell width="3ch" className="text-content-text-secondary">
+      {state.value}
+    </NumberCell>
+  );
 }

--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -91,6 +91,8 @@ function makeSetlist(overrides: { showDate?: string } = {}): SetlistLight {
             ratingsCount: 0,
             gap: null,
             previousPerformanceShowId: null,
+            duration: null,
+            durationSource: null,
             previousPerformanceShow: null,
             song: { id: "song-1", title: "Basis for a Day", slug: "basis-for-a-day" },
           },

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -4,19 +4,17 @@ import { memo, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { RatingBadgeButton } from "~/components/rating/rating-badge-button";
 import { ShowDate } from "~/components/show-date";
-import { NoteworthyMarker } from "~/components/track/noteworthy-marker";
 import { Card, CardContent, CardHeader } from "~/components/ui/card";
 import { useSession } from "~/hooks/use-session";
 import { useAttendanceMutation } from "~/hooks/use-show-user-data";
 import { cn } from "~/lib/utils";
 import { AnniversaryBadge } from "./anniversary-badge";
 import { RockOperaAnnotations } from "./rock-opera-annotations";
-import { countSetlistEncores, formatSetLabel } from "./set-label";
+import { SetlistFlow } from "./setlist-flow";
 import { SetlistTable } from "./setlist-table";
 import { SetlistTablePersonal } from "./setlist-table-personal";
 import { SetlistViewControl, type SetlistViewSummary } from "./setlist-view-control";
 import { ShowExternalBadges, type ShowExternalSources } from "./show-external-badges";
-import { TrackRatingOverlay } from "./track-rating-overlay";
 
 export type SetlistView = "setlist" | "gap-chart" | "personal";
 
@@ -142,61 +140,6 @@ function SetlistCardComponent({
       },
     );
   };
-
-  // Create a map to store unique annotations by description
-  const uniqueAnnotations = new Map<string, { index: number; desc: string }>();
-
-  // Create a map of trackId to array of annotation indices for quick lookup
-  const trackAnnotationMap = new Map<string, number[]>();
-
-  // Process annotations in order of tracks in the setlist
-  let annotationIndex = 1;
-
-  // Create a flat array of all tracks in order
-  const allTracks = [];
-  for (const set of setlist.sets) {
-    for (const track of set.tracks) {
-      allTracks.push(track);
-    }
-  }
-
-  // First pass: identify all unique annotations and assign indices in order of appearance
-  for (const track of allTracks) {
-    // Get annotations for this track
-    const trackAnnotations = setlist.annotations.filter((a) => a.trackId === track.id);
-    const trackIndices: number[] = [];
-
-    for (const annotation of trackAnnotations) {
-      if (annotation.desc) {
-        // If this description hasn't been seen before, assign a new index
-        if (!uniqueAnnotations.has(annotation.desc)) {
-          uniqueAnnotations.set(annotation.desc, {
-            index: annotationIndex++,
-            desc: annotation.desc,
-          });
-        }
-
-        // Add this annotation index to the track's indices array
-        const index = uniqueAnnotations.get(annotation.desc)?.index;
-        if (index) {
-          trackIndices.push(index);
-        }
-      }
-    }
-
-    // Map this track to all its annotation indices
-    if (trackIndices.length > 0) {
-      trackAnnotationMap.set(track.id, trackIndices);
-    }
-  }
-
-  // Convert the unique annotations map to an array for display
-  // Sort by index to maintain the order they were encountered
-  const orderedAnnotations = Array.from(uniqueAnnotations.values()).sort((a, b) => a.index - b.index);
-
-  // Encore label collapse ("E1" → "E") fires only when the show has a
-  // single encore.
-  const encoresInSet = countSetlistEncores(setlist.sets);
 
   return (
     <Card className="card-premium relative overflow-hidden">
@@ -346,63 +289,7 @@ function SetlistCardComponent({
               </div>
             ) : (
               <>
-                <div className="space-y-2 md:space-y-4">
-                  {setlist.sets.map((set, setIndex) => (
-                    <span
-                      key={setlist.show.id + set.label}
-                      className="inline-block w-full md:flex md:gap-4 md:items-baseline"
-                    >
-                      <span className="inline text-base font-medium text-content-text-tertiary">
-                        {formatSetLabel(set.label, { encoresInSet })}
-                      </span>
-                      <span className="inline ml-2 md:ml-0 md:flex-1">
-                        {set.tracks.map((track, i) => (
-                          <span key={track.id} className="inline">
-                            <TrackRatingOverlay track={track}>
-                              <span
-                                className={cn(
-                                  "relative text-brand-primary hover:text-brand-secondary hover:underline transition-colors text-base",
-                                  track.allTimer && "font-medium",
-                                )}
-                              >
-                                <NoteworthyMarker
-                                  track={track}
-                                  iconClassName="h-3 w-3 md:h-4 md:w-4 inline-block mr-1 transform -translate-y-0.5"
-                                />
-                                <Link to={`/songs/${track.song?.slug}`}>{track.song?.title}</Link>
-                                {trackAnnotationMap.has(track.id) && (
-                                  <sup className="text-brand-secondary ml-0.5 font-medium text-xs">
-                                    {trackAnnotationMap.get(track.id)?.map((index, i) => (
-                                      <span key={index} className={i > 0 ? "ml-1" : ""}>
-                                        {index}
-                                      </span>
-                                    ))}
-                                  </sup>
-                                )}
-                              </span>
-                            </TrackRatingOverlay>
-                            {i < set.tracks.length - 1 && (
-                              <span className="text-content-text-secondary mx-1 font-medium text-base">
-                                {track.segue ? " > " : ", "}
-                              </span>
-                            )}
-                          </span>
-                        ))}
-                      </span>
-                      {setIndex < setlist.sets.length - 1 && <span className="hidden"> </span>}
-                    </span>
-                  ))}
-                </div>
-
-                {orderedAnnotations.length > 0 && (
-                  <div className="mt-6 pt-4 border-t border-glass-border/30 space-y-2">
-                    {orderedAnnotations.map((annotation) => (
-                      <div key={`annotation-${annotation.index}`} className="text-sm text-content-text-secondary">
-                        <sup className="text-brand-secondary">{annotation.index}</sup> {annotation.desc}
-                      </div>
-                    ))}
-                  </div>
-                )}
+                <SetlistFlow setlist={setlist} />
                 <div className="mt-4">
                   <SetlistViewControl
                     view={view}

--- a/apps/web/app/components/setlist/setlist-columns-personal.tsx
+++ b/apps/web/app/components/setlist/setlist-columns-personal.tsx
@@ -3,6 +3,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import type { PersonalSetlistRow } from "~/lib/personal-setlist-columns";
 import {
   createCountColumn,
+  createDurationColumn,
   createGapColumn,
   createRatingColumn,
   createSetlistCommonColumns,
@@ -31,6 +32,7 @@ export function createPersonalSetlistColumns(
   };
   return [
     ...createSetlistCommonColumns<PersonalSetlistTableRow>({ songLinkSearchParams: "attended=attended" }),
+    createDurationColumn<PersonalSetlistTableRow>(),
     createGapColumn<PersonalSetlistTableRow>({
       id: "yourGap",
       label: "Your Gap",
@@ -41,9 +43,11 @@ export function createPersonalSetlistColumns(
     }),
     createShowDateLinkColumn<PersonalSetlistTableRow>({
       id: "lastSeen",
+      // 5rem → compact M/D/YY date (see the Last Played note), freeing width
+      // for the Song column.
       label: "Last Seen",
       accessor: (row) => row.personal.lastSeen,
-      fixedWidth: "7.5rem",
+      fixedWidth: "5rem",
       hideOnMobile: true,
     }),
     // "Seen Before" — attended performances strictly before this show.

--- a/apps/web/app/components/setlist/setlist-columns.test.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.test.tsx
@@ -33,6 +33,8 @@ function makeTrack(
     ratingsCount: overrides.ratingsCount ?? 0,
     gap: overrides.gap ?? null,
     previousPerformanceShowId: overrides.previousPerformanceShowId ?? null,
+    duration: overrides.duration ?? null,
+    durationSource: overrides.durationSource ?? null,
     previousPerformanceShow: overrides.previousPerformanceShow ?? null,
     song: overrides.song ?? { id: overrides.songId, title: "Basis for a Day", slug: "basis-for-a-day" },
     priorPerformanceCount: overrides.priorPerformanceCount ?? 0,
@@ -82,13 +84,14 @@ describe("createSetlistColumns", () => {
   // older Last Played date and prior-play count. Rating anchors the right
   // edge — it's the action column (click to rate) so it lives where the
   // eye lands at the end of the row scan.
-  test("returns columns in order [Set, Track, All-timer, Song, Gap, Last Played, Played Before, Rating]", () => {
+  test("returns columns in order [Set, Track, All-timer, Song, Time, Gap, Last Played, Played Before, Rating]", () => {
     const columns = createSetlistColumns();
     expect(columns.map((c) => c.id)).toEqual([
       "set",
       "track",
       "allTimer",
       "song",
+      "duration",
       "gap",
       "lastPlayed",
       "priorPerformanceCount",
@@ -96,12 +99,13 @@ describe("createSetlistColumns", () => {
     ]);
   });
 
-  // Every column is sortable.
-  test("Set, Track, Song, Gap, Last Played, Played Before, and Rating are all sortable", () => {
+  // Every column is sortable except Track #, which shares Set's set+position
+  // order and so carries no sort affordance of its own.
+  test("Set, Song, Gap, Last Played, Played Before, and Rating are sortable; Track is not", () => {
     const columns = createSetlistColumns();
     const sortable = new Map(columns.map((c) => [c.id, c.enableSorting]));
     expect(sortable.get("set")).toBe(true);
-    expect(sortable.get("track")).toBe(true);
+    expect(sortable.get("track")).toBe(false);
     expect(sortable.get("song")).toBe(true);
     expect(sortable.get("gap")).toBe(true);
     expect(sortable.get("lastPlayed")).toBe(true);
@@ -124,7 +128,7 @@ describe("createSetlistColumns", () => {
     // the Set header puts the table into "sorted by set" mode.
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /^Set$/i }));
-    const setCells = screen.getAllByRole("cell").filter((_, i) => i % 8 === 0);
+    const setCells = screen.getAllByRole("cell").filter((_, i) => i % 9 === 0);
     expect(setCells.map((c) => c.textContent)).toEqual(["1", "", "2", ""]);
   });
 
@@ -151,7 +155,7 @@ describe("createSetlistColumns", () => {
       makeTrack({ songId: "c", position: 3, set: "S2", gap: 20, song: { id: "c", title: "Confrontation", slug: "z" } }),
     ]);
     await user.click(screen.getByRole("button", { name: /Gap/i }));
-    const setCells = screen.getAllByRole("cell").filter((_, i) => i % 8 === 0);
+    const setCells = screen.getAllByRole("cell").filter((_, i) => i % 9 === 0);
     // After asc-by-gap: gap=5 (S1), gap=10 (S1), gap=20 (S2). Every row
     // displays its set label.
     expect(setCells.map((c) => c.textContent)).toEqual(["1", "1", "2"]);
@@ -187,7 +191,7 @@ describe("createSetlistColumns", () => {
     ]);
     // Label is split into stacked spans; accessible name is "LastPlayed".
     await user.click(screen.getByRole("button", { name: /LastPlayed/i }));
-    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 8 === 3);
+    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 9 === 3);
     expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
       "Basis for a Day",
       "Above the Waves",
@@ -218,7 +222,7 @@ describe("createSetlistColumns", () => {
       }),
     ]);
     await user.click(screen.getByRole("button", { name: /Gap/i }));
-    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 8 === 3);
+    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 9 === 3);
     expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
       "Basis for a Day",
       "Above the Waves",
@@ -263,7 +267,7 @@ describe("createSetlistColumns", () => {
     ]);
     // First click on Rating sorts descending ("best first" via sortDescFirst).
     await user.click(screen.getByRole("button", { name: /Rating/i }));
-    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 8 === 3);
+    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 9 === 3);
     // 4.5/50 (Confrontation) > 4.5/3 (Crickets) > 3.0 (Above the Waves).
     expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
       "Confrontation",
@@ -307,7 +311,7 @@ describe("createSetlistColumns", () => {
       }),
     ]);
     await user.click(screen.getByRole("button", { name: /Rating/i }));
-    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 8 === 3);
+    const songCells = screen.getAllByRole("cell").filter((_, i) => i % 9 === 3);
     // All three tied → set+position takes over, inverted by desc → 3, 2, 1.
     expect(songCells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
       "Crickets",
@@ -326,11 +330,11 @@ describe("createSetlistColumns", () => {
       makeTrack({ songId: "d", position: 4, set: "E1", song: { id: "d", title: "Crickets", slug: "w" } }),
     ]);
     const cells = screen.getAllByRole("cell");
-    // Each row produces 8 cells; cells[1], cells[9], cells[17], cells[25] are Track #.
+    // Each row produces 9 cells; cells[1], cells[10], cells[19], cells[28] are Track #.
     expect(cells[1].textContent).toBe("1");
-    expect(cells[9].textContent).toBe("2");
-    expect(cells[17].textContent).toBe("1");
-    expect(cells[25].textContent).toBe("1");
+    expect(cells[10].textContent).toBe("2");
+    expect(cells[19].textContent).toBe("1");
+    expect(cells[28].textContent).toBe("1");
   });
 
   // Set column drops the "S" prefix (S1 → 1, S2 → 2, etc.) — the column
@@ -343,9 +347,9 @@ describe("createSetlistColumns", () => {
       makeTrack({ songId: "b", position: 2, set: "S2", song: { id: "b", title: "Tempest", slug: "t" } }),
     ]);
     const cells = screen.getAllByRole("cell");
-    // 8 cells per row; cells[0] = Set of row 0, cells[8] = Set of row 1.
+    // 9 cells per row; cells[0] = Set of row 0, cells[9] = Set of row 1.
     expect(cells[0].textContent).toBe("1");
-    expect(cells[8].textContent).toBe("2");
+    expect(cells[9].textContent).toBe("2");
   });
 
   // Single encore collapses E1 → E because there's no second encore to
@@ -357,9 +361,9 @@ describe("createSetlistColumns", () => {
       makeTrack({ songId: "b", position: 2, set: "E1", song: { id: "b", title: "Crickets", slug: "c" } }),
     ]);
     const singleCells = screen.getAllByRole("cell");
-    // 8 cells per row; cells[0] = Set row 0, cells[8] = Set row 1.
+    // 9 cells per row; cells[0] = Set row 0, cells[9] = Set row 1.
     expect(singleCells[0].textContent).toBe("1");
-    expect(singleCells[8].textContent).toBe("E");
+    expect(singleCells[9].textContent).toBe("E");
 
     // Re-render with two encores to confirm we keep the numbering.
     document.body.innerHTML = "";
@@ -369,7 +373,7 @@ describe("createSetlistColumns", () => {
     ]);
     const multiCells = screen.getAllByRole("cell");
     expect(multiCells[0].textContent).toBe("E1");
-    expect(multiCells[8].textContent).toBe("E2");
+    expect(multiCells[9].textContent).toBe("E2");
   });
 
   // Normal row: gap renders as the integer; Last Played renders the prior

--- a/apps/web/app/components/setlist/setlist-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.tsx
@@ -3,6 +3,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { buildGapCellState, isWithinShowRepeat } from "./gap-cell";
 import {
   createCountColumn,
+  createDurationColumn,
   createGapColumn,
   createRatingColumn,
   createSetlistCommonColumns,
@@ -34,6 +35,7 @@ export function createSetlistColumns(ctx?: Partial<SetlistRatingContext>): Colum
   };
   return [
     ...createSetlistCommonColumns<SetlistTableRow>(),
+    createDurationColumn<SetlistTableRow>(),
     createGapColumn<SetlistTableRow>({
       id: "gap",
       label: "Gap",
@@ -44,9 +46,12 @@ export function createSetlistColumns(ctx?: Partial<SetlistRatingContext>): Colum
     }),
     createShowDateLinkColumn<SetlistTableRow>({
       id: "lastPlayed",
+      // 5rem keeps the cell under the ~6rem @container threshold, so ShowDate
+      // renders the compact M/D/YY form (matching the performance table) and
+      // the freed width flows to Song.
       label: "Last Played",
       accessor: (row) => row.previousPerformanceShow,
-      fixedWidth: "7.5rem",
+      fixedWidth: "5rem",
     }),
     // Desktop-only "Played Before" — the personal view's Seen Before peer
     // stays visible on mobile because that's its existing layout; the

--- a/apps/web/app/components/setlist/setlist-common-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-common-columns.tsx
@@ -3,6 +3,8 @@ import { type ColumnDef, createColumnHelper, type Row, type SortingFn } from "@t
 import { TrackRatingCell } from "~/components/performance/track-rating-cell";
 import { ShowDateLink } from "~/components/show-date-link";
 import { AllTimerCell, allTimerColumnMeta } from "~/components/track/all-timer-cell";
+import { DurationValue } from "~/components/track/duration-cell";
+import { NumberCell } from "~/components/ui/number-cell";
 import { SortableHeader } from "~/components/ui/sortable-header";
 import { GapCell, type GapCellState } from "./gap-cell";
 import { compareBySetThenPosition, countDistinctEncores, formatSetLabel } from "./set-label";
@@ -137,7 +139,11 @@ export function createCountColumn<T extends TrackLight>(opts: {
     sortDescFirst: false,
     cell: (info) => {
       const value = opts.accessor(info.row.original);
-      return <span className="text-content-text-secondary tabular-nums">{value === null ? "—" : value}</span>;
+      return (
+        <NumberCell width="4ch" className="text-content-text-secondary">
+          {value === null ? "—" : value}
+        </NumberCell>
+      );
     },
   }) as ColumnDef<T, unknown>;
 }
@@ -268,6 +274,32 @@ export function createGapColumn<T extends TrackLight>(opts: {
   ) as ColumnDef<T, unknown>;
 }
 
+/**
+ * "Time" column for the gap-chart views: each track's duration, with
+ * archive-sourced values shown as estimates. Reused by both the catalog and
+ * personal column factories. Sorts numerically (longest first on the first
+ * click) with the canonical set+position tiebreak; unknown durations cluster
+ * at the bottom on descending sort.
+ */
+export function createDurationColumn<T extends TrackLight>(): ColumnDef<T, unknown> {
+  const columnHelper = createColumnHelper<T>();
+  return columnHelper.accessor((row) => row.duration ?? Number.NEGATIVE_INFINITY, {
+    id: "duration",
+    header: ({ column }) => <SortableHeader column={column} label="Time" />,
+    // Wide enough for the h:mm:ss form ("1:04:18"). Hidden on mobile — the
+    // gap-chart already runs out of width there.
+    meta: { fixedWidth: "5.25rem", hideOnMobile: true },
+    enableSorting: true,
+    sortingFn: withSetPositionTiebreak<T>((a, b) => (a.duration ?? -1) - (b.duration ?? -1)),
+    sortDescFirst: true,
+    cell: (info) => (
+      <NumberCell width="5ch">
+        <DurationValue seconds={info.row.original.duration} />
+      </NumberCell>
+    ),
+  }) as ColumnDef<T, unknown>;
+}
+
 export function createSetlistCommonColumns<T extends TrackLight>(options?: {
   /** Optional query suffix appended to every Song-cell `/songs/{slug}` link. */
   songLinkSearchParams?: string;
@@ -292,15 +324,16 @@ export function createSetlistCommonColumns<T extends TrackLight>(options?: {
         />
       ),
       // Set values max out at "E2" (2 chars). Bounded content → fixed
-      // 3rem on desktop. On mobile the column also doubles as the home
+      // 2.25rem on desktop. On mobile the column also doubles as the home
       // for the all-timer flame icon (standalone AllTimer column is
       // hidden on mobile to save space), so it's wide enough for either
-      // the flame or "E1" stacked vertically.
+      // the flame or "E1" stacked vertically. Tighter desktop padding
+      // (px-1) keeps the left-edge columns from stealing width from Song.
       meta: {
-        fixedWidth: "2.5rem",
+        fixedWidth: "2.25rem",
         mobileFixedWidth: "1.25rem",
-        cellClassName: "!px-0 sm:!px-2",
-        headerClassName: "!px-0 sm:!px-2",
+        cellClassName: "!px-0",
+        headerClassName: "!px-0 sm:!px-1",
       },
       enableSorting: true,
       sortingFn: (a, b) => compareBySetThenPosition(a.original, b.original),
@@ -324,7 +357,9 @@ export function createSetlistCommonColumns<T extends TrackLight>(options?: {
         return (
           <div className="flex flex-col items-center sm:items-start gap-0.5">
             {!hideSetLabel && (
-              <span className="text-content-text-secondary">{formatSetLabel(raw, { encoresInSet })}</span>
+              <NumberCell width="2ch" className="text-content-text-secondary">
+                {formatSetLabel(raw, { encoresInSet })}
+              </NumberCell>
             )}
             <span className="sm:hidden">
               <AllTimerCell track={row} />
@@ -335,14 +370,20 @@ export function createSetlistCommonColumns<T extends TrackLight>(options?: {
     }) as ColumnDef<T, unknown>,
     columnHelper.display({
       id: "track",
-      header: ({ column }) => <SortableHeader column={column} label="Track" />,
+      // No header of its own — it reads as one "Set" heading spanning the two
+      // adjacent number columns. Sorting lives on the Set column (same
+      // set+position order), so this column needs no sort affordance.
+      header: () => null,
       // Drops on narrow viewports — the Set column already orients the row,
       // and a tiny Track column would steal width from Song on mobile.
-      // Track # (position within set) — bounded to 3 digits max. 3.5rem
-      // accommodates the "Track" header word + sort arrow + tighter
-      // padding on desktop.
-      meta: { fixedWidth: "3.5rem", hideOnMobile: true },
-      enableSorting: true,
+      // Track # (position within set) — 1.75rem holds up to 2 digits flush
+      // against the Set column with zero horizontal padding.
+      meta: {
+        fixedWidth: "1.75rem",
+        hideOnMobile: true,
+        cellClassName: "!px-0",
+      },
+      enableSorting: false,
       // Track # = position-within-set, computed at render time from the
       // unsorted row model. The comparator falls through to the canonical
       // set+position order so sorting either restores narrative order.
@@ -352,7 +393,11 @@ export function createSetlistCommonColumns<T extends TrackLight>(options?: {
         const allRows = info.table.getCoreRowModel().rows;
         const trackNumber =
           allRows.filter((r) => r.original.set === row.set && r.original.position < row.position).length + 1;
-        return <span className="text-content-text-secondary tabular-nums">{trackNumber}</span>;
+        return (
+          <NumberCell width="2ch" className="text-content-text-secondary">
+            {trackNumber}
+          </NumberCell>
+        );
       },
     }) as ColumnDef<T, unknown>,
     columnHelper.display({

--- a/apps/web/app/components/setlist/setlist-duration.test.ts
+++ b/apps/web/app/components/setlist/setlist-duration.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import { formatSetHeading, summarizeDurations } from "./setlist-duration";
+
+describe("summarizeDurations", () => {
+  test("sums known durations and counts none missing when all are timed", () => {
+    expect(summarizeDurations([{ duration: 522 }, { duration: 410 }])).toEqual({ seconds: 932, known: 2, missing: 0 });
+  });
+
+  test("sums only the known durations and counts the rest as missing", () => {
+    expect(summarizeDurations([{ duration: 522 }, { duration: null }, { duration: null }])).toEqual({
+      seconds: 522,
+      known: 1,
+      missing: 2,
+    });
+  });
+
+  test("reports nothing known when no track is timed", () => {
+    expect(summarizeDurations([{ duration: null }, { duration: null }])).toEqual({ seconds: 0, known: 0, missing: 2 });
+  });
+});
+
+describe("formatSetHeading", () => {
+  test("spells out regular sets", () => {
+    expect(formatSetHeading("S1", 1)).toBe("Set 1");
+    expect(formatSetHeading("S2", 1)).toBe("Set 2");
+  });
+
+  test("drops the number for a lone encore", () => {
+    expect(formatSetHeading("E1", 1)).toBe("Encore");
+  });
+
+  test("numbers encores when the show has more than one", () => {
+    expect(formatSetHeading("E1", 2)).toBe("Encore 1");
+    expect(formatSetHeading("E2", 2)).toBe("Encore 2");
+  });
+
+  test("renders an unrecognized label verbatim", () => {
+    expect(formatSetHeading("Soundcheck", 0)).toBe("Soundcheck");
+  });
+});

--- a/apps/web/app/components/setlist/setlist-duration.ts
+++ b/apps/web/app/components/setlist/setlist-duration.ts
@@ -1,0 +1,43 @@
+/** Running-time helpers for the SetlistCard flow view. Pure (no React) so the
+ * total/partial math and the set-heading labels are unit-tested directly. */
+
+export interface DurationSummary {
+  /** Sum of known track durations (seconds). */
+  seconds: number;
+  /** How many tracks carry a known duration. */
+  known: number;
+  /** How many tracks are still untimed. */
+  missing: number;
+}
+
+/**
+ * Sum the known track durations and count how many are still untimed, so the
+ * UI can render a Total and flag a partial sum (some tracks not yet resolved)
+ * rather than imply the figure is complete.
+ */
+export function summarizeDurations(tracks: ReadonlyArray<{ duration: number | null }>): DurationSummary {
+  let seconds = 0;
+  let known = 0;
+  for (const track of tracks) {
+    if (track.duration != null) {
+      seconds += track.duration;
+      known += 1;
+    }
+  }
+  return { seconds, known, missing: tracks.length - known };
+}
+
+/**
+ * Block-style set heading for the flow view: spelled-out "Set 1" / "Encore" /
+ * "Encore 2" (vs the compact "1" / "E" the table views use). A lone encore
+ * drops its number, so pass the show's distinct-encore count. Unknown labels
+ * (e.g. "Soundcheck") render verbatim.
+ */
+export function formatSetHeading(label: string, encoresInSet: number): string {
+  const upper = label.toUpperCase();
+  const setMatch = upper.match(/^S(\d+)$/);
+  if (setMatch) return `Set ${setMatch[1]}`;
+  const encoreMatch = upper.match(/^E(\d+)$/);
+  if (encoreMatch) return encoresInSet === 1 ? "Encore" : `Encore ${encoreMatch[1]}`;
+  return label;
+}

--- a/apps/web/app/components/setlist/setlist-flow.test.tsx
+++ b/apps/web/app/components/setlist/setlist-flow.test.tsx
@@ -1,0 +1,135 @@
+import type { SetlistLight } from "@bip/domain";
+import { setupWithRouter } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+// TrackRatingOverlay wraps each song in a hover popover that needs React Query
+// + session context; render its children straight through. NoteworthyMarker is
+// an icon the flow tests don't assert on.
+vi.mock("./track-rating-overlay", () => ({
+  TrackRatingOverlay: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("~/components/track/noteworthy-marker", () => ({
+  NoteworthyMarker: () => null,
+}));
+
+import { SetlistFlow } from "./setlist-flow";
+
+function durTrack(id: string, title: string, duration: number | null, set: string, position: number) {
+  return {
+    id,
+    showId: "show-1",
+    songId: id,
+    set,
+    position,
+    segue: null,
+    likesCount: 0,
+    note: null,
+    allTimer: false,
+    averageRating: null,
+    ratingsCount: 0,
+    gap: null,
+    previousPerformanceShowId: null,
+    duration,
+    durationSource: duration === null ? null : "nugs",
+    previousPerformanceShow: null,
+    song: { id, title, slug: title.toLowerCase().replace(/\s+/g, "-") },
+  };
+}
+
+function flowSetlist(
+  sets: Array<{ label: string; tracks: ReturnType<typeof durTrack>[] }>,
+  annotations: Array<{ trackId: string; desc: string }> = [],
+): SetlistLight {
+  return {
+    show: { id: "show-1" },
+    sets: sets.map((s, i) => ({ label: s.label, sort: i + 1, tracks: s.tracks })),
+    annotations,
+  } as unknown as SetlistLight;
+}
+
+describe("SetlistFlow", () => {
+  // A single-set show drops the "Set 1" heading; its time reads only as the
+  // show Total.
+  test("a single-set show shows the Total but suppresses the set heading", async () => {
+    await setupWithRouter(
+      <SetlistFlow setlist={flowSetlist([{ label: "S1", tracks: [durTrack("a", "Helicopters", 522, "S1", 1), durTrack("b", "Spaga", 410, "S1", 2)] }])} />,
+    );
+    expect(screen.getByText("Total")).toBeInTheDocument();
+    expect(screen.getByText("15:32")).toBeInTheDocument();
+    expect(screen.queryByText("Set 1")).not.toBeInTheDocument();
+  });
+
+  test("a multi-set show shows per-set headings and the Total", async () => {
+    await setupWithRouter(
+      <SetlistFlow
+        setlist={flowSetlist([
+          { label: "S1", tracks: [durTrack("a", "Helicopters", 522, "S1", 1)] },
+          { label: "S2", tracks: [durTrack("b", "Spaga", 410, "S2", 1)] },
+        ])}
+      />,
+    );
+    expect(screen.getByText("Set 1")).toBeInTheDocument();
+    expect(screen.getByText("Set 2")).toBeInTheDocument();
+    expect(screen.getByText("Total")).toBeInTheDocument();
+  });
+
+  test("flags a partial total when some tracks are untimed", async () => {
+    await setupWithRouter(
+      <SetlistFlow setlist={flowSetlist([{ label: "S1", tracks: [durTrack("a", "Helicopters", 522, "S1", 1), durTrack("b", "Spaga", null, "S1", 2)] }])} />,
+    );
+    expect(screen.getByText(/Partial: 1 track not yet timed/)).toBeInTheDocument();
+  });
+
+  test("shows no Total or partial note when nothing is timed", async () => {
+    await setupWithRouter(
+      <SetlistFlow setlist={flowSetlist([{ label: "S1", tracks: [durTrack("a", "Helicopters", null, "S1", 1)] }])} />,
+    );
+    expect(screen.queryByText("Total")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Partial/)).not.toBeInTheDocument();
+  });
+
+  // A lone encore reads "Encore" (no number).
+  test("labels a single encore 'Encore'", async () => {
+    await setupWithRouter(
+      <SetlistFlow
+        setlist={flowSetlist([
+          { label: "S1", tracks: [durTrack("a", "Helicopters", null, "S1", 1)] },
+          { label: "E1", tracks: [durTrack("b", "Spaga", null, "E1", 1)] },
+        ])}
+      />,
+    );
+    expect(screen.getByText("Encore")).toBeInTheDocument();
+    expect(screen.queryByText("Encore 1")).not.toBeInTheDocument();
+  });
+
+  test("numbers multiple encores", async () => {
+    await setupWithRouter(
+      <SetlistFlow
+        setlist={flowSetlist([
+          { label: "S1", tracks: [durTrack("a", "Helicopters", null, "S1", 1)] },
+          { label: "E1", tracks: [durTrack("b", "Spaga", null, "E1", 1)] },
+          { label: "E2", tracks: [durTrack("c", "Crickets", null, "E2", 1)] },
+        ])}
+      />,
+    );
+    expect(screen.getByText("Encore 1")).toBeInTheDocument();
+    expect(screen.getByText("Encore 2")).toBeInTheDocument();
+  });
+
+  // A track with an annotation gets an inline superscript marker and a matching
+  // footnote line.
+  test("numbers track annotations inline and footnotes them", async () => {
+    await setupWithRouter(
+      <SetlistFlow
+        setlist={flowSetlist(
+          [{ label: "S1", tracks: [durTrack("a", "Helicopters", 522, "S1", 1)] }],
+          [{ trackId: "a", desc: "Glow-stick war peak" }],
+        )}
+      />,
+    );
+    expect(screen.getByText("Glow-stick war peak")).toBeInTheDocument();
+    // The inline superscript marker "1" and the footnote index "1" both render.
+    expect(screen.getAllByText("1").length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/app/components/setlist/setlist-flow.tsx
+++ b/apps/web/app/components/setlist/setlist-flow.tsx
@@ -1,0 +1,135 @@
+import type { Setlist, SetlistLight } from "@bip/domain";
+import { formatDuration } from "@bip/domain";
+import { Link } from "react-router-dom";
+import { NoteworthyMarker } from "~/components/track/noteworthy-marker";
+import { cn } from "~/lib/utils";
+import { countSetlistEncores } from "./set-label";
+import { formatSetHeading, summarizeDurations } from "./setlist-duration";
+import { TrackRatingOverlay } from "./track-rating-overlay";
+
+/**
+ * The default "flow" rendering of a setlist: each set's tracks inline with
+ * segue markers, per-set and total running times, and the footnoted track
+ * annotations. Extracted from SetlistCard so this (the bulk of the card body)
+ * can be rendered and tested on its own, apart from the rating/attendance/
+ * view-toggle machinery around it.
+ */
+export function SetlistFlow({ setlist }: { setlist: Setlist | SetlistLight }) {
+  // Number annotations in track order: each distinct description gets the next
+  // index, and each track maps to the indices it carries, so the inline `sup`
+  // markers and the footnote list agree.
+  const uniqueAnnotations = new Map<string, { index: number; desc: string }>();
+  const trackAnnotationMap = new Map<string, number[]>();
+  let annotationIndex = 1;
+  const allTracks = setlist.sets.flatMap((set) => set.tracks);
+  for (const track of allTracks) {
+    const trackIndices: number[] = [];
+    for (const annotation of setlist.annotations.filter((a) => a.trackId === track.id)) {
+      if (!annotation.desc) continue;
+      if (!uniqueAnnotations.has(annotation.desc)) {
+        uniqueAnnotations.set(annotation.desc, { index: annotationIndex++, desc: annotation.desc });
+      }
+      const index = uniqueAnnotations.get(annotation.desc)?.index;
+      if (index) trackIndices.push(index);
+    }
+    if (trackIndices.length > 0) trackAnnotationMap.set(track.id, trackIndices);
+  }
+  const orderedAnnotations = Array.from(uniqueAnnotations.values()).sort((a, b) => a.index - b.index);
+
+  const encoresInSet = countSetlistEncores(setlist.sets);
+  const showDuration = summarizeDurations(allTracks);
+  // A single-set show (no encore) needs no heading — its time is the Total.
+  const showSetHeadings = setlist.sets.length > 1;
+
+  return (
+    <>
+      <div className="space-y-3 md:space-y-4">
+        {setlist.sets.map((set) => {
+          const setDuration = summarizeDurations(set.tracks);
+          return (
+            <div key={setlist.show.id + set.label}>
+              {showSetHeadings && (
+                <div className="flex items-baseline gap-2">
+                  <span className="text-base font-medium text-content-text-tertiary">
+                    {formatSetHeading(set.label, encoresInSet)}
+                  </span>
+                  {setDuration.known > 0 && (
+                    <span
+                      className="text-sm text-content-text-tertiary tabular-nums"
+                      title={
+                        setDuration.missing > 0
+                          ? `Partial: ${setDuration.missing} track${setDuration.missing > 1 ? "s" : ""} not yet timed`
+                          : undefined
+                      }
+                    >
+                      {formatDuration(setDuration.seconds)}
+                      {setDuration.missing > 0 && "*"}
+                    </span>
+                  )}
+                </div>
+              )}
+              <div className={showSetHeadings ? "text-base pl-4" : "text-base"}>
+                {set.tracks.map((track, i) => (
+                  <span key={track.id} className="inline">
+                    <TrackRatingOverlay track={track}>
+                      <span
+                        className={cn(
+                          "relative text-brand-primary hover:text-brand-secondary hover:underline transition-colors text-base",
+                          track.allTimer && "font-medium",
+                        )}
+                      >
+                        <NoteworthyMarker
+                          track={track}
+                          iconClassName="h-3 w-3 md:h-4 md:w-4 inline-block mr-1 transform -translate-y-0.5"
+                        />
+                        <Link to={`/songs/${track.song?.slug}`}>{track.song?.title}</Link>
+                        {trackAnnotationMap.has(track.id) && (
+                          <sup className="text-brand-secondary ml-0.5 font-medium text-xs">
+                            {trackAnnotationMap.get(track.id)?.map((index, markerPosition) => (
+                              <span key={index} className={markerPosition > 0 ? "ml-1" : ""}>
+                                {index}
+                              </span>
+                            ))}
+                          </sup>
+                        )}
+                      </span>
+                    </TrackRatingOverlay>
+                    {i < set.tracks.length - 1 && (
+                      <span className="text-content-text-secondary mx-1 font-medium text-base">
+                        {track.segue ? " > " : ", "}
+                      </span>
+                    )}
+                  </span>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {(showDuration.known > 0 || orderedAnnotations.length > 0) && (
+        <div className="mt-6 pt-4 border-t border-glass-border/30 space-y-2">
+          {showDuration.known > 0 && (
+            <div className="text-sm text-content-text-secondary">
+              <span className="font-medium text-content-text-tertiary">Total</span>{" "}
+              <span className="tabular-nums">
+                {formatDuration(showDuration.seconds)}
+                {showDuration.missing > 0 && "*"}
+              </span>
+            </div>
+          )}
+          {showDuration.known > 0 && showDuration.missing > 0 && (
+            <div className="text-xs text-content-text-tertiary">
+              * Partial: {showDuration.missing} track{showDuration.missing > 1 ? "s" : ""} not yet timed
+            </div>
+          )}
+          {orderedAnnotations.map((annotation) => (
+            <div key={`annotation-${annotation.index}`} className="text-sm text-content-text-secondary">
+              <sup className="text-brand-secondary">{annotation.index}</sup> {annotation.desc}
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/app/components/setlist/setlist-list.test.tsx
+++ b/apps/web/app/components/setlist/setlist-list.test.tsx
@@ -76,6 +76,8 @@ function makeSetlist(id: string, title: string, averageRating: number | null = 4
             ratingsCount: 0,
             gap: null,
             previousPerformanceShowId: null,
+            duration: null,
+            durationSource: null,
             previousPerformanceShow: null,
             song: { id: "song-1", title, slug: title.toLowerCase().replace(/\s+/g, "-") },
           },

--- a/apps/web/app/components/setlist/setlist-table-personal.test.tsx
+++ b/apps/web/app/components/setlist/setlist-table-personal.test.tsx
@@ -58,6 +58,8 @@ function makeTrack(overrides: Partial<TrackLight> & { id: string; songId: string
     ratingsCount: 0,
     gap: null,
     previousPerformanceShowId: null,
+    duration: overrides.duration ?? null,
+    durationSource: overrides.durationSource ?? null,
     previousPerformanceShow: null,
     song: overrides.song ?? { id: overrides.songId, title: "Tractorbeam", slug: "tractorbeam" },
   };

--- a/apps/web/app/components/setlist/setlist-table.test.tsx
+++ b/apps/web/app/components/setlist/setlist-table.test.tsx
@@ -41,6 +41,8 @@ function makeTrack(overrides: Partial<TrackLight> & { songId: string; position: 
     ratingsCount: 0,
     gap: overrides.gap ?? null,
     previousPerformanceShowId: overrides.previousPerformanceShowId ?? null,
+    duration: overrides.duration ?? null,
+    durationSource: overrides.durationSource ?? null,
     previousPerformanceShow: overrides.previousPerformanceShow ?? null,
     song: overrides.song ?? { id: overrides.songId, title: "Basis for a Day", slug: "basis-for-a-day" },
   };
@@ -85,7 +87,7 @@ describe("SetlistTable", () => {
         ]}
       />,
     );
-    const cells = screen.getAllByRole("cell").filter((_, i) => i % 8 === 3);
+    const cells = screen.getAllByRole("cell").filter((_, i) => i % 9 === 3);
     expect(cells.map((c) => c.textContent?.replace(">", "").trim())).toEqual([
       "Basis for a Day",
       "Above the Waves",
@@ -195,10 +197,10 @@ describe("SetlistTable", () => {
       />,
     );
 
-    // Each row has 8 cells; Played Before is index 6. Cells 6 + 14 are the
+    // Each row has 9 cells; Played Before is index 7. Cells 7 + 16 are the
     // Played Before cells for the two rows respectively.
     const cells = screen.getAllByRole("cell");
-    expect(cells[6].textContent).toBe("3");
-    expect(cells[14].textContent).toBe("0");
+    expect(cells[7].textContent).toBe("3");
+    expect(cells[16].textContent).toBe("0");
   });
 });

--- a/apps/web/app/components/song/songs-columns.tsx
+++ b/apps/web/app/components/song/songs-columns.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { ShowDate } from "~/components/show-date";
 import { Button } from "~/components/ui/button";
+import { NumberCell } from "~/components/ui/number-cell";
 
 /**
  * Inline funnel icon used to mark "this column / control is the filtered
@@ -199,24 +200,6 @@ function DateVenueCell({ date, show }: { date: Date | null; show?: Show | null }
 function dashOrSpan(content: ReactNode | null | undefined, className = "text-content-text-primary"): ReactNode {
   if (content === null || content === undefined) return <span className="text-content-text-tertiary text-sm">—</span>;
   return <span className={className}>{content}</span>;
-}
-
-/**
- * Right-aligns digits inside an inline-block sized to the column's widest
- * realistic value, so 1 / 10 / 100 stack with their ones digit aligned and
- * larger numbers extend further left. The block itself sits flush-left in
- * the cell (cells are left-aligned), so the whole column reads as
- * "left-anchored numbers with right-aligned digits" rather than as a
- * right-aligned column. `width` is the min-width of the slot in `ch`
- * units; tabular-nums makes every digit the same `0`-glyph width so the
- * digit columns actually align.
- */
-function NumberCell({ width, className, children }: { width: string; className?: string; children: ReactNode }) {
-  return (
-    <span className={`inline-block text-right tabular-nums ${className ?? ""}`} style={{ minWidth: width }}>
-      {children}
-    </span>
-  );
 }
 
 interface GetSongsColumnsOptions {

--- a/apps/web/app/components/track/duration-cell.test.tsx
+++ b/apps/web/app/components/track/duration-cell.test.tsx
@@ -1,0 +1,24 @@
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { DurationValue } from "./duration-cell";
+
+describe("DurationValue", () => {
+  // The branch the typechecker can't see: a known duration formats to m:ss /
+  // h:mm:ss, an unknown one collapses to an em-dash.
+
+  test("formats a known duration", async () => {
+    await setup(<DurationValue seconds={3858} />);
+    expect(screen.getByText("1:04:18")).toBeInTheDocument();
+  });
+
+  test("formats a sub-hour duration as m:ss", async () => {
+    await setup(<DurationValue seconds={522} />);
+    expect(screen.getByText("8:42")).toBeInTheDocument();
+  });
+
+  test("renders an em-dash when the duration is unknown", async () => {
+    await setup(<DurationValue seconds={null} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/track/duration-cell.tsx
+++ b/apps/web/app/components/track/duration-cell.tsx
@@ -1,0 +1,19 @@
+import { formatDuration } from "@bip/domain";
+import { cn } from "~/lib/utils";
+
+interface DurationValueProps {
+  /** Track duration in seconds, or null when unknown. */
+  seconds: number | null | undefined;
+  className?: string;
+}
+
+/**
+ * Renders a track duration consistently everywhere it appears (setlist tables,
+ * performance tables). Unknown durations render an em-dash.
+ */
+export function DurationValue({ seconds, className }: DurationValueProps) {
+  if (seconds == null) {
+    return <span className={cn("text-content-text-tertiary", className)}>—</span>;
+  }
+  return <span className={cn("tabular-nums text-content-text-secondary", className)}>{formatDuration(seconds)}</span>;
+}

--- a/apps/web/app/components/track/sortable-track-item.test.tsx
+++ b/apps/web/app/components/track/sortable-track-item.test.tsx
@@ -43,6 +43,8 @@ function makeTrack(overrides: Partial<Track> = {}): Track {
     ratingsCount: 0,
     gap: null,
     previousPerformanceShowId: null,
+    duration: null,
+    durationSource: null,
     previousPerformanceShow: null,
     // Component only reads `song.title`; the rest of the Song shape is
     // irrelevant for these tests, so cast through `unknown` to avoid

--- a/apps/web/app/components/track/sortable-track-item.tsx
+++ b/apps/web/app/components/track/sortable-track-item.tsx
@@ -1,4 +1,5 @@
 import type { Track } from "@bip/domain";
+import { formatDuration } from "@bip/domain";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Edit2, GripVertical, Trash } from "lucide-react";
@@ -48,6 +49,14 @@ export function SortableTrackItem({ track, onEdit, onDelete, isDeleting }: Sorta
               <span className="text-white font-medium">{track.song?.title || "Unknown Song"}</span>
               <TrackIcon track={track} iconClassName="h-4 w-4" />
               {track.segue && <span className="text-content-text-secondary text-sm">{track.segue}</span>}
+              {track.duration != null && (
+                <span className="text-content-text-secondary text-sm tabular-nums">
+                  {formatDuration(track.duration)}
+                  {track.durationSource && (
+                    <span className="ml-1 text-xs text-content-text-tertiary">({track.durationSource})</span>
+                  )}
+                </span>
+              )}
             </div>
           </div>
 

--- a/apps/web/app/components/track/track-edit-form.test.tsx
+++ b/apps/web/app/components/track/track-edit-form.test.tsx
@@ -13,6 +13,8 @@ const BASE_FORM: TrackFormData = {
   note: null,
   annotationDesc: null,
   allTimer: false,
+  duration: "",
+  durationSource: null,
 };
 
 describe("TrackEditForm", () => {

--- a/apps/web/app/components/track/track-edit-form.tsx
+++ b/apps/web/app/components/track/track-edit-form.tsx
@@ -3,6 +3,7 @@ import { SongSearch } from "~/components/song/song-search";
 import { Button } from "~/components/ui/button";
 import { Checkbox } from "~/components/ui/checkbox";
 import { GlassSelect } from "~/components/ui/glass-select";
+import { Input } from "~/components/ui/input";
 import { Textarea } from "~/components/ui/textarea";
 import { formInputClass, formLabelClass } from "~/lib/form-styles";
 import { SEGUE_OPTIONS, SET_OPTIONS } from "./track-constants";
@@ -70,6 +71,25 @@ export function TrackEditForm({
             onValueChange={(value) => onFormDataChange((prev) => ({ ...prev, segue: value }))}
             options={SEGUE_OPTIONS}
             className="w-full"
+          />
+        </div>
+
+        <div className="w-28">
+          <label htmlFor="track-duration" className={formLabelClass}>
+            Duration
+            {formData.durationSource && (
+              <span className="ml-1 text-xs font-normal text-content-text-tertiary">({formData.durationSource})</span>
+            )}
+          </label>
+          <Input
+            id="track-duration"
+            value={formData.duration}
+            onChange={(e) => {
+              const value = e.target.value;
+              onFormDataChange((prev) => ({ ...prev, duration: value }));
+            }}
+            placeholder="8:42"
+            className={formInputClass}
           />
         </div>
 

--- a/apps/web/app/components/track/track-manager.tsx
+++ b/apps/web/app/components/track/track-manager.tsx
@@ -1,4 +1,5 @@
 import type { Track } from "@bip/domain";
+import { formatDuration, parseDuration } from "@bip/domain";
 import {
   closestCenter,
   DndContext,
@@ -43,6 +44,8 @@ const INITIAL_FORM: TrackFormData = {
   note: null,
   annotationDesc: null,
   allTimer: false,
+  duration: "",
+  durationSource: null,
 };
 
 /**
@@ -92,6 +95,8 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
           .filter((desc) => desc)
           .join("\n") || null,
       allTimer: track.allTimer ?? false,
+      duration: track.duration != null ? formatDuration(track.duration) : "",
+      durationSource: track.durationSource,
     });
   };
 
@@ -104,6 +109,11 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
   const handleSubmit = async () => {
     if (formData.songId === "none") {
       toast.error("Please select a song");
+      return;
+    }
+
+    if (formData.duration.trim() !== "" && parseDuration(formData.duration) === null) {
+      toast.error("Duration must look like 8:42, 1:04:18, or a number of seconds");
       return;
     }
 

--- a/apps/web/app/components/track/use-track-api.test.tsx
+++ b/apps/web/app/components/track/use-track-api.test.tsx
@@ -45,6 +45,8 @@ const BASE_FORM = {
   note: null,
   annotationDesc: null,
   allTimer: false,
+  duration: "",
+  durationSource: null,
 };
 
 function setupHook(initialTracks: Track[] = []) {
@@ -226,6 +228,24 @@ describe("useTrackApi", () => {
       });
 
       expect(getTracks().map((t) => t.id)).toEqual(["t-2", "t-1"]);
+    });
+
+    // The admin types a human duration ("8:42"); it must reach the API as
+    // whole seconds, and an empty field must clear it (null), not send "".
+    test("parses the duration field to seconds on save, and clears it when blank", async () => {
+      const { hook } = setupHook([makeTrack({ id: "t-1" })]);
+
+      fetchMock.mockResolvedValueOnce({ ok: true, json: async () => makeTrack({ id: "t-1" }) });
+      await act(async () => {
+        await hook.result.current.updateTrack({ ...BASE_FORM, id: "t-1", duration: "8:42" });
+      });
+      expect(JSON.parse(fetchMock.mock.calls[0][1].body).duration).toBe(522);
+
+      fetchMock.mockResolvedValueOnce({ ok: true, json: async () => makeTrack({ id: "t-1" }) });
+      await act(async () => {
+        await hook.result.current.updateTrack({ ...BASE_FORM, id: "t-1", duration: "" });
+      });
+      expect(JSON.parse(fetchMock.mock.calls[1][1].body).duration).toBeNull();
     });
   });
 

--- a/apps/web/app/components/track/use-track-api.ts
+++ b/apps/web/app/components/track/use-track-api.ts
@@ -1,4 +1,5 @@
 import type { Track } from "@bip/domain";
+import { parseDuration } from "@bip/domain";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import { compareSets } from "./track-constants";
@@ -13,6 +14,10 @@ export interface TrackFormData {
   song?: Track["song"];
   annotationDesc?: string | null;
   allTimer: boolean;
+  /** Raw admin input ("8:42" / "1:04:18" / "522"); parsed to seconds on save. */
+  duration: string;
+  /** Where the current duration came from (nugs/archive/manual); display only. */
+  durationSource: string | null;
 }
 
 type SetTracks = (updater: (prev: Track[]) => Track[]) => void;
@@ -27,11 +32,16 @@ function sortTracks(tracks: Track[]): Track[] {
 // Translates the form's "none" sentinels to the shape the API expects.
 // "none" songId → undefined (omitted), "none" segue → null (explicitly cleared).
 function buildSavePayload(data: TrackFormData) {
+  // durationSource is display-only — the server stamps "manual" on save.
+  const { duration, durationSource: _durationSource, ...rest } = data;
   return {
-    ...data,
+    ...rest,
     songId: data.songId === "none" ? undefined : data.songId,
     segue: data.segue === "none" ? null : data.segue,
     annotationDesc: data.annotationDesc,
+    // Empty clears the duration; a non-empty value is pre-validated by the
+    // caller, so parseDuration is guaranteed to succeed here.
+    duration: duration.trim() === "" ? null : parseDuration(duration),
   };
 }
 

--- a/apps/web/app/components/ui/number-cell.tsx
+++ b/apps/web/app/components/ui/number-cell.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+import { cn } from "~/lib/utils";
+
+/**
+ * Right-aligns digits inside an inline-block sized to the column's widest
+ * realistic value, so 1 / 10 / 100 stack with their ones digit aligned and
+ * larger numbers extend further left. The block itself sits flush-left in the
+ * cell (cells are left-aligned), so the whole column reads as "left-anchored
+ * numbers with right-aligned digits" rather than as a right-aligned column.
+ * `width` is the min-width of the slot in `ch` units; tabular-nums makes every
+ * digit the same `0`-glyph width so the digit columns actually align.
+ *
+ * Shared across every data-table numeric column (songs, gap-chart, performance)
+ * so they read consistently.
+ */
+export function NumberCell({ width, className, children }: { width: string; className?: string; children: ReactNode }) {
+  return (
+    <span className={cn("inline-block text-right tabular-nums", className)} style={{ minWidth: width }}>
+      {children}
+    </span>
+  );
+}

--- a/apps/web/app/routes/api/tracks.tsx
+++ b/apps/web/app/routes/api/tracks.tsx
@@ -40,6 +40,7 @@ export const action = adminAction(async ({ request }) => {
         segue: data.segue,
         note: data.note,
         allTimer: data.allTimer,
+        duration: data.duration ?? null,
       });
 
       // Create annotations if provided

--- a/apps/web/app/routes/mcp/index.tsx
+++ b/apps/web/app/routes/mcp/index.tsx
@@ -611,6 +611,10 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
                   // and to drift-update existing rows.
                   note: t.note,
                   allTimer: t.allTimer ?? false,
+                  // Track length (seconds) + provenance, so local dev DBs
+                  // mirror the durations prod resolved from nugs/archive.
+                  duration: t.duration ?? null,
+                  durationSource: t.durationSource ?? null,
                   annotations: annotationsByTrackId.get(t.id) ?? [],
                 })),
               })),

--- a/apps/web/app/server/show-external-sources.test.ts
+++ b/apps/web/app/server/show-external-sources.test.ts
@@ -5,6 +5,7 @@ const getReleaseUrlsByDate = vi.fn();
 const getPrimaryUrlsByDate = vi.fn();
 const getFirstVideoUrlByShowIds = vi.fn();
 const getRelistenUrlsByDate = vi.fn();
+const resolvePending = vi.fn();
 
 vi.mock("~/server/services", () => ({
   services: {
@@ -12,6 +13,7 @@ vi.mock("~/server/services", () => ({
     relisten: { getUrlsByDate: () => getRelistenUrlsByDate() },
     archiveDotOrg: { getPrimaryUrlsByDate: () => getPrimaryUrlsByDate() },
     youtube: { getFirstVideoUrlByShowIds: (ids: string[]) => getFirstVideoUrlByShowIds(ids) },
+    trackDurations: { resolvePending: (ids: string[]) => resolvePending(ids) },
   },
 }));
 
@@ -22,6 +24,7 @@ describe("computeShowExternalSources", () => {
     getPrimaryUrlsByDate.mockResolvedValue({});
     getFirstVideoUrlByShowIds.mockResolvedValue({});
     getRelistenUrlsByDate.mockResolvedValue({});
+    resolvePending.mockResolvedValue(undefined);
   });
 
   // Empty input short-circuits so loaders can pass whatever list they have
@@ -34,6 +37,14 @@ describe("computeShowExternalSources", () => {
     expect(getPrimaryUrlsByDate).not.toHaveBeenCalled();
     expect(getFirstVideoUrlByShowIds).not.toHaveBeenCalled();
     expect(getRelistenUrlsByDate).not.toHaveBeenCalled();
+    expect(resolvePending).not.toHaveBeenCalled();
+  });
+
+  // The pass doubles as the lazy duration-resolution trigger: it hands the
+  // batch's show ids to the (fire-and-forget) resolver.
+  test("triggers lazy duration resolution for the batch's show ids", async () => {
+    await computeShowExternalSources([{ id: "show-nye04", date: "2004-12-31" }]);
+    expect(resolvePending).toHaveBeenCalledWith(["show-nye04"]);
   });
 
   // Shows are keyed by id in the result; nugs/archive URLs lookup by date,

--- a/apps/web/app/server/show-external-sources.ts
+++ b/apps/web/app/server/show-external-sources.ts
@@ -26,6 +26,12 @@ export async function computeShowExternalSources(shows: ShowLike[]): Promise<Rec
   if (shows.length === 0) return result;
 
   const showIds = shows.map((s) => s.id);
+
+  // Lazily self-populate track durations for this batch from nugs/archive.
+  // Fire-and-forget and capped inside the service so a list page never blocks
+  // on (or bursts) external fetches; resolved durations appear on later loads.
+  void services.trackDurations.resolvePending(showIds).catch(() => {});
+
   const [nugsUrlsByDate, relistenUrlsByDate, archiveUrlsByDate, youtubeUrlsByShowId] = await Promise.all([
     services.nugs.getReleaseUrlsByDate(),
     services.relisten.getUrlsByDate(),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
     "prisma:generate": "doppler run -- prisma generate --config=./src/_shared/prisma/prisma.config.ts",
     "prisma:generate:prod": "prisma generate --config=./src/_shared/prisma/prisma.config.ts",
     "prisma:migrate:dev": "doppler run -- prisma migrate dev --config=./src/_shared/prisma/prisma.config.ts",
+    "prisma:migrate:deploy": "doppler run -- prisma migrate deploy --config=./src/_shared/prisma/prisma.config.ts",
     "prisma:migrate:create": "doppler run -- prisma migrate dev --create-only --config=./src/_shared/prisma/prisma.config.ts",
     "prisma:migrate:baseline": "doppler run -- prisma migrate resolve --applied 20250301154946_init --config=./src/_shared/prisma/prisma.config.ts",
     "prisma:introspect": "doppler run -- prisma db pull --config=./src/_shared/prisma/prisma.config.ts",

--- a/packages/core/scripts/sync-missing-shows.test.ts
+++ b/packages/core/scripts/sync-missing-shows.test.ts
@@ -981,6 +981,8 @@ describe("buildSetlistReconciliation", () => {
         segue: ">",
         note: null,
         allTimer: false,
+        duration: null,
+        durationSource: null,
         annotations: [],
       },
     ];
@@ -1022,6 +1024,8 @@ describe("buildSetlistReconciliation", () => {
         segue: null,
         note: null,
         allTimer: false,
+        duration: null,
+        durationSource: null,
         annotations: [],
       },
     ];
@@ -1070,6 +1074,8 @@ describe("buildSetlistReconciliation", () => {
         segue: ">",
         note: null,
         allTimer: false,
+        duration: null,
+        durationSource: null,
         annotations: [],
       },
     ];
@@ -1111,6 +1117,8 @@ describe("buildSetlistReconciliation", () => {
         segue: null,
         note: null,
         allTimer: false,
+        duration: null,
+        durationSource: null,
         annotations: [],
       },
       {
@@ -1121,6 +1129,8 @@ describe("buildSetlistReconciliation", () => {
         segue: null,
         note: null,
         allTimer: false,
+        duration: null,
+        durationSource: null,
         annotations: [
           { id: "ann-a-uuid", desc: "stray" },
           { id: "ann-b-uuid", desc: "still stray" },
@@ -1157,6 +1167,8 @@ describe("buildSetlistReconciliation", () => {
         segue: null,
         note: null,
         allTimer: false,
+        duration: null,
+        durationSource: null,
         annotations: [],
       },
     ];
@@ -1178,6 +1190,61 @@ describe("buildSetlistReconciliation", () => {
     expect(recon.cosmeticallyChanged).toBe(false);
   });
 
+  // Duration drift: prod resolved a duration our local row lacks. Patches the
+  // value and its provenance together, counted as cosmetic (no SegueRun regen).
+  test("patches a track duration mirrored from prod", () => {
+    const local: LocalTrackForReconcile[] = [
+      {
+        id: "track-1-uuid",
+        set: "S1",
+        position: 1,
+        songId: "song-crystal-uuid",
+        segue: null,
+        note: null,
+        allTimer: false,
+        duration: null,
+        durationSource: null,
+        annotations: [],
+      },
+    ];
+    const remote: McpSetlist = {
+      showSlug: "show",
+      showDate: "2025-08-30",
+      venue: { name: "v", city: "c", state: "s" },
+      sets: [
+        {
+          label: "S1",
+          tracks: [
+            { position: 1, songTitle: "Crystal Ball", songSlug: "crystal-ball", segue: null, duration: 845, durationSource: "nugs" },
+          ],
+        },
+      ],
+    };
+    const recon = buildSetlistReconciliation(local, remote, songMap);
+    expect(recon.toUpdate[0]?.patch).toEqual({ duration: 845, durationSource: "nugs" });
+    expect(recon.structurallyChanged).toBe(false);
+    expect(recon.cosmeticallyChanged).toBe(true);
+  });
+
+  // A duration on a remote-only track rides onto the insert op.
+  test("carries duration onto an inserted track", () => {
+    const remote: McpSetlist = {
+      showSlug: "show",
+      showDate: "2025-08-30",
+      venue: { name: "v", city: "c", state: "s" },
+      sets: [
+        {
+          label: "S1",
+          tracks: [
+            { position: 1, songTitle: "Crystal Ball", songSlug: "crystal-ball", segue: null, duration: 845, durationSource: "archive" },
+          ],
+        },
+      ],
+    };
+    const recon = buildSetlistReconciliation([], remote, songMap);
+    expect(recon.toInsert[0]).toMatchObject({ duration: 845, durationSource: "archive" });
+  });
+
   // Cosmetic-only drift: segue / note / allTimer changed, songId is unchanged.
   // Must NOT flip structurallyChanged (no SegueRun regen needed for a segue
   // marker change — the trackIds array is still valid).
@@ -1191,6 +1258,8 @@ describe("buildSetlistReconciliation", () => {
         segue: ">",
         note: null,
         allTimer: false,
+        duration: null,
+        durationSource: null,
         annotations: [],
       },
     ];
@@ -1226,6 +1295,8 @@ describe("buildSetlistReconciliation", () => {
         segue: null,
         note: "kept locally",
         allTimer: true,
+        duration: null,
+        durationSource: null,
         annotations: [{ id: "ann-a-uuid", desc: "still here" }],
       },
     ];
@@ -1259,6 +1330,8 @@ describe("buildSetlistReconciliation", () => {
         segue: null,
         note: null,
         allTimer: false,
+        duration: null,
+        durationSource: null,
         annotations: [{ id: "ann-keep-uuid", desc: "first time played" }, { id: "ann-drop-uuid", desc: "to remove" }],
       },
     ];
@@ -1367,6 +1440,8 @@ describe("buildSetlistReconciliation", () => {
         segue: null,
         note: null,
         allTimer: false,
+        duration: null,
+        durationSource: null,
         annotations: [],
       },
     ];
@@ -1407,6 +1482,8 @@ describe("buildSetlistReconciliation", () => {
         segue: ">",
         note: null,
         allTimer: false,
+        duration: null,
+        durationSource: null,
         annotations: [{ id: "ann-local", desc: "explosive intro" }],
       },
     ];
@@ -1462,6 +1539,8 @@ describe("buildSetlistReconciliation", () => {
         segue: null,
         note: null,
         allTimer: false,
+        duration: null,
+        durationSource: null,
         annotations: [],
       },
     ];

--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -23,6 +23,7 @@ import { RedisService } from "../src/_shared/redis";
 import { RatingService } from "../src/ratings/rating-service";
 import { SegueRunGeneratorService } from "../src/segue-run/segue-run-generator-service";
 import { StatsService } from "../src/stats/stats-service";
+import { recomputeShowDuration } from "../src/tracks/show-duration";
 import { createTestLogger } from "../src/_shared/test-logger";
 
 const MCP_URL = process.env.MCP_URL ?? "https://discobiscuits.net/mcp";
@@ -89,6 +90,12 @@ export interface McpSetlistTrack {
   // Admin-curated; optional on the wire so older MCP responses parse cleanly.
   allTimer?: boolean | null;
   note?: string | null;
+  // Track duration (seconds) + its provenance, mirrored from prod so local
+  // dev DBs get the durations prod resolved from nugs/archive without each
+  // dev re-hitting those APIs. Optional on the wire = "no opinion" (pre-deploy
+  // MCP) so a sparse upstream can't clobber locally resolved/edited values.
+  duration?: number | null;
+  durationSource?: string | null;
   // Per-track annotations from the Annotation table. `undefined` means
   // "no opinion" (pre-deploy MCP); an explicit empty array means "prod has
   // zero". Replace-not-merge semantics on sync — see diffTrackAnnotations.
@@ -611,6 +618,8 @@ export interface LocalTrackForReconcile {
   segue: string | null;
   note: string | null;
   allTimer: boolean | null;
+  duration: number | null;
+  durationSource: string | null;
   annotations: Array<{ id: string; desc: string | null }>;
 }
 
@@ -619,6 +628,8 @@ export interface TrackPatch {
   segue?: string | null;
   note?: string | null;
   allTimer?: boolean;
+  duration?: number | null;
+  durationSource?: string | null;
 }
 
 export interface TrackInsertOp {
@@ -632,6 +643,8 @@ export interface TrackInsertOp {
   segue: string | null;
   note: string | null;
   allTimer: boolean;
+  duration: number | null;
+  durationSource: string | null;
   annotationDescs: string[];
 }
 
@@ -714,6 +727,8 @@ export function buildSetlistReconciliation(
         segue: track.segue,
         note: track.note ?? null,
         allTimer: track.allTimer ?? false,
+        duration: track.duration ?? null,
+        durationSource: track.durationSource ?? null,
         annotationDescs: track.annotations ?? [],
       });
       structurallyChanged = true;
@@ -743,6 +758,8 @@ export function buildSetlistReconciliation(
         segue: track.segue,
         note: track.note ?? null,
         allTimer: track.allTimer ?? false,
+        duration: track.duration ?? null,
+        durationSource: track.durationSource ?? null,
         annotationDescs: track.annotations ?? [],
       });
       structurallyChanged = true;
@@ -773,6 +790,13 @@ export function buildSetlistReconciliation(
         patch.allTimer = remoteFlag;
         cosmeticallyChanged = true;
       }
+    }
+    // Duration + its provenance move together; `undefined` remote = "no
+    // opinion" so a pre-deploy MCP can't wipe locally resolved durations.
+    if (track.duration !== undefined && localTrack.duration !== track.duration) {
+      patch.duration = track.duration;
+      patch.durationSource = track.durationSource ?? null;
+      cosmeticallyChanged = true;
     }
     const annotationDiff = diffTrackAnnotations(localTrack.annotations, track.annotations);
     if (annotationDiff.toCreateDescs.length > 0 || annotationDiff.toDeleteIds.length > 0) {
@@ -2228,6 +2252,8 @@ async function syncMissingShows(): Promise<void> {
           segue: true,
           note: true,
           allTimer: true,
+          duration: true,
+          durationSource: true,
           annotations: { select: { id: true, desc: true } },
         },
       });
@@ -2241,6 +2267,8 @@ async function syncMissingShows(): Promise<void> {
           segue: row.segue,
           note: row.note,
           allTimer: row.allTimer,
+          duration: row.duration,
+          durationSource: row.durationSource,
           annotations: row.annotations,
         };
         if (arr) arr.push(tr);
@@ -2330,6 +2358,8 @@ async function syncMissingShows(): Promise<void> {
                 segue: ins.segue,
                 note: ins.note,
                 allTimer: ins.allTimer,
+                duration: ins.duration,
+                durationSource: ins.durationSource,
                 createdAt: now,
                 updatedAt: now,
                 annotations: ins.annotationDescs.length > 0
@@ -2368,6 +2398,9 @@ async function syncMissingShows(): Promise<void> {
           }
         });
         changedSlugs.add(slug);
+        // Keep the denormalized Show.duration in step with the mirrored track
+        // durations. Cheap (one aggregate + one update) and idempotent.
+        await recomputeShowDuration(db, local.id);
         console.log(
           `  📝 ${slug}: +${recon.toInsert.length} ~${recon.toUpdate.length} -${recon.toDelete.length} track(s)`,
         );

--- a/packages/core/src/_shared/catalog/date-indexed-catalog.ts
+++ b/packages/core/src/_shared/catalog/date-indexed-catalog.ts
@@ -7,7 +7,7 @@ import type { RedisService } from "../redis";
  * releases and remasters trickle in over days, not minutes — while still
  * bounding the window where a stale cache hides a newly-added show.
  */
-const TTL_SECONDS = 60 * 60 * 24;
+export const CATALOG_TTL_SECONDS = 60 * 60 * 24;
 
 /**
  * Shared caching layer for external catalogs that are small enough to fetch in
@@ -75,7 +75,7 @@ export class DateIndexedCatalog<T> {
     try {
       const map = await this.fetcher();
       if (Object.keys(map).length > 0) {
-        await this.redis.set<Record<string, T>>(this.cacheKey, map, { EX: TTL_SECONDS });
+        await this.redis.set<Record<string, T>>(this.cacheKey, map, { EX: CATALOG_TTL_SECONDS });
       }
       return map;
     } catch (error) {

--- a/packages/core/src/_shared/prisma/migrations/20260530120000_add_track_durations/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260530120000_add_track_durations/migration.sql
@@ -1,0 +1,9 @@
+-- Per-track durations (seconds) with provenance, plus a denormalized show
+-- total and a throttle timestamp for lazy external resolution. No backfill:
+-- durations populate live from nugs.net / archive.org as shows are viewed.
+
+ALTER TABLE "tracks" ADD COLUMN "duration" INTEGER;
+ALTER TABLE "tracks" ADD COLUMN "duration_source" VARCHAR;
+
+ALTER TABLE "shows" ADD COLUMN "duration" INTEGER;
+ALTER TABLE "shows" ADD COLUMN "duration_checked_at" TIMESTAMP(6);

--- a/packages/core/src/_shared/prisma/migrations/20260530130000_add_duration_sources/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260530130000_add_duration_sources/migration.sql
@@ -1,0 +1,21 @@
+-- Canonical lookup table for Track.duration provenance, plus an FK from
+-- tracks.duration_source so only known sources can be stored (no loose
+-- strings, no typos). The natural key is the source name the app writes.
+
+CREATE TABLE "duration_sources" (
+  "name" VARCHAR NOT NULL,
+  "description" VARCHAR,
+  "created_at" TIMESTAMP(6) NOT NULL DEFAULT now(),
+  "updated_at" TIMESTAMP(6) NOT NULL DEFAULT now(),
+  CONSTRAINT "duration_sources_pkey" PRIMARY KEY ("name")
+);
+
+INSERT INTO "duration_sources" ("name", "description") VALUES
+  ('nugs', 'Official nugs.net release (authoritative)'),
+  ('archive', 'Averaged from archive.org audience recordings (estimate)'),
+  ('manual', 'Entered or corrected by an admin');
+
+ALTER TABLE "tracks"
+  ADD CONSTRAINT "fk_tracks_duration_source"
+  FOREIGN KEY ("duration_source") REFERENCES "duration_sources"("name")
+  ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/packages/core/src/_shared/prisma/schema.prisma
+++ b/packages/core/src/_shared/prisma/schema.prisma
@@ -331,6 +331,8 @@ model Show {
   reviewsCount      Int                      @default(0) @map("reviews_count")
   countForStats     Boolean                  @default(true) @map("count_for_stats")
   dayOrder          Int?                     @map("day_order")
+  duration          Int?
+  durationCheckedAt DateTime?                @map("duration_checked_at") @db.Timestamp(6)
   searchText        String?                  @map("search_text") @db.Text
   searchVector      Unsupported("tsvector")? @map("search_vector")
   attendances       Attendance[]
@@ -506,10 +508,13 @@ model Track {
   searchVector    Unsupported("tsvector")? @map("search_vector")
   gap                       Int?
   previousPerformanceShowId String?         @map("previous_performance_show_id") @db.Uuid
+  duration        Int?
+  durationSource  String?                  @map("duration_source") @db.VarChar
   annotations     Annotation[]
   show            Show                     @relation(fields: [showId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_tracks_shows_show_id")
   song            Song                     @relation(fields: [songId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_tracks_songs_song_id")
   previousPerformanceShow   Show?           @relation("TrackPreviousPerformance", fields: [previousPerformanceShowId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_tracks_previous_performance_show_id")
+  durationSourceRef         DurationSource? @relation(fields: [durationSource], references: [name], onDelete: NoAction, onUpdate: NoAction, map: "fk_tracks_duration_source")
 
   @@index([likesCount])
   @@index([nextTrackId])
@@ -518,6 +523,20 @@ model Track {
   @@index([previousPerformanceShowId])
   @@index([showId, set, position], map: "tracks_show_set_position_idx")
   @@map("tracks")
+}
+
+/// Canonical list of where a Track.duration came from. A lookup table (rather
+/// than a bare string column) so the values are defined in one place and the
+/// FK rejects typos. The `name` is the natural key the app code writes
+/// ("nugs" | "archive" | "manual").
+model DurationSource {
+  name        String   @id @db.VarChar
+  description String?  @db.VarChar
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamp(6)
+  updatedAt   DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamp(6)
+  tracks      Track[]
+
+  @@map("duration_sources")
 }
 
 model User {

--- a/packages/core/src/_shared/services.ts
+++ b/packages/core/src/_shared/services.ts
@@ -19,6 +19,7 @@ import { TourDatesService } from "../shows/tour-dates-service";
 import { YoutubeService } from "../shows/youtube-service";
 import { SongService } from "../songs/song-service";
 import { StatsService } from "../stats/stats-service";
+import { TrackDurationService } from "../tracks/track-duration-service";
 import { TrackService } from "../tracks/track-service";
 import { PersonalSongHistoryService } from "../users/personal-song-history-service";
 import { UserService } from "../users/user-service";
@@ -36,6 +37,7 @@ export interface Services {
   songs: SongService;
   stats: StatsService;
   tracks: TrackService;
+  trackDurations: TrackDurationService;
   setlists: SetlistService;
   venues: VenueService;
   users: UserService;
@@ -75,6 +77,11 @@ export function createServices(container: ServiceContainer): Services {
   // lookup — SetlistService takes RockOperaService as a constructor dep.
   const rockOperaService = new RockOperaService(container.db, container.logger, statsService);
 
+  // nugs/archive are shared by their own service slots and by the duration
+  // resolver, which reads each source's per-show track lists.
+  const nugsService = new NugsService(container.redis, container.logger);
+  const archiveDotOrgService = new ArchiveDotOrgService(container.redis, container.logger);
+
   return {
     annotations: new AnnotationService(container.db, container.logger, container.cacheInvalidation),
     authors: new AuthorService(container.db, container.logger),
@@ -83,6 +90,13 @@ export function createServices(container: ServiceContainer): Services {
     songs: songService,
     stats: statsService,
     tracks: new TrackService(container.db, container.logger, container.cacheInvalidation),
+    trackDurations: new TrackDurationService(
+      container.db,
+      nugsService,
+      archiveDotOrgService,
+      container.cacheInvalidation,
+      container.logger,
+    ),
     setlists: new SetlistService(container.db, rockOperaService),
     venues: new VenueService(container.db, container.logger),
     users: new UserService(container.db, container.logger),
@@ -93,9 +107,9 @@ export function createServices(container: ServiceContainer): Services {
     attendances: new AttendanceService(container.db, container.logger),
     songPageComposer: new SongPageComposer(container.db, songService, statsService),
     tourDatesService: new TourDatesService(container.redis),
-    nugs: new NugsService(container.redis, container.logger),
+    nugs: nugsService,
     relisten: new RelistenService(container.redis, container.logger),
-    archiveDotOrg: new ArchiveDotOrgService(container.redis, container.logger),
+    archiveDotOrg: archiveDotOrgService,
     youtube: new YoutubeService(container.db, container.cacheInvalidation),
     files: new FileService(container.db, container.logger, {
       accountId: container.env.CLOUDFLARE_ACCOUNT_ID,

--- a/packages/core/src/_shared/show-ordering.test.ts
+++ b/packages/core/src/_shared/show-ordering.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { setSortKeySql, showOrderBySql } from "./show-ordering";
+import { setSortKey, setSortKeySql, showOrderBySql } from "./show-ordering";
 
 function renderSql(fragment: { strings: readonly string[]; values: unknown[] }): string {
   const parts: string[] = [];
@@ -28,12 +28,30 @@ describe("showOrderBySql", () => {
   });
 });
 
+describe("setSortKey", () => {
+  // The in-memory rank track-ordering code sorts by. Encores must rank after
+  // sets even though "E1" precedes "S1" alphabetically.
+  test("ranks Soundcheck before sets before encores", () => {
+    expect(setSortKey("Soundcheck")).toBeLessThan(setSortKey("S1"));
+    expect(setSortKey("S1")).toBeLessThan(setSortKey("S4"));
+    expect(setSortKey("S4")).toBeLessThan(setSortKey("E1"));
+    expect(setSortKey("E1")).toBeLessThan(setSortKey("E3"));
+  });
+
+  test("is case-insensitive on the label", () => {
+    expect(setSortKey("e1")).toBe(setSortKey("E1"));
+  });
+
+  test("sorts unrecognized labels last", () => {
+    expect(setSortKey("encore-jam")).toBeGreaterThan(setSortKey("E3"));
+  });
+});
+
 describe("setSortKeySql", () => {
-  // Mirrors apps/web/app/components/setlist/set-label.ts:setSortKey so
-  // SQL ORDER BY and the in-memory comparator agree on canonical order:
-  // Soundcheck → S1..S4 → E1..E3 → unknown. The numeric arms have to
-  // line up with the TS function — drift means table rows sort one way
-  // server-side and another client-side on a re-sort.
+  // Built from the same SET_SORT_ORDER map as setSortKey, so SQL ORDER BY and
+  // the in-memory comparator agree on canonical order: Soundcheck → S1..S4 →
+  // E1..E3 → unknown. Drift means table rows sort one way server-side and
+  // another client-side on a re-sort.
   test("renders a CASE expression keyed by the alias's set column", () => {
     const sql = renderSql(setSortKeySql("t") as never);
     expect(sql).toMatch(/CASE/);

--- a/packages/core/src/_shared/show-ordering.ts
+++ b/packages/core/src/_shared/show-ordering.ts
@@ -57,30 +57,48 @@ type TrackAlias = "t" | "tracks";
 type SortDirection = "ASC" | "DESC";
 
 /**
- * Raw-SQL CASE expression mirroring `setSortKey` from
- * apps/web/app/components/setlist/set-label.ts. Use in $queryRaw ORDER BY
- * clauses so SQL-side ordering by set matches the in-memory
- * `compareBySetThenPosition` comparator: Soundcheck → S1..S4 → E1..E3 →
- * unknown. Pass the alias your tracks table has in the query (`t` or
- * `tracks`).
- *
- * Keep the ordinals in sync with the TS function; drift produces
- * inconsistent ordering between paginated server fetches and any
- * client-side re-sort sharing the same rows.
+ * Play-order rank for each set label: Soundcheck → S1..S4 → E1..E3. The single
+ * source of truth shared by the in-memory `setSortKey` and the raw-SQL
+ * `setSortKeySql`, so server-side `ORDER BY` and any client re-sort of the same
+ * rows can't drift. Labels are matched case-insensitively; anything unlisted
+ * sorts last via `UNKNOWN_SET_RANK`.
+ */
+const SET_SORT_ORDER: Record<string, number> = {
+  soundcheck: 0,
+  s1: 10,
+  s2: 20,
+  s3: 30,
+  s4: 40,
+  e1: 50,
+  e2: 60,
+  e3: 70,
+};
+const UNKNOWN_SET_RANK = 999;
+
+/**
+ * In-memory play-order rank for a set label. Encores don't sort alphabetically
+ * into play order ("E1" would precede "S1"), so callers ordering tracks by set
+ * must rank through this rather than comparing labels directly.
+ */
+export function setSortKey(label: string): number {
+  return SET_SORT_ORDER[label.toLowerCase()] ?? UNKNOWN_SET_RANK;
+}
+
+/**
+ * Raw-SQL CASE expression equivalent to `setSortKey`, built from the same
+ * `SET_SORT_ORDER` map. Use in $queryRaw ORDER BY clauses so SQL-side ordering
+ * by set matches the in-memory `compareBySetThenPosition` comparator. Pass the
+ * alias your tracks table has in the query (`t` or `tracks`).
  */
 export function setSortKeySql(alias: TrackAlias): Prisma.Sql {
   const a = Prisma.raw(alias);
-  return Prisma.sql`CASE LOWER(${a}.set)
-    WHEN 'soundcheck' THEN 0
-    WHEN 's1' THEN 10
-    WHEN 's2' THEN 20
-    WHEN 's3' THEN 30
-    WHEN 's4' THEN 40
-    WHEN 'e1' THEN 50
-    WHEN 'e2' THEN 60
-    WHEN 'e3' THEN 70
-    ELSE 999
-  END`;
+  // SET_SORT_ORDER holds fixed, module-private labels (never user input), so the
+  // arms inline as literals, matching how the comparator compares lowercased
+  // labels and keeping the rendered CASE readable.
+  const arms = Object.entries(SET_SORT_ORDER)
+    .map(([label, rank]) => `WHEN '${label}' THEN ${rank}`)
+    .join(" ");
+  return Prisma.sql`CASE LOWER(${a}.set) ${Prisma.raw(arms)} ELSE ${UNKNOWN_SET_RANK} END`;
 }
 
 /**

--- a/packages/core/src/page-composers/song-page-composer.test.ts
+++ b/packages/core/src/page-composers/song-page-composer.test.ts
@@ -81,6 +81,8 @@ function makeDto(overrides: Partial<PerformanceDto> = {}): PerformanceDto {
     ratings_count: 12,
     note: null,
     gap: null,
+    duration: null,
+    duration_source: null,
     previous_performance_show_id: null,
     previous_show_slug: null,
     previous_show_date: null,

--- a/packages/core/src/page-composers/song-page-composer.ts
+++ b/packages/core/src/page-composers/song-page-composer.ts
@@ -561,6 +561,8 @@ export class SongPageComposer {
         tracks.ratings_count,
         tracks.note,
         tracks.gap,
+        tracks.duration,
+        tracks.duration_source,
         tracks.previous_performance_show_id,
         prevShows.slug as previous_show_slug,
         prevShows.date as previous_show_date
@@ -834,6 +836,8 @@ export function transformToSongPagePerformanceView(row: PerformanceDto): SongPag
     position: row.position,
     cover: row.song_cover ?? undefined,
     authorId: row.song_author_id ?? null,
+    duration: row.duration ?? null,
+    durationSource: row.duration_source ?? null,
     gap: row.gap,
     previousPerformanceShowId: row.previous_performance_show_id,
     previousShow:
@@ -916,6 +920,8 @@ export type PerformanceDto = {
   ratings_count: number;
   note: string | null;
   gap: number | null;
+  duration: number | null;
+  duration_source: string | null;
   previous_performance_show_id: string | null;
   previous_show_slug: string | null;
   previous_show_date: string | null;

--- a/packages/core/src/setlists/setlist-service.ts
+++ b/packages/core/src/setlists/setlist-service.ts
@@ -57,6 +57,8 @@ type DbTrackLight = {
   ratingsCount: number;
   gap: number | null;
   previousPerformanceShowId: string | null;
+  duration: number | null;
+  durationSource: string | null;
   previousPerformanceShow: { date: string; slug: string | null } | null;
   song: { id: string; title: string; slug: string } | null;
   annotations: DbAnnotation[];
@@ -285,6 +287,8 @@ function mapTrackLightToDomainEntity(track: DbTrackLight): TrackLight {
     ratingsCount: track.ratingsCount,
     gap: track.gap,
     previousPerformanceShowId: track.previousPerformanceShowId,
+    duration: track.duration,
+    durationSource: track.durationSource,
     previousPerformanceShow: previousPerformanceShowFromDb(track.previousPerformanceShow),
     song: track.song ?? undefined,
   };
@@ -594,6 +598,8 @@ export class SetlistService {
             ratingsCount: true,
             gap: true,
             previousPerformanceShowId: true,
+            duration: true,
+            durationSource: true,
             previousPerformanceShow: { select: { date: true, slug: true } },
             song: {
               select: {

--- a/packages/core/src/shows/archive-dot-org-service.test.ts
+++ b/packages/core/src/shows/archive-dot-org-service.test.ts
@@ -1,7 +1,29 @@
 import type { ArchiveDotOrgRecording } from "@bip/domain";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { RedisService } from "../_shared/redis";
-import { ArchiveDotOrgService } from "./archive-dot-org-service";
+import { ArchiveDotOrgService, parseArchiveLength } from "./archive-dot-org-service";
+
+describe("parseArchiveLength", () => {
+  // archive.org reports FLAC lengths as fractional seconds and mp3/ogg lengths
+  // as mm:ss / h:mm:ss; both must reduce to whole seconds.
+
+  test("rounds fractional-second (FLAC) values", () => {
+    expect(parseArchiveLength("179.51")).toBe(180);
+    expect(parseArchiveLength("822.0")).toBe(822);
+  });
+
+  test("parses mm:ss and h:mm:ss (mp3/ogg) values", () => {
+    expect(parseArchiveLength("13:43")).toBe(823);
+    expect(parseArchiveLength("1:02:03")).toBe(3723);
+  });
+
+  test("rejects zero, negative, and unparseable values", () => {
+    expect(parseArchiveLength("0")).toBeNull();
+    expect(parseArchiveLength("0:00")).toBeNull();
+    expect(parseArchiveLength("-5")).toBeNull();
+    expect(parseArchiveLength("abc")).toBeNull();
+  });
+});
 
 function makeRedisMock() {
   const store = new Map<string, unknown>();
@@ -233,5 +255,56 @@ describe("ArchiveDotOrgService.hasRecordings", () => {
 
   test("returns false when no recording matches", async () => {
     expect(await service.hasRecordings("1999-04-09")).toBe(false);
+  });
+});
+
+describe("ArchiveDotOrgService.fetchRecordingTracks", () => {
+  let redis: ReturnType<typeof makeRedisMock>;
+  let service: ArchiveDotOrgService;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    redis = makeRedisMock();
+    service = new ArchiveDotOrgService(redis);
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Fixture mirrors archive.org's metadata `files` array: each track repeats
+  // across audio formats (flac/mp3), non-audio files lack title/length, and a
+  // multi-disc show reuses track numbers per disc (d1t01 / d2t01).
+  function makeMetadataResponse(
+    files: Array<{ name?: string; title?: string; track?: string; length?: string; format?: string }>,
+  ) {
+    return { ok: true, json: async () => ({ files }) } as unknown as Response;
+  }
+
+  test("dedups formats (FLAC wins), keeps multi-disc tracks distinct, drops non-audio", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeMetadataResponse([
+        { name: "db_d1t01_helicopters.mp3", title: "Helicopters", track: "01", length: "8:40", format: "VBR MP3" },
+        { name: "db_d1t01_helicopters.flac", title: "Helicopters", track: "01", length: "520.0", format: "Flac" },
+        // Disc 2 reuses track "01" — must NOT collapse into Helicopters.
+        { name: "db_d2t01_spaga.flac", title: "Spaga", track: "01", length: "410.5", format: "Flac" },
+        { name: "db_cover.jpg", format: "JPEG" },
+        { name: "db_meta.xml", format: "Metadata" },
+      ]),
+    );
+
+    const tracks = await service.fetchRecordingTracks("db-show");
+
+    expect(tracks).toEqual([
+      { title: "Helicopters", seconds: 520 },
+      { title: "Spaga", seconds: 411 },
+    ]);
+  });
+
+  test("returns [] without throwing on a non-ok response", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 404 } as unknown as Response);
+    expect(await service.fetchRecordingTracks("missing")).toEqual([]);
   });
 });

--- a/packages/core/src/shows/archive-dot-org-service.ts
+++ b/packages/core/src/shows/archive-dot-org-service.ts
@@ -2,6 +2,41 @@ import type { ArchiveDotOrgRecording, Logger } from "@bip/domain";
 import { CacheKeys, pickPrimaryArchiveRecording } from "@bip/domain";
 import { DateIndexedCatalog } from "../_shared/catalog/date-indexed-catalog";
 import type { RedisService } from "../_shared/redis";
+import type { ExternalDurationTrack } from "../tracks/duration-matching";
+
+/** Per-recording track-list cache lifetime — a recording's files are stable. */
+const RECORDING_TTL_SECONDS = 60 * 60 * 24 * 7;
+
+/** One file entry from archive.org's metadata API. */
+interface ArchiveMetadataFile {
+  name?: string;
+  title?: string;
+  track?: string;
+  /** Either fractional seconds ("179.51") or "mm:ss" / "h:mm:ss". */
+  length?: string;
+  format?: string;
+}
+
+/** Envelope shape from archive.org's metadata endpoint. */
+interface ArchiveMetadataResponse {
+  files?: ArchiveMetadataFile[];
+}
+
+/**
+ * Parse an archive.org `length` value into whole seconds. FLAC files report
+ * fractional seconds ("179.51"); mp3/ogg derivatives report "mm:ss". Returns
+ * null for anything unparseable.
+ */
+export function parseArchiveLength(raw: string): number | null {
+  if (raw.includes(":")) {
+    const parts = raw.split(":").map((p) => Number.parseInt(p, 10));
+    if (parts.some((n) => Number.isNaN(n))) return null;
+    const seconds = parts.reduce((acc, n) => acc * 60 + n, 0);
+    return seconds > 0 ? seconds : null;
+  }
+  const value = Number.parseFloat(raw);
+  return Number.isFinite(value) && value > 0 ? Math.round(value) : null;
+}
 
 /**
  * Raw shape returned by archive.org's advancedsearch endpoint. Not exported —
@@ -68,12 +103,15 @@ export class ArchiveDotOrgService {
    * @param logger Optional logger; fetch failures are swallowed so a show page
    *   never breaks on archive.org downtime.
    */
-  constructor(redis: RedisService, logger?: Logger) {
+  constructor(
+    private readonly redis: RedisService,
+    private readonly logger?: Logger,
+  ) {
     this.catalog = new DateIndexedCatalog<ArchiveDotOrgRecording[]>(
-      redis,
+      this.redis,
       CacheKeys.archiveDotOrg.catalog(),
-      buildFetcher(logger),
-      logger,
+      buildFetcher(this.logger),
+      this.logger,
     );
   }
 
@@ -116,5 +154,58 @@ export class ArchiveDotOrgService {
    */
   pickPrimary(recordings: ArchiveDotOrgRecording[]): ArchiveDotOrgRecording | null {
     return pickPrimaryArchiveRecording(recordings);
+  }
+
+  /**
+   * Fetch the ordered track list (title + duration seconds) for one recording
+   * via the metadata API. Each track is published in several audio formats; we
+   * keep one row per track, preferring the FLAC length (most precise). Cached
+   * per identifier in Redis. Returns an empty list on any failure so duration
+   * resolution degrades gracefully.
+   */
+  async fetchRecordingTracks(identifier: string): Promise<ExternalDurationTrack[]> {
+    const cacheKey = CacheKeys.archiveDotOrg.recording(identifier);
+    const cached = await this.redis.get<ExternalDurationTrack[]>(cacheKey);
+    if (cached) return cached;
+
+    try {
+      const response = await fetch(`https://archive.org/metadata/${identifier}`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch archive.org metadata for ${identifier}: ${response.status}`);
+      }
+      const data: ArchiveMetadataResponse = await response.json();
+      const files = data.files ?? [];
+
+      // One row per track, preferring the FLAC length (most precise). Dedup on
+      // the filename minus its extension: that collapses the same track's
+      // flac/mp3/ogg copies into one entry while keeping multi-disc tracks
+      // distinct (their `track` numbers repeat per disc, e.g. d1_01 / d2_01).
+      const byTrack = new Map<string, { title: string; seconds: number; isFlac: boolean; name: string }>();
+      for (const file of files) {
+        if (!file.title || !file.length || !file.name) continue;
+        const seconds = parseArchiveLength(file.length);
+        if (seconds === null) continue;
+        const stem = file.name.replace(/\.[^./]+$/, "");
+        const isFlac = (file.format ?? "").toLowerCase().includes("flac");
+        const existing = byTrack.get(stem);
+        if (!existing || (isFlac && !existing.isFlac)) {
+          byTrack.set(stem, { title: file.title, seconds, isFlac, name: file.name });
+        }
+      }
+
+      // Filenames embed disc+track in zero-padded order, so a lexical sort
+      // restores play order across discs.
+      const tracks = [...byTrack.values()]
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map(({ title, seconds }) => ({ title, seconds }));
+
+      if (tracks.length > 0) {
+        await this.redis.set<ExternalDurationTrack[]>(cacheKey, tracks, { EX: RECORDING_TTL_SECONDS });
+      }
+      return tracks;
+    } catch (error) {
+      this.logger?.error("archive.org recording fetch failed", { identifier, error });
+      return [];
+    }
   }
 }

--- a/packages/core/src/shows/nugs-service.test.ts
+++ b/packages/core/src/shows/nugs-service.test.ts
@@ -63,7 +63,9 @@ describe("NugsService.findReleasesForDate", () => {
 
     const releases = await service.findReleasesForDate("2007-12-28");
 
-    expect(releases).toEqual([{ artistName: "The Disco Biscuits", url: "https://play.nugs.net/release/2189" }]);
+    expect(releases).toEqual([
+      { artistName: "The Disco Biscuits", url: "https://play.nugs.net/release/2189", containerId: 2189 },
+    ]);
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls[0][0]).toContain(`artistID=${NUGS_ARTIST_IDS.discoBiscuits}`);
     expect(fetchMock.mock.calls[1][0]).toContain(`artistID=${NUGS_ARTIST_IDS.tractorbeam}`);
@@ -82,7 +84,9 @@ describe("NugsService.findReleasesForDate", () => {
 
     const releases = await service.findReleasesForDate("2026-03-20");
 
-    expect(releases).toEqual([{ artistName: "Tractorbeam", url: "https://play.nugs.net/release/47100" }]);
+    expect(releases).toEqual([
+      { artistName: "Tractorbeam", url: "https://play.nugs.net/release/47100", containerId: 47100 },
+    ]);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -117,10 +121,12 @@ describe("NugsService.findReleasesForDate", () => {
     expect(releases).toContainEqual({
       artistName: "The Disco Biscuits",
       url: "https://play.nugs.net/release/9999",
+      containerId: 9999,
     });
     expect(releases).toContainEqual({
       artistName: "Tractorbeam",
       url: "https://play.nugs.net/release/47100",
+      containerId: 47100,
     });
   });
 
@@ -146,7 +152,9 @@ describe("NugsService.findReleasesForDate", () => {
       .mockResolvedValueOnce(makeCatalogResponse([]));
     const releases = await service.findReleasesForDate("2007-12-28");
 
-    expect(releases).toEqual([{ artistName: "The Disco Biscuits", url: "https://play.nugs.net/release/2189" }]);
+    expect(releases).toEqual([
+      { artistName: "The Disco Biscuits", url: "https://play.nugs.net/release/2189", containerId: 2189 },
+    ]);
   });
 
   // The catalog map is persisted under the same cache key the domain layer
@@ -165,5 +173,73 @@ describe("NugsService.findReleasesForDate", () => {
     for (const call of setCalls) {
       expect(call[2]).toEqual({ EX: 60 * 60 * 24 });
     }
+  });
+});
+
+describe("NugsService.fetchContainerTracks", () => {
+  let redis: ReturnType<typeof makeRedisMock>;
+  let service: NugsService;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    redis = makeRedisMock();
+    service = new NugsService(redis);
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Fixture mirrors the real catalog.container shape: per-track running times
+  // live on Response.tracks (songTitle + totalRunningTime whole seconds +
+  // disc/track ordinals). The sibling Response.songs array has NO durations
+  // and must be ignored — reading it was the bug this fixture now guards.
+  function makeContainerResponse(
+    tracks: Array<{ songTitle?: string; totalRunningTime?: number; discNum?: number; trackNum?: number }>,
+  ) {
+    return {
+      ok: true,
+      json: async () => ({ Response: { tracks, songs: tracks.map((t) => ({ songTitle: t.songTitle })) } }),
+    } as unknown as Response;
+  }
+
+  test("parses titles + running times in disc/track order, dropping non-timed rows", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeContainerResponse([
+        { songTitle: "Plan B", totalRunningTime: 745, discNum: 2, trackNum: 2 },
+        { songTitle: "Mishawaka Jam", totalRunningTime: 3858, discNum: 1, trackNum: 1 },
+        { songTitle: "Crowd", totalRunningTime: 36, discNum: 2, trackNum: 1 },
+        { songTitle: "Missing Time", discNum: 2, trackNum: 3 },
+        { songTitle: "Zero Time", totalRunningTime: 0, discNum: 2, trackNum: 4 },
+      ]),
+    );
+
+    const tracks = await service.fetchContainerTracks(48634);
+
+    expect(tracks).toEqual([
+      { title: "Mishawaka Jam", seconds: 3858 },
+      { title: "Crowd", seconds: 36 },
+      { title: "Plan B", seconds: 745 },
+    ]);
+  });
+
+  test("returns [] without throwing on a non-ok response", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500 } as unknown as Response);
+    expect(await service.fetchContainerTracks(1)).toEqual([]);
+  });
+
+  test("serves the second call from cache without re-fetching", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeContainerResponse([{ songTitle: "Spaga", totalRunningTime: 410, discNum: 1, trackNum: 1 }]),
+    );
+    await service.fetchContainerTracks(99);
+    fetchMock.mockClear();
+
+    const again = await service.fetchContainerTracks(99);
+
+    expect(again).toEqual([{ title: "Spaga", seconds: 410 }]);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/shows/nugs-service.ts
+++ b/packages/core/src/shows/nugs-service.ts
@@ -2,11 +2,15 @@ import type { Logger } from "@bip/domain";
 import { CacheKeys } from "@bip/domain";
 import { DateIndexedCatalog } from "../_shared/catalog/date-indexed-catalog";
 import type { RedisService } from "../_shared/redis";
+import type { ExternalDurationTrack } from "../tracks/duration-matching";
 
 export const NUGS_ARTIST_IDS = {
   discoBiscuits: 128,
   tractorbeam: 514,
 } as const;
+
+/** Per-container track-list cache lifetime — these never change once posted. */
+const CONTAINER_TTL_SECONDS = 60 * 60 * 24 * 7;
 
 /**
  * A single official release on nugs.net. `artistName` matters when the same
@@ -18,6 +22,8 @@ export interface NugsRelease {
   artistName: string;
   /** Fully-qualified `play.nugs.net/release/{containerID}` link. */
   url: string;
+  /** Container id, needed to fetch the per-track running times. */
+  containerId: number;
 }
 
 /**
@@ -34,6 +40,26 @@ interface NugsApiContainer {
 interface NugsApiResponse {
   Response?: {
     containers?: NugsApiContainer[];
+  };
+}
+
+/** One track row from the catalog.container detail endpoint. */
+interface NugsApiTrack {
+  songTitle?: string;
+  /** Running time in whole seconds. */
+  totalRunningTime?: number;
+  discNum?: number;
+  trackNum?: number;
+}
+
+/**
+ * Envelope shape from nugs.net's catalog.container endpoint. The per-track
+ * running times live on `Response.tracks`; the sibling `Response.songs` array
+ * is the catalog-style listing WITHOUT durations, so it must not be read here.
+ */
+interface NugsContainerResponse {
+  Response?: {
+    tracks?: NugsApiTrack[];
   };
 }
 
@@ -55,6 +81,7 @@ function buildFetcher(artistId: number, logger?: Logger) {
       map[isoDate] = {
         artistName: c.artistName,
         url: `https://play.nugs.net/release/${c.containerID}`,
+        containerId: c.containerID,
       };
     }
     return map;
@@ -78,14 +105,17 @@ export class NugsService {
    * @param logger Optional logger; fetch failures are swallowed so a show page
    *   renders even when nugs.net is unreachable.
    */
-  constructor(redis: RedisService, logger?: Logger) {
+  constructor(
+    private readonly redis: RedisService,
+    private readonly logger?: Logger,
+  ) {
     this.catalogs = Object.values(NUGS_ARTIST_IDS).map(
       (artistId) =>
         new DateIndexedCatalog<NugsRelease>(
-          redis,
+          this.redis,
           CacheKeys.nugs.catalog(artistId),
-          buildFetcher(artistId, logger),
-          logger,
+          buildFetcher(artistId, this.logger),
+          this.logger,
         ),
     );
   }
@@ -119,5 +149,44 @@ export class NugsService {
       }
     }
     return urls;
+  }
+
+  /**
+   * Fetch the ordered track list (title + running time in seconds) for one
+   * release via the catalog.container detail endpoint, the authoritative
+   * source of per-track durations. Cached per container in Redis since the
+   * track list of a posted release never changes. Returns an empty list on any
+   * failure so duration resolution degrades to the next source.
+   */
+  async fetchContainerTracks(containerId: number): Promise<ExternalDurationTrack[]> {
+    const cacheKey = CacheKeys.nugs.container(containerId);
+    const cached = await this.redis.get<ExternalDurationTrack[]>(cacheKey);
+    if (cached) return cached;
+
+    try {
+      const url = `https://streamapi.nugs.net/api.aspx?method=catalog.container&containerID=${containerId}&vdisp=1`;
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch nugs container ${containerId}: ${response.status}`);
+      }
+      const data: NugsContainerResponse = await response.json();
+      const containerTracks = data.Response?.tracks ?? [];
+
+      const tracks = containerTracks
+        .filter(
+          (t): t is Required<Pick<NugsApiTrack, "songTitle" | "totalRunningTime">> & NugsApiTrack =>
+            Boolean(t.songTitle) && typeof t.totalRunningTime === "number" && t.totalRunningTime > 0,
+        )
+        .sort((a, b) => (a.discNum ?? 0) - (b.discNum ?? 0) || (a.trackNum ?? 0) - (b.trackNum ?? 0))
+        .map((t) => ({ title: t.songTitle, seconds: t.totalRunningTime }));
+
+      if (tracks.length > 0) {
+        await this.redis.set<ExternalDurationTrack[]>(cacheKey, tracks, { EX: CONTAINER_TTL_SECONDS });
+      }
+      return tracks;
+    } catch (error) {
+      this.logger?.error("nugs container fetch failed", { containerId, error });
+      return [];
+    }
   }
 }

--- a/packages/core/src/tracks/duration-matching.test.ts
+++ b/packages/core/src/tracks/duration-matching.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "vitest";
+import { matchTrackDurations, normalizeTrackTitle } from "./duration-matching";
+
+// ---------------------------------------------------------------------------
+// normalizeTrackTitle
+// ---------------------------------------------------------------------------
+
+describe("normalizeTrackTitle", () => {
+  // Aligns our setlist titles with the punctuation/segue-marker noise that
+  // external sources (nugs, archive.org) put in their track titles.
+
+  test("lowercases and collapses whitespace", () => {
+    expect(normalizeTrackTitle("Basis For A Day")).toBe(normalizeTrackTitle("basis for a day"));
+  });
+
+  test("strips segue markers and surrounding punctuation", () => {
+    expect(normalizeTrackTitle("Aceetobee >")).toBe(normalizeTrackTitle("Aceetobee"));
+    expect(normalizeTrackTitle("Spaga ->")).toBe(normalizeTrackTitle("Spaga"));
+    expect(normalizeTrackTitle("I-Man")).toBe(normalizeTrackTitle("I Man"));
+  });
+
+  test("treats & as and", () => {
+    expect(normalizeTrackTitle("On & On")).toBe(normalizeTrackTitle("On and On"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchTrackDurations
+// ---------------------------------------------------------------------------
+
+describe("matchTrackDurations", () => {
+  // Maps our ordered setlist tracks to external durations, skipping filler
+  // tracks the external source inserts (crowd noise, tuning) and summing a
+  // song the external source split across consecutive files.
+
+  test("aligns a clean 1:1 setlist", () => {
+    const result = matchTrackDurations(
+      [
+        { key: "a", title: "Helicopters" },
+        { key: "b", title: "Basis for a Day" },
+        { key: "c", title: "Spaga" },
+      ],
+      [
+        { title: "Helicopters", seconds: 522 },
+        { title: "Basis For A Day", seconds: 845 },
+        { title: "Spaga", seconds: 410 },
+      ],
+    );
+    expect(result.get("a")).toBe(522);
+    expect(result.get("b")).toBe(845);
+    expect(result.get("c")).toBe(410);
+  });
+
+  test("skips external filler tracks between songs", () => {
+    const result = matchTrackDurations(
+      [
+        { key: "a", title: "Helicopters" },
+        { key: "b", title: "Spaga" },
+      ],
+      [
+        { title: "Crowd", seconds: 30 },
+        { title: "Helicopters", seconds: 522 },
+        { title: "Tuning", seconds: 12 },
+        { title: "Spaga", seconds: 410 },
+      ],
+    );
+    expect(result.get("a")).toBe(522);
+    expect(result.get("b")).toBe(410);
+  });
+
+  test("resyncs past an unknown interloper that is not in our setlist", () => {
+    const result = matchTrackDurations(
+      [
+        { key: "a", title: "Helicopters" },
+        { key: "b", title: "Spaga" },
+      ],
+      [
+        { title: "Helicopters", seconds: 500 },
+        { title: "Banter", seconds: 20 },
+        { title: "Spaga", seconds: 400 },
+      ],
+    );
+    expect(result.get("a")).toBe(500);
+    expect(result.get("b")).toBe(400);
+  });
+
+  test("sums a song the external source split across consecutive files", () => {
+    const result = matchTrackDurations(
+      [{ key: "a", title: "Munchkin Invasion" }],
+      [
+        { title: "Munchkin Invasion", seconds: 200 },
+        { title: "Munchkin Invasion", seconds: 150 },
+      ],
+    );
+    expect(result.get("a")).toBe(350);
+  });
+
+  test("leaves tracks the source lacks unassigned", () => {
+    const result = matchTrackDurations(
+      [
+        { key: "a", title: "Konkrete" },
+        { key: "b", title: "Astronaut" },
+      ],
+      [{ title: "Konkrete", seconds: 300 }],
+    );
+    expect(result.get("a")).toBe(300);
+    expect(result.has("b")).toBe(false);
+  });
+
+  test("returns an empty map for empty inputs", () => {
+    expect(matchTrackDurations([], [{ title: "Spaga", seconds: 1 }]).size).toBe(0);
+    expect(matchTrackDurations([{ key: "a", title: "Spaga" }], []).size).toBe(0);
+  });
+
+  test("ignores zero/negative external lengths", () => {
+    const result = matchTrackDurations([{ key: "a", title: "Crickets" }], [{ title: "Crickets", seconds: 0 }]);
+    expect(result.has("a")).toBe(false);
+  });
+
+  // "jam"/"improv" naming drifts between sources (our "Mishawaka Improv Jam"
+  // vs nugs' "Mishawaka Jam"), so those words are dropped before comparing
+  // when either side carries one.
+  test("matches jam/improv titles flexibly by their distinctive words", () => {
+    const result = matchTrackDurations(
+      [
+        { key: "a", title: "Helicopters" },
+        { key: "b", title: "Mishawaka Improv Jam" },
+      ],
+      [
+        { title: "Helicopters", seconds: 500 },
+        { title: "Mishawaka Jam", seconds: 3858 },
+      ],
+    );
+    expect(result.get("a")).toBe(500);
+    expect(result.get("b")).toBe(3858);
+  });
+
+  test("relaxes when the jam word is on our side", () => {
+    const result = matchTrackDurations(
+      [{ key: "a", title: "Crystal Ball Jam" }],
+      [{ title: "Crystal Ball", seconds: 612 }],
+    );
+    expect(result.get("a")).toBe(612);
+  });
+
+  test("does not match a bare 'Jam' to an unrelated track", () => {
+    const result = matchTrackDurations([{ key: "a", title: "Jam" }], [{ title: "Helicopters", seconds: 500 }]);
+    expect(result.has("a")).toBe(false);
+  });
+
+  // Word spacing drifts between sources — our "Sugarplum" vs archive's
+  // "Sugar Plum" — so comparison ignores spaces.
+  test("matches across word-spacing differences", () => {
+    const result = matchTrackDurations(
+      [{ key: "a", title: "Dance of the Sugarplum Fairies" }],
+      [{ title: "Dance Of The Sugar Plum Fairies >", seconds: 540 }],
+    );
+    expect(result.get("a")).toBe(540);
+  });
+
+  test("does not match unrelated titles just because spaces are removed", () => {
+    const result = matchTrackDurations([{ key: "a", title: "Crickets" }], [{ title: "Helicopters", seconds: 500 }]);
+    expect(result.has("a")).toBe(false);
+  });
+
+  // External sources have typos — nugs spelled the reprise "Munckin Invasion"
+  // (missing the h) — so a single-character difference in a long title still
+  // matches as a last resort.
+  test("tolerates a single-character typo in a long title", () => {
+    const result = matchTrackDurations(
+      [{ key: "a", title: "Munchkin Invasion" }],
+      [{ title: "Munckin Invasion", seconds: 472 }],
+    );
+    expect(result.get("a")).toBe(472);
+  });
+
+  test("does not fuzzy-match short titles or titles more than one edit apart", () => {
+    // Too short to risk a fuzzy match.
+    expect(matchTrackDurations([{ key: "a", title: "Spaga" }], [{ title: "Spago", seconds: 100 }]).has("a")).toBe(
+      false,
+    );
+    // Two substitutions apart (Crickets vs Crackers).
+    expect(matchTrackDurations([{ key: "b", title: "Crickets" }], [{ title: "Crackers", seconds: 100 }]).has("b")).toBe(
+      false,
+    );
+  });
+});

--- a/packages/core/src/tracks/duration-matching.ts
+++ b/packages/core/src/tracks/duration-matching.ts
@@ -1,0 +1,163 @@
+/**
+ * Aligns our ordered setlist tracks with the track list an external source
+ * (nugs.net, archive.org) reports for the same show, so we can attach each of
+ * our tracks a duration. The two lists never line up cleanly: external sources
+ * insert filler tracks (crowd noise, tuning, banter), title songs with their
+ * own punctuation and segue markers, and occasionally split one song across
+ * consecutive files. The matcher is deliberately conservative — it only
+ * assigns a duration when titles agree, and leaves anything ambiguous
+ * unassigned for an admin to fill in.
+ */
+
+/** A track on our side, keyed by whatever identifier the caller wants back. */
+export interface MatchableTrack {
+  key: string;
+  title: string;
+}
+
+/** A track from an external source, with its duration in seconds. */
+export interface ExternalDurationTrack {
+  title: string;
+  seconds: number;
+}
+
+/**
+ * Reduce a track title to a comparison key: lowercase, fold "&"→"and", drop
+ * segue markers and punctuation, collapse whitespace. So "Aceetobee >" /
+ * "aceetobee", "I-Man" / "I Man", and "On & On" / "On and On" each compare
+ * equal across our data and theirs.
+ */
+export function normalizeTrackTitle(title: string): string {
+  return (
+    title
+      .toLowerCase()
+      // "&" and "and" are the same word ("On & On" vs "On and On"); fold before
+      // dropping punctuation so the ampersand doesn't just vanish.
+      .replace(/&/g, " and ")
+      .replace(/[^a-z0-9\s]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+  );
+}
+
+/**
+ * Words that drift between sources and don't change which song a jam belongs
+ * to — our "Mishawaka Improv Jam" is nugs' "Mishawaka Jam". Dropped before a
+ * relaxed comparison so those titles still align on their distinctive words.
+ */
+const JAM_WORDS = new Set(["jam", "improv", "improvisation"]);
+
+function hasJamWord(normalized: string): boolean {
+  return normalized.split(" ").some((word) => JAM_WORDS.has(word));
+}
+
+function withoutJamWords(normalized: string): string {
+  return normalized
+    .split(" ")
+    .filter((word) => word.length > 0 && !JAM_WORDS.has(word))
+    .join(" ");
+}
+
+/** Minimum length before a single-character typo is tolerated — short titles
+ * ("On" vs "In") are too easy to confuse, so fuzzy matching only kicks in for
+ * longer titles where one differing character is almost certainly a typo. */
+const TYPO_MIN_LENGTH = 6;
+
+/**
+ * True when `a` and `b` are within one edit (insert, delete, or substitute) —
+ * i.e. Levenshtein distance ≤ 1. Used to forgive single-character typos in
+ * external track titles (nugs' "Munckin Invasion" for "Munchkin Invasion").
+ */
+function withinOneEdit(a: string, b: string): boolean {
+  if (a === b) return true;
+  const [short, long] = a.length <= b.length ? [a, b] : [b, a];
+  if (long.length - short.length > 1) return false;
+  if (long.length === short.length) {
+    let diffs = 0;
+    for (let i = 0; i < short.length; i++) {
+      if (short[i] !== long[i] && ++diffs > 1) return false;
+    }
+    return diffs === 1;
+  }
+  // `long` is exactly one char longer — it matches with a single deletion.
+  let i = 0;
+  let j = 0;
+  let skipped = false;
+  while (i < short.length && j < long.length) {
+    if (short[i] === long[j]) {
+      i++;
+      j++;
+    } else {
+      if (skipped) return false;
+      skipped = true;
+      j++;
+    }
+  }
+  return true;
+}
+
+/**
+ * True when two normalized titles refer to the same track. Exact match is the
+ * common case. Word spacing drifts between sources ("Sugarplum" vs "Sugar
+ * Plum"), so a space-insensitive compare is tried next; then jam/improv words
+ * are stripped (so "Mishawaka Improv Jam" finds "Mishawaka Jam"); finally a
+ * single-character typo in a long title is forgiven (nugs' "Munckin Invasion").
+ */
+function titlesMatch(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (a.replaceAll(" ", "") === b.replaceAll(" ", "")) return true;
+  if (hasJamWord(a) || hasJamWord(b)) {
+    const strippedA = withoutJamWords(a);
+    if (strippedA.length > 0 && strippedA === withoutJamWords(b)) return true;
+  }
+  return Math.min(a.length, b.length) >= TYPO_MIN_LENGTH && withinOneEdit(a, b);
+}
+
+/**
+ * Returns a map of our-track `key` → duration seconds for every track we could
+ * confidently align. Walks both lists with a two-pointer pass: on a title
+ * match it assigns (summing consecutive external files that carry the same
+ * title), otherwise it tries to resync by finding the current track later in
+ * the external list (skipping filler/extra tracks) and gives up on a track
+ * the source simply doesn't have.
+ */
+export function matchTrackDurations(ours: MatchableTrack[], external: ExternalDurationTrack[]): Map<string, number> {
+  const result = new Map<string, number>();
+  const ourNorms = ours.map((t) => normalizeTrackTitle(t.title));
+  const extNorms = external.map((t) => normalizeTrackTitle(t.title));
+
+  let i = 0;
+  let j = 0;
+  while (i < ours.length && j < external.length) {
+    if (titlesMatch(ourNorms[i], extNorms[j])) {
+      let sum = external[j].seconds > 0 ? external[j].seconds : 0;
+      j++;
+      // Sum consecutive external files for the same song (a split track), but
+      // don't steal the duration of the same song played again next in our set.
+      const nextOurNorm = i + 1 < ours.length ? ourNorms[i + 1] : null;
+      while (j < external.length && extNorms[j] === ourNorms[i] && ourNorms[i] !== nextOurNorm) {
+        if (external[j].seconds > 0) sum += external[j].seconds;
+        j++;
+      }
+      if (sum > 0) result.set(ours[i].key, sum);
+      i++;
+    } else {
+      // Look for our current track further down the external list, skipping
+      // whatever filler/extra tracks sit in between.
+      let found = -1;
+      for (let k = j + 1; k < external.length; k++) {
+        if (titlesMatch(ourNorms[i], extNorms[k])) {
+          found = k;
+          break;
+        }
+      }
+      if (found !== -1) {
+        j = found;
+      } else {
+        i++;
+      }
+    }
+  }
+
+  return result;
+}

--- a/packages/core/src/tracks/show-duration.ts
+++ b/packages/core/src/tracks/show-duration.ts
@@ -1,0 +1,16 @@
+import type { DbClient } from "../_shared/database/models";
+
+/**
+ * Recompute and persist a show's denormalized total duration as the sum of its
+ * tracks' durations (seconds). Null tracks are ignored by the SQL sum, so a
+ * partially-resolved show stores the total of what's known; a show with no
+ * known track durations stores null. Called after any write that changes a
+ * track's duration (live resolution or an admin edit) so the denormalized
+ * `Show.duration` that backs cross-show table views stays consistent.
+ */
+export async function recomputeShowDuration(db: DbClient, showId: string): Promise<number | null> {
+  const agg = await db.track.aggregate({ where: { showId }, _sum: { duration: true } });
+  const total = agg._sum.duration ?? null;
+  await db.show.update({ where: { id: showId }, data: { duration: total } });
+  return total;
+}

--- a/packages/core/src/tracks/track-duration-service.test.ts
+++ b/packages/core/src/tracks/track-duration-service.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test, vi } from "vitest";
+import { TrackDurationService } from "./track-duration-service";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+
+/**
+ * A dual-billed night ships two nugs releases (Disco Biscuits + Tractorbeam),
+ * each holding only its own sets. Resolution must merge both so every track
+ * gets a duration — returning the first release alone would leave the other
+ * billing's set untimed.
+ */
+describe("TrackDurationService — nugs releases combine", () => {
+  test("merges matches across both nugs releases for a dual-billed show", async () => {
+    const trackUpdate = vi.fn().mockResolvedValue({});
+    const db = {
+      show: {
+        findMany: vi.fn().mockResolvedValue([{ id: "show1", slug: "2026-04-12-stratton", date: "2026-04-12" }]),
+        update: vi.fn().mockResolvedValue({}),
+      },
+      track: {
+        findMany: vi.fn().mockResolvedValue([
+          { id: "ta", set: "S1", position: 1, durationSource: null, song: { title: "Helicopters" } },
+          { id: "tb", set: "S2", position: 1, durationSource: null, song: { title: "Tractorbeam" } },
+        ]),
+        update: trackUpdate,
+        aggregate: vi.fn().mockResolvedValue({ _sum: { duration: 1700 } }),
+      },
+    };
+    const nugs = {
+      findReleasesForDate: vi.fn().mockResolvedValue([
+        { artistName: "The Disco Biscuits", url: "", containerId: 1 },
+        { artistName: "Tractorbeam", url: "", containerId: 2 },
+      ]),
+      // Each container holds only its own billing's set.
+      fetchContainerTracks: vi.fn(async (containerId: number) =>
+        containerId === 1 ? [{ title: "Helicopters", seconds: 500 }] : [{ title: "Tractorbeam", seconds: 1200 }],
+      ),
+    };
+    const archive = { findRecordingsForDate: vi.fn().mockResolvedValue([]) };
+    const cacheInvalidation = { invalidateShowComprehensive: vi.fn().mockResolvedValue(undefined) };
+
+    const service = new TrackDurationService(
+      db as never,
+      nugs as never,
+      archive as never,
+      cacheInvalidation as never,
+      logger,
+    );
+
+    await service.resolvePending(["show1"]);
+
+    // Both tracks get a nugs duration — one from each release.
+    const updates = new Map(trackUpdate.mock.calls.map((c) => [c[0].where.id, c[0].data]));
+    expect(updates.get("ta")).toMatchObject({ duration: 500, durationSource: "nugs" });
+    expect(updates.get("tb")).toMatchObject({ duration: 1200, durationSource: "nugs" });
+    // Archive is the fallback; nugs covered everything, so it's never consulted.
+    expect(archive.findRecordingsForDate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/tracks/track-duration-service.ts
+++ b/packages/core/src/tracks/track-duration-service.ts
@@ -1,0 +1,203 @@
+import type { Logger } from "@bip/domain";
+import type { CacheInvalidationService } from "../_shared/cache";
+import { yearFromShowDate } from "../_shared/cache";
+import { CATALOG_TTL_SECONDS } from "../_shared/catalog/date-indexed-catalog";
+import type { DbClient } from "../_shared/database/models";
+import { SHOW_ORDER_DESC, setSortKey } from "../_shared/show-ordering";
+import type { ArchiveDotOrgService } from "../shows/archive-dot-org-service";
+import type { NugsService } from "../shows/nugs-service";
+import { type MatchableTrack, matchTrackDurations } from "./duration-matching";
+import { recomputeShowDuration } from "./show-duration";
+
+/** Which source filled a track's duration, lowest-to-highest authority. */
+type DurationSource = "archive" | "nugs" | "manual";
+const SOURCE_RANK: Record<DurationSource, number> = { archive: 1, nugs: 2, manual: 3 };
+
+/**
+ * Re-attempt resolution for a show this stale. Matches the catalog cache
+ * lifetime, so a show becomes eligible to upgrade (e.g. archive to a
+ * freshly-posted nugs release) on the same cadence the source catalogs
+ * refresh. The per-container/per-recording detail fetches stay Redis-cached,
+ * so a re-check that finds nothing new is cheap.
+ */
+const RECHECK_AFTER_MS = CATALOG_TTL_SECONDS * 1000;
+
+/** Cap archive recordings averaged per show; diminishing returns past a few. */
+const MAX_ARCHIVE_RECORDINGS = 4;
+
+/**
+ * Decide whether a freshly-resolved source may overwrite a track's existing
+ * duration. Manual edits are never clobbered; a higher-authority source
+ * replaces a lower one (nugs over archive); same-or-lower is left alone.
+ */
+function shouldOverwrite(existing: string | null, incoming: DurationSource): boolean {
+  if (existing === "manual") return false;
+  if (!existing) return true;
+  return SOURCE_RANK[incoming] > (SOURCE_RANK[existing as DurationSource] ?? 0);
+}
+
+/**
+ * Populates per-track durations for a show by matching our setlist against the
+ * track lists external sources publish, persisting the result and the
+ * denormalized show total. nugs.net is authoritative; archive.org (averaged
+ * across the show's recordings) covers everything nugs lacks. Resolution is
+ * lazy and idempotent — triggered as shows are browsed, throttled per show,
+ * and a no-op once a show is up to date — so the catalog fills in over normal
+ * traffic without a backfill.
+ */
+export class TrackDurationService {
+  constructor(
+    private readonly db: DbClient,
+    private readonly nugs: NugsService,
+    private readonly archive: ArchiveDotOrgService,
+    private readonly cacheInvalidation: CacheInvalidationService,
+    private readonly logger: Logger,
+  ) {}
+
+  /**
+   * Resolve durations for up to `limit` of the given shows that are unresolved
+   * or due for a re-check, marking each checked up front so concurrent requests
+   * don't pile onto the same shows. Bounds external-fetch burst per request;
+   * the rest of a page's shows get picked up on later loads.
+   */
+  async resolvePending(showIds: string[], limit = 5): Promise<void> {
+    if (showIds.length === 0) return;
+
+    const threshold = new Date(Date.now() - RECHECK_AFTER_MS);
+    const candidates = await this.db.show.findMany({
+      where: {
+        id: { in: showIds },
+        OR: [{ durationCheckedAt: null }, { durationCheckedAt: { lt: threshold } }],
+      },
+      // Newest-first: recent shows are the most likely to have a nugs release
+      // (the best source) and the most likely to be viewed, so they pay off
+      // first. Also makes the per-request pick deterministic.
+      orderBy: SHOW_ORDER_DESC,
+      select: { id: true, slug: true, date: true },
+      take: limit,
+    });
+
+    for (const show of candidates) {
+      try {
+        await this.resolveShow(show.id, show.slug, show.date);
+      } catch (error) {
+        this.logger.error("track duration resolution failed", { showId: show.id, error });
+      }
+    }
+  }
+
+  /**
+   * Resolve one show end to end: match the best available source, write the
+   * durations precedence allows, recompute the show total, stamp the check
+   * time, and invalidate the show's caches so the new times surface.
+   */
+  private async resolveShow(showId: string, slug: string | null, date: string): Promise<void> {
+    const tracks = await this.loadOrderedTracks(showId);
+
+    let assignments: Map<string, number> | null = null;
+    let source: DurationSource | null = null;
+
+    if (tracks.length > 0) {
+      const nugsAssignments = await this.resolveFromNugs(date, tracks);
+      if (nugsAssignments && nugsAssignments.size > 0) {
+        assignments = nugsAssignments;
+        source = "nugs";
+      } else {
+        const archiveAssignments = await this.resolveFromArchive(date, tracks);
+        if (archiveAssignments && archiveAssignments.size > 0) {
+          assignments = archiveAssignments;
+          source = "archive";
+        }
+      }
+    }
+
+    let wroteAnyTrack = false;
+    if (assignments && source) {
+      const sourceTracks = source;
+      const writes = tracks
+        .filter((t) => assignments?.has(t.key) && shouldOverwrite(t.durationSource, sourceTracks))
+        .map((t) =>
+          this.db.track.update({
+            where: { id: t.key },
+            data: { duration: assignments?.get(t.key), durationSource: sourceTracks },
+          }),
+        );
+      if (writes.length > 0) {
+        await Promise.all(writes);
+        await recomputeShowDuration(this.db, showId);
+        wroteAnyTrack = true;
+      }
+    }
+
+    await this.db.show.update({ where: { id: showId }, data: { durationCheckedAt: new Date() } });
+
+    if (wroteAnyTrack && slug) {
+      const year = yearFromShowDate(date);
+      await this.cacheInvalidation.invalidateShowComprehensive(showId, slug, [year]);
+    }
+  }
+
+  /** Load the show's tracks in setlist order with the data the matcher needs. */
+  private async loadOrderedTracks(showId: string): Promise<(MatchableTrack & { durationSource: string | null })[]> {
+    const rows = await this.db.track.findMany({
+      where: { showId },
+      select: { id: true, set: true, position: true, durationSource: true, song: { select: { title: true } } },
+    });
+    return rows
+      .filter((r) => r.song?.title)
+      .sort((a, b) => setSortKey(a.set) - setSortKey(b.set) || a.position - b.position)
+      .map((r) => ({ key: r.id, title: r.song?.title ?? "", durationSource: r.durationSource }));
+  }
+
+  /**
+   * Authoritative source: merge matches across every nugs release for the
+   * date. A rare dual-billed night ships two releases (a Disco Biscuits
+   * container and a Tractorbeam one), each holding only its own sets, so
+   * combining them covers tracks no single release does. An overlapping track
+   * keeps the first release's value — both are official, so they agree.
+   */
+  private async resolveFromNugs(date: string, tracks: MatchableTrack[]): Promise<Map<string, number> | null> {
+    const releases = await this.nugs.findReleasesForDate(date);
+    const combined = new Map<string, number>();
+    for (const release of releases) {
+      const external = await this.nugs.fetchContainerTracks(release.containerId);
+      if (external.length === 0) continue;
+      for (const [key, seconds] of matchTrackDurations(tracks, external)) {
+        if (!combined.has(key)) combined.set(key, seconds);
+      }
+    }
+    return combined.size > 0 ? combined : null;
+  }
+
+  /**
+   * Fallback source: match each of the show's archive recordings (primary
+   * first, capped) and average each track's duration across the recordings
+   * that produced one, so a single noisy tape doesn't skew the value.
+   */
+  private async resolveFromArchive(date: string, tracks: MatchableTrack[]): Promise<Map<string, number> | null> {
+    const recordings = await this.archive.findRecordingsForDate(date);
+    if (recordings.length === 0) return null;
+
+    const primary = this.archive.pickPrimary(recordings);
+    const ordered = primary ? [primary, ...recordings.filter((r) => r.identifier !== primary.identifier)] : recordings;
+
+    const samples = new Map<string, number[]>();
+    for (const recording of ordered.slice(0, MAX_ARCHIVE_RECORDINGS)) {
+      const external = await this.archive.fetchRecordingTracks(recording.identifier);
+      if (external.length === 0) continue;
+      const matched = matchTrackDurations(tracks, external);
+      for (const [key, seconds] of matched) {
+        const list = samples.get(key) ?? [];
+        list.push(seconds);
+        samples.set(key, list);
+      }
+    }
+
+    if (samples.size === 0) return null;
+    const averaged = new Map<string, number>();
+    for (const [key, values] of samples) {
+      averaged.set(key, Math.round(values.reduce((a, b) => a + b, 0) / values.length));
+    }
+    return averaged;
+  }
+}

--- a/packages/core/src/tracks/track-service.test.ts
+++ b/packages/core/src/tracks/track-service.test.ts
@@ -71,3 +71,72 @@ describe("TrackService — Cloudflare year-tag wiring", () => {
     expect(cache.invalidateShowComprehensive).toHaveBeenCalledWith("show-id", "2018-07-12-red-rocks", [2018]);
   });
 });
+
+describe("TrackService — duration provenance", () => {
+  // The edit form always re-sends the duration, so the service must decide
+  // provenance from whether the value actually changed — not from its mere
+  // presence. Otherwise editing a song/segue/note would silently convert a
+  // nugs/archive time to `manual` and freeze it against future resolution.
+  function makeDb(currentDuration: number | null) {
+    const update = vi.fn().mockResolvedValue({
+      id: "track-id",
+      slug: "slug",
+      showId: "show-id",
+      songId: "song-id",
+      position: 1,
+      set: "S1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      duration: 700,
+      durationSource: "manual",
+    });
+    const db = {
+      track: {
+        findUnique: vi.fn().mockResolvedValue({ showId: "show-id", duration: currentDuration }),
+        update,
+        aggregate: vi.fn().mockResolvedValue({ _sum: { duration: 700 } }),
+      },
+      show: {
+        findUnique: vi.fn().mockResolvedValue({ slug: "2024-01-01-x", date: "2024-01-01" }),
+        update: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+    return { db, update };
+  }
+
+  test("leaves duration + source untouched when the value is resent unchanged", async () => {
+    const { db, update } = makeDb(690);
+    const service = new TrackService(db as never, logger, makeCacheInvalidationStub());
+
+    await service.update("track-id", { duration: 690, note: "fixed a typo" });
+
+    const data = update.mock.calls[0][0].data;
+    expect(data.duration).toBeUndefined();
+    expect(data.durationSource).toBeUndefined();
+    // No show-total recompute when the duration didn't move.
+    expect(db.track.aggregate).not.toHaveBeenCalled();
+  });
+
+  test("stamps manual when the duration changes to a new value", async () => {
+    const { db, update } = makeDb(690);
+    const service = new TrackService(db as never, logger, makeCacheInvalidationStub());
+
+    await service.update("track-id", { duration: 700 });
+
+    const data = update.mock.calls[0][0].data;
+    expect(data.duration).toBe(700);
+    expect(data.durationSource).toBe("manual");
+    expect(db.track.aggregate).toHaveBeenCalled();
+  });
+
+  test("resets source to null when the duration is cleared", async () => {
+    const { db, update } = makeDb(690);
+    const service = new TrackService(db as never, logger, makeCacheInvalidationStub());
+
+    await service.update("track-id", { duration: null });
+
+    const data = update.mock.calls[0][0].data;
+    expect(data.duration).toBeNull();
+    expect(data.durationSource).toBeNull();
+  });
+});

--- a/packages/core/src/tracks/track-service.ts
+++ b/packages/core/src/tracks/track-service.ts
@@ -4,6 +4,7 @@ import type { DbAnnotation, DbClient, DbSong, DbTrack } from "../_shared/databas
 import { buildIncludeClause, buildOrderByClause, buildWhereClause } from "../_shared/database/query-utils";
 import type { QueryOptions } from "../_shared/database/types";
 import { slugify } from "../_shared/utils/slugify";
+import { recomputeShowDuration } from "./show-duration";
 
 // Database query result that includes song and annotations
 type DbTrackWithSongAndAnnotations = DbTrack & {
@@ -180,13 +181,24 @@ export class TrackService {
       }
     }
 
-    const dbData = mapTrackToDbModel({ ...data, slug });
+    // An explicit duration at create time is an admin entry — mark it `manual`
+    // so live resolution leaves it alone.
+    const dbData = mapTrackToDbModel({
+      ...data,
+      slug,
+      ...(data.duration != null ? { durationSource: "manual" } : {}),
+    });
     const result = await this.db.track.create({
       // biome-ignore lint/suspicious/noExplicitAny: Prisma type requires any for dynamic data mapping
       data: dbData as any,
     });
 
     const track = mapTrackToDomainEntity(result);
+
+    // Keep the denormalized show total consistent when a duration was set.
+    if (data.duration != null && data.showId) {
+      await recomputeShowDuration(this.db, data.showId);
+    }
 
     // Invalidate show caches (track changes affect setlist data)
     if (this.cacheInvalidation && data.showId) {
@@ -206,11 +218,23 @@ export class TrackService {
     const { ...updateableData } = data;
     const updateData = mapTrackToDbModel(updateableData);
 
-    // Get current track info for cache invalidation
+    // Get current track info for cache invalidation + duration-change detection.
     const currentTrack = await this.db.track.findUnique({
       where: { id },
-      select: { showId: true },
+      select: { showId: true, duration: true },
     });
+
+    // The edit form always re-sends the duration, even when an admin only
+    // touched the song/segue/note — so flip provenance only when the value
+    // actually changed. A new value is a manual edit; clearing it resets the
+    // source to null so live resolution can refill it; an unchanged value
+    // leaves both the duration and its source untouched.
+    const durationChanged = data.duration !== undefined && data.duration !== (currentTrack?.duration ?? null);
+    if (durationChanged) {
+      updateData.durationSource = data.duration === null ? null : "manual";
+    } else {
+      updateData.duration = undefined;
+    }
 
     const result = await this.db.track.update({
       where: { id },
@@ -219,6 +243,11 @@ export class TrackService {
     });
 
     const track = mapTrackToDomainEntity(result);
+
+    // Keep the denormalized show total in step with an edited track duration.
+    if (durationChanged && currentTrack?.showId) {
+      await recomputeShowDuration(this.db, currentTrack.showId);
+    }
 
     // Invalidate show caches
     if (currentTrack?.showId) {

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -12,7 +12,7 @@ export const CacheKeys = {
    */
   show: {
     /** Complete show + setlist data for show page */
-    data: (slug: string) => `show:${slug}:data:v5`,
+    data: (slug: string) => `show:${slug}:data:v6`,
 
     // Note: Reviews are loaded fresh from DB, not cached
 
@@ -31,7 +31,7 @@ export const CacheKeys = {
     /** Paginated show listings with filters */
     list: (filters: CacheFilters) => {
       const filterHash = hashFilters(filters);
-      return `shows:list:${filterHash}:v5`;
+      return `shows:list:${filterHash}:v6`;
     },
 
     /** All show listing caches (for pattern deletion) */
@@ -46,7 +46,7 @@ export const CacheKeys = {
    */
   setlist: {
     /** Complete setlist data with tracks and annotations */
-    data: (slug: string) => `setlist:${slug}:data:v5`,
+    data: (slug: string) => `setlist:${slug}:data:v6`,
   },
 
   /**
@@ -54,13 +54,19 @@ export const CacheKeys = {
    */
   archiveDotOrg: {
     catalog: () => "archive-dot-org-catalog-disco-biscuits",
+    /** Per-recording track list (title + duration seconds) from the metadata API. */
+    recording: (identifier: string) => `archive-dot-org-recording:${identifier}:v1`,
   },
 
   /**
    * nugs.net catalog cache keys (keyed by nugs artist id)
    */
   nugs: {
-    catalog: (artistId: number) => `nugs-catalog-artist-${artistId}`,
+    // :v2 — NugsRelease gained `containerId` (needed to fetch per-track
+    // running times); pre-bump cached entries lack it.
+    catalog: (artistId: number) => `nugs-catalog-artist-${artistId}:v2`,
+    /** Per-container track list (title + totalRunningTime seconds) from catalog.container. */
+    container: (containerId: number) => `nugs-container:${containerId}:v1`,
   },
 
   /**
@@ -109,7 +115,7 @@ export const CacheKeys = {
      * have 400+ attended shows and the un-paginated payload is large enough
      * to be slow to deserialize/transport even from Redis.
      */
-    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}:v6`,
+    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}:v7`,
     /** All pages of a single user's attended-setlists caches (for per-user invalidation). */
     allAttendedSetlistsForUser: (userId: string) => `user:${userId}:attended-setlists:*`,
     /** All per-user attended-setlists caches (for pattern deletion on broad show mutations). */
@@ -134,7 +140,7 @@ export const CacheKeys = {
    */
   rockOperas: {
     /** Resource-page list payload: setlists + external sources for one rock opera. */
-    performances: (slug: string) => `rock-operas:performances:${slug}:v4`,
+    performances: (slug: string) => `rock-operas:performances:${slug}:v5`,
     /** Pattern for invalidating every performances cache (broad mutations). */
     allPerformances: () => "rock-operas:performances:*",
   },
@@ -144,7 +150,7 @@ export const CacheKeys = {
    */
   home: {
     /** Recent setlists for home page (limit + sort direction) */
-    recentSetlists: (limit: number) => `home:recent-setlists:${limit}:v5`,
+    recentSetlists: (limit: number) => `home:recent-setlists:${limit}:v6`,
   },
 
   /**

--- a/packages/domain/src/duration.test.ts
+++ b/packages/domain/src/duration.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "vitest";
+import { formatDuration, parseDuration } from "./duration";
+
+// ---------------------------------------------------------------------------
+// formatDuration — seconds → "m:ss" / "h:mm:ss"
+// ---------------------------------------------------------------------------
+
+describe("formatDuration", () => {
+  // Drives the per-track Time column and the per-set / show-total labels.
+
+  test("formats sub-minute durations with a zero minute", () => {
+    expect(formatDuration(0)).toBe("0:00");
+    expect(formatDuration(42)).toBe("0:42");
+  });
+
+  test("formats minutes:seconds with a non-padded minute under an hour", () => {
+    expect(formatDuration(522)).toBe("8:42");
+    expect(formatDuration(3133)).toBe("52:13");
+  });
+
+  test("switches to h:mm:ss at one hour, zero-padding minutes and seconds", () => {
+    expect(formatDuration(3600)).toBe("1:00:00");
+    expect(formatDuration(3858)).toBe("1:04:18");
+  });
+
+  test("rounds fractional seconds (archive lengths arrive as floats)", () => {
+    expect(formatDuration(179.51)).toBe("3:00");
+    expect(formatDuration(8.4)).toBe("0:08");
+  });
+
+  test("returns empty string for invalid input", () => {
+    expect(formatDuration(Number.NaN)).toBe("");
+    expect(formatDuration(-5)).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseDuration — admin input "h:mm:ss" / "m:ss" / raw seconds → seconds
+// ---------------------------------------------------------------------------
+
+describe("parseDuration", () => {
+  // Backs the admin per-track duration field, which accepts any of the three
+  // forms a human might type.
+
+  test("parses m:ss", () => {
+    expect(parseDuration("8:42")).toBe(522);
+    expect(parseDuration("0:42")).toBe(42);
+    expect(parseDuration("52:13")).toBe(3133);
+  });
+
+  test("parses h:mm:ss", () => {
+    expect(parseDuration("1:04:18")).toBe(3858);
+    expect(parseDuration("1:00:00")).toBe(3600);
+  });
+
+  test("parses raw seconds (string or number)", () => {
+    expect(parseDuration("522")).toBe(522);
+    expect(parseDuration(522)).toBe(522);
+    expect(parseDuration("0")).toBe(0);
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(parseDuration("  52:13  ")).toBe(3133);
+  });
+
+  test("rejects out-of-range minute/second parts", () => {
+    expect(parseDuration("8:60")).toBeNull();
+    expect(parseDuration("1:60:00")).toBeNull();
+  });
+
+  test("rejects garbage and negatives", () => {
+    expect(parseDuration("")).toBeNull();
+    expect(parseDuration("abc")).toBeNull();
+    expect(parseDuration("-5")).toBeNull();
+    expect(parseDuration(-5)).toBeNull();
+    expect(parseDuration("5.5")).toBeNull();
+  });
+});

--- a/packages/domain/src/duration.ts
+++ b/packages/domain/src/duration.ts
@@ -1,0 +1,53 @@
+/**
+ * Track/set/show durations are stored as integer seconds. These pure helpers
+ * convert between that storage form and the human-facing `m:ss` / `h:mm:ss`
+ * strings shown in setlists and tables and typed into the admin editor.
+ * Domain-only (no Prisma) so they're safe in client bundles.
+ */
+
+/**
+ * Render a second count as `m:ss` under an hour or `h:mm:ss` at/over an hour.
+ * Set and show totals routinely cross an hour, so the hour form is the common
+ * case for aggregates. Fractional input (archive.org reports lengths as
+ * floats) is rounded. Invalid input (negative/NaN) renders as an empty string
+ * so callers can drop the cell rather than print garbage.
+ */
+export function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return "";
+  const total = Math.round(seconds);
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const secs = total % 60;
+  const ss = secs.toString().padStart(2, "0");
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, "0")}:${ss}`;
+  }
+  return `${minutes}:${ss}`;
+}
+
+/**
+ * Parse an admin-entered duration into integer seconds, accepting `h:mm:ss`,
+ * `m:ss`, or a raw whole-second count. Colon-separated lower parts must be in
+ * range (0–59) so a typo like `8:60` is rejected rather than silently
+ * misread. Returns null for anything unparseable so the caller can surface a
+ * validation error instead of storing a bad value.
+ */
+export function parseDuration(input: string | number): number | null {
+  if (typeof input === "number") {
+    return Number.isInteger(input) && input >= 0 ? input : null;
+  }
+  const trimmed = input.trim();
+  if (trimmed === "") return null;
+
+  if (/^\d+$/.test(trimmed)) return Number.parseInt(trimmed, 10);
+
+  const parts = trimmed.split(":");
+  if (parts.length !== 2 && parts.length !== 3) return null;
+  if (!parts.every((p) => /^\d+$/.test(p))) return null;
+
+  const nums = parts.map((p) => Number.parseInt(p, 10));
+  // Every part after the first (the largest unit) must be a valid 0–59 subunit.
+  if (nums.slice(1).some((n) => n > 59)) return null;
+
+  return parts.length === 3 ? nums[0] * 3600 + nums[1] * 60 + nums[2] : nums[0] * 60 + nums[1];
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./archive-dot-org";
 export * from "./cache-keys";
+export * from "./duration";
 export * from "./math";
 export * from "./models/annotation";
 export * from "./models/attendance";

--- a/packages/domain/src/models/show.ts
+++ b/packages/domain/src/models/show.ts
@@ -21,6 +21,7 @@ export const showSchema = z.object({
   reviewsCount: z.number().default(0),
   countForStats: z.boolean().default(true),
   dayOrder: z.number().nullable().optional(),
+  duration: z.number().nullable().optional(),
   tracks: z.array(trackSchema).nullable().optional(),
   venue: venueSchema.optional(),
 });

--- a/packages/domain/src/models/track.ts
+++ b/packages/domain/src/models/track.ts
@@ -28,6 +28,8 @@ export const trackSchema = z.object({
   ratingsCount: z.number().default(0),
   gap: z.number().nullable(),
   previousPerformanceShowId: z.string().uuid().nullable(),
+  duration: z.number().nullable(),
+  durationSource: z.string().nullable(),
   previousPerformanceShow: previousPerformanceShowSchema,
   song: songSchema.optional(),
   annotations: z.array(annotationSchema).optional(),
@@ -67,6 +69,8 @@ export const trackLightSchema = z.object({
   ratingsCount: z.number().default(0),
   gap: z.number().nullable(),
   previousPerformanceShowId: z.string().uuid().nullable(),
+  duration: z.number().nullable(),
+  durationSource: z.string().nullable(),
   previousPerformanceShow: previousPerformanceShowSchema,
   song: songLightSchema.optional(),
 });
@@ -81,6 +85,7 @@ export const trackUpdateSchema = trackSchema
     segue: true,
     note: true,
     allTimer: true,
+    duration: true,
   })
   .extend({
     annotationDesc: z.string().nullable().optional(),

--- a/packages/domain/src/views/song-page.ts
+++ b/packages/domain/src/views/song-page.ts
@@ -28,6 +28,8 @@ export type SongPagePerformance = {
   songSlug?: string;
   cover?: boolean;
   authorId?: string | null;
+  duration?: number | null;
+  durationSource?: string | null;
   gap?: number | null;
   // Gap measured against the previous performance of this song within the
   // currently-applied filter scope. Populated server-side only when a


### PR DESCRIPTION
## What you get

- **Setlists show timing.** Each song displays its length, each set shows a running time, and the show footnotes a Total. Partial totals (some tracks not yet timed) are flagged.
- **A Time column everywhere a track is a row.** Song detail, jam charts, all-timers, on-this-day, the gap-chart view, and the personal view all get a sortable Time column.
- **Admins can hand-edit a track's duration** (accepts `h:mm:ss`, `m:ss`, or raw seconds) on the track edit form. Manual edits are authoritative and survive re-resolution.

## How durations get filled in

Durations resolve lazily from external sources as shows are browsed, triggered off the existing external-source pass that already runs for show pages and setlist lists. Per request, a handful of unresolved shows (newest first) are resolved in the background and stamped, so the catalog fills in across normal traffic rather than via a backfill.

- **nugs.net** is authoritative (covers nearly every show for ~the last 20 years); each track carries `totalRunningTime` in seconds.
- **archive.org** is the fallback for older tape-only shows; per-track lengths are averaged across the show's recordings.
- Precedence is `manual` > `nugs` > `archive`. A better source upgrades a worse one on the next 24h recheck; manual is never clobbered. Provenance lives in a `duration_sources` FK table.

Title matching tolerates the real-world mismatches between our setlists and external tracklists: segue markers, jam/improv suffixes, spacing (`Sugarplum` / `Sugar Plum`), `&` vs `and`, single-character typos, and shows that ship across two nugs releases.

## Display consistency

All numeric table cells route through a shared `NumberCell` (left-anchored, right-aligned digits, tabular-nums), including the Set columns on the performance and admin-authors tables that previously rendered plain spans.

## Notes for the reviewer

- **The duration data lives on `Response.tracks` in the nugs `catalog.container` payload, not `Response.songs`** (the sibling `songs[]` has no durations). The fixture tests bake in real API responses to lock this shape down.
- Cache-key versions were bumped on every key that embeds a track/show/setlist payload, since `duration` changes the cached shape. On deploy, `Show.durationCheckedAt` is null everywhere, so resolution starts cold and fills in as shows are viewed; only a resolved show's own caches are invalidated (the broad list caches ride their normal TTL to avoid churn as the catalog fills).
- Set ordering is centralized: `SET_SORT_ORDER` in `show-ordering.ts` is the single source for both the in-memory `setSortKey` and the raw-SQL `setSortKeySql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
