### PR TITLE
Show lineup editor, show deletion, and create-show venue requirement

### DIFF
--- a/apps/web/app/components/admin/delete-entity-button.tsx
+++ b/apps/web/app/components/admin/delete-entity-button.tsx
@@ -74,7 +74,7 @@ export function DeleteEntityButton({
           <Trash2 className="h-4 w-4" />
         </Button>
       ) : (
-        <Button variant="destructive" onClick={() => setIsOpen(true)} className="gap-2">
+        <Button variant="destructiveOutline" onClick={() => setIsOpen(true)} className="gap-2">
           <Trash2 className="h-4 w-4" />
           Delete {titleLabel}
         </Button>

--- a/apps/web/app/components/musician/musician-search.tsx
+++ b/apps/web/app/components/musician/musician-search.tsx
@@ -5,6 +5,6 @@ import { type EntityPickerProps, EntitySearch } from "~/components/ui/entity-sea
  * Musician picker for the show lineup and per-track performer editors. With
  * allowCreate it lets admins add a guest who isn't on file yet.
  */
-export function MusicianSearch(props: EntityPickerProps) {
+export function MusicianSearch(props: EntityPickerProps & { onItemChange?: (item: Musician | null) => void }) {
   return <EntitySearch<Musician> resource="musicians" noneLabel="No Musician" itemLabel={(m) => m.name} {...props} />;
 }

--- a/apps/web/app/components/show/show-form.test.tsx
+++ b/apps/web/app/components/show/show-form.test.tsx
@@ -41,3 +41,46 @@ describe("ShowForm countForStats", () => {
     expect(screen.getByRole("switch", { name: /count for stats/i })).toBeChecked();
   });
 });
+
+describe("ShowForm requireVenue", () => {
+  // Create flow opts in to requireVenue so a show can't be saved without a
+  // venue (which would otherwise become a hidden orphan stub).
+  test("blocks submit and shows an error when no venue is selected", async () => {
+    const onSubmit = vi.fn();
+    const { user } = await setup(
+      <ShowForm defaultValues={baseValues} onSubmit={onSubmit} submitLabel="Create Show" requireVenue />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /create show/i }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(await screen.findByText(/venue is required/i)).toBeInTheDocument();
+  });
+
+  // With a venue chosen, the same form submits normally.
+  test("submits when a venue is selected", async () => {
+    const onSubmit = vi.fn();
+    const { user } = await setup(
+      <ShowForm
+        defaultValues={{ ...baseValues, venueId: "venue-1" }}
+        onSubmit={onSubmit}
+        submitLabel="Create Show"
+        requireVenue
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /create show/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  // Edit flow (default) leaves venue optional, so existing flows are unchanged.
+  test("allows an empty venue when requireVenue is not set", async () => {
+    const onSubmit = vi.fn();
+    const { user } = await setup(<ShowForm defaultValues={baseValues} onSubmit={onSubmit} submitLabel="Update Show" />);
+
+    await user.click(screen.getByRole("button", { name: /update show/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/app/components/show/show-form.tsx
+++ b/apps/web/app/components/show/show-form.tsx
@@ -1,5 +1,6 @@
 import type { Band, RockOpera } from "@bip/domain";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useMemo } from "react";
 import type { ControllerRenderProps } from "react-hook-form";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -40,6 +41,11 @@ interface ShowFormProps {
    * rock operas seeded yet).
    */
   rockOperas?: RockOpera[];
+  /**
+   * Require a venue selection (the create flow). Without it, "No venue" would
+   * produce a hidden orphan-stub show that's filtered from listings/search.
+   */
+  requireVenue?: boolean;
 }
 
 export function ShowForm({
@@ -49,9 +55,20 @@ export function ShowForm({
   cancelHref,
   showId,
   rockOperas = [],
+  requireVenue = false,
 }: ShowFormProps) {
+  const schema = useMemo(
+    () =>
+      requireVenue
+        ? showFormSchema.refine((values) => values.venueId !== "none" && values.venueId !== "", {
+            path: ["venueId"],
+            message: "Venue is required",
+          })
+        : showFormSchema,
+    [requireVenue],
+  );
   const form = useForm<ShowFormValues>({
-    resolver: zodResolver(showFormSchema),
+    resolver: zodResolver(schema),
     defaultValues: defaultValues || {
       date: "",
       venueId: "none",

--- a/apps/web/app/components/show/show-lineup-manager.test.tsx
+++ b/apps/web/app/components/show/show-lineup-manager.test.tsx
@@ -1,0 +1,167 @@
+import { setupWithRouter } from "@test/test-utils";
+import { screen, waitFor } from "@testing-library/react";
+import type { UserEvent } from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { ShowLineupManager } from "./show-lineup-manager";
+
+vi.mock("sonner", () => ({
+  toast: { loading: vi.fn(), success: vi.fn(), error: vi.fn() },
+}));
+
+// Catalog the picker endpoints hit by the real MusicianSearch/InstrumentSearch
+// so a click resolves to a known record. Tests assert behavior through the
+// Save payload, which exercises the full pick → state → POST path.
+const MUSICIANS: Record<string, { id: string; name: string; defaultInstrumentId: string | null }> = {
+  "m-marc": { id: "m-marc", name: "Marc Brownstein", defaultInstrumentId: "i-bass" },
+  "m-aron": { id: "m-aron", name: "Aron Magner", defaultInstrumentId: "i-keys" },
+};
+const INSTRUMENTS: Record<string, { id: string; name: string }> = {
+  "i-bass": { id: "i-bass", name: "Bass" },
+  "i-keys": { id: "i-keys", name: "Keys" },
+};
+
+function routeFetch(url: string, init?: RequestInit): Response {
+  const json = (body: unknown) => ({ ok: true, json: async () => body }) as Response;
+  if (url.startsWith("/api/musicians/")) return json(MUSICIANS[url.split("/").pop() as string] ?? null);
+  if (url.startsWith("/api/musicians")) return json(Object.values(MUSICIANS));
+  if (url.startsWith("/api/instruments/")) return json(INSTRUMENTS[url.split("/").pop() as string] ?? null);
+  if (url.startsWith("/api/instruments")) return json(Object.values(INSTRUMENTS));
+  if (url.includes("/lineup") && init?.method === "POST") return json({ ok: true, lineup: [] });
+  return json([]);
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+beforeEach(() => {
+  fetchMock = vi.fn((url: string, init?: RequestInit) => Promise.resolve(routeFetch(url, init)));
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+afterEach(() => vi.restoreAllMocks());
+
+const instrument = (id: string, name: string) => ({ id, name, slug: id, createdAt: new Date(), updatedAt: new Date() });
+function member(id: string, name: string, slug: string, instruments: ReturnType<typeof instrument>[]) {
+  return { musician: { id, name, slug, knownFrom: null, defaultInstrument: null }, instruments };
+}
+
+// Pick a musician in an already-open picker (autoOpen row) by typing and clicking.
+async function pickInOpenPicker(user: UserEvent, name: string) {
+  await user.type(await screen.findByPlaceholderText("Search musicians..."), name.slice(0, 4));
+  await user.click(await screen.findByText(name, undefined, { timeout: 1500 }));
+}
+
+// Open the first (closed) musician picker, then pick.
+async function openAndPick(user: UserEvent, name: string) {
+  await user.click(screen.getAllByRole("combobox")[0]);
+  await pickInOpenPicker(user, name);
+}
+
+function savedEntries(): unknown {
+  const post = fetchMock.mock.calls.find((c) => String(c[0]).includes("/lineup") && c[1]?.method === "POST");
+  return JSON.parse(post?.[1]?.body as string).entries;
+}
+
+describe("ShowLineupManager", () => {
+  // Read-only by default, using the same render as the public show page.
+  test("renders the lineup read-only with an Edit button and no pickers", async () => {
+    await setupWithRouter(
+      <ShowLineupManager
+        showId="show-1"
+        initialLineup={[member("m-marc", "Marc Brownstein", "marc-brownstein", [instrument("i-bass", "Bass")])]}
+      />,
+    );
+
+    expect(screen.getByText("Marc Brownstein")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /edit lineup/i })).toBeInTheDocument();
+    expect(screen.queryAllByRole("combobox")).toHaveLength(0);
+  });
+
+  // Clicking Edit swaps the whole section into the picker editor.
+  test("clicking Edit reveals the pickers and Save/Cancel", async () => {
+    const { user } = await setupWithRouter(
+      <ShowLineupManager
+        showId="show-1"
+        initialLineup={[member("m-aron", "Aron Magner", "aron-magner", [instrument("i-keys", "Keys")])]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /edit lineup/i }));
+
+    expect(screen.getAllByRole("combobox").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /save lineup/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^cancel$/i })).toBeInTheDocument();
+  });
+
+  // Adding a row auto-opens its musician picker so the admin can type the name
+  // immediately.
+  test("Add opens the new musician picker focused", async () => {
+    const { user } = await setupWithRouter(<ShowLineupManager showId="show-1" initialLineup={[]} />);
+
+    await user.click(screen.getByRole("button", { name: /edit lineup/i }));
+    await user.click(screen.getByRole("button", { name: /add musician/i }));
+
+    expect(await screen.findByPlaceholderText("Search musicians...")).toBeInTheDocument();
+  });
+
+  // Picking a musician on an empty row seeds their default instrument.
+  test("prefills the picked musician's default instrument on an empty row", async () => {
+    const { user } = await setupWithRouter(<ShowLineupManager showId="show-1" initialLineup={[]} />);
+
+    await user.click(screen.getByRole("button", { name: /edit lineup/i }));
+    await user.click(screen.getByRole("button", { name: /add musician/i }));
+    await pickInOpenPicker(user, "Marc Brownstein");
+    await user.click(screen.getByRole("button", { name: /save lineup/i }));
+
+    await waitFor(() => expect(savedEntries()).toEqual([{ musicianId: "m-marc", instrumentIds: ["i-bass"] }]));
+  });
+
+  // Changing the musician on a row that already has instruments keeps them.
+  test("does not overwrite existing instruments when the musician changes", async () => {
+    const { user } = await setupWithRouter(
+      <ShowLineupManager
+        showId="show-1"
+        initialLineup={[member("m-aron", "Aron Magner", "aron-magner", [instrument("i-keys", "Keys")])]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /edit lineup/i }));
+    await openAndPick(user, "Marc Brownstein");
+    await user.click(screen.getByRole("button", { name: /save lineup/i }));
+
+    await waitFor(() => expect(savedEntries()).toEqual([{ musicianId: "m-marc", instrumentIds: ["i-keys"] }]));
+  });
+
+  // Empty rows (added but no musician picked) are excluded from the save.
+  test("excludes empty rows from the saved payload", async () => {
+    const { user } = await setupWithRouter(
+      <ShowLineupManager
+        showId="show-1"
+        initialLineup={[member("m-marc", "Marc Brownstein", "marc-brownstein", [instrument("i-bass", "Bass")])]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /edit lineup/i }));
+    await user.click(screen.getByRole("button", { name: /add musician/i }));
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByRole("button", { name: /save lineup/i }));
+
+    await waitFor(() => expect(savedEntries()).toEqual([{ musicianId: "m-marc", instrumentIds: ["i-bass"] }]));
+  });
+
+  // Cancel discards the draft and returns to read-only without saving.
+  test("Cancel returns to read-only without posting", async () => {
+    const { user } = await setupWithRouter(
+      <ShowLineupManager
+        showId="show-1"
+        initialLineup={[member("m-marc", "Marc Brownstein", "marc-brownstein", [instrument("i-bass", "Bass")])]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /edit lineup/i }));
+    await user.click(screen.getByRole("button", { name: /add musician/i }));
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    expect(screen.getByRole("button", { name: /edit lineup/i })).toBeInTheDocument();
+    expect(fetchMock.mock.calls.some((c) => c[1]?.method === "POST")).toBe(false);
+  });
+});

--- a/apps/web/app/components/show/show-lineup-manager.tsx
+++ b/apps/web/app/components/show/show-lineup-manager.tsx
@@ -1,0 +1,206 @@
+import type { Musician, ShowLineupMember } from "@bip/domain";
+import { Edit2, Plus, Trash2 } from "lucide-react";
+import { useRef, useState } from "react";
+import { toast } from "sonner";
+import { InstrumentSearch } from "~/components/musician/instrument-search";
+import { MusicianSearch } from "~/components/musician/musician-search";
+import { ShowLineupSection } from "~/components/show/show-lineup-section";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { sortLineup } from "~/lib/musicians-constants";
+
+interface LineupRow {
+  uid: string;
+  musicianId: string;
+  instrumentIds: string[];
+  autoOpen?: boolean;
+}
+
+interface ShowLineupManagerProps {
+  showId: string;
+  initialLineup: ShowLineupMember[];
+}
+
+/**
+ * Admin lineup editor on the show edit page. Shows the lineup read-only using
+ * the same component as the public show page, with an Edit toggle that swaps in
+ * the picker-based editor for the whole set at once. Saves via
+ * /api/shows/:showId/lineup, which returns the resolved lineup so the read-only
+ * view refreshes without a second fetch. Picking a musician pre-fills their
+ * default instrument so the common case is one click.
+ */
+export function ShowLineupManager({ showId, initialLineup }: ShowLineupManagerProps) {
+  const [lineup, setLineup] = useState<ShowLineupMember[]>(initialLineup);
+  const [editing, setEditing] = useState(false);
+  const [rows, setRows] = useState<LineupRow[]>([]);
+  const [saving, setSaving] = useState(false);
+  const nextUid = useRef(0);
+  const makeUid = () => String(nextUid.current++);
+
+  const beginEdit = () => {
+    // Seed rows in the same order the read-only view shows them.
+    setRows(
+      sortLineup(lineup).map((member) => ({
+        uid: makeUid(),
+        musicianId: member.musician.id,
+        instrumentIds: member.instruments.map((instrument) => instrument.id),
+      })),
+    );
+    setEditing(true);
+  };
+
+  const updateRow = (uid: string, change: (row: LineupRow) => LineupRow) => {
+    setRows((prev) => prev.map((row) => (row.uid === uid ? change(row) : row)));
+  };
+
+  const setMusician = (uid: string, musicianId: string | null) => {
+    updateRow(uid, (row) => ({ ...row, musicianId: musicianId ?? "" }));
+  };
+
+  // Only seed a default instrument when the row has none yet, so changing a
+  // musician never clobbers an instrument an admin set deliberately.
+  const prefillInstrument = (uid: string, musician: Musician | null) => {
+    if (!musician?.defaultInstrumentId) return;
+    const defaultInstrumentId = musician.defaultInstrumentId;
+    updateRow(uid, (row) => (row.instrumentIds.length === 0 ? { ...row, instrumentIds: [defaultInstrumentId] } : row));
+  };
+
+  const replaceInstrument = (uid: string, instrumentIndex: number, instrumentId: string | null) => {
+    updateRow(uid, (row) => {
+      const next = instrumentId
+        ? row.instrumentIds.map((id, i) => (i === instrumentIndex ? instrumentId : id))
+        : row.instrumentIds.filter((_, i) => i !== instrumentIndex);
+      return { ...row, instrumentIds: next };
+    });
+  };
+
+  const addInstrument = (uid: string, instrumentId: string | null) => {
+    if (!instrumentId) return;
+    updateRow(uid, (row) => ({ ...row, instrumentIds: [...row.instrumentIds, instrumentId] }));
+  };
+
+  const addRow = () =>
+    setRows((prev) => [...prev, { uid: makeUid(), musicianId: "", instrumentIds: [], autoOpen: true }]);
+  const removeRow = (uid: string) => setRows((prev) => prev.filter((row) => row.uid !== uid));
+
+  const save = async () => {
+    setSaving(true);
+    const loadingToast = toast.loading("Saving lineup...");
+    const entries = rows
+      .filter((row) => row.musicianId)
+      .map((row) => ({ musicianId: row.musicianId, instrumentIds: row.instrumentIds }));
+    try {
+      const response = await fetch(`/api/shows/${showId}/lineup`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entries }),
+      });
+      if (!response.ok) throw new Error("Save failed");
+      const data = (await response.json()) as { lineup: ShowLineupMember[] };
+      setLineup(data.lineup);
+      setEditing(false);
+      toast.success("Lineup saved", { id: loadingToast });
+    } catch {
+      toast.error("Failed to save lineup", { id: loadingToast });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!editing) {
+    return (
+      <Card className="card-premium">
+        <CardContent className="p-4">
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <h3 className="text-base font-medium text-content-text-primary">Lineup</h3>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              aria-label="Edit lineup"
+              onClick={beginEdit}
+              className="h-8 w-8 p-0 border-gray-600 text-gray-300 hover:bg-gray-700"
+            >
+              <Edit2 className="h-3 w-3" />
+            </Button>
+          </div>
+          {lineup.length > 0 ? (
+            <ShowLineupSection lineup={lineup} bare />
+          ) : (
+            <p className="text-sm text-content-text-tertiary">No lineup recorded yet.</p>
+          )}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="card-premium">
+      <CardHeader className="flex-row flex-wrap items-center justify-between gap-2 space-y-0 py-3">
+        <CardTitle className="text-base text-content-text-primary">Edit lineup</CardTitle>
+        <div className="flex items-center gap-2">
+          <Button type="button" variant="secondary" size="sm" aria-label="Add musician" onClick={addRow}>
+            <Plus className="mr-1 h-4 w-4" />
+            Add
+          </Button>
+          <Button type="button" variant="ghost" size="sm" aria-label="Cancel" onClick={() => setEditing(false)}>
+            Cancel
+          </Button>
+          <Button type="button" variant="brand" size="sm" aria-label="Save lineup" onClick={save} disabled={saving}>
+            Save
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-1.5 pb-3">
+        <ul className="space-y-2 sm:space-y-1.5">
+          {rows.map((row) => (
+            // Bordered block on mobile so each member's stacked pickers read as a
+            // group; collapses to a single inline row on sm+.
+            <li
+              key={row.uid}
+              className="flex flex-wrap items-center gap-1.5 rounded-md border border-glass-border/30 p-2 sm:rounded-none sm:border-0 sm:p-0"
+            >
+              <MusicianSearch
+                value={row.musicianId || null}
+                onValueChange={(id) => setMusician(row.uid, id)}
+                onItemChange={(musician) => prefillInstrument(row.uid, musician)}
+                allowCreate
+                autoOpen={row.autoOpen}
+                className="h-8 w-full sm:w-48"
+              />
+              {row.musicianId &&
+                row.instrumentIds.map((instrumentId, instrumentIndex) => (
+                  <InstrumentSearch
+                    key={instrumentId}
+                    value={instrumentId}
+                    onValueChange={(id) => replaceInstrument(row.uid, instrumentIndex, id)}
+                    allowCreate
+                    className="h-8 w-full sm:w-36"
+                  />
+                ))}
+              {row.musicianId && (
+                <InstrumentSearch
+                  value={null}
+                  onValueChange={(id) => addInstrument(row.uid, id)}
+                  allowCreate
+                  placeholder="+ instrument"
+                  className="h-8 w-full sm:w-32"
+                />
+              )}
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Remove musician"
+                onClick={() => removeRow(row.uid)}
+                className="ml-auto h-8 w-8 shrink-0 sm:ml-0"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/app/components/show/show-lineup-section.tsx
+++ b/apps/web/app/components/show/show-lineup-section.tsx
@@ -5,30 +5,38 @@ import { sortLineup } from "~/lib/musicians-constants";
 /**
  * The show's default performer lineup, shown below the setlist. Each member's
  * name links to their profile page, followed by the instruments they played.
- * Renders nothing when no lineup is recorded.
+ * Renders nothing when no lineup is recorded. Pass `bare` to render just the
+ * member list (no heading or top divider) when the caller supplies its own
+ * chrome — e.g. the admin edit page's read-only lineup card.
  */
-export function ShowLineupSection({ lineup }: { lineup: ShowLineupMember[] }) {
+export function ShowLineupSection({ lineup, bare = false }: { lineup: ShowLineupMember[]; bare?: boolean }) {
   if (lineup.length === 0) return null;
+
+  const list = (
+    <ul className="space-y-1">
+      {sortLineup(lineup).map((member) => {
+        const instruments = member.instruments.map((instrument) => instrument.name).join(", ");
+        return (
+          <li key={member.musician.id} className="text-sm text-content-text-secondary">
+            <Link
+              to={`/musicians/${member.musician.slug}`}
+              className="text-brand-primary hover:text-brand-secondary hover:underline"
+            >
+              {member.musician.name}
+            </Link>
+            {instruments ? <span className="lowercase"> · {instruments}</span> : ""}
+          </li>
+        );
+      })}
+    </ul>
+  );
+
+  if (bare) return list;
 
   return (
     <div className="mt-6 pt-4 border-t border-glass-border/30">
       <h3 className="text-base font-medium text-content-text-tertiary mb-2">Lineup</h3>
-      <ul className="space-y-1">
-        {sortLineup(lineup).map((member) => {
-          const instruments = member.instruments.map((instrument) => instrument.name).join(", ");
-          return (
-            <li key={member.musician.id} className="text-sm text-content-text-secondary">
-              <Link
-                to={`/musicians/${member.musician.slug}`}
-                className="text-brand-primary hover:text-brand-secondary hover:underline"
-              >
-                {member.musician.name}
-              </Link>
-              {instruments ? <span className="lowercase"> · {instruments}</span> : ""}
-            </li>
-          );
-        })}
-      </ul>
+      {list}
     </div>
   );
 }

--- a/apps/web/app/components/track/sortable-track-item.tsx
+++ b/apps/web/app/components/track/sortable-track-item.tsx
@@ -72,10 +72,10 @@ export function SortableTrackItem({ track, onEdit, onDelete, isDeleting }: Sorta
             </Button>
             <Button
               size="sm"
-              variant="outline"
+              variant="destructiveOutline"
               onClick={() => onDelete(track.id)}
               disabled={isDeleting}
-              className="h-8 w-8 p-0 md:h-9 md:w-auto md:px-3 border-red-600 text-red-400 hover:bg-red-900/20"
+              className="h-8 w-8 p-0 md:h-9 md:w-auto md:px-3"
             >
               <Trash className="h-3 w-3" />
             </Button>

--- a/apps/web/app/components/ui/button.tsx
+++ b/apps/web/app/components/ui/button.tsx
@@ -20,6 +20,9 @@ const buttonVariants = cva(
         cancel:
           "border border-content-bg-secondary bg-transparent text-content-text-secondary hover:bg-content-bg-secondary hover:text-content-text-primary",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        // Outlined red delete affordance — shared by the track delete row and
+        // the show/entity delete buttons so every "delete" reads the same.
+        destructiveOutline: "border border-red-600 bg-transparent text-red-400 hover:bg-red-900/20",
         outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",

--- a/apps/web/app/components/ui/entity-search.tsx
+++ b/apps/web/app/components/ui/entity-search.tsx
@@ -8,6 +8,8 @@ export interface EntityPickerProps {
   placeholder?: string;
   className?: string;
   allowCreate?: boolean;
+  /** Start open with the search input focused — for a freshly added picker row. */
+  autoOpen?: boolean;
 }
 
 interface EntitySearchProps<T extends { id: string }> extends EntityPickerProps {
@@ -16,6 +18,8 @@ interface EntitySearchProps<T extends { id: string }> extends EntityPickerProps 
   /** Label for the clear-selection row, e.g. "No Musician" or "All Authors". */
   noneLabel: string;
   itemLabel: (item: T) => ReactNode;
+  /** Fires with the full resolved record on selection — for callers that need fields beyond the id. */
+  onItemChange?: (item: T | null) => void;
 }
 
 /**
@@ -28,9 +32,11 @@ interface EntitySearchProps<T extends { id: string }> extends EntityPickerProps 
 export function EntitySearch<T extends { id: string }>({
   value,
   onValueChange,
+  onItemChange,
   placeholder,
   className,
   allowCreate = false,
+  autoOpen,
   resource,
   noneLabel,
   itemLabel,
@@ -40,6 +46,8 @@ export function EntitySearch<T extends { id: string }>({
     <SearchPicker<T>
       value={value ?? null}
       onValueChange={onValueChange}
+      onItemChange={onItemChange}
+      autoOpen={autoOpen}
       className={className}
       placeholder={searchPlaceholder}
       searchPlaceholder={searchPlaceholder}

--- a/apps/web/app/components/ui/form.tsx
+++ b/apps/web/app/components/ui/form.tsx
@@ -1,5 +1,6 @@
 import type * as LabelPrimitive from "@radix-ui/react-label";
 import { Slot } from "@radix-ui/react-slot";
+import { AlertCircle } from "lucide-react";
 import * as React from "react";
 import {
   Controller,
@@ -122,6 +123,23 @@ const FormMessage = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<
 
     if (!body) {
       return null;
+    }
+
+    // Validation errors render as a boxed, icon-led red alert so they read as
+    // an alert across every form; non-error children stay as plain text.
+    if (error) {
+      return (
+        <div
+          id={formMessageId}
+          className={cn(
+            "mt-1 flex items-center gap-2 rounded-md border border-red-500/40 bg-red-500/15 px-3 py-2 text-sm text-red-300",
+            className,
+          )}
+        >
+          <AlertCircle className="h-4 w-4 shrink-0 text-red-400" />
+          <span>{body}</span>
+        </div>
+      );
     }
 
     return (

--- a/apps/web/app/components/ui/search-picker.test.tsx
+++ b/apps/web/app/components/ui/search-picker.test.tsx
@@ -218,6 +218,37 @@ describe("SearchPicker", () => {
     expect(screen.queryByText(/Create "/)).not.toBeInTheDocument();
   });
 
+  // `onItemChange` surfaces the full selected record (not just its id) so a
+  // parent can react to the picked item's fields — e.g. the lineup editor
+  // pre-filling a musician's default instrument. Fires on explicit selection.
+  test("clicking a result fires onItemChange with the full item", async () => {
+    const onItemChange = vi.fn();
+    const fetchResults = vi.fn().mockResolvedValue(ITEMS);
+
+    const { user } = await setup(<SearchPicker<Item> {...baseProps({ onItemChange, fetchResults })} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("Banana"));
+
+    expect(onItemChange).toHaveBeenCalledWith({ id: "2", name: "Banana" });
+  });
+
+  // Clearing the selection via the none row reports null through onItemChange
+  // too, so the parent can reset any derived state.
+  test("selecting the clear row fires onItemChange with null", async () => {
+    const onItemChange = vi.fn();
+    const fetchResults = vi.fn().mockResolvedValue(ITEMS);
+
+    const { user } = await setup(
+      <SearchPicker<Item> {...baseProps({ value: "1", onItemChange, fetchResults, noneLabel: "Clear" })} />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("Clear"));
+
+    expect(onItemChange).toHaveBeenCalledWith(null);
+  });
+
   // fetchResults rejecting (e.g. server 500) is handled gracefully: items
   // clear and the configured emptyMessage shows. Prevents a transient
   // network error from corrupting the local items list.

--- a/apps/web/app/components/ui/search-picker.tsx
+++ b/apps/web/app/components/ui/search-picker.tsx
@@ -22,6 +22,10 @@ interface SearchPickerProps<T> {
   // The selected item's id, or null when nothing is selected.
   value: string | null;
   onValueChange: (value: string | null) => void;
+  // Optional: fires alongside onValueChange with the full resolved record on
+  // an explicit selection (item click, clear row, or create), so a parent can
+  // react to the picked item's fields. Not fired by the fetchById seed effect.
+  onItemChange?: (item: T | null) => void;
 
   // Returns items matching the current query. Wrappers decide what "empty
   // query" means — return [] to suppress the list, or return top-N items.
@@ -49,6 +53,11 @@ interface SearchPickerProps<T> {
   // when the wrapper wants to seed a top-N list before the user types.
   loadOnOpen?: boolean;
 
+  // If true, the popover starts open on mount with its search input focused —
+  // used when a caller adds a fresh picker (e.g. a new lineup row) and wants
+  // the user typing the name immediately.
+  autoOpen?: boolean;
+
   placeholder?: string;
   searchPlaceholder?: string;
   // Static message OR function of the current query. The function form
@@ -71,6 +80,7 @@ interface SearchPickerProps<T> {
 export function SearchPicker<T>({
   value,
   onValueChange,
+  onItemChange,
   fetchResults,
   fetchById,
   initialItem,
@@ -79,13 +89,14 @@ export function SearchPicker<T>({
   noneLabel,
   allowCreate,
   loadOnOpen = false,
+  autoOpen = false,
   placeholder = "Search…",
   searchPlaceholder = "Search…",
   emptyMessage = "No results found.",
   loadingMessage = "Searching…",
   className,
 }: SearchPickerProps<T>) {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(autoOpen);
   const [items, setItems] = useState<T[]>([]);
   const [loading, setLoading] = useState(false);
   const [creating, setCreating] = useState(false);
@@ -176,6 +187,7 @@ export function SearchPicker<T>({
       if (created) {
         setItems((prev) => [created, ...prev]);
         onValueChange(itemId(created));
+        onItemChange?.(created);
         setCurrentItem(created);
         setSearchQuery("");
         setOpen(false);
@@ -223,6 +235,7 @@ export function SearchPicker<T>({
                   value="__none__"
                   onSelect={() => {
                     onValueChange(null);
+                    onItemChange?.(null);
                     setOpen(false);
                   }}
                   className="text-content-text-primary hover:bg-hover-glass"
@@ -251,6 +264,7 @@ export function SearchPicker<T>({
                     value={id}
                     onSelect={() => {
                       onValueChange(id);
+                      onItemChange?.(item);
                       setCurrentItem(item);
                       setOpen(false);
                     }}

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -120,6 +120,8 @@ export default [
     route("attendances", "routes/api/attendances.tsx"),
     route("shows/user-data", "routes/api/shows/user-data.tsx"),
     route("shows/reorder", "routes/api/shows/reorder.tsx"),
+    route("shows/:showId/lineup", "routes/api/shows/$showId.lineup.tsx"),
+    route("shows/:showId", "routes/api/shows/$showId.tsx"),
     route("show-youtubes", "routes/api/show-youtubes.tsx"),
     route("authors", "routes/api/authors.tsx"),
     route("authors/:id", "routes/api/authors/$id.tsx"),

--- a/apps/web/app/routes/api/shows/$showId.lineup.test.ts
+++ b/apps/web/app/routes/api/shows/$showId.lineup.test.ts
@@ -1,0 +1,91 @@
+import type { ActionFunctionArgs } from "react-router-dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// adminAction normally wraps the inner function with auth. For action-level
+// unit tests we bypass auth and run the inner function directly so we can
+// exercise body parsing, validation, and service delegation in isolation.
+vi.mock("~/lib/base-loaders", () => ({
+  adminAction: <T>(fn: (args: ActionFunctionArgs) => Promise<T>) => fn,
+}));
+
+const setLineup = vi.fn();
+const getLineup = vi.fn();
+vi.mock("~/server/services", () => ({
+  services: { shows: { setLineup, getLineup } },
+}));
+
+vi.mock("~/lib/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn() },
+}));
+
+const { action } = await import("./$showId.lineup");
+
+function makeRequest(body: unknown, method = "POST", showId = "show-1"): ActionFunctionArgs {
+  const init: RequestInit = { method, headers: { "Content-Type": "application/json" } };
+  if (method !== "GET" && method !== "HEAD") {
+    init.body = JSON.stringify(body);
+  }
+  return {
+    request: new Request(`http://localhost/api/shows/${showId}/lineup`, init),
+    params: { showId },
+    context: {},
+  } as unknown as ActionFunctionArgs;
+}
+
+describe("POST /api/shows/:showId/lineup", () => {
+  beforeEach(() => {
+    setLineup.mockReset().mockResolvedValue(undefined);
+    getLineup.mockReset().mockResolvedValue([]);
+  });
+
+  // Happy path: parsed entries delegate straight to ShowService.setLineup,
+  // keyed by the showId route param, and the resolved lineup comes back so the
+  // widget can re-render its read-only view without a second fetch.
+  test("delegates parsed entries to ShowService.setLineup and returns the fresh lineup", async () => {
+    const entries = [
+      { musicianId: "m-marc", instrumentIds: ["i-bass", "i-vocals"] },
+      { musicianId: "m-aron", instrumentIds: ["i-keys"] },
+    ];
+    const fresh = [{ musician: { id: "m-marc" }, instruments: [{ id: "i-bass" }] }];
+    getLineup.mockResolvedValue(fresh);
+
+    const result = await action(makeRequest({ entries }));
+
+    expect(setLineup).toHaveBeenCalledWith("show-1", entries);
+    expect(getLineup).toHaveBeenCalledWith("show-1");
+    expect(result).toEqual({ ok: true, lineup: fresh });
+  });
+
+  // An entry may legitimately have no instruments yet — the picker row exists
+  // but the admin hasn't assigned one. Missing instrumentIds is allowed.
+  test("accepts an entry with no instrumentIds", async () => {
+    await action(makeRequest({ entries: [{ musicianId: "m-marc" }] }));
+    expect(setLineup).toHaveBeenCalledWith("show-1", [{ musicianId: "m-marc" }]);
+  });
+
+  // Method guard: only POST writes the lineup.
+  test("rejects non-POST methods with 405", async () => {
+    await expect(action(makeRequest({ entries: [] }, "GET"))).rejects.toMatchObject({ status: 405 });
+    expect(setLineup).not.toHaveBeenCalled();
+  });
+
+  // Validation: entries must be an array of objects with a string musicianId
+  // and (if present) a string-array instrumentIds. Garbage is rejected before
+  // it reaches the transactional write.
+  test("rejects malformed entries with 400", async () => {
+    await expect(action(makeRequest({ entries: "nope" }))).rejects.toMatchObject({ status: 400 });
+    await expect(action(makeRequest({ entries: [{ instrumentIds: ["i-1"] }] }))).rejects.toMatchObject({ status: 400 });
+    await expect(action(makeRequest({ entries: [{ musicianId: 7 }] }))).rejects.toMatchObject({ status: 400 });
+    await expect(action(makeRequest({ entries: [{ musicianId: "m-1", instrumentIds: [9] }] }))).rejects.toMatchObject({
+      status: 400,
+    });
+    expect(setLineup).not.toHaveBeenCalled();
+  });
+
+  // Service-level failures surface as 400 with the service message rather than
+  // a generic 500, so admins get a useful response.
+  test("translates service errors into 400 responses", async () => {
+    setLineup.mockRejectedValueOnce(new Error("boom"));
+    await expect(action(makeRequest({ entries: [{ musicianId: "m-1" }] }))).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/apps/web/app/routes/api/shows/$showId.lineup.tsx
+++ b/apps/web/app/routes/api/shows/$showId.lineup.tsx
@@ -1,0 +1,53 @@
+import { adminAction } from "~/lib/base-loaders";
+import { logger } from "~/lib/logger";
+import { services } from "~/server/services";
+
+interface LineupEntryInput {
+  musicianId: string;
+  instrumentIds?: string[];
+}
+
+function parseEntries(raw: unknown): LineupEntryInput[] {
+  if (!Array.isArray(raw)) {
+    throw new Response("entries must be an array", { status: 400 });
+  }
+  return raw.map((entry) => {
+    if (typeof entry !== "object" || entry === null) {
+      throw new Response("each entry must be an object", { status: 400 });
+    }
+    const { musicianId, instrumentIds } = entry as Record<string, unknown>;
+    if (typeof musicianId !== "string" || !musicianId) {
+      throw new Response("each entry needs a string musicianId", { status: 400 });
+    }
+    if (instrumentIds !== undefined) {
+      if (!Array.isArray(instrumentIds) || !instrumentIds.every((id) => typeof id === "string")) {
+        throw new Response("instrumentIds must be an array of strings", { status: 400 });
+      }
+      return { musicianId, instrumentIds: instrumentIds as string[] };
+    }
+    return { musicianId };
+  });
+}
+
+// POST /api/shows/:showId/lineup - Full-set replace of a show's musician lineup.
+export const action = adminAction(async ({ request, params }) => {
+  if (request.method !== "POST") {
+    throw new Response("Method not allowed", { status: 405 });
+  }
+
+  const showId = params.showId as string;
+  const { entries } = (await request.json()) as { entries?: unknown };
+  const parsed = parseEntries(entries);
+
+  try {
+    await services.shows.setLineup(showId, parsed);
+    logger.info("Set show lineup", { showId, count: parsed.length });
+    // Return the resolved lineup (with names) so the widget can re-render its
+    // read-only view without a second round trip.
+    const lineup = await services.shows.getLineup(showId);
+    return { ok: true, lineup };
+  } catch (error) {
+    logger.error("Error setting show lineup", { error });
+    throw new Response(error instanceof Error ? error.message : "Failed to set lineup", { status: 400 });
+  }
+});

--- a/apps/web/app/routes/api/shows/$showId.test.ts
+++ b/apps/web/app/routes/api/shows/$showId.test.ts
@@ -1,0 +1,53 @@
+import type { ActionFunctionArgs } from "react-router-dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// adminAction normally wraps the inner function with auth. For action-level
+// unit tests we bypass auth and run the inner function directly.
+vi.mock("~/lib/base-loaders", () => ({
+  adminAction: <T>(fn: (args: ActionFunctionArgs) => Promise<T>) => fn,
+}));
+
+const deleteShow = vi.fn();
+vi.mock("~/server/services", () => ({
+  services: { shows: { delete: deleteShow } },
+}));
+
+vi.mock("~/lib/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn() },
+}));
+
+const { action } = await import("./$showId");
+
+function makeRequest(method = "DELETE", showId = "show-1"): ActionFunctionArgs {
+  return {
+    request: new Request(`http://localhost/api/shows/${showId}`, { method }),
+    params: { showId },
+    context: {},
+  } as unknown as ActionFunctionArgs;
+}
+
+describe("DELETE /api/shows/:showId", () => {
+  beforeEach(() => {
+    deleteShow.mockReset().mockResolvedValue(true);
+  });
+
+  // Happy path: the route param drives the delete and we report ok.
+  test("deletes the show identified by the route param", async () => {
+    const result = await action(makeRequest("DELETE", "show-42"));
+
+    expect(deleteShow).toHaveBeenCalledWith("show-42");
+    expect(result).toEqual({ ok: true });
+  });
+
+  // Method guard: only DELETE removes a show.
+  test("rejects non-DELETE methods with 405", async () => {
+    await expect(action(makeRequest("POST"))).rejects.toMatchObject({ status: 405 });
+    expect(deleteShow).not.toHaveBeenCalled();
+  });
+
+  // Service failure surfaces as 400 with the service message.
+  test("translates service errors into 400 responses", async () => {
+    deleteShow.mockRejectedValueOnce(new Error("boom"));
+    await expect(action(makeRequest("DELETE"))).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/apps/web/app/routes/api/shows/$showId.tsx
+++ b/apps/web/app/routes/api/shows/$showId.tsx
@@ -1,0 +1,20 @@
+import { adminAction } from "~/lib/base-loaders";
+import { logger } from "~/lib/logger";
+import { services } from "~/server/services";
+
+// DELETE /api/shows/:showId - Remove a show (and its cascade) from the admin UI.
+export const action = adminAction(async ({ request, params }) => {
+  if (request.method !== "DELETE") {
+    throw new Response("Method not allowed", { status: 405 });
+  }
+
+  const showId = params.showId as string;
+  try {
+    await services.shows.delete(showId);
+    logger.info("Deleted show", { showId });
+    return { ok: true };
+  } catch (error) {
+    logger.error("Error deleting show", { error });
+    throw new Response(error instanceof Error ? error.message : "Failed to delete show", { status: 400 });
+  }
+});

--- a/apps/web/app/routes/shows/$slug.edit.test.ts
+++ b/apps/web/app/routes/shows/$slug.edit.test.ts
@@ -17,10 +17,11 @@ const updateShow = vi.fn();
 
 const findAllRockOperas = vi.fn().mockResolvedValue([]);
 const findRockOperaPerformancesForShow = vi.fn().mockResolvedValue([]);
+const getLineup = vi.fn().mockResolvedValue([]);
 
 vi.mock("~/server/services", () => ({
   services: {
-    shows: { findBySlug, findByDate, update: updateShow },
+    shows: { findBySlug, findByDate, update: updateShow, getLineup },
     venues: { findMany: findVenues },
     tracks: { findByShowId: findTracksByShowId },
     rockOperas: {

--- a/apps/web/app/routes/shows/$slug.edit.tsx
+++ b/apps/web/app/routes/shows/$slug.edit.tsx
@@ -1,9 +1,11 @@
-import type { Band, RockOpera, Show, Track, Venue } from "@bip/domain";
+import type { Band, RockOpera, Show, ShowLineupMember, Track, Venue } from "@bip/domain";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
+import { DeleteEntityButton } from "~/components/admin/delete-entity-button";
 import { ShowDayOrderManager, type ShowDayOrderRow } from "~/components/show/show-day-order-manager";
 import { ShowForm, type ShowFormValues } from "~/components/show/show-form";
+import { ShowLineupManager } from "~/components/show/show-lineup-manager";
 import { TrackManager } from "~/components/track/track-manager";
 import { Card, CardContent } from "~/components/ui/card";
 import { PageHeader } from "~/components/ui/page-header";
@@ -20,6 +22,7 @@ interface LoaderData {
   sameDateShows: ShowDayOrderRow[];
   rockOperas: RockOpera[];
   currentRockOperaIds: string[];
+  initialLineup: ShowLineupMember[];
 }
 
 export const loader = adminLoader(async ({ params }) => {
@@ -61,7 +64,10 @@ export const loader = adminLoader(async ({ params }) => {
     .map((annotation) => slugToId.get(annotation.rockOpera.slug))
     .filter((id): id is string => id !== undefined);
 
-  return { show, bands, venues, tracks, sameDateShows, rockOperas, currentRockOperaIds };
+  // Seed the lineup editor from the show's current ShowMusician rows.
+  const initialLineup = await services.shows.getLineup(show.id);
+
+  return { show, bands, venues, tracks, sameDateShows, rockOperas, currentRockOperaIds, initialLineup };
 });
 
 export const action = adminAction(async ({ request, params }) => {
@@ -90,7 +96,8 @@ export const action = adminAction(async ({ request, params }) => {
 });
 
 export default function EditShow() {
-  const { show, bands, tracks, sameDateShows, rockOperas, currentRockOperaIds } = useSerializedLoaderData<LoaderData>();
+  const { show, bands, tracks, sameDateShows, rockOperas, currentRockOperaIds, initialLineup } =
+    useSerializedLoaderData<LoaderData>();
   const navigate = useNavigate();
   const [defaultValues, setDefaultValues] = useState<ShowFormValues | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(true);
@@ -149,7 +156,20 @@ export default function EditShow() {
   return (
     <div>
       <div className="mb-6">
-        <PageHeader title="Edit Show" backLink={{ to: `/shows/${show.slug}`, label: "Back to Show" }} />
+        <PageHeader
+          title="Edit Show"
+          backLink={{ to: `/shows/${show.slug}`, label: "Back to Show" }}
+          actions={
+            <DeleteEntityButton
+              entityId={show.id}
+              entityName={show.date}
+              entityLabel="show"
+              endpoint={`/api/shows/${show.id}`}
+              variant="button"
+              onDeleted={() => navigate("/shows")}
+            />
+          }
+        />
       </div>
 
       <div className="space-y-6">
@@ -166,6 +186,8 @@ export default function EditShow() {
             />
           </CardContent>
         </Card>
+
+        <ShowLineupManager showId={show.id} initialLineup={initialLineup} />
 
         {sameDateShows.length >= 2 && (
           <ShowDayOrderManager currentShowId={show.id} date={show.date} initialShows={sameDateShows} />

--- a/apps/web/app/routes/shows/new.tsx
+++ b/apps/web/app/routes/shows/new.tsx
@@ -51,7 +51,7 @@ export default function NewShow() {
 
       <Card className="card-premium">
         <CardContent className="p-6">
-          <ShowForm onSubmit={handleSubmit} submitLabel="Create Show" cancelHref="/shows" />
+          <ShowForm onSubmit={handleSubmit} submitLabel="Create Show" cancelHref="/shows" requireVenue />
         </CardContent>
       </Card>
     </div>

--- a/packages/core/src/setlists/setlist-service.ts
+++ b/packages/core/src/setlists/setlist-service.ts
@@ -449,7 +449,7 @@ type DbTrackMusicianWithRelations = {
   instruments: { instrument: DbInstrument }[];
 };
 
-function mapShowMusicianToLineupMember(db: DbShowMusicianWithRelations): ShowLineupMember {
+export function mapShowMusicianToLineupMember(db: DbShowMusicianWithRelations): ShowLineupMember {
   return {
     musician: mapMusicianRefToDomainEntity(db.musician),
     instruments: db.instruments.map((row) => mapInstrumentRowToDomainEntity(row.instrument)),
@@ -659,12 +659,18 @@ function mapSetlistLightToDomainEntity(
 // instruments played. Loaded on list queries too (not just single-show fetches)
 // so the synthesized "with <guest> on <instrument>" footnotes render in setlist
 // listings, matching the free-text annotations they replaced.
+// The musician (with default instrument) + played instruments for one lineup
+// row. Shared so ShowService.getLineup loads exactly what
+// mapShowMusicianToLineupMember reads, keeping the edit page's read-only
+// lineup identical to the show page's.
+export const LINEUP_MEMBER_INCLUDE = {
+  musician: { include: { defaultInstrument: true } },
+  instruments: { include: { instrument: true } },
+} as const;
+
 const SINGLE_SHOW_PERFORMER_INCLUDE = {
   showMusicians: {
-    include: {
-      musician: { include: { defaultInstrument: true } },
-      instruments: { include: { instrument: true } },
-    },
+    include: LINEUP_MEMBER_INCLUDE,
   },
 } as const;
 

--- a/packages/core/src/shows/show-service.test.ts
+++ b/packages/core/src/shows/show-service.test.ts
@@ -83,6 +83,7 @@ function makeMockDb() {
       findMany: vi.fn().mockResolvedValue([]),
     },
     showMusician: {
+      findMany: vi.fn().mockResolvedValue([]),
       deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
       create: vi.fn().mockResolvedValue({}),
     },
@@ -696,6 +697,59 @@ describe("ShowService — default lineup on create", () => {
 
     expect(db.showMusician.create).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalled();
+  });
+
+  // The edit page renders the lineup with the same ShowLineupSection component
+  // as the public show page, so getLineup resolves musician + instrument names
+  // (ShowLineupMember[]), not just ids.
+  test("getLineup returns resolved ShowLineupMember entries", async () => {
+    const db = makeMockDb();
+    const now = new Date();
+    db.showMusician.findMany.mockResolvedValue([
+      {
+        musician: {
+          id: "m-marc",
+          name: "Marc Brownstein",
+          slug: "marc-brownstein",
+          knownFrom: null,
+          defaultInstrument: null,
+        },
+        instruments: [
+          { instrument: { id: "i-bass", name: "Bass", slug: "bass", createdAt: now, updatedAt: now } },
+          { instrument: { id: "i-vocals", name: "Vocals", slug: "vocals", createdAt: now, updatedAt: now } },
+        ],
+      },
+    ]);
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), makeStatsStub());
+
+    const lineup = await service.getLineup("show-id");
+
+    expect(db.showMusician.findMany.mock.calls[0][0]).toMatchObject({ where: { showId: "show-id" } });
+    expect(lineup).toEqual([
+      {
+        musician: {
+          id: "m-marc",
+          name: "Marc Brownstein",
+          slug: "marc-brownstein",
+          knownFrom: null,
+          defaultInstrument: null,
+        },
+        instruments: [
+          { id: "i-bass", name: "Bass", slug: "bass", createdAt: now, updatedAt: now },
+          { id: "i-vocals", name: "Vocals", slug: "vocals", createdAt: now, updatedAt: now },
+        ],
+      },
+    ]);
+  });
+
+  // A show with no lineup rows yields an empty list (not null), so the editor
+  // renders an empty form rather than crashing.
+  test("getLineup returns an empty array when the show has no lineup", async () => {
+    const db = makeMockDb();
+    db.showMusician.findMany.mockResolvedValue([]);
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), makeStatsStub());
+
+    expect(await service.getLineup("show-id")).toEqual([]);
   });
 
   // setLineup is a full-set replace: existing rows are deleted, then the new

--- a/packages/core/src/shows/show-service.ts
+++ b/packages/core/src/shows/show-service.ts
@@ -1,4 +1,4 @@
-import type { Logger, Show, Venue } from "@bip/domain";
+import type { Logger, Show, ShowLineupMember, Venue } from "@bip/domain";
 import { Prisma } from "@prisma/client";
 import { type CacheInvalidationService, yearFromShowDate } from "../_shared/cache";
 import type { DbClient, DbShow, DbVenue } from "../_shared/database/models";
@@ -16,6 +16,7 @@ import {
 } from "../_shared/show-ordering";
 import { slugify } from "../_shared/utils/slugify";
 import { MARLON_LINEUP_SLUGS } from "../musicians/musician-constants";
+import { LINEUP_MEMBER_INCLUDE, mapShowMusicianToLineupMember } from "../setlists/setlist-service";
 import type { StatsService } from "../stats/stats-service";
 
 export interface ShowFilter {
@@ -443,6 +444,22 @@ export class ShowService {
         }),
       ),
     ]);
+  }
+
+  /**
+   * Current lineup for a show as resolved ShowLineupMember[] (the same shape the
+   * show page renders), so the admin edit page can show a read-only lineup with
+   * the identical component and seed its editor from the same data. findBySlug
+   * doesn't carry the lineup; only the heavier setlist query does, so this
+   * focused reader is the cheap path.
+   */
+  async getLineup(showId: string): Promise<ShowLineupMember[]> {
+    const rows = await this.db.showMusician.findMany({
+      where: { showId },
+      include: LINEUP_MEMBER_INCLUDE,
+      orderBy: { createdAt: "asc" },
+    });
+    return rows.map(mapShowMusicianToLineupMember);
   }
 
   /**


### PR DESCRIPTION
## What admins can now do

- **Edit a show's lineup.** The show edit page shows the lineup read-only (the
  same component the public show page uses), with an Edit toggle that opens a
  picker editor for all members at once. Picking a musician auto-fills their
  default instrument, "Add" focuses the new musician picker so you can type
  immediately, and "Save" writes the whole lineup and refreshes the view.
  Mobile groups each member in its own block.
- **Delete a show.** A "Delete Show" button (confirm dialog) on the edit page
  removes the show and redirects to the shows list.
- **Create requires a venue.** The create form blocks submission without a
  venue, so you can't accidentally create a venueless orphan-stub show that's
  hidden from listings/search.

## UI consistency

- Form validation errors now render as a red alert box with an icon.
- "Delete Show" and the track-row delete share one `destructiveOutline` button
  variant.

## Notes for reviewers

- The error-alert styling lives in the shared `FormMessage`, so it applies to
  **every** form in the app, not just the show form (non-error `FormMessage`
  children, of which there are none today, still render as plain text).
- `ShowService.getLineup` returns `ShowLineupMember[]` by reusing
  setlist-service's exported lineup mapper/include, so the edit page's
  read-only lineup stays identical to the show page's.
- The lineup save endpoint returns the resolved lineup so the widget refreshes
  without a second fetch; the editor seeds rows with the same `sortLineup`
  order the read-only view uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
