### PR TITLE
Show read-only track footnotes on the show edit page

### DIFF
--- a/apps/web/app/components/setlist/footnotes.test.tsx
+++ b/apps/web/app/components/setlist/footnotes.test.tsx
@@ -1,15 +1,17 @@
-import type { Annotation, Instrument, TrackMusicianDelta } from "@bip/domain";
+import type { Annotation, Instrument, Setlist, TrackMusicianDelta } from "@bip/domain";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, test } from "vitest";
 import {
   annotationFootnoteSources,
   buildDebutText,
+  buildShowFootnotes,
   dataDrivenFootnoteSources,
   debutFootnoteSources,
   deriveFootnotes,
   type FootnoteSource,
   type FootnoteTrack,
+  footnotesByTrack,
   guestExclusionFootnotes,
   lastTimePlayedFootnoteSources,
   synthesizePerformerFootnotes,
@@ -328,7 +330,9 @@ describe("buildDebutText", () => {
   });
 
   test("an original with no known author reads 'debut (original - unknown author)'", () => {
-    expect(buildDebutText({ slug: "story", kind: "original", authorName: null })).toBe("debut (original - unknown author)");
+    expect(buildDebutText({ slug: "story", kind: "original", authorName: null })).toBe(
+      "debut (original - unknown author)",
+    );
   });
 
   test("an original with a known author names it: 'debut (original - X)'", () => {
@@ -348,9 +352,7 @@ describe("buildDebutText", () => {
   });
 
   test("a cover with no author flags the missing attribution", () => {
-    expect(buildDebutText({ slug: "shimmy", kind: "cover", authorName: null })).toBe(
-      "debut (cover - unknown author)",
-    );
+    expect(buildDebutText({ slug: "shimmy", kind: "cover", authorName: null })).toBe("debut (cover - unknown author)");
   });
 
   test("a mashup with known artists names them", () => {
@@ -793,5 +795,96 @@ describe("dataDrivenFootnoteSources", () => {
     expect(container).toHaveTextContent(
       "dyslexic, ending only, completes 11/14/2025 version, completed by 11/16/2025 version",
     );
+  });
+});
+
+// A minimal Setlist carrying only the fields buildShowFootnotes reads (sets,
+// show.date, lineup, trackMusicianDeltas, annotations). A recent date keeps
+// flags/performers out of the early-era suppression window.
+function makeSetlist(overrides: {
+  tracks: Array<Partial<FootnoteTrack> & { id: string }>;
+  deltas?: TrackMusicianDelta[];
+  annotations?: Annotation[];
+}): Setlist {
+  return {
+    show: { id: "show-1", date: "2025-11-15" },
+    // A small non-null gap keeps each track out of the debut (gap === null) and
+    // last-time-played (gap >= threshold) auto-footnotes, isolating the flag /
+    // performer footnotes under test.
+    sets: [{ label: "S1", sort: 1, tracks: overrides.tracks.map((track) => makeTrack({ gap: 5, ...track })) }],
+    annotations: overrides.annotations ?? [],
+    lineup: [],
+    trackMusicianDeltas: overrides.deltas ?? [],
+  } as unknown as Setlist;
+}
+
+describe("buildShowFootnotes", () => {
+  test("derives flag and performer footnotes for a setlist through the same engine", () => {
+    const setlist = makeSetlist({
+      tracks: [{ id: "t1", flags: ["DYSLEXIC"] }, { id: "t2" }],
+      deltas: [makeDelta({ trackId: "t2", present: true, instruments: [makeInstrument("guitar")] })],
+    });
+
+    const { trackFootnoteIndices, orderedFootnotes } = buildShowFootnotes(setlist);
+
+    expect(trackFootnoteIndices.get("t1")).toEqual([1]);
+    expect(trackFootnoteIndices.get("t2")).toEqual([2]);
+    const flagContent = renderContent(orderedFootnotes[0].content);
+    expect(flagContent.container).toHaveTextContent("dyslexic");
+    const performerContent = renderContent(orderedFootnotes[1].content);
+    expect(performerContent.container).toHaveTextContent("with Mike Greenfield on guitar");
+  });
+
+  // The early-era show date predates both the debut and gap trustworthy-data
+  // start dates, so debut + last-time-played + recurrence footnotes are
+  // suppressed — but observed facts (flags) still render. This is the whole
+  // reason buildShowFootnotes wraps deriveFootnotes: it applies that gating.
+  test("suppresses debut/last-time-played/recurrence footnotes before the era start dates, but keeps flags", () => {
+    const setlist = makeSetlist({
+      tracks: [
+        // A flagged track that, recently, would also read ", 1st time" from its
+        // flag recurrence — the flag survives the early era, the recurrence clause does not.
+        {
+          id: "t1",
+          gap: 5,
+          flags: ["DYSLEXIC"],
+          flagRecurrences: [{ flag: "DYSLEXIC", versionGap: null, gap: null, lastPlayed: null }],
+        },
+        // gap === null would be a debut; suppressed pre-1998-02-19.
+        { id: "t2", gap: null },
+        // gap past the LTP threshold would be "last played …"; suppressed pre-1998-08-28.
+        { id: "t3", gap: 50, previousPerformanceShow: { date: "1996-01-01", slug: "1996-01-01-show" } },
+      ],
+    });
+    setlist.show.date = "1997-01-01";
+
+    const { trackFootnoteIndices, orderedFootnotes } = buildShowFootnotes(setlist);
+
+    // Only the flag footnote survives — no debut (t2) or last-time-played (t3).
+    expect(orderedFootnotes).toHaveLength(1);
+    expect(trackFootnoteIndices.get("t1")).toEqual([1]);
+    expect(trackFootnoteIndices.has("t2")).toBe(false);
+    expect(trackFootnoteIndices.has("t3")).toBe(false);
+    // The flag renders, but its gap-derived ", 1st time" recurrence clause is gated off.
+    const { container } = renderContent(orderedFootnotes[0].content);
+    expect(container).toHaveTextContent("dyslexic");
+    expect(container).not.toHaveTextContent("1st time");
+  });
+});
+
+describe("footnotesByTrack", () => {
+  test("maps each track id to its footnote contents in ascending index order", () => {
+    const setlist = makeSetlist({
+      tracks: [{ id: "t1", flags: ["DYSLEXIC"] }, { id: "t2" }],
+      deltas: [makeDelta({ trackId: "t2", present: true, instruments: [makeInstrument("guitar")] })],
+    });
+
+    const byTrack = footnotesByTrack(buildShowFootnotes(setlist));
+
+    expect(byTrack.get("t1")).toHaveLength(1);
+    expect(renderContent(byTrack.get("t1")?.[0]).container).toHaveTextContent("dyslexic");
+    expect(byTrack.get("t2")).toHaveLength(1);
+    expect(renderContent(byTrack.get("t2")?.[0]).container).toHaveTextContent("with Mike Greenfield on guitar");
+    expect(byTrack.has("t3")).toBe(false);
   });
 });

--- a/apps/web/app/components/setlist/footnotes.tsx
+++ b/apps/web/app/components/setlist/footnotes.tsx
@@ -1,6 +1,12 @@
-import type { Annotation, SegueRecurrenceKind, TrackMusicianDelta } from "@bip/domain";
+import type { Annotation, SegueRecurrenceKind, Setlist, SetlistLight, TrackMusicianDelta } from "@bip/domain";
 import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
+import {
+  debutFootnoteSuppressed,
+  gapFootnoteSuppressed,
+  LAST_TIME_PLAYED_GAP_THRESHOLD,
+} from "~/lib/footnote-constants";
+import { deriveShowLineupNotes, elevatedGuestIds } from "~/lib/lineup-notes";
 import { formatDateShort } from "~/lib/utils";
 
 /**
@@ -688,4 +694,63 @@ export function dataDrivenFootnoteSources(
     });
   }
   return sources;
+}
+
+/**
+ * The single source of truth for a show's footnotes: collects every footnote
+ * source (annotations, flags/completions, performer deltas, guest exclusions,
+ * last-time-played, debuts) in precedence order, applies the era-based gaps/
+ * debut suppression, and numbers them. Both the public setlist view and the
+ * admin show-edit view derive through this so their wording can never diverge.
+ */
+export function buildShowFootnotes(setlist: Setlist | SetlistLight): DerivedFootnotes {
+  const allTracks = setlist.sets.flatMap((set) => set.tracks);
+  // Whole-show guests are surfaced in the show-level lineup note, so their
+  // per-track "with" footnotes are suppressed; for guests below 100% coverage
+  // the tracks they sat out are footnoted ("except where noted").
+  const lineupNotes = deriveShowLineupNotes(
+    setlist.show.date,
+    setlist.lineup,
+    setlist.trackMusicianDeltas,
+    allTracks.map((track) => track.id),
+  );
+  // The early setlists are too scattered to trust a song's gap or first
+  // appearance. Debuts firm up sooner than gaps, so they have separate start
+  // dates: before each, that category is suppressed. Flags, completions,
+  // annotations, and performer notes still render — observed facts, not stats.
+  const suppressDebuts = debutFootnoteSuppressed(setlist.show.date);
+  const suppressGaps = gapFootnoteSuppressed(setlist.show.date);
+  const footnoteSources = [
+    // DB annotations are numbered before synthesized performer footnotes on any
+    // given track, so the existing annotation indices stay stable.
+    ...annotationFootnoteSources(setlist.annotations),
+    // All of a track's structured flags + completion links read on one line,
+    // right after annotations so the setlist reads like its annotation era.
+    ...dataDrivenFootnoteSources(allTracks, { suppressRecurrences: suppressGaps }),
+    ...synthesizePerformerFootnotes(setlist.trackMusicianDeltas, elevatedGuestIds(lineupNotes)),
+    ...guestExclusionFootnotes(lineupNotes.guests, setlist.trackMusicianDeltas),
+    // Auto last-time-played / debut footnotes append after the above so the
+    // existing annotation and performer footnote numbers stay stable.
+    ...(!suppressGaps ? lastTimePlayedFootnoteSources(allTracks, LAST_TIME_PLAYED_GAP_THRESHOLD) : []),
+    ...(!suppressDebuts ? debutFootnoteSources(allTracks) : []),
+  ];
+  return deriveFootnotes(allTracks, footnoteSources);
+}
+
+/**
+ * Slice the show-level derivation into per-track footnote contents, so a view
+ * that renders each track's footnotes in isolation (the admin show-edit rows)
+ * can list them without the central numbered list. Keyed by track id; the
+ * contents stay in the same ascending order as the track's `sup` markers.
+ */
+export function footnotesByTrack(derived: DerivedFootnotes): Map<string, ReactNode[]> {
+  const contentByIndex = new Map(derived.orderedFootnotes.map((footnote) => [footnote.index, footnote.content]));
+  const byTrack = new Map<string, ReactNode[]>();
+  for (const [trackId, indices] of derived.trackFootnoteIndices) {
+    byTrack.set(
+      trackId,
+      indices.map((index) => contentByIndex.get(index)),
+    );
+  }
+  return byTrack;
 }

--- a/apps/web/app/components/setlist/setlist-flow.tsx
+++ b/apps/web/app/components/setlist/setlist-flow.tsx
@@ -2,22 +2,8 @@ import type { Setlist, SetlistLight } from "@bip/domain";
 import { formatDuration } from "@bip/domain";
 import { Link } from "react-router-dom";
 import { NoteworthyMarker } from "~/components/track/noteworthy-marker";
-import {
-  debutFootnoteSuppressed,
-  gapFootnoteSuppressed,
-  LAST_TIME_PLAYED_GAP_THRESHOLD,
-} from "~/lib/footnote-constants";
-import { deriveShowLineupNotes, elevatedGuestIds } from "~/lib/lineup-notes";
 import { cn } from "~/lib/utils";
-import {
-  annotationFootnoteSources,
-  dataDrivenFootnoteSources,
-  debutFootnoteSources,
-  deriveFootnotes,
-  guestExclusionFootnotes,
-  lastTimePlayedFootnoteSources,
-  synthesizePerformerFootnotes,
-} from "./footnotes";
+import { buildShowFootnotes } from "./footnotes";
 import { countSetlistEncores } from "./set-label";
 import { formatSetHeading, summarizeDurations } from "./setlist-duration";
 import { TrackRatingOverlay } from "./track-rating-overlay";
@@ -31,37 +17,7 @@ import { TrackRatingOverlay } from "./track-rating-overlay";
  */
 export function SetlistFlow({ setlist }: { setlist: Setlist | SetlistLight }) {
   const allTracks = setlist.sets.flatMap((set) => set.tracks);
-  // DB annotations are numbered before synthesized performer footnotes on any
-  // given track, so the existing annotation indices stay stable.
-  //
-  // Whole-show guests are surfaced in the show-level lineup note, so their
-  // per-track "with" footnotes are suppressed; for guests below 100% coverage
-  // the tracks they sat out are footnoted ("except where noted").
-  const lineupNotes = deriveShowLineupNotes(
-    setlist.show.date,
-    setlist.lineup,
-    setlist.trackMusicianDeltas,
-    allTracks.map((track) => track.id),
-  );
-  // The early setlists are too scattered to trust a song's gap or first
-  // appearance. Debuts firm up sooner than gaps, so they have separate start
-  // dates: before each, that category is suppressed. Flags, completions,
-  // annotations, and performer notes still render — observed facts, not stats.
-  const suppressDebuts = debutFootnoteSuppressed(setlist.show.date);
-  const suppressGaps = gapFootnoteSuppressed(setlist.show.date);
-  const footnoteSources = [
-    ...annotationFootnoteSources(setlist.annotations),
-    // All of a track's structured flags + completion links read on one line,
-    // right after annotations so the setlist reads like its annotation era.
-    ...dataDrivenFootnoteSources(allTracks, { suppressRecurrences: suppressGaps }),
-    ...synthesizePerformerFootnotes(setlist.trackMusicianDeltas, elevatedGuestIds(lineupNotes)),
-    ...guestExclusionFootnotes(lineupNotes.guests, setlist.trackMusicianDeltas),
-    // Auto last-time-played / debut footnotes append after the above so the
-    // existing annotation and performer footnote numbers stay stable.
-    ...(!suppressGaps ? lastTimePlayedFootnoteSources(allTracks, LAST_TIME_PLAYED_GAP_THRESHOLD) : []),
-    ...(!suppressDebuts ? debutFootnoteSources(allTracks) : []),
-  ];
-  const { trackFootnoteIndices, orderedFootnotes } = deriveFootnotes(allTracks, footnoteSources);
+  const { trackFootnoteIndices, orderedFootnotes } = buildShowFootnotes(setlist);
 
   const encoresInSet = countSetlistEncores(setlist.sets);
   const showDuration = summarizeDurations(allTracks);

--- a/apps/web/app/components/track/sortable-track-item.test.tsx
+++ b/apps/web/app/components/track/sortable-track-item.test.tsx
@@ -131,70 +131,32 @@ describe("SortableTrackItem", () => {
     expect(screen.getByText(">")).toBeInTheDocument();
   });
 
-  // Annotations render below the note in their own section. Each annotation
-  // is its own row so multi-line annotations don't collapse together.
-  test("renders each annotation as its own row when annotations exist", async () => {
-    await setup(
+  // Read-only footnotes (annotations, flags, performers, completions) come
+  // pre-derived from the show-level engine and render below the note, each on
+  // its own row so multi-line footnotes don't collapse together.
+  test("renders each footnote as its own row when footnotes are passed", async () => {
+    const { container } = await setup(
       <SortableTrackItem
-        track={makeTrack({
-          annotations: [
-            {
-              id: "ann-1",
-              trackId: "track-1",
-              desc: "inverted",
-              createdAt: new Date(),
-              updatedAt: new Date(),
-            },
-            {
-              id: "ann-2",
-              trackId: "track-1",
-              desc: "with 'Floes' tease",
-              createdAt: new Date(),
-              updatedAt: new Date(),
-            },
-          ],
-        })}
+        track={makeTrack()}
+        footnotes={["inverted", "with Mike Greenfield on guitar"]}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />,
     );
 
     expect(screen.getByText("inverted")).toBeInTheDocument();
-    expect(screen.getByText("with 'Floes' tease")).toBeInTheDocument();
+    expect(screen.getByText("with Mike Greenfield on guitar")).toBeInTheDocument();
+    expect(container.querySelectorAll("div.border-l-2").length).toBe(2);
   });
 
-  // Annotations with empty desc are skipped — they'd render as visual noise
-  // (an empty bordered row). This is a defensive check against bad data.
-  test("skips annotations whose desc is null or empty", async () => {
+  // No footnotes (empty or omitted) renders no footnote rows — keeps rows for
+  // tracks with no structured data compact.
+  test("renders no footnote rows when footnotes is empty or omitted", async () => {
     const { container } = await setup(
-      <SortableTrackItem
-        track={makeTrack({
-          annotations: [
-            {
-              id: "ann-1",
-              trackId: "track-1",
-              desc: null,
-              createdAt: new Date(),
-              updatedAt: new Date(),
-            },
-            {
-              id: "ann-2",
-              trackId: "track-1",
-              desc: "real annotation",
-              createdAt: new Date(),
-              updatedAt: new Date(),
-            },
-          ],
-        })}
-        onEdit={vi.fn()}
-        onDelete={vi.fn()}
-      />,
+      <SortableTrackItem track={makeTrack()} footnotes={[]} onEdit={vi.fn()} onDelete={vi.fn()} />,
     );
 
-    expect(screen.getByText("real annotation")).toBeInTheDocument();
-    // Only one annotation row (the real one) renders.
-    const annotationRows = container.querySelectorAll("div.border-l-2");
-    expect(annotationRows.length).toBe(1);
+    expect(container.querySelector("div.border-l-2")).toBeNull();
   });
 
   // Edit button fires onEdit with the full track so the parent can hydrate

--- a/apps/web/app/components/track/sortable-track-item.tsx
+++ b/apps/web/app/components/track/sortable-track-item.tsx
@@ -3,6 +3,7 @@ import { formatDuration } from "@bip/domain";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Edit2, GripVertical, Trash } from "lucide-react";
+import type { ReactNode } from "react";
 import { TrackIcon } from "~/components/track/track-icon";
 import { Button } from "~/components/ui/button";
 import { listRowClass } from "~/lib/form-styles";
@@ -13,9 +14,13 @@ interface SortableTrackItemProps {
   onEdit: (track: Track) => void;
   onDelete: (id: string) => void;
   isDeleting?: boolean;
+  /** This track's read-only footnotes (annotations, flags, performers,
+   *  completions), pre-derived by the show-level footnote engine so the wording
+   *  matches the public setlist exactly. */
+  footnotes?: ReactNode[];
 }
 
-export function SortableTrackItem({ track, onEdit, onDelete, isDeleting }: SortableTrackItemProps) {
+export function SortableTrackItem({ track, onEdit, onDelete, isDeleting, footnotes }: SortableTrackItemProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: track.id });
 
   const style = {
@@ -85,20 +90,19 @@ export function SortableTrackItem({ track, onEdit, onDelete, isDeleting }: Sorta
         {/* Note (full-width, below title) */}
         {track.note && <p className="text-content-text-secondary text-sm italic pl-8 md:pl-12">{track.note}</p>}
 
-        {/* Annotations (full-width, below note) */}
-        {track.annotations && track.annotations.length > 0 && (
+        {/* Read-only footnotes (full-width, below note) — one row each, mirroring
+            the public setlist wording. */}
+        {footnotes && footnotes.length > 0 && (
           <div className="space-y-1 pl-8 md:pl-12">
-            {track.annotations.map(
-              (annotation, index) =>
-                annotation.desc && (
-                  <div
-                    key={annotation.id || index}
-                    className="text-content-text-accent text-sm pl-2 border-l-2 border-content-bg-secondary"
-                  >
-                    {annotation.desc}
-                  </div>
-                ),
-            )}
+            {footnotes.map((footnote, index) => (
+              <div
+                // biome-ignore lint/suspicious/noArrayIndexKey: footnotes are positional and stable per render
+                key={index}
+                className="text-content-text-accent text-sm pl-2 border-l-2 border-content-bg-secondary"
+              >
+                {footnote}
+              </div>
+            ))}
           </div>
         )}
       </div>

--- a/apps/web/app/components/track/track-manager.test.tsx
+++ b/apps/web/app/components/track/track-manager.test.tsx
@@ -12,6 +12,7 @@ const capturedRowProps: Array<{
   onEdit: (track: Track) => void;
   onDelete: (id: string) => void;
   isDeleting?: boolean;
+  footnotes?: React.ReactNode[];
 }> = [];
 vi.mock("./sortable-track-item", () => ({
   SortableTrackItem: (props: {
@@ -19,6 +20,7 @@ vi.mock("./sortable-track-item", () => ({
     onEdit: (track: Track) => void;
     onDelete: (id: string) => void;
     isDeleting?: boolean;
+    footnotes?: React.ReactNode[];
   }) => {
     capturedRowProps.push(props);
     return (
@@ -124,6 +126,41 @@ describe("TrackManager", () => {
       const urls = fetchMock.mock.calls.map((c) => c[0]);
       expect(urls).toContain("/api/tracks?showId=show-1");
     });
+  });
+
+  // The footnoteSetlist runs through the same engine as the public setlist and
+  // is sliced per track: a flagged track gets its footnote content, an
+  // unrelated track gets none.
+  test("derives per-track footnotes from footnoteSetlist and hands them to each row", async () => {
+    const footnoteSetlist = {
+      show: { id: "show-1", date: "2025-11-15" },
+      sets: [
+        {
+          label: "S1",
+          sort: 1,
+          tracks: [
+            { id: "t-1", songId: "song-1", gap: 5, previousPerformanceShow: null, flags: ["DYSLEXIC"] },
+            { id: "t-2", songId: "song-2", gap: 5, previousPerformanceShow: null, flags: [] },
+          ],
+        },
+      ],
+      annotations: [],
+      lineup: [],
+      trackMusicianDeltas: [],
+    };
+
+    await setup(
+      <TrackManager
+        showId="show-1"
+        initialTracks={[makeTrack({ id: "t-1" }), makeTrack({ id: "t-2", position: 2 })]}
+        footnoteSetlist={footnoteSetlist as never}
+      />,
+    );
+
+    const flaggedRow = capturedRowProps.find((p) => p.track.id === "t-1");
+    const plainRow = capturedRowProps.find((p) => p.track.id === "t-2");
+    expect(flaggedRow?.footnotes).toHaveLength(1);
+    expect(plainRow?.footnotes ?? []).toHaveLength(0);
   });
 
   // Initial tracks render grouped by set with section headers, in the

--- a/apps/web/app/components/track/track-manager.tsx
+++ b/apps/web/app/components/track/track-manager.tsx
@@ -1,4 +1,4 @@
-import type { Track } from "@bip/domain";
+import type { Setlist, Track } from "@bip/domain";
 import { formatDuration, parseDuration } from "@bip/domain";
 import {
   closestCenter,
@@ -12,8 +12,9 @@ import {
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { arrayMove, SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { Plus } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { buildShowFootnotes, footnotesByTrack } from "~/components/setlist/footnotes";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -34,6 +35,10 @@ import { type TrackFormData, useTrackApi } from "./use-track-api";
 interface TrackManagerProps {
   showId: string;
   initialTracks?: Track[];
+  /** The show's setlist, used only to derive each track's read-only footnotes
+   *  (flags, performers, completions, recurrence) through the same engine as
+   *  the public setlist. Absent when the parent has no setlist to pass. */
+  footnoteSetlist?: Setlist;
 }
 
 const INITIAL_FORM: TrackFormData = {
@@ -55,8 +60,15 @@ const INITIAL_FORM: TrackFormData = {
  * drop reorder is handled inline because it needs access to the live
  * tracks list to compute optimistic position updates.
  */
-export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) {
+export function TrackManager({ showId, initialTracks = [], footnoteSetlist }: TrackManagerProps) {
   const [tracks, setTracks] = useState<Track[]>(initialTracks);
+  // Derive the show's footnotes once, then slice per track id. Keyed by id so
+  // reordering or editing a row keeps each track's footnotes attached.
+  const footnotesByTrackId = useMemo(
+    () =>
+      footnoteSetlist ? footnotesByTrack(buildShowFootnotes(footnoteSetlist)) : new Map<string, React.ReactNode[]>(),
+    [footnoteSetlist],
+  );
   const [editingId, setEditingId] = useState<string | null>(null);
   const [isAddingNew, setIsAddingNew] = useState(false);
   const [deleteTrackId, setDeleteTrackId] = useState<string | null>(null);
@@ -258,6 +270,7 @@ export function TrackManager({ showId, initialTracks = [] }: TrackManagerProps) 
                             <SortableTrackItem
                               key={track.id}
                               track={track}
+                              footnotes={footnotesByTrackId.get(track.id)}
                               onEdit={startEditing}
                               onDelete={handleDelete}
                               isDeleting={api.isDeleting}

--- a/apps/web/app/routes/shows/$slug.edit.test.ts
+++ b/apps/web/app/routes/shows/$slug.edit.test.ts
@@ -13,6 +13,7 @@ const findBySlug = vi.fn();
 const findByDate = vi.fn();
 const findVenues = vi.fn();
 const findTracksByShowId = vi.fn();
+const findSetlistByShowSlug = vi.fn();
 const updateShow = vi.fn();
 
 const findAllRockOperas = vi.fn().mockResolvedValue([]);
@@ -24,6 +25,7 @@ vi.mock("~/server/services", () => ({
     shows: { findBySlug, findByDate, update: updateShow, getLineup },
     venues: { findMany: findVenues },
     tracks: { findByShowId: findTracksByShowId },
+    setlists: { findByShowSlug: findSetlistByShowSlug },
     rockOperas: {
       findAll: findAllRockOperas,
       findPerformancesForShow: findRockOperaPerformancesForShow,
@@ -62,6 +64,24 @@ describe("shows/$slug.edit loader", () => {
     findByDate.mockReset();
     findVenues.mockReset().mockResolvedValue([]);
     findTracksByShowId.mockReset().mockResolvedValue([]);
+    findSetlistByShowSlug.mockReset().mockResolvedValue(null);
+  });
+
+  // The read-only track footnotes on the edit page run through the same engine
+  // as the public setlist, so the loader fetches the full setlist (by slug) and
+  // returns it for TrackManager to derive per-track footnotes from.
+  test("returns the setlist from findByShowSlug(slug) as footnoteSetlist", async () => {
+    const setlist = { show: showEarly, sets: [] };
+    findBySlug.mockResolvedValue(showEarly);
+    findByDate.mockResolvedValue([showEarly]);
+    findSetlistByShowSlug.mockResolvedValue(setlist);
+
+    const result = (await loader({
+      params: { slug: showEarly.slug },
+    } as unknown as LoaderFunctionArgs)) as { footnoteSetlist: unknown };
+
+    expect(findSetlistByShowSlug).toHaveBeenCalledWith(showEarly.slug);
+    expect(result.footnoteSetlist).toBe(setlist);
   });
 
   // The loader's main new responsibility is seeding the same-date reorder

--- a/apps/web/app/routes/shows/$slug.edit.tsx
+++ b/apps/web/app/routes/shows/$slug.edit.tsx
@@ -1,4 +1,4 @@
-import type { Band, RockOpera, Show, ShowLineupMember, Track, Venue } from "@bip/domain";
+import type { Band, RockOpera, Setlist, Show, ShowLineupMember, Track, Venue } from "@bip/domain";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
@@ -19,6 +19,7 @@ interface LoaderData {
   bands: Band[];
   venues: Venue[];
   tracks: Track[];
+  footnoteSetlist: Setlist | null;
   sameDateShows: ShowDayOrderRow[];
   rockOperas: RockOpera[];
   currentRockOperaIds: string[];
@@ -39,8 +40,14 @@ export const loader = adminLoader(async ({ params }) => {
   // Get venues for the venue selector
   const venues = await services.venues.findMany({});
 
-  // Get tracks for this show
+  // Get tracks for this show. The edit forms use this lighter shape; the
+  // read-only footnotes derive from the heavier setlist below.
   const tracks = await services.tracks.findByShowId(show.id);
+
+  // The full setlist carries flags/performers/completions/recurrence per track,
+  // which TrackManager runs through the same footnote engine as the public
+  // setlist so admins see the current derived state before editing.
+  const footnoteSetlist = await services.setlists.findByShowSlug(slug as string);
 
   // Same-date show group — drives the reorder widget visibility/seed.
   const sameDateRaw = await services.shows.findByDate(show.date);
@@ -67,7 +74,17 @@ export const loader = adminLoader(async ({ params }) => {
   // Seed the lineup editor from the show's current ShowMusician rows.
   const initialLineup = await services.shows.getLineup(show.id);
 
-  return { show, bands, venues, tracks, sameDateShows, rockOperas, currentRockOperaIds, initialLineup };
+  return {
+    show,
+    bands,
+    venues,
+    tracks,
+    footnoteSetlist,
+    sameDateShows,
+    rockOperas,
+    currentRockOperaIds,
+    initialLineup,
+  };
 });
 
 export const action = adminAction(async ({ request, params }) => {
@@ -96,7 +113,7 @@ export const action = adminAction(async ({ request, params }) => {
 });
 
 export default function EditShow() {
-  const { show, bands, tracks, sameDateShows, rockOperas, currentRockOperaIds, initialLineup } =
+  const { show, bands, tracks, footnoteSetlist, sameDateShows, rockOperas, currentRockOperaIds, initialLineup } =
     useSerializedLoaderData<LoaderData>();
   const navigate = useNavigate();
   const [defaultValues, setDefaultValues] = useState<ShowFormValues | undefined>(undefined);
@@ -194,7 +211,7 @@ export default function EditShow() {
         )}
 
         <div className="mt-6">
-          <TrackManager showId={show.id} initialTracks={tracks} />
+          <TrackManager showId={show.id} initialTracks={tracks} footnoteSetlist={footnoteSetlist ?? undefined} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Admins editing a show now see each track's footnotes (annotations,
flags, performer sit-ins/sat-outs, completions, recurrence, debut /
last-time-played) inline on its row in the Track List, so the current
structured state is visible before editing. The wording is identical to
the public setlist.

## What changed
- Extracted `buildShowFootnotes(setlist)` into `setlist/footnotes.tsx`:
  the footnote source-collection + era-gating that was inlined in
  `SetlistFlow`; the public setlist now derives through it too, so the
  two views can't diverge.
- Added `footnotesByTrack(derived)` to slice the show-level derivation
  into per-track contents.
- `SortableTrackItem` takes a `footnotes` prop and renders them per row;
  the old inline `track.annotations` block is removed (annotations are
  footnote sources now, so keeping both would double-print).
- `TrackManager` takes a `footnoteSetlist` prop, derives once, and hands
  each row its slice.
- The show-edit loader fetches `setlists.findByShowSlug(slug)` for the
  footnote data; the edit forms keep their existing track data.

This is the per-track-inline rendering (footnotes shown like the old
annotation block, no global superscript markers or bottom numbered
list), so the index numbers are omitted on this view.

## Notes for the reviewer
The one cross-cutting change is the `setlist-flow.tsx` refactor to call
`buildShowFootnotes`. It's a pure extraction (same inputs, same
`DerivedFootnotes` output), guarded by the existing footnote and
setlist-flow tests; a new test asserts the extraction preserves the
early-era debut/gap suppression.

## Testing
`make tc`, full suite (core 484, web 1136), biome, and build all green.
Not yet browser-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
