### PR TITLE
Clear all-timers, jam-charts, and on-this-day caches on track duration changes

### DIFF
--- a/packages/core/src/_shared/cache/cache-invalidation-service.test.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.test.ts
@@ -41,6 +41,24 @@ describe("CacheInvalidationService.invalidateAttendanceCaches", () => {
   });
 });
 
+describe("CacheInvalidationService.invalidatePerformanceListings", () => {
+  // The per-track Time column renders on three listing pages that each key off
+  // their own cache: All-Timers, Jam Charts, and the per-day On-This-Day
+  // all-timer list. A track duration save (manual or nugs/archive) must wipe
+  // all three, or those pages keep showing stale times even after the show
+  // detail page updates.
+  test("wipes all-timers, jam-charts, and every on-this-day cache", async () => {
+    const cache = makeCache();
+    const service = new CacheInvalidationService(cache as never, logger);
+
+    await service.invalidatePerformanceListings();
+
+    expect(cache.del).toHaveBeenCalledWith(CacheKeys.songs.allTimers());
+    expect(cache.del).toHaveBeenCalledWith(CacheKeys.songs.jamCharts());
+    expect(cache.delPattern).toHaveBeenCalledWith(CacheKeys.songs.allTimersOnThisDayAll());
+  });
+});
+
 describe("CacheInvalidationService.invalidateShowListings", () => {
   // Admin edits to show metadata (date, venue, etc.) bubble through here.
   // Per-user attended-setlists caches embed that metadata, so they must be

--- a/packages/core/src/_shared/cache/cache-invalidation-service.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.ts
@@ -141,11 +141,18 @@ export class CacheInvalidationService {
   }
 
   /**
-   * Invalidate the all-timers cache
+   * Invalidate the performance-listing caches — All-Timers, Jam Charts, and
+   * the per-day On-This-Day all-timer lists. Each renders a per-track row (the
+   * Time column, plus all_timer / note membership), so any track mutation that
+   * changes a duration, the all_timer flag, or a note can stale them.
    */
-  async invalidateAllTimers(): Promise<void> {
-    this.logger.info("Invalidating all-timers cache");
-    await this.cache.del(CacheKeys.songs.allTimers());
+  async invalidatePerformanceListings(): Promise<void> {
+    this.logger.info("Invalidating performance-listing caches (all-timers, jam-charts, on-this-day)");
+    await Promise.all([
+      this.cache.del(CacheKeys.songs.allTimers()),
+      this.cache.del(CacheKeys.songs.jamCharts()),
+      this.cache.delPattern(CacheKeys.songs.allTimersOnThisDayAll()),
+    ]);
   }
 
   /**

--- a/packages/core/src/shows/show-service.test.ts
+++ b/packages/core/src/shows/show-service.test.ts
@@ -17,7 +17,7 @@ function makeCacheInvalidationStub(): CacheInvalidationService & {
     invalidateShowListings: vi.fn(),
     invalidateShowComprehensive: vi.fn(),
     invalidateSongCaches: vi.fn(),
-    invalidateAllTimers: vi.fn(),
+    invalidatePerformanceListings: vi.fn(),
     invalidateRockOperaAssignment: vi.fn(),
   } as unknown as CacheInvalidationService & { invalidateRockOperaAssignment: Mock };
 }

--- a/packages/core/src/tracks/track-duration-service.test.ts
+++ b/packages/core/src/tracks/track-duration-service.test.ts
@@ -37,7 +37,10 @@ describe("TrackDurationService — nugs releases combine", () => {
       ),
     };
     const archive = { findRecordingsForDate: vi.fn().mockResolvedValue([]) };
-    const cacheInvalidation = { invalidateShowComprehensive: vi.fn().mockResolvedValue(undefined) };
+    const cacheInvalidation = {
+      invalidateShowComprehensive: vi.fn().mockResolvedValue(undefined),
+      invalidatePerformanceListings: vi.fn().mockResolvedValue(undefined),
+    };
 
     const service = new TrackDurationService(
       db as never,
@@ -55,5 +58,8 @@ describe("TrackDurationService — nugs releases combine", () => {
     expect(updates.get("tb")).toMatchObject({ duration: 1200, durationSource: "nugs" });
     // Archive is the fallback; nugs covered everything, so it's never consulted.
     expect(archive.findRecordingsForDate).not.toHaveBeenCalled();
+    // Writing a duration must wipe the All-Timers / Jam Charts / On-This-Day
+    // listings, which render the same Time column from their own caches.
+    expect(cacheInvalidation.invalidatePerformanceListings).toHaveBeenCalled();
   });
 });

--- a/packages/core/src/tracks/track-duration-service.ts
+++ b/packages/core/src/tracks/track-duration-service.ts
@@ -131,9 +131,14 @@ export class TrackDurationService {
 
     await this.db.show.update({ where: { id: showId }, data: { durationCheckedAt: new Date() } });
 
-    if (wroteAnyTrack && slug) {
-      const year = yearFromShowDate(date);
-      await this.cacheInvalidation.invalidateShowComprehensive(showId, slug, [year]);
+    if (wroteAnyTrack) {
+      // The Time column also rides the All-Timers / Jam Charts / On-This-Day
+      // listings, which key off their own caches independent of this show.
+      await this.cacheInvalidation.invalidatePerformanceListings();
+      if (slug) {
+        const year = yearFromShowDate(date);
+        await this.cacheInvalidation.invalidateShowComprehensive(showId, slug, [year]);
+      }
     }
   }
 

--- a/packages/core/src/tracks/track-service.test.ts
+++ b/packages/core/src/tracks/track-service.test.ts
@@ -6,14 +6,14 @@ const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } 
 
 function makeCacheInvalidationStub(): CacheInvalidationService & {
   invalidateShowComprehensive: Mock;
-  invalidateAllTimers: Mock;
+  invalidatePerformanceListings: Mock;
 } {
   return {
     invalidateShowComprehensive: vi.fn().mockResolvedValue(undefined),
-    invalidateAllTimers: vi.fn().mockResolvedValue(undefined),
+    invalidatePerformanceListings: vi.fn().mockResolvedValue(undefined),
   } as unknown as CacheInvalidationService & {
     invalidateShowComprehensive: Mock;
-    invalidateAllTimers: Mock;
+    invalidatePerformanceListings: Mock;
   };
 }
 
@@ -127,6 +127,19 @@ describe("TrackService — duration provenance", () => {
     expect(data.duration).toBe(700);
     expect(data.durationSource).toBe("manual");
     expect(db.track.aggregate).toHaveBeenCalled();
+  });
+
+  // The Time column also renders on the All-Timers / Jam Charts / On-This-Day
+  // listings, which key off their own caches — a manual duration edit must
+  // wipe them or those pages keep the stale time.
+  test("invalidates the performance listings on a duration edit", async () => {
+    const { db } = makeDb(690);
+    const cache = makeCacheInvalidationStub();
+    const service = new TrackService(db as never, logger, cache);
+
+    await service.update("track-id", { duration: 700 });
+
+    expect(cache.invalidatePerformanceListings).toHaveBeenCalled();
   });
 
   test("resets source to null when the duration is cleared", async () => {

--- a/packages/core/src/tracks/track-service.ts
+++ b/packages/core/src/tracks/track-service.ts
@@ -66,9 +66,9 @@ export class TrackService {
     }
   }
 
-  private async invalidateAllTimersCache(): Promise<void> {
+  private async invalidatePerformanceListings(): Promise<void> {
     if (!this.cacheInvalidation) return;
-    await this.cacheInvalidation.invalidateAllTimers();
+    await this.cacheInvalidation.invalidatePerformanceListings();
   }
 
   private async generateTrackSlug(
@@ -205,10 +205,9 @@ export class TrackService {
       await this.invalidateShowCaches(data.showId);
     }
 
-    // Invalidate all-timers cache if this track is an all-timer
-    if (data.allTimer) {
-      await this.invalidateAllTimersCache();
-    }
+    // A new track's duration, all_timer flag, or note can all surface on the
+    // All-Timers / Jam Charts / On-This-Day listings — wipe them.
+    await this.invalidatePerformanceListings();
 
     return track;
   }
@@ -254,10 +253,9 @@ export class TrackService {
       await this.invalidateShowCaches(currentTrack.showId);
     }
 
-    // Invalidate all-timers cache if allTimer field was changed
-    if (data.allTimer !== undefined) {
-      await this.invalidateAllTimersCache();
-    }
+    // An edited duration, all_timer flag, or note can all surface on the
+    // All-Timers / Jam Charts / On-This-Day listings — wipe them.
+    await this.invalidatePerformanceListings();
 
     return track;
   }
@@ -316,7 +314,8 @@ export class TrackService {
       await this.invalidateShowCaches(track.showId);
     }
 
-    // Invalidate all-timers cache (deleted track may have been an all-timer)
-    await this.invalidateAllTimersCache();
+    // A deleted track may have appeared on the All-Timers / Jam Charts /
+    // On-This-Day listings — wipe them.
+    await this.invalidatePerformanceListings();
   }
 }

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -90,6 +90,8 @@ export const CacheKeys = {
     histories: () => "songs:histories:v3",
     /** All-timers for a specific calendar day (On This Day page) */
     allTimersOnThisDay: (monthDay: string) => `songs:all-timers:on-this-day:${monthDay}:v3`,
+    /** Every On-This-Day all-timer cache across all calendar days (for pattern deletion). */
+    allTimersOnThisDayAll: () => "songs:all-timers:on-this-day:*",
     /** Filtered song results by era/author/cover/tags/attended */
     filtered: (filters: CacheFilters) => {
       const filterHash = hashFilters(filters);


### PR DESCRIPTION
Track times now appear on the All-Timers, Jam Charts, and On-This-Day pages as
soon as a duration is saved, instead of lagging behind until the cache expired.

Those three pages render the per-track Time column from their own caches
(`songs:all-timers`, `songs:jam-charts`, `songs:all-timers:on-this-day:*`), which
neither track-update path was busting. So a duration that showed correctly on a
show's detail page stayed stale or blank on these listings.

## Changes

- Add `CacheInvalidationService.invalidatePerformanceListings()` to wipe all
  three listing caches in one call (new `allTimersOnThisDayAll` pattern key).
- Call it from `TrackService` create/update/delete and from the
  `TrackDurationService` nugs/archive resolver on every track write.
- Replaces the previous `invalidateAllTimers` call, which only cleared the
  all-timers cache and only fired on an `all_timer` toggle, never on a
  duration change.

The show/setlist/year-listing caches were already invalidated correctly and are
unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
