### PR TITLE
Refine setlist set labels, total placement, and mobile photo badge

### DIFF
--- a/apps/web/app/components/setlist/setlist-duration.ts
+++ b/apps/web/app/components/setlist/setlist-duration.ts
@@ -30,13 +30,15 @@ export function summarizeDurations(tracks: ReadonlyArray<{ duration: number | nu
 /**
  * Block-style set heading for the flow view: spelled-out "Set 1" / "Encore" /
  * "Encore 2" (vs the compact "1" / "E" the table views use). A lone encore
- * drops its number, so pass the show's distinct-encore count. Unknown labels
- * (e.g. "Soundcheck") render verbatim.
+ * drops its number, so pass the show's distinct-encore count. A show with a
+ * single regular set drops the number too, reading just "Set" (even when an
+ * encore follows), so pass isSoleRegularSet. Unknown labels (e.g.
+ * "Soundcheck") render verbatim.
  */
-export function formatSetHeading(label: string, encoresInSet: number): string {
+export function formatSetHeading(label: string, encoresInSet: number, isSoleRegularSet = false): string {
   const upper = label.toUpperCase();
   const setMatch = upper.match(/^S(\d+)$/);
-  if (setMatch) return `Set ${setMatch[1]}`;
+  if (setMatch) return isSoleRegularSet ? "Set" : `Set ${setMatch[1]}`;
   const encoreMatch = upper.match(/^E(\d+)$/);
   if (encoreMatch) return encoresInSet === 1 ? "Encore" : `Encore ${encoreMatch[1]}`;
   return label;

--- a/apps/web/app/components/setlist/setlist-flow.test.tsx
+++ b/apps/web/app/components/setlist/setlist-flow.test.tsx
@@ -49,15 +49,37 @@ function flowSetlist(
 }
 
 describe("SetlistFlow", () => {
-  // A single-set show drops the "Set 1" heading; its time reads only as the
-  // show Total.
-  test("a single-set show shows the Total but suppresses the set heading", async () => {
+  // A single-set show labels its one set "Set" (no number) with its duration
+  // inline, and drops the redundant Total.
+  test("a single-set show labels it 'Set' with inline duration and no Total", async () => {
     await setupWithRouter(
-      <SetlistFlow setlist={flowSetlist([{ label: "S1", tracks: [durTrack("a", "Helicopters", 522, "S1", 1), durTrack("b", "Spaga", 410, "S1", 2)] }])} />,
+      <SetlistFlow
+        setlist={flowSetlist([
+          { label: "S1", tracks: [durTrack("a", "Helicopters", 522, "S1", 1), durTrack("b", "Spaga", 410, "S1", 2)] },
+        ])}
+      />,
     );
-    expect(screen.getByText("Total")).toBeInTheDocument();
+    expect(screen.getByText("Set")).toBeInTheDocument();
     expect(screen.getByText("15:32")).toBeInTheDocument();
     expect(screen.queryByText("Set 1")).not.toBeInTheDocument();
+    expect(screen.queryByText("Total")).not.toBeInTheDocument();
+  });
+
+  // With one regular set plus an encore, the regular set still reads "Set"
+  // (no number), but the Total returns since the show spans multiple sets.
+  test("a one-set-plus-encore show labels the set 'Set' and keeps the Total", async () => {
+    await setupWithRouter(
+      <SetlistFlow
+        setlist={flowSetlist([
+          { label: "S1", tracks: [durTrack("a", "Helicopters", 522, "S1", 1)] },
+          { label: "E1", tracks: [durTrack("b", "Spaga", 410, "E1", 1)] },
+        ])}
+      />,
+    );
+    expect(screen.getByText("Set")).toBeInTheDocument();
+    expect(screen.queryByText("Set 1")).not.toBeInTheDocument();
+    expect(screen.getByText("Encore")).toBeInTheDocument();
+    expect(screen.getByText("Total")).toBeInTheDocument();
   });
 
   test("a multi-set show shows per-set headings and the Total", async () => {
@@ -74,9 +96,36 @@ describe("SetlistFlow", () => {
     expect(screen.getByText("Total")).toBeInTheDocument();
   });
 
+  // The Total sits directly under the sets, above the divider that fronts the
+  // annotation footnotes — not bundled in the bordered footnote block.
+  test("renders the Total above the footnote divider", async () => {
+    const { container } = await setupWithRouter(
+      <SetlistFlow
+        setlist={flowSetlist(
+          [
+            { label: "S1", tracks: [durTrack("a", "Helicopters", 522, "S1", 1)] },
+            { label: "S2", tracks: [durTrack("b", "Spaga", 410, "S2", 1)] },
+          ],
+          [{ trackId: "a", desc: "Glow-stick war peak" }],
+        )}
+      />,
+    );
+    const total = screen.getByText("Total");
+    const divider = container.querySelector(".border-t");
+    expect(divider).not.toBeNull();
+    // Total is not nested inside the bordered footnote block...
+    expect(divider?.contains(total)).toBe(false);
+    // ...and precedes it in document order.
+    expect(total.compareDocumentPosition(divider as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   test("flags a partial total when some tracks are untimed", async () => {
     await setupWithRouter(
-      <SetlistFlow setlist={flowSetlist([{ label: "S1", tracks: [durTrack("a", "Helicopters", 522, "S1", 1), durTrack("b", "Spaga", null, "S1", 2)] }])} />,
+      <SetlistFlow
+        setlist={flowSetlist([
+          { label: "S1", tracks: [durTrack("a", "Helicopters", 522, "S1", 1), durTrack("b", "Spaga", null, "S1", 2)] },
+        ])}
+      />,
     );
     expect(screen.getByText(/Partial: 1 track not yet timed/)).toBeInTheDocument();
   });

--- a/apps/web/app/components/setlist/setlist-flow.tsx
+++ b/apps/web/app/components/setlist/setlist-flow.tsx
@@ -38,8 +38,12 @@ export function SetlistFlow({ setlist }: { setlist: Setlist | SetlistLight }) {
 
   const encoresInSet = countSetlistEncores(setlist.sets);
   const showDuration = summarizeDurations(allTracks);
-  // A single-set show (no encore) needs no heading — its time is the Total.
-  const showSetHeadings = setlist.sets.length > 1;
+  // One regular (non-encore) set reads just "Set" (no number), whether or not
+  // an encore follows.
+  const isSoleRegularSet = setlist.sets.filter((set) => /^S\d+$/i.test(set.label)).length === 1;
+  // A truly single-set show (no encore) also skips the redundant Total — its
+  // set time already is the show time.
+  const isSoleSet = setlist.sets.length === 1;
 
   return (
     <>
@@ -48,27 +52,25 @@ export function SetlistFlow({ setlist }: { setlist: Setlist | SetlistLight }) {
           const setDuration = summarizeDurations(set.tracks);
           return (
             <div key={setlist.show.id + set.label}>
-              {showSetHeadings && (
-                <div className="flex items-baseline gap-2">
-                  <span className="text-base font-medium text-content-text-tertiary">
-                    {formatSetHeading(set.label, encoresInSet)}
+              <div className="flex items-baseline gap-2">
+                <span className="text-base font-medium text-content-text-tertiary">
+                  {formatSetHeading(set.label, encoresInSet, isSoleRegularSet)}
+                </span>
+                {setDuration.known > 0 && (
+                  <span
+                    className="text-sm text-content-text-tertiary tabular-nums"
+                    title={
+                      setDuration.missing > 0
+                        ? `Partial: ${setDuration.missing} track${setDuration.missing > 1 ? "s" : ""} not yet timed`
+                        : undefined
+                    }
+                  >
+                    {formatDuration(setDuration.seconds)}
+                    {setDuration.missing > 0 && "*"}
                   </span>
-                  {setDuration.known > 0 && (
-                    <span
-                      className="text-sm text-content-text-tertiary tabular-nums"
-                      title={
-                        setDuration.missing > 0
-                          ? `Partial: ${setDuration.missing} track${setDuration.missing > 1 ? "s" : ""} not yet timed`
-                          : undefined
-                      }
-                    >
-                      {formatDuration(setDuration.seconds)}
-                      {setDuration.missing > 0 && "*"}
-                    </span>
-                  )}
-                </div>
-              )}
-              <div className={showSetHeadings ? "text-base pl-4" : "text-base"}>
+                )}
+              </div>
+              <div className="text-base pl-4">
                 {set.tracks.map((track, i) => (
                   <span key={track.id} className="inline">
                     <TrackRatingOverlay track={track}>
@@ -107,22 +109,23 @@ export function SetlistFlow({ setlist }: { setlist: Setlist | SetlistLight }) {
         })}
       </div>
 
-      {(showDuration.known > 0 || orderedAnnotations.length > 0) && (
+      {showDuration.known > 0 && !isSoleSet && (
+        <div className="mt-4 text-sm text-content-text-secondary">
+          <span className="font-medium text-content-text-tertiary">Total</span>{" "}
+          <span className="tabular-nums">
+            {formatDuration(showDuration.seconds)}
+            {showDuration.missing > 0 && "*"}
+          </span>
+        </div>
+      )}
+      {showDuration.known > 0 && showDuration.missing > 0 && (
+        <div className={cn(isSoleSet ? "mt-4" : "mt-1", "text-xs text-content-text-tertiary")}>
+          * Partial: {showDuration.missing} track{showDuration.missing > 1 ? "s" : ""} not yet timed
+        </div>
+      )}
+
+      {orderedAnnotations.length > 0 && (
         <div className="mt-6 pt-4 border-t border-glass-border/30 space-y-2">
-          {showDuration.known > 0 && (
-            <div className="text-sm text-content-text-secondary">
-              <span className="font-medium text-content-text-tertiary">Total</span>{" "}
-              <span className="tabular-nums">
-                {formatDuration(showDuration.seconds)}
-                {showDuration.missing > 0 && "*"}
-              </span>
-            </div>
-          )}
-          {showDuration.known > 0 && showDuration.missing > 0 && (
-            <div className="text-xs text-content-text-tertiary">
-              * Partial: {showDuration.missing} track{showDuration.missing > 1 ? "s" : ""} not yet timed
-            </div>
-          )}
           {orderedAnnotations.map((annotation) => (
             <div key={`annotation-${annotation.index}`} className="text-sm text-content-text-secondary">
               <sup className="text-brand-secondary">{annotation.index}</sup> {annotation.desc}

--- a/apps/web/app/components/setlist/show-external-badges.tsx
+++ b/apps/web/app/components/setlist/show-external-badges.tsx
@@ -84,7 +84,8 @@ function PhotosBadge({ href, count }: PhotosBadgeProps) {
   return (
     <Link to={href} title={`${count} photos`} className={cn(EXTERNAL_FAVICON_LINK_CLASS, "gap-1")}>
       <Camera className={BADGE_ICON_CLASS} />
-      <span className="text-sm">{count}</span>
+      {/* Count crowds the icon strip on mobile; show it from `sm` up. */}
+      <span className="hidden sm:inline text-sm">{count}</span>
     </Link>
   );
 }


### PR DESCRIPTION
A show with a single set now labels it **"Set"** (no number) with its running time inline, instead of hiding the heading and showing the time only as a Total. The set still reads "Set" when an encore follows it. Multi-set shows are unchanged ("Set 1", "Set 2", ...).

The **total show time** now sits directly under the sets, above the divider; the divider fronts only the annotation footnotes.

On **mobile**, the photo count next to the camera icon is hidden so it stops crowding the other source icons. The count still powers the tooltip and still hides the badge when zero.

## Notes for the reviewer

Two booleans drive the heading logic: `isSoleRegularSet` (exactly one non-encore set → drop the number) controls the label, and `isSoleSet` (only one set total) controls dropping the Total. A single-set show that's partially timed suppresses the Total but keeps the partial-tracks footnote, so its top margin widens to stand off the tracks when no Total precedes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
