### PR TITLE
Add musicians/performers data model, services, and seed

### DIFF
--- a/apps/web/app/lib/format-venue.test.ts
+++ b/apps/web/app/lib/format-venue.test.ts
@@ -45,3 +45,20 @@ describe("formatVenueLocation", () => {
     expect(formatVenueLocation({ city: "", state: "NY", country: "USA" })).toBe("");
   });
 });
+
+/**
+ * Country code for a venue's schema.org PostalAddress. A missing country
+ * defaults to "US" because the catalog is US-majority and a NULL historically
+ * meant a domestic venue.
+ */
+describe("venueAddressCountry", () => {
+  it("returns the venue's country when present", () => {
+    expect(venueAddressCountry("Canada")).toBe("Canada");
+  });
+
+  it("defaults to US when the country is null, undefined, or empty", () => {
+    expect(venueAddressCountry(null)).toBe("US");
+    expect(venueAddressCountry(undefined)).toBe("US");
+    expect(venueAddressCountry("")).toBe("US");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "bun --cwd apps/web run dev",
     "build": "cd apps/web && bun run build",
-    "lint": "biome lint .",
+    "lint": "biome lint --error-on-warnings .",
     "format": "biome format . --write",
     "typecheck": "cd apps/web && bun react-router typegen && cd ../.. && bun tsc --noEmit",
     "typecheck:all": "bun run -F '*' typecheck",

--- a/packages/core/src/_shared/database/models.ts
+++ b/packages/core/src/_shared/database/models.ts
@@ -11,12 +11,16 @@ import type {
   Author as PrismaAuthor,
   BlogPost as PrismaBlogPost,
   PrismaClient,
+  Instrument as PrismaInstrument,
+  Musician as PrismaMusician,
   Rating as PrismaRating,
   Review as PrismaReview,
   SearchHistory as PrismaSearchHistory,
   Show as PrismaShow,
+  ShowMusician as PrismaShowMusician,
   Song as PrismaSong,
   Track as PrismaTrack,
+  TrackMusician as PrismaTrackMusician,
   User as PrismaUser,
   Venue as PrismaVenue,
 } from "@prisma/client";
@@ -29,6 +33,10 @@ export type DbReview = PrismaReview;
 export type DbSearchHistory = PrismaSearchHistory;
 export type DbSong = PrismaSong;
 export type DbAuthor = PrismaAuthor;
+export type DbInstrument = PrismaInstrument;
+export type DbMusician = PrismaMusician;
+export type DbShowMusician = PrismaShowMusician;
+export type DbTrackMusician = PrismaTrackMusician;
 export type DbShow = PrismaShow;
 export type DbTrack = PrismaTrack;
 export type DbVenue = PrismaVenue;

--- a/packages/core/src/_shared/prisma/migrations/20260601120000_add_musicians_performers/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260601120000_add_musicians_performers/migration.sql
@@ -1,0 +1,123 @@
+-- Structured performers: an admin-managed list of musicians and instruments,
+-- a per-show lineup bridge, and per-track sit-in/sat-out deltas. Purely
+-- additive; nothing references these tables yet.
+
+-- CreateTable
+CREATE TABLE "instruments" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "name" VARCHAR NOT NULL,
+    "slug" VARCHAR NOT NULL,
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT now(),
+    "updated_at" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "instruments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "musicians" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "name" VARCHAR NOT NULL,
+    "slug" VARCHAR NOT NULL,
+    "default_instrument_id" UUID,
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT now(),
+    "updated_at" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "musicians_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "show_musicians" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "show_id" UUID NOT NULL,
+    "musician_id" UUID NOT NULL,
+    "instrument_id" UUID,
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT now(),
+    "updated_at" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "show_musicians_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "track_musicians" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "track_id" UUID NOT NULL,
+    "musician_id" UUID NOT NULL,
+    "present" BOOLEAN NOT NULL,
+    "instrument_id" UUID,
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT now(),
+    "updated_at" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "track_musicians_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "instruments_slug_unique" ON "instruments"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "musicians_slug_unique" ON "musicians"("slug");
+
+-- CreateIndex
+CREATE INDEX "musicians_slug_idx" ON "musicians"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "show_musicians_show_musician_unique" ON "show_musicians"("show_id", "musician_id");
+
+-- CreateIndex
+CREATE INDEX "show_musicians_musician_id_idx" ON "show_musicians"("musician_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "track_musicians_track_musician_unique" ON "track_musicians"("track_id", "musician_id");
+
+-- CreateIndex
+CREATE INDEX "track_musicians_musician_id_idx" ON "track_musicians"("musician_id");
+
+-- CreateIndex
+CREATE INDEX "track_musicians_track_id_idx" ON "track_musicians"("track_id");
+
+-- AddForeignKey
+ALTER TABLE "musicians" ADD CONSTRAINT "fk_musicians_default_instrument_id" FOREIGN KEY ("default_instrument_id") REFERENCES "instruments"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "show_musicians" ADD CONSTRAINT "fk_show_musicians_shows_show_id" FOREIGN KEY ("show_id") REFERENCES "shows"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "show_musicians" ADD CONSTRAINT "fk_show_musicians_musicians_musician_id" FOREIGN KEY ("musician_id") REFERENCES "musicians"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "show_musicians" ADD CONSTRAINT "fk_show_musicians_instruments_instrument_id" FOREIGN KEY ("instrument_id") REFERENCES "instruments"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "track_musicians" ADD CONSTRAINT "fk_track_musicians_tracks_track_id" FOREIGN KEY ("track_id") REFERENCES "tracks"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "track_musicians" ADD CONSTRAINT "fk_track_musicians_musicians_musician_id" FOREIGN KEY ("musician_id") REFERENCES "musicians"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "track_musicians" ADD CONSTRAINT "fk_track_musicians_instruments_instrument_id" FOREIGN KEY ("instrument_id") REFERENCES "instruments"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+
+-- Seed the canonical instrument vocabulary and the founding/current musicians:
+-- the four Marlon-era members (with default instruments) plus the former
+-- drummers Sam Altman and Allen Aucoin, who are deliberately NOT part of the
+-- default lineup. ON CONFLICT keeps this idempotent and non-destructive to
+-- later admin edits.
+INSERT INTO "instruments" ("name", "slug", "updated_at") VALUES
+  ('Drums', 'drums', now()),
+  ('Bass', 'bass', now()),
+  ('Guitar', 'guitar', now()),
+  ('Keys', 'keys', now()),
+  ('Vocals', 'vocals', now()),
+  ('Percussion', 'percussion', now())
+ON CONFLICT ("slug") DO NOTHING;
+
+INSERT INTO "musicians" ("name", "slug", "default_instrument_id", "updated_at")
+SELECT m.name, m.slug, i.id, now()
+FROM (VALUES
+  ('Jon Gutwillig', 'jon-gutwillig', 'guitar'),
+  ('Marc Brownstein', 'marc-brownstein', 'bass'),
+  ('Aron Magner', 'aron-magner', 'keys'),
+  ('Marlon Lewis', 'marlon-lewis', 'drums'),
+  ('Sam Altman', 'sam-altman', 'drums'),
+  ('Allen Aucoin', 'allen-aucoin', 'drums')
+) AS m(name, slug, instrument_slug)
+JOIN "instruments" i ON i.slug = m.instrument_slug
+ON CONFLICT ("slug") DO NOTHING;

--- a/packages/core/src/_shared/prisma/schema.prisma
+++ b/packages/core/src/_shared/prisma/schema.prisma
@@ -347,6 +347,7 @@ model Show {
   segueRuns         SegueRun[]
   files             ShowToFile[]
   rockOperaPerformances RockOperaPerformance[]
+  showMusicians         ShowMusician[]
 
   @@index([likesCount])
   @@index([date])
@@ -377,6 +378,72 @@ model RockOperaPerformance {
   @@unique([showId, rockOperaId], map: "rock_opera_performances_show_rock_opera_unique")
   @@index([rockOperaId])
   @@map("rock_opera_performances")
+}
+
+model Instrument {
+  id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name      String   @db.VarChar
+  slug      String   @unique(map: "instruments_slug_unique") @db.VarChar
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamp(6)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamp(6)
+
+  musicians       Musician[]
+  showMusicians   ShowMusician[]
+  trackMusicians  TrackMusician[]
+
+  @@map("instruments")
+}
+
+model Musician {
+  id                  String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name                String   @db.VarChar
+  slug                String   @unique(map: "musicians_slug_unique") @db.VarChar
+  defaultInstrumentId String?  @map("default_instrument_id") @db.Uuid
+  createdAt           DateTime @default(now()) @map("created_at") @db.Timestamp(6)
+  updatedAt           DateTime @updatedAt @map("updated_at") @db.Timestamp(6)
+
+  defaultInstrument Instrument?     @relation(fields: [defaultInstrumentId], references: [id], onDelete: SetNull, onUpdate: NoAction, map: "fk_musicians_default_instrument_id")
+  showMusicians     ShowMusician[]
+  trackMusicians    TrackMusician[]
+
+  @@index([slug])
+  @@map("musicians")
+}
+
+model ShowMusician {
+  id           String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  showId       String   @map("show_id") @db.Uuid
+  musicianId   String   @map("musician_id") @db.Uuid
+  instrumentId String?  @map("instrument_id") @db.Uuid
+  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamp(6)
+  updatedAt    DateTime @updatedAt @map("updated_at") @db.Timestamp(6)
+
+  show       Show        @relation(fields: [showId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_show_musicians_shows_show_id")
+  musician   Musician    @relation(fields: [musicianId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_show_musicians_musicians_musician_id")
+  instrument Instrument? @relation(fields: [instrumentId], references: [id], onDelete: SetNull, onUpdate: NoAction, map: "fk_show_musicians_instruments_instrument_id")
+
+  @@unique([showId, musicianId], map: "show_musicians_show_musician_unique")
+  @@index([musicianId])
+  @@map("show_musicians")
+}
+
+model TrackMusician {
+  id           String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  trackId      String   @map("track_id") @db.Uuid
+  musicianId   String   @map("musician_id") @db.Uuid
+  present      Boolean
+  instrumentId String?  @map("instrument_id") @db.Uuid
+  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamp(6)
+  updatedAt    DateTime @updatedAt @map("updated_at") @db.Timestamp(6)
+
+  track      Track       @relation(fields: [trackId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_track_musicians_tracks_track_id")
+  musician   Musician    @relation(fields: [musicianId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_track_musicians_musicians_musician_id")
+  instrument Instrument? @relation(fields: [instrumentId], references: [id], onDelete: SetNull, onUpdate: NoAction, map: "fk_track_musicians_instruments_instrument_id")
+
+  @@unique([trackId, musicianId], map: "track_musicians_track_musician_unique")
+  @@index([musicianId])
+  @@index([trackId])
+  @@map("track_musicians")
 }
 
 model SideProject {
@@ -515,6 +582,7 @@ model Track {
   song            Song                     @relation(fields: [songId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_tracks_songs_song_id")
   previousPerformanceShow   Show?           @relation("TrackPreviousPerformance", fields: [previousPerformanceShowId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_tracks_previous_performance_show_id")
   durationSourceRef         DurationSource? @relation(fields: [durationSource], references: [name], onDelete: NoAction, onUpdate: NoAction, map: "fk_tracks_duration_source")
+  trackMusicians            TrackMusician[]
 
   @@index([likesCount])
   @@index([nextTrackId])

--- a/packages/core/src/_shared/services.ts
+++ b/packages/core/src/_shared/services.ts
@@ -4,6 +4,7 @@ import { AttendanceService } from "../attendances/attendance-service";
 import { AuthorService } from "../authors/author-service";
 import { BlogPostService } from "../blog-posts/blog-post-service";
 import { FileService } from "../files/file-service";
+import { InstrumentService, MusicianService } from "../musicians/musician-service";
 import { SongPageComposer } from "../page-composers/song-page-composer";
 import { RatingService } from "../ratings/rating-service";
 import { ReviewService } from "../reviews/review-service";
@@ -33,6 +34,8 @@ export interface Services {
   annotations: AnnotationService;
   authors: AuthorService;
   blogPosts: BlogPostService;
+  instruments: InstrumentService;
+  musicians: MusicianService;
   shows: ShowService;
   songs: SongService;
   stats: StatsService;
@@ -86,6 +89,8 @@ export function createServices(container: ServiceContainer): Services {
     annotations: new AnnotationService(container.db, container.logger, container.cacheInvalidation),
     authors: new AuthorService(container.db, container.logger),
     blogPosts: new BlogPostService(container.db, container.redis, container.logger),
+    instruments: new InstrumentService(container.db, container.logger),
+    musicians: new MusicianService(container.db, container.logger),
     shows: new ShowService(container.db, container.logger, container.cacheInvalidation, statsService),
     songs: songService,
     stats: statsService,

--- a/packages/core/src/musicians/musician-constants.ts
+++ b/packages/core/src/musicians/musician-constants.ts
@@ -1,0 +1,8 @@
+// Slugs of the Marlon-era band members, applied as the default lineup when a
+// show is created with no explicit lineup. The musicians themselves (and the
+// instrument vocabulary) are seeded by the add_musicians_performers migration;
+// this list is how the service resolves them back to ids at create time.
+//
+// No server-only imports, so this is safe to pull into client bundles (filter
+// controls, lineup display) as well as services.
+export const MARLON_LINEUP_SLUGS = ["jon-gutwillig", "marc-brownstein", "aron-magner", "marlon-lewis"] as const;

--- a/packages/core/src/musicians/musician-service.test.ts
+++ b/packages/core/src/musicians/musician-service.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test, vi } from "vitest";
+import { InstrumentService, MusicianService } from "./musician-service";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+
+function makeMusicianDb(existingBySlug: Record<string, unknown> = {}) {
+  return {
+    musician: {
+      findUnique: vi.fn(({ where }: { where: { slug?: string } }) =>
+        Promise.resolve(where.slug ? (existingBySlug[where.slug] ?? null) : null),
+      ),
+      create: vi.fn(({ data }: { data: Record<string, unknown> }) => Promise.resolve({ id: "new-id", ...data })),
+    },
+  };
+}
+
+function makeInstrumentDb(existingBySlug: Record<string, unknown> = {}) {
+  return {
+    instrument: {
+      findUnique: vi.fn(({ where }: { where: { slug?: string } }) =>
+        Promise.resolve(where.slug ? (existingBySlug[where.slug] ?? null) : null),
+      ),
+      create: vi.fn(({ data }: { data: Record<string, unknown> }) => Promise.resolve({ id: "new-id", ...data })),
+    },
+  };
+}
+
+describe("MusicianService.create — dedupe by slug", () => {
+  // Re-running the seed/backfill must not spawn "sam-altman-2"; an existing
+  // slug returns the existing row instead.
+  test("returns the existing musician when the slug already exists, without creating", async () => {
+    const existing = {
+      id: "existing-id",
+      name: "Sam Altman",
+      slug: "sam-altman",
+      defaultInstrumentId: null,
+      createdAt: new Date("2020-01-01"),
+      updatedAt: new Date("2020-01-01"),
+    };
+    const db = makeMusicianDb({ "sam-altman": existing });
+    const service = new MusicianService(db as never, logger);
+
+    const result = await service.create({ name: "Sam Altman" });
+
+    expect(result.id).toBe("existing-id");
+    expect(db.musician.create).not.toHaveBeenCalled();
+  });
+
+  test("creates a new musician when the slug is free", async () => {
+    const db = makeMusicianDb();
+    const service = new MusicianService(db as never, logger);
+
+    const result = await service.create({ name: "Marlon Lewis", defaultInstrumentId: "drums-id" });
+
+    expect(db.musician.create).toHaveBeenCalledTimes(1);
+    expect(result.slug).toBe("marlon-lewis");
+    expect(result.defaultInstrumentId).toBe("drums-id");
+  });
+});
+
+describe("InstrumentService.create — dedupe by slug", () => {
+  test("returns the existing instrument when the slug already exists, without creating", async () => {
+    const existing = {
+      id: "drums-id",
+      name: "Drums",
+      slug: "drums",
+      createdAt: new Date("2020-01-01"),
+      updatedAt: new Date("2020-01-01"),
+    };
+    const db = makeInstrumentDb({ drums: existing });
+    const service = new InstrumentService(db as never, logger);
+
+    const result = await service.create({ name: "Drums" });
+
+    expect(result.id).toBe("drums-id");
+    expect(db.instrument.create).not.toHaveBeenCalled();
+  });
+
+  test("creates a new instrument when the slug is free", async () => {
+    const db = makeInstrumentDb();
+    const service = new InstrumentService(db as never, logger);
+
+    const result = await service.create({ name: "Percussion" });
+
+    expect(db.instrument.create).toHaveBeenCalledTimes(1);
+    expect(result.slug).toBe("percussion");
+  });
+});

--- a/packages/core/src/musicians/musician-service.ts
+++ b/packages/core/src/musicians/musician-service.ts
@@ -1,0 +1,165 @@
+import type { Instrument, Logger, Musician } from "@bip/domain";
+import type { DbClient, DbInstrument, DbMusician } from "../_shared/database/models";
+import { buildOrderByClause, buildWhereClause } from "../_shared/database/query-utils";
+import type { FilterCondition, QueryOptions } from "../_shared/database/types";
+import { slugify } from "../_shared/utils/slugify";
+
+export interface CreateInstrumentInput {
+  name: string;
+}
+
+export interface CreateMusicianInput {
+  name: string;
+  defaultInstrumentId?: string | null;
+}
+
+function mapInstrumentToDomainEntity(db: DbInstrument): Instrument {
+  return {
+    id: db.id,
+    name: db.name,
+    slug: db.slug,
+    createdAt: new Date(db.createdAt),
+    updatedAt: new Date(db.updatedAt),
+  };
+}
+
+function mapMusicianToDomainEntity(db: DbMusician): Musician {
+  return {
+    id: db.id,
+    name: db.name,
+    slug: db.slug,
+    defaultInstrumentId: db.defaultInstrumentId ?? null,
+    createdAt: new Date(db.createdAt),
+    updatedAt: new Date(db.updatedAt),
+  };
+}
+
+/**
+ * Unlike AuthorService, both services here dedupe on create by slug and return
+ * the existing row rather than appending a `-2` suffix. Musicians and
+ * instruments are a small shared vocabulary: two "Sam Altman" entries would be
+ * the same person, and the performer backfill (which resolves names to
+ * musicians and re-runs as data is corrected) needs create to be idempotent on
+ * slug. Do not "fix" this back to the auto-suffix scheme.
+ */
+export class InstrumentService {
+  constructor(
+    protected readonly db: DbClient,
+    protected readonly logger: Logger,
+  ) {}
+
+  async findById(id: string): Promise<Instrument | null> {
+    const result = await this.db.instrument.findUnique({ where: { id } });
+    return result ? mapInstrumentToDomainEntity(result) : null;
+  }
+
+  async findBySlug(slug: string): Promise<Instrument | null> {
+    const result = await this.db.instrument.findUnique({ where: { slug } });
+    return result ? mapInstrumentToDomainEntity(result) : null;
+  }
+
+  async findMany(): Promise<Instrument[]> {
+    const results = await this.db.instrument.findMany({ orderBy: { name: "asc" } });
+    return results.map(mapInstrumentToDomainEntity);
+  }
+
+  async create(data: CreateInstrumentInput): Promise<Instrument> {
+    const name = data.name?.trim();
+    if (!name) {
+      throw new Error("Instrument name is required");
+    }
+
+    const slug = slugify(name);
+    const existing = await this.db.instrument.findUnique({ where: { slug } });
+    if (existing) {
+      return mapInstrumentToDomainEntity(existing);
+    }
+
+    const result = await this.db.instrument.create({
+      data: { name, slug, createdAt: new Date(), updatedAt: new Date() },
+    });
+    return mapInstrumentToDomainEntity(result);
+  }
+}
+
+/** Dedupes on create by slug like InstrumentService — see the note there. */
+export class MusicianService {
+  constructor(
+    protected readonly db: DbClient,
+    protected readonly logger: Logger,
+  ) {}
+
+  async findById(id: string): Promise<Musician | null> {
+    const result = await this.db.musician.findUnique({ where: { id } });
+    return result ? mapMusicianToDomainEntity(result) : null;
+  }
+
+  async findBySlug(slug: string): Promise<Musician | null> {
+    const result = await this.db.musician.findUnique({ where: { slug } });
+    return result ? mapMusicianToDomainEntity(result) : null;
+  }
+
+  async findMany(options?: QueryOptions<Musician>): Promise<Musician[]> {
+    const where = options?.filters ? buildWhereClause(options.filters) : {};
+    const orderBy = options?.sort ? buildOrderByClause(options.sort) : [{ name: "asc" }];
+    const skip =
+      options?.pagination?.page && options?.pagination?.limit
+        ? (options.pagination.page - 1) * options.pagination.limit
+        : undefined;
+    const take = options?.pagination?.limit;
+
+    const results = await this.db.musician.findMany({ where, orderBy, skip, take });
+    return results.map(mapMusicianToDomainEntity);
+  }
+
+  async search(query: string, limit = 10): Promise<Musician[]> {
+    const queryOptions: QueryOptions<Musician> = {
+      filters: [{ field: "name", operator: "contains", value: query }] as FilterCondition<Musician>[],
+      pagination: { limit: limit * 3 },
+    };
+
+    const results = await this.findMany(queryOptions);
+
+    const queryLower = query.toLowerCase();
+    const sorted = results.sort((a, b) => {
+      const aNameLower = a.name.toLowerCase();
+      const bNameLower = b.name.toLowerCase();
+
+      const aExact = aNameLower === queryLower ? 0 : 1;
+      const bExact = bNameLower === queryLower ? 0 : 1;
+      if (aExact !== bExact) return aExact - bExact;
+
+      const aStartsWith = aNameLower.startsWith(queryLower) ? 0 : 1;
+      const bStartsWith = bNameLower.startsWith(queryLower) ? 0 : 1;
+      if (aStartsWith !== bStartsWith) return aStartsWith - bStartsWith;
+
+      return aNameLower.localeCompare(bNameLower);
+    });
+
+    return sorted.slice(0, limit);
+  }
+
+  async create(data: CreateMusicianInput): Promise<Musician> {
+    const name = data.name?.trim();
+    if (!name) {
+      throw new Error("Musician name is required");
+    }
+
+    const slug = slugify(name);
+    const existing = await this.db.musician.findUnique({ where: { slug } });
+    if (existing) {
+      return mapMusicianToDomainEntity(existing);
+    }
+
+    const result = await this.db.musician.create({
+      data: {
+        name,
+        slug,
+        defaultInstrumentId: data.defaultInstrumentId ?? null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+    return mapMusicianToDomainEntity(result);
+  }
+}

--- a/packages/core/src/shows/show-service.test.ts
+++ b/packages/core/src/shows/show-service.test.ts
@@ -76,6 +76,15 @@ function makeMockDb() {
       deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
       createMany: vi.fn().mockResolvedValue({ count: 0 }),
     },
+    // Default: no seeded musicians, so create() applies an empty lineup. The
+    // lineup-specific tests below override musician.findMany to seed the four.
+    musician: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    showMusician: {
+      deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      create: vi.fn().mockResolvedValue({}),
+    },
   };
   db.$transaction = vi.fn(async (input: unknown) => {
     // Two forms: an array of pre-built calls, or a callback that receives
@@ -601,5 +610,61 @@ describe("ShowService — gap rebuild on mutation", () => {
     await service.delete("show-id");
 
     expect(rebuild).toHaveBeenCalledWith("1999-12-31");
+  });
+});
+
+describe("ShowService — default lineup on create", () => {
+  // A new show inherits the current band makeup. With the four Marlon-era
+  // members seeded, create() writes a ShowMusician row per member using each
+  // musician's default instrument.
+  test("applies the four seeded members as the new show's lineup", async () => {
+    const db = makeMockDb();
+    db.musician.findMany.mockResolvedValue([
+      { id: "m-jon", slug: "jon-gutwillig", defaultInstrumentId: "i-guitar" },
+      { id: "m-marc", slug: "marc-brownstein", defaultInstrumentId: "i-bass" },
+      { id: "m-aron", slug: "aron-magner", defaultInstrumentId: "i-keys" },
+      { id: "m-marlon", slug: "marlon-lewis", defaultInstrumentId: "i-drums" },
+    ]);
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), makeStatsStub());
+
+    await service.create({ date: "1999-12-31" });
+
+    expect(db.showMusician.create).toHaveBeenCalledTimes(4);
+    const written = db.showMusician.create.mock.calls.map((c: [{ data: Record<string, unknown> }]) => ({
+      musicianId: c[0].data.musicianId,
+      instrumentId: c[0].data.instrumentId,
+    }));
+    expect(written).toContainEqual({ musicianId: "m-marlon", instrumentId: "i-drums" });
+    expect(written).toContainEqual({ musicianId: "m-jon", instrumentId: "i-guitar" });
+  });
+
+  // Missing seeds (fresh DB, or a sync that ran before seeding) must not break
+  // show creation — the lineup is left empty and a warning is logged.
+  test("creates with an empty lineup and warns when seeds are missing", async () => {
+    const db = makeMockDb();
+    db.musician.findMany.mockResolvedValue([]);
+    const warn = vi.fn();
+    const partialLogger = { info: vi.fn(), warn, error: vi.fn(), debug: vi.fn() } as never;
+    const service = new ShowService(db as never, partialLogger, makeCacheInvalidationStub(), makeStatsStub());
+
+    await expect(service.create({ date: "1999-12-31" })).resolves.toBeTruthy();
+
+    expect(db.showMusician.create).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  // setLineup is a full-set replace: existing rows are deleted, then the new
+  // entries inserted, and the show's caches invalidated.
+  test("setLineup deletes existing rows, inserts the new entries, and invalidates", async () => {
+    const db = makeMockDb();
+    db.show.findUnique.mockResolvedValue({ slug: "1999-12-31-test", date: "1999-12-31" });
+    const cache = makeCacheInvalidationStub();
+    const service = new ShowService(db as never, logger, cache, makeStatsStub());
+
+    await service.setLineup("show-id", [{ musicianId: "m-1", instrumentId: "i-1" }]);
+
+    expect(db.showMusician.deleteMany).toHaveBeenCalledWith({ where: { showId: "show-id" } });
+    expect(db.showMusician.create).toHaveBeenCalledTimes(1);
+    expect(cache.invalidateShowComprehensive).toHaveBeenCalledWith("show-id", "1999-12-31-test", [1999]);
   });
 });

--- a/packages/core/src/shows/show-service.ts
+++ b/packages/core/src/shows/show-service.ts
@@ -14,6 +14,7 @@ import {
   showOrderTuple,
 } from "../_shared/show-ordering";
 import { slugify } from "../_shared/utils/slugify";
+import { MARLON_LINEUP_SLUGS } from "../musicians/musician-constants";
 import type { StatsService } from "../stats/stats-service";
 
 export interface ShowFilter {
@@ -45,6 +46,11 @@ export interface ShowServiceCreateInput {
 }
 
 export type ShowCreateInput = Prisma.ShowCreateInput;
+
+export interface LineupEntry {
+  musicianId: string;
+  instrumentId?: string | null;
+}
 
 // Mapper functions
 function mapShowToDomainEntity(show: DbShow): Show {
@@ -358,6 +364,11 @@ export class ShowService {
 
     const show = mapShowToDomainEntity(result);
 
+    // New shows default to the current band makeup. Resolve the seeded
+    // musicians lazily so an unseeded environment degrades to an empty lineup
+    // (logged) rather than failing show creation.
+    await this.applyDefaultLineup(result.id);
+
     // Invalidate show listing caches (new show affects listings)
     await this.cacheInvalidation.invalidateShowListings([yearFromShowDate(createInput.date)]);
 
@@ -370,6 +381,72 @@ export class ShowService {
     await this.stats.rebuildGapsAndSongStatsSince(String(data.date));
 
     return show;
+  }
+
+  /**
+   * Resolve the Marlon-era default lineup from its seed slugs and write the
+   * ShowMusician rows. Never throws: if the seeds are missing (fresh DB, or a
+   * sync that ran before the seed), it logs a warning and leaves the lineup
+   * empty so show creation still succeeds. Stats are untouched — lineup data
+   * does not feed gap/play math.
+   */
+  private async applyDefaultLineup(showId: string): Promise<void> {
+    const musicians = await this.db.musician.findMany({
+      where: { slug: { in: [...MARLON_LINEUP_SLUGS] } },
+      select: { id: true, slug: true, defaultInstrumentId: true },
+    });
+
+    if (musicians.length < MARLON_LINEUP_SLUGS.length) {
+      this.logger.warn(
+        `Default lineup seeds missing (found ${musicians.length}/${MARLON_LINEUP_SLUGS.length}); show ${showId} created with an empty lineup`,
+      );
+    }
+
+    if (musicians.length === 0) return;
+
+    const entries: LineupEntry[] = musicians.map((musician) => ({
+      musicianId: musician.id,
+      instrumentId: musician.defaultInstrumentId ?? null,
+    }));
+
+    // No cache invalidation here: the caller (create) is about to run its own
+    // listing invalidation, and a just-created show has nothing comprehensively
+    // cached yet.
+    await this.replaceLineupRows(showId, entries);
+  }
+
+  /** Diff-replace the ShowMusician rows for a show in a single transaction. */
+  private async replaceLineupRows(showId: string, entries: LineupEntry[]): Promise<void> {
+    await this.db.$transaction([
+      this.db.showMusician.deleteMany({ where: { showId } }),
+      ...entries.map((entry) =>
+        this.db.showMusician.create({
+          data: {
+            showId,
+            musicianId: entry.musicianId,
+            instrumentId: entry.instrumentId ?? null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        }),
+      ),
+    ]);
+  }
+
+  /**
+   * Full-set replace of a show's lineup, then a comprehensive cache bust.
+   * Used by the admin lineup editor where the show already exists and its
+   * pages may be cached.
+   */
+  async setLineup(showId: string, entries: LineupEntry[]): Promise<void> {
+    await this.replaceLineupRows(showId, entries);
+
+    const show = await this.db.show.findUnique({ where: { id: showId }, select: { slug: true, date: true } });
+    if (show?.slug) {
+      await this.cacheInvalidation.invalidateShowComprehensive(showId, show.slug, [
+        yearFromShowDate(String(show.date)),
+      ]);
+    }
   }
 
   async update(slug: string, data: ShowServiceCreateInput): Promise<Show> {

--- a/packages/core/src/tracks/track-service.test.ts
+++ b/packages/core/src/tracks/track-service.test.ts
@@ -153,3 +153,66 @@ describe("TrackService — duration provenance", () => {
     expect(data.durationSource).toBeNull();
   });
 });
+
+describe("TrackService.setTrackMusicianDeltas", () => {
+  function makeDeltaDb(lineupMatches: Array<{ musicianId: string }> = []) {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const db: any = {
+      track: {
+        findUnique: vi.fn().mockResolvedValue({ showId: "show-id" }),
+      },
+      showMusician: {
+        findMany: vi.fn().mockResolvedValue(lineupMatches),
+      },
+      trackMusician: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        create: vi.fn().mockResolvedValue({}),
+      },
+      show: {
+        findUnique: vi.fn().mockResolvedValue({ slug: "2018-07-12-red-rocks", date: "2018-07-12" }),
+      },
+    };
+    db.$transaction = vi.fn((calls: Array<Promise<unknown>>) => Promise.all(calls));
+    return db;
+  }
+
+  // Full-set replace: existing deltas are deleted, then the passed ones
+  // inserted, and the show's caches invalidated.
+  test("deletes existing deltas, inserts the new ones, and invalidates show caches", async () => {
+    const db = makeDeltaDb();
+    const cache = makeCacheInvalidationStub();
+    const service = new TrackService(db as never, logger, cache);
+
+    await service.setTrackMusicianDeltas("track-id", [{ musicianId: "m-sam", present: true, instrumentId: "i-drums" }]);
+
+    expect(db.trackMusician.deleteMany).toHaveBeenCalledWith({ where: { trackId: "track-id" } });
+    expect(db.trackMusician.create).toHaveBeenCalledTimes(1);
+    expect(cache.invalidateShowComprehensive).toHaveBeenCalledWith("show-id", "2018-07-12-red-rocks", [2018]);
+  });
+
+  // A sit-in for a musician already in the show lineup is redundant and would
+  // double-render — reject it without writing anything.
+  test("rejects a sit-in delta for a musician already in the show lineup", async () => {
+    const db = makeDeltaDb([{ musicianId: "m-marlon" }]);
+    const service = new TrackService(db as never, logger, makeCacheInvalidationStub());
+
+    await expect(
+      service.setTrackMusicianDeltas("track-id", [{ musicianId: "m-marlon", present: true }]),
+    ).rejects.toThrow(/already in the show lineup/);
+
+    expect(db.trackMusician.deleteMany).not.toHaveBeenCalled();
+    expect(db.trackMusician.create).not.toHaveBeenCalled();
+  });
+
+  // A sat-out (present=false) for a lineup member is the expected case and
+  // must NOT trip the sit-in guard.
+  test("allows a sat-out delta for a musician in the lineup", async () => {
+    const db = makeDeltaDb();
+    const service = new TrackService(db as never, logger, makeCacheInvalidationStub());
+
+    await service.setTrackMusicianDeltas("track-id", [{ musicianId: "m-marlon", present: false }]);
+
+    expect(db.showMusician.findMany).not.toHaveBeenCalled();
+    expect(db.trackMusician.create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/tracks/track-service.ts
+++ b/packages/core/src/tracks/track-service.ts
@@ -6,6 +6,13 @@ import type { QueryOptions } from "../_shared/database/types";
 import { slugify } from "../_shared/utils/slugify";
 import { recomputeShowDuration } from "./show-duration";
 
+export interface TrackMusicianDelta {
+  musicianId: string;
+  /** true → sat in (also played); false → sat out. */
+  present: boolean;
+  instrumentId?: string | null;
+}
+
 // Database query result that includes song and annotations
 type DbTrackWithSongAndAnnotations = DbTrack & {
   song?: DbSong | null;
@@ -317,5 +324,56 @@ export class TrackService {
     // A deleted track may have appeared on the All-Timers / Jam Charts /
     // On-This-Day listings — wipe them.
     await this.invalidatePerformanceListings();
+  }
+
+  /**
+   * Full-set replace of a track's performer deltas (sit-ins / sat-outs).
+   * Deletes the track's existing TrackMusician rows, then inserts the passed
+   * ones. Rejects a `present=true` (sat-in) delta for a musician already in
+   * the show's lineup — that musician is already implied, so a sit-in row
+   * would be redundant and would double-render in footnotes. Mirrors the
+   * delete-all-then-insert shape of AnnotationService.upsertMultipleForTrack.
+   */
+  async setTrackMusicianDeltas(trackId: string, deltas: TrackMusicianDelta[]): Promise<void> {
+    const track = await this.db.track.findUnique({
+      where: { id: trackId },
+      select: { showId: true },
+    });
+    if (!track) {
+      throw new Error(`Track with id "${trackId}" not found`);
+    }
+
+    const satInIds = deltas.filter((delta) => delta.present).map((delta) => delta.musicianId);
+    if (satInIds.length > 0) {
+      const alreadyInLineup = await this.db.showMusician.findMany({
+        where: { showId: track.showId, musicianId: { in: satInIds } },
+        select: { musicianId: true },
+      });
+      if (alreadyInLineup.length > 0) {
+        throw new Error(
+          `Cannot add a sit-in delta for musician(s) already in the show lineup: ${alreadyInLineup
+            .map((row) => row.musicianId)
+            .join(", ")}`,
+        );
+      }
+    }
+
+    await this.db.$transaction([
+      this.db.trackMusician.deleteMany({ where: { trackId } }),
+      ...deltas.map((delta) =>
+        this.db.trackMusician.create({
+          data: {
+            trackId,
+            musicianId: delta.musicianId,
+            present: delta.present,
+            instrumentId: delta.instrumentId ?? null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        }),
+      ),
+    ]);
+
+    await this.invalidateShowCaches(track.showId);
   }
 }

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -10,6 +10,7 @@ export * from "./models/blog-post";
 export * from "./models/cloudflare-images";
 export * from "./models/file";
 export * from "./models/logger";
+export * from "./models/musician";
 export * from "./models/rating";
 export * from "./models/review";
 export * from "./models/rock-opera";

--- a/packages/domain/src/models/musician.ts
+++ b/packages/domain/src/models/musician.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+export const instrumentSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type Instrument = z.infer<typeof instrumentSchema>;
+
+export const musicianSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  defaultInstrumentId: z.string().uuid().nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type Musician = z.infer<typeof musicianSchema>;
+
+export const showMusicianSchema = z.object({
+  id: z.string().uuid(),
+  showId: z.string().uuid(),
+  musicianId: z.string().uuid(),
+  instrumentId: z.string().uuid().nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type ShowMusician = z.infer<typeof showMusicianSchema>;
+
+export const trackMusicianSchema = z.object({
+  id: z.string().uuid(),
+  trackId: z.string().uuid(),
+  musicianId: z.string().uuid(),
+  present: z.boolean(),
+  instrumentId: z.string().uuid().nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type TrackMusician = z.infer<typeof trackMusicianSchema>;


### PR DESCRIPTION
## Structured performers: foundation

Adds the data model and service layer for tracking who played each show and
each song: an admin-managed list of musicians and instruments, a per-show
lineup, and per-track sit-in/sat-out deltas. Nothing is fan-facing yet; this
is the additive groundwork for the lineup display, automatic footnotes, and a
"played by musician" filter in later phases.

New shows automatically get the current Marlon-era lineup. Admins will be able
to override a show's lineup (`setLineup`) and record per-track deviations
(`setTrackMusicianDeltas`). For example, Sam Altman sitting in on drums for a
few songs during the Marlon era, which the date-derived era filter can't
express.

The migration seeds the instrument vocabulary and the band members (plus former
drummers Sam Altman and Allen Aucoin), so the reference data lands on every
environment automatically.

## Also in this PR

`bun run lint` now fails on warnings (`--error-on-warnings`). It previously
exited 0 on warning-level findings, so the pre-commit hook and CI passed
despite unused imports and similar. The one existing warning is cleared by
adding the missing `venueAddressCountry` test.

## Notes for the reviewer

- **Slug dedupe diverges from AuthorService on purpose.** Musician/Instrument
  `create` returns an existing row on slug collision rather than auto-suffixing
  (`name-2`), so the later performer backfill is idempotent. Commented at the
  source.
- **Seed lives in the migration, not a script**, mirroring the `duration_sources`
  lookup-table precedent, so it deploys everywhere without a manual step.
- The sync script (`sync-missing-shows.ts`) is intentionally unchanged: synced
  shows get an empty lineup until prod has performer rows to mirror (a later
  phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
