### PR TITLE
Fix @bip/domain resolution for the deploy-time recompute script

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -43,6 +43,13 @@ COPY --from=builder /app/packages/core/src ./packages/core/src
 # Copy deploy-time scripts run from docker-entrypoint.sh.
 COPY --from=builder /app/packages/core/scripts ./packages/core/scripts
 
+# The dev @bip/domain package.json points main/exports at ./src/index.ts, but the
+# runner only ships packages/domain/dist (not src). When the deploy-time script
+# runs core's raw TS, its `import "@bip/domain"` must resolve to the built dist —
+# rewrite the runner copy's entry points to dist so resolution succeeds.
+RUN cd packages/domain && \
+    sed -i 's#"./src/index.ts"#"./dist/index.js"#g' package.json
+
 # Copy web app
 COPY --from=builder /app/apps/web/build ./apps/web/build
 COPY --from=builder /app/apps/web/package.json ./apps/web/


### PR DESCRIPTION
## What changed

Production deploys are unblocked: the deploy-time stats recompute added in #155 no longer crashes the container on boot.

## The bug

#155 wired `scripts/recompute-pending.ts` into `docker-entrypoint.sh` after `prisma migrate deploy`. On boot it crashed with:

```
Recomputing pending stats...
error: Cannot find module '@bip/domain' from '/app/packages/core/src/stats/stats-service.ts'
```

Under `set -e` that aborts boot, the container never becomes healthy, and Kamal fails the deploy.

Root cause: the runner image ships `packages/domain/dist` but not `packages/domain/src`, while the dev `@bip/domain` `package.json` points `main`/`exports` at `./src/index.ts`. When bun runs core's raw TS, `import "@bip/domain"` resolves to the missing `src`.

## The fix

A single Dockerfile step rewrites the runner copy's `packages/domain/package.json` entry points from `./src/index.ts` to `./dist/index.js`, so resolution lands on the shipped build. The dev `package.json` is untouched (local dev/tests still use `src`).

## Verification

Built the runner image and ran the script inside it. The `Cannot find module '@bip/domain'` error is gone; the script resolves `@bip/domain` + `@prisma/client`, executes `runPendingRecompute`, and reaches the DB query — failing only on "Can't reach database server" because the test container has no DB (prod has `DATABASE_URL`).

The recompute deliberately stays fatal: a failure should fail the deploy, not silently continue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
