### PR TITLE
Add a per-track performer editor to the show edit page

### DIFF
--- a/apps/web/app/components/track/track-edit-form.tsx
+++ b/apps/web/app/components/track/track-edit-form.tsx
@@ -1,4 +1,5 @@
 import { Check, X } from "lucide-react";
+import type { ReactNode } from "react";
 import { SongSearch } from "~/components/song/song-search";
 import { Button } from "~/components/ui/button";
 import { Checkbox } from "~/components/ui/checkbox";
@@ -16,6 +17,9 @@ interface TrackEditFormProps {
   isSubmitting: boolean;
   onSubmit: () => void;
   onCancel: () => void;
+  /** Extra fields rendered above the save row — the performer-delta editor,
+   *  which saves alongside the track under the same button. */
+  children?: ReactNode;
 }
 
 /**
@@ -31,6 +35,7 @@ export function TrackEditForm({
   isSubmitting,
   onSubmit,
   onCancel,
+  children,
 }: TrackEditFormProps) {
   return (
     <div className="flex flex-col gap-4 p-4 bg-content-bg/50 rounded-lg border border-content-bg-secondary">
@@ -139,6 +144,8 @@ export function TrackEditForm({
           rows={3}
         />
       </div>
+
+      {children}
 
       <div className="flex flex-wrap items-center justify-end gap-2">
         <Button onClick={onCancel} variant="cancel">

--- a/apps/web/app/components/track/track-manager.test.tsx
+++ b/apps/web/app/components/track/track-manager.test.tsx
@@ -233,6 +233,154 @@ describe("TrackManager", () => {
     expect(screen.getByRole("button", { name: /update/i })).toBeInTheDocument();
   });
 
+  describe("performer deltas", () => {
+    const mike = {
+      id: "m-mike",
+      name: "Mike Gordon",
+      slug: "mike-gordon",
+      knownFrom: null,
+      defaultInstrument: null,
+    };
+    const bass = { id: "i-bass", name: "Bass", slug: "bass", createdAt: new Date(), updatedAt: new Date() };
+
+    // Two tracks so a sit-in on one is a genuine per-track footnote — a guest
+    // who covers 100% of the show is elevated into the show-level lineup note
+    // instead, which would suppress the per-track footnote we assert on.
+    function footnoteSetlistWith(trackMusicianDeltas: unknown[]) {
+      return {
+        show: { id: "show-1", date: "2025-11-15" },
+        sets: [
+          {
+            label: "S1",
+            sort: 1,
+            tracks: [
+              { id: "t-1", songId: "song-1", gap: 5, previousPerformanceShow: null, flags: [] },
+              { id: "t-2", songId: "song-2", gap: 5, previousPerformanceShow: null, flags: [] },
+            ],
+          },
+        ],
+        annotations: [],
+        lineup: [],
+        trackMusicianDeltas,
+      } as never;
+    }
+    const oneDelta = [{ trackId: "t-1", musician: mike, present: true, instruments: [bass] }];
+
+    // Editing a track seeds the performer editor from the show's saved deltas;
+    // saving the track PUTs those deltas to the performers endpoint, keyed by
+    // the edited track's id and converted to the id-only service shape.
+    test("seeds the editor from footnoteSetlist and PUTs the deltas on save", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => makeTrack({ id: "t-1" }) });
+      globalThis.fetch = fetchMock as never;
+
+      const { user } = await setup(
+        <TrackManager
+          showId="show-1"
+          initialTracks={[makeTrack({ id: "t-1" })]}
+          footnoteSetlist={footnoteSetlistWith(oneDelta)}
+        />,
+      );
+
+      await user.click(screen.getByText("edit-t-1"));
+      await user.click(screen.getByRole("button", { name: /update/i }));
+
+      await waitFor(() => {
+        const call = fetchMock.mock.calls.find((c) => String(c[0]) === "/api/tracks/t-1/performers");
+        expect(call).toBeTruthy();
+        expect(JSON.parse(call?.[1].body)).toEqual({
+          deltas: [{ musicianId: "m-mike", present: true, instrumentIds: ["i-bass"] }],
+        });
+      });
+    });
+
+    // The read-only footnotes derive from the show's deltas; after removing a
+    // performer and saving, the track's footnote must disappear without a page
+    // reload (the editor re-derives from the server's fresh deltas).
+    test("clears a track's footnote after its only performer is removed and saved", async () => {
+      const fetchMock = vi.fn((url: string) => {
+        const u = String(url);
+        if (u === "/api/tracks/t-1/performers") {
+          return Promise.resolve({ ok: true, json: async () => ({ ok: true, deltas: [] }) });
+        }
+        if (u.startsWith("/api/musicians/")) return Promise.resolve({ ok: true, json: async () => mike });
+        if (u.startsWith("/api/musicians")) return Promise.resolve({ ok: true, json: async () => [mike] });
+        if (u.startsWith("/api/instruments")) return Promise.resolve({ ok: true, json: async () => [bass] });
+        return Promise.resolve({ ok: true, json: async () => makeTrack({ id: "t-1" }) });
+      });
+      globalThis.fetch = fetchMock as never;
+
+      const { user } = await setup(
+        <TrackManager
+          showId="show-1"
+          initialTracks={[makeTrack({ id: "t-1" })]}
+          footnoteSetlist={footnoteSetlistWith(oneDelta)}
+        />,
+      );
+
+      expect(capturedRowProps.find((p) => p.track.id === "t-1")?.footnotes).toHaveLength(1);
+
+      await user.click(screen.getByText("edit-t-1"));
+      await user.click(screen.getByRole("button", { name: /remove performer/i }));
+      await user.click(screen.getByRole("button", { name: /update/i }));
+
+      await waitFor(() => {
+        const latest = capturedRowProps.filter((p) => p.track.id === "t-1").at(-1);
+        expect(latest?.footnotes ?? []).toHaveLength(0);
+      });
+    });
+
+    // Symmetric to the removal case: adding a performer to a track with none and
+    // saving makes its footnote appear immediately.
+    test("renders a track's footnote after a performer is added and saved", async () => {
+      const fresh = [{ trackId: "t-1", musician: mike, present: true, instruments: [bass] }];
+      const fetchMock = vi.fn((url: string) => {
+        const u = String(url);
+        if (u === "/api/tracks/t-1/performers") {
+          return Promise.resolve({ ok: true, json: async () => ({ ok: true, deltas: fresh }) });
+        }
+        if (u.startsWith("/api/musicians/")) return Promise.resolve({ ok: true, json: async () => mike });
+        if (u.startsWith("/api/musicians")) return Promise.resolve({ ok: true, json: async () => [mike] });
+        if (u.startsWith("/api/instruments")) return Promise.resolve({ ok: true, json: async () => [bass] });
+        return Promise.resolve({ ok: true, json: async () => makeTrack({ id: "t-1" }) });
+      });
+      globalThis.fetch = fetchMock as never;
+
+      const footnoteSetlist = footnoteSetlistWith([]);
+
+      const { user } = await setup(
+        <TrackManager showId="show-1" initialTracks={[makeTrack({ id: "t-1" })]} footnoteSetlist={footnoteSetlist} />,
+      );
+
+      expect(capturedRowProps.find((p) => p.track.id === "t-1")?.footnotes ?? []).toHaveLength(0);
+
+      await user.click(screen.getByText("edit-t-1"));
+      await user.click(screen.getByRole("button", { name: /add performer/i }));
+      await user.type(await screen.findByPlaceholderText("Search musicians..."), "Mike");
+      await user.click(await screen.findByText("Mike Gordon", undefined, { timeout: 1500 }));
+      await user.click(screen.getByRole("button", { name: /update/i }));
+
+      await waitFor(() => {
+        const latest = capturedRowProps.filter((p) => p.track.id === "t-1").at(-1);
+        expect(latest?.footnotes ?? []).toHaveLength(1);
+      });
+    });
+
+    // A note-only edit on a track that had no performers must not pay for the
+    // performer write — the track PUT goes out, the performers PUT does not.
+    test("does not PUT performers when the track had none and none were added", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => makeTrack({ id: "t-1" }) });
+      globalThis.fetch = fetchMock as never;
+
+      const { user } = await setup(<TrackManager showId="show-1" initialTracks={[makeTrack({ id: "t-1" })]} />);
+
+      await user.click(screen.getByText("edit-t-1"));
+      await user.click(screen.getByRole("button", { name: /update/i }));
+
+      await waitFor(() => expect(fetchMock.mock.calls.some((c) => String(c[0]) === "/api/tracks/t-1")).toBe(true));
+      expect(fetchMock.mock.calls.some((c) => String(c[0]).endsWith("/performers"))).toBe(false);
+    });
+  });
+
   describe("drag-and-drop reorder", () => {
     // Same-set reorder: drop t-2 onto t-1's position. The component should
     // PUT /api/tracks/reorder with the new index-based positions for the

--- a/apps/web/app/components/track/track-manager.tsx
+++ b/apps/web/app/components/track/track-manager.tsx
@@ -1,4 +1,4 @@
-import type { Setlist, Track } from "@bip/domain";
+import type { Setlist, Track, TrackMusicianDelta } from "@bip/domain";
 import { formatDuration, parseDuration } from "@bip/domain";
 import {
   closestCenter,
@@ -30,6 +30,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { SortableTrackItem } from "./sortable-track-item";
 import { compareSets, SET_OPTIONS } from "./track-constants";
 import { TrackEditForm } from "./track-edit-form";
+import { deltasToRows, type PerformerRow, rowsToDeltas, TrackPerformerEditor } from "./track-performer-editor";
 import { type TrackFormData, useTrackApi } from "./use-track-api";
 
 interface TrackManagerProps {
@@ -62,17 +63,29 @@ const INITIAL_FORM: TrackFormData = {
  */
 export function TrackManager({ showId, initialTracks = [], footnoteSetlist }: TrackManagerProps) {
   const [tracks, setTracks] = useState<Track[]>(initialTracks);
-  // Derive the show's footnotes once, then slice per track id. Keyed by id so
+  // The show's performer deltas, kept in local state so saving a track's
+  // performers refreshes its footnotes immediately. Seeded from the loader's
+  // setlist; replaced per-track from the save response.
+  const [liveDeltas, setLiveDeltas] = useState<TrackMusicianDelta[]>(footnoteSetlist?.trackMusicianDeltas ?? []);
+  // Derive the show's footnotes, then slice per track id. Keyed by id so
   // reordering or editing a row keeps each track's footnotes attached.
   const footnotesByTrackId = useMemo(
     () =>
-      footnoteSetlist ? footnotesByTrack(buildShowFootnotes(footnoteSetlist)) : new Map<string, React.ReactNode[]>(),
-    [footnoteSetlist],
+      footnoteSetlist
+        ? footnotesByTrack(buildShowFootnotes({ ...footnoteSetlist, trackMusicianDeltas: liveDeltas }))
+        : new Map<string, React.ReactNode[]>(),
+    [footnoteSetlist, liveDeltas],
   );
   const [editingId, setEditingId] = useState<string | null>(null);
   const [isAddingNew, setIsAddingNew] = useState(false);
   const [deleteTrackId, setDeleteTrackId] = useState<string | null>(null);
   const [formData, setFormData] = useState<TrackFormData>(INITIAL_FORM);
+  // Performer deltas save through their own endpoint, so they live outside
+  // formData (which feeds the track PUT). `performersWereSeeded` records
+  // whether the open track started with deltas, so clearing them all still
+  // fires the save (to delete them) while a never-touched track skips it.
+  const [performerRows, setPerformerRows] = useState<PerformerRow[]>([]);
+  const [performersWereSeeded, setPerformersWereSeeded] = useState(false);
 
   const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor));
   const api = useTrackApi(showId, setTracks);
@@ -87,10 +100,22 @@ export function TrackManager({ showId, initialTracks = [], footnoteSetlist }: Tr
     // We only want to load once on mount when initialTracks is empty.
   }, [initialTracks.length, api.loadTracks]);
 
-  const resetForm = () => setFormData(INITIAL_FORM);
+  const resetForm = () => {
+    setFormData(INITIAL_FORM);
+    setPerformerRows([]);
+    setPerformersWereSeeded(false);
+  };
+
+  const startAdding = () => {
+    resetForm();
+    setIsAddingNew(true);
+  };
 
   const startEditing = (track: Track) => {
     setEditingId(track.id);
+    const deltas = liveDeltas.filter((delta) => delta.trackId === track.id);
+    setPerformerRows(deltasToRows(deltas));
+    setPerformersWereSeeded(deltas.length > 0);
     setFormData({
       id: track.id,
       songId: track.songId,
@@ -140,11 +165,25 @@ export function TrackManager({ showId, initialTracks = [], footnoteSetlist }: Tr
       ? await api.updateTrack({ ...submitData, id: editingId })
       : await api.createTrack(submitData);
 
-    if (result) {
-      setEditingId(null);
-      setIsAddingNew(false);
-      resetForm();
+    if (!result) return;
+
+    // Save performer deltas under the same button, keyed by the resulting
+    // track id (the newly created id for an add). Skip the write entirely when
+    // the track had no deltas and none were added, so a plain note edit pays
+    // nothing for performers.
+    const deltas = rowsToDeltas(performerRows);
+    if (deltas.length > 0 || performersWereSeeded) {
+      const fresh = await api.setPerformers(result.id, deltas);
+      // Swap this track's deltas in local state so its read-only footnotes
+      // re-derive immediately, without reloading the page.
+      if (fresh) {
+        setLiveDeltas((prev) => [...prev.filter((delta) => delta.trackId !== result.id), ...fresh]);
+      }
     }
+
+    setEditingId(null);
+    setIsAddingNew(false);
+    resetForm();
   };
 
   const handleDelete = (id: string) => setDeleteTrackId(id);
@@ -211,7 +250,7 @@ export function TrackManager({ showId, initialTracks = [], footnoteSetlist }: Tr
       <CardHeader>
         <div className="flex justify-between items-center">
           <CardTitle className="text-content-text-primary">Track List</CardTitle>
-          <Button onClick={() => setIsAddingNew(true)} disabled={isFormOpen} variant="brand">
+          <Button onClick={startAdding} disabled={isFormOpen} variant="brand">
             <Plus className="h-4 w-4 mr-1" />
             Add Track
           </Button>
@@ -224,10 +263,12 @@ export function TrackManager({ showId, initialTracks = [], footnoteSetlist }: Tr
             formData={formData}
             onFormDataChange={setFormData}
             isEditing={false}
-            isSubmitting={api.isCreating}
+            isSubmitting={api.isCreating || api.isSavingPerformers}
             onSubmit={handleSubmit}
             onCancel={cancelEditing}
-          />
+          >
+            <TrackPerformerEditor rows={performerRows} onChange={setPerformerRows} />
+          </TrackEditForm>
         )}
 
         {Object.keys(tracksBySet).length === 0 ? (
@@ -262,10 +303,12 @@ export function TrackManager({ showId, initialTracks = [], footnoteSetlist }: Tr
                               formData={formData}
                               onFormDataChange={setFormData}
                               isEditing
-                              isSubmitting={api.isUpdating}
+                              isSubmitting={api.isUpdating || api.isSavingPerformers}
                               onSubmit={handleSubmit}
                               onCancel={cancelEditing}
-                            />
+                            >
+                              <TrackPerformerEditor rows={performerRows} onChange={setPerformerRows} />
+                            </TrackEditForm>
                           ) : (
                             <SortableTrackItem
                               key={track.id}

--- a/apps/web/app/components/track/track-performer-editor.test.tsx
+++ b/apps/web/app/components/track/track-performer-editor.test.tsx
@@ -1,0 +1,140 @@
+import type { Instrument, MusicianRef, TrackMusicianDelta } from "@bip/domain";
+import { setupWithRouter } from "@test/test-utils";
+import { screen, waitFor } from "@testing-library/react";
+import type { UserEvent } from "@testing-library/user-event";
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { deltasToRows, type PerformerRow, rowsToDeltas, TrackPerformerEditor } from "./track-performer-editor";
+
+vi.mock("sonner", () => ({ toast: { loading: vi.fn(), success: vi.fn(), error: vi.fn() } }));
+
+// Catalog the picker endpoints hit by the real MusicianSearch/InstrumentSearch
+// so a click resolves to a known record.
+const MUSICIANS: Record<string, { id: string; name: string; defaultInstrumentId: string | null }> = {
+  "m-mike": { id: "m-mike", name: "Mike Gordon", defaultInstrumentId: "i-bass" },
+};
+const INSTRUMENTS: Record<string, { id: string; name: string }> = {
+  "i-bass": { id: "i-bass", name: "Bass" },
+};
+
+function routeFetch(url: string): Response {
+  const json = (body: unknown) => ({ ok: true, json: async () => body }) as Response;
+  if (url.startsWith("/api/musicians/")) return json(MUSICIANS[url.split("/").pop() as string] ?? null);
+  if (url.startsWith("/api/musicians")) return json(Object.values(MUSICIANS));
+  if (url.startsWith("/api/instruments/")) return json(INSTRUMENTS[url.split("/").pop() as string] ?? null);
+  if (url.startsWith("/api/instruments")) return json(Object.values(INSTRUMENTS));
+  return json([]);
+}
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn((url: string) => Promise.resolve(routeFetch(url))) as unknown as typeof fetch;
+});
+afterEach(() => vi.restoreAllMocks());
+
+// Controlled component — drive it through a stateful harness and read the
+// current rows (minus the transient uid/autoOpen) back out of the DOM.
+function Harness({ initialRows }: { initialRows: PerformerRow[] }) {
+  const [rows, setRows] = useState(initialRows);
+  return (
+    <>
+      <TrackPerformerEditor rows={rows} onChange={setRows} />
+      <output data-testid="rows">
+        {JSON.stringify(rows.map(({ musicianId, present, instrumentIds }) => ({ musicianId, present, instrumentIds })))}
+      </output>
+    </>
+  );
+}
+function currentRows() {
+  return JSON.parse(screen.getByTestId("rows").textContent as string);
+}
+
+async function pickInOpenPicker(user: UserEvent, name: string) {
+  await user.type(await screen.findByPlaceholderText("Search musicians..."), name.slice(0, 4));
+  await user.click(await screen.findByText(name, undefined, { timeout: 1500 }));
+}
+
+const ref = (id: string, name: string): MusicianRef => ({
+  id,
+  name,
+  slug: id,
+  knownFrom: null,
+  defaultInstrument: null,
+});
+const inst = (id: string, name: string): Instrument =>
+  ({ id, name, slug: id, createdAt: new Date(), updatedAt: new Date() }) as Instrument;
+
+describe("rowsToDeltas", () => {
+  // Rows with no musician picked are draft rows and never reach the API.
+  test("drops rows with no musician", () => {
+    const rows: PerformerRow[] = [
+      { uid: "1", musicianId: "", present: true, instrumentIds: [] },
+      { uid: "2", musicianId: "m-mike", present: true, instrumentIds: ["i-bass"] },
+    ];
+    expect(rowsToDeltas(rows)).toEqual([{ musicianId: "m-mike", present: true, instrumentIds: ["i-bass"] }]);
+  });
+
+  // A sat-out has no instruments — any instruments retained in the row (e.g.
+  // from toggling back and forth) are stripped on the way out.
+  test("clears instruments for a sat-out row", () => {
+    const rows: PerformerRow[] = [{ uid: "1", musicianId: "m-marc", present: false, instrumentIds: ["i-bass"] }];
+    expect(rowsToDeltas(rows)).toEqual([{ musicianId: "m-marc", present: false, instrumentIds: [] }]);
+  });
+});
+
+describe("deltasToRows", () => {
+  // Seeds the editor from the saved domain deltas (musician + instrument refs)
+  // into the id-only row shape the pickers drive.
+  test("maps domain deltas to id-only rows", () => {
+    const deltas: TrackMusicianDelta[] = [
+      { trackId: "t-1", musician: ref("m-mike", "Mike Gordon"), present: true, instruments: [inst("i-bass", "Bass")] },
+      { trackId: "t-1", musician: ref("m-marc", "Marc Brownstein"), present: false, instruments: [] },
+    ];
+    expect(
+      deltasToRows(deltas).map(({ musicianId, present, instrumentIds }) => ({ musicianId, present, instrumentIds })),
+    ).toEqual([
+      { musicianId: "m-mike", present: true, instrumentIds: ["i-bass"] },
+      { musicianId: "m-marc", present: false, instrumentIds: [] },
+    ]);
+  });
+});
+
+describe("TrackPerformerEditor", () => {
+  // Instrument pickers belong to a sit-in only; a sat-out hides them.
+  test("shows the instrument picker for 'Also played' and hides it for 'Sat out'", async () => {
+    const { rerender } = await setupWithRouter(
+      <Harness initialRows={[{ uid: "a", musicianId: "m-mike", present: true, instrumentIds: [] }]} />,
+    );
+    expect(screen.getByText("+ instrument")).toBeInTheDocument();
+
+    rerender(<Harness initialRows={[{ uid: "a", musicianId: "m-mike", present: false, instrumentIds: [] }]} />);
+    expect(screen.queryByText("+ instrument")).not.toBeInTheDocument();
+  });
+
+  // Add appends a fresh empty sit-in row; remove drops it.
+  test("adds and removes rows", async () => {
+    const { user } = await setupWithRouter(
+      <Harness initialRows={[{ uid: "a", musicianId: "m-mike", present: true, instrumentIds: ["i-bass"] }]} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /add performer/i }));
+    expect(currentRows()).toHaveLength(2);
+    expect(currentRows()[1]).toEqual({ musicianId: "", present: true, instrumentIds: [] });
+
+    await user.click(screen.getAllByRole("button", { name: /remove performer/i })[1]);
+    expect(currentRows()).toHaveLength(1);
+  });
+
+  // Picking a musician on an empty sit-in row seeds their default instrument.
+  test("prefills the picked musician's default instrument on an empty row", async () => {
+    const { user } = await setupWithRouter(
+      <Harness initialRows={[{ uid: "a", musicianId: "", present: true, instrumentIds: [], autoOpen: true }]} />,
+    );
+
+    await pickInOpenPicker(user, "Mike Gordon");
+
+    await waitFor(() =>
+      expect(currentRows()[0]).toEqual({ musicianId: "m-mike", present: true, instrumentIds: ["i-bass"] }),
+    );
+  });
+});

--- a/apps/web/app/components/track/track-performer-editor.tsx
+++ b/apps/web/app/components/track/track-performer-editor.tsx
@@ -1,0 +1,179 @@
+import type { Musician, TrackMusicianDelta } from "@bip/domain";
+import { Plus, Trash2 } from "lucide-react";
+import { useRef } from "react";
+import { InstrumentSearch } from "~/components/musician/instrument-search";
+import { MusicianSearch } from "~/components/musician/musician-search";
+import { Button } from "~/components/ui/button";
+import { GlassSelect } from "~/components/ui/glass-select";
+import { formLabelClass } from "~/lib/form-styles";
+import type { TrackPerformerDelta } from "./use-track-api";
+
+/** One editable performer row. `uid` keys the row across edits; `autoOpen`
+ *  focuses a freshly-added row's musician picker. */
+export interface PerformerRow {
+  uid: string;
+  musicianId: string;
+  present: boolean;
+  instrumentIds: string[];
+  autoOpen?: boolean;
+}
+
+const STATUS_OPTIONS = [
+  { value: "present", label: "Also played" },
+  { value: "out", label: "Sat out" },
+];
+
+/** Seed editor rows from the track's saved domain deltas. */
+export function deltasToRows(deltas: TrackMusicianDelta[]): PerformerRow[] {
+  return deltas.map((delta, index) => ({
+    uid: `seed-${index}`,
+    musicianId: delta.musician.id,
+    present: delta.present,
+    instrumentIds: delta.instruments.map((instrument) => instrument.id),
+  }));
+}
+
+/** Convert editor rows to the performers-endpoint payload: drop draft rows with
+ *  no musician, and strip instruments from a sat-out (it played nothing). */
+export function rowsToDeltas(rows: PerformerRow[]): TrackPerformerDelta[] {
+  return rows
+    .filter((row) => row.musicianId)
+    .map((row) => ({
+      musicianId: row.musicianId,
+      present: row.present,
+      instrumentIds: row.present ? row.instrumentIds : [],
+    }));
+}
+
+interface TrackPerformerEditorProps {
+  rows: PerformerRow[];
+  onChange: (rows: PerformerRow[]) => void;
+}
+
+/**
+ * The "Performer changes" section of the track edit form: repeatable rows that
+ * capture per-track sit-ins ("Also played") and sat-outs against the show
+ * lineup. Controlled — the parent (`TrackManager`) owns the rows and saves them
+ * through the performers endpoint when the track is saved. Picking a musician
+ * pre-fills their default instrument so the common sit-in is one click.
+ */
+export function TrackPerformerEditor({ rows, onChange }: TrackPerformerEditorProps) {
+  const nextUid = useRef(0);
+  const makeUid = () => `new-${nextUid.current++}`;
+
+  // Selecting a musician fires onValueChange (set id) and onItemChange (prefill
+  // instrument) synchronously. Both read the same `rows` prop, so without a ref
+  // the second onChange would clobber the first. The ref composes them the way
+  // a functional setState would.
+  const rowsRef = useRef(rows);
+  rowsRef.current = rows;
+  const commit = (next: PerformerRow[]) => {
+    rowsRef.current = next;
+    onChange(next);
+  };
+
+  const updateRow = (uid: string, change: (row: PerformerRow) => PerformerRow) =>
+    commit(rowsRef.current.map((row) => (row.uid === uid ? change(row) : row)));
+
+  const setMusician = (uid: string, musicianId: string | null) =>
+    updateRow(uid, (row) => ({ ...row, musicianId: musicianId ?? "" }));
+
+  // Only seed a default instrument on an empty sit-in row, so changing a
+  // musician never clobbers an instrument an admin set deliberately.
+  const prefillInstrument = (uid: string, musician: Musician | null) => {
+    if (!musician?.defaultInstrumentId) return;
+    const defaultInstrumentId = musician.defaultInstrumentId;
+    updateRow(uid, (row) =>
+      row.present && row.instrumentIds.length === 0 ? { ...row, instrumentIds: [defaultInstrumentId] } : row,
+    );
+  };
+
+  const setPresent = (uid: string, present: boolean) => updateRow(uid, (row) => ({ ...row, present }));
+
+  const replaceInstrument = (uid: string, instrumentIndex: number, instrumentId: string | null) =>
+    updateRow(uid, (row) => {
+      const next = instrumentId
+        ? row.instrumentIds.map((id, i) => (i === instrumentIndex ? instrumentId : id))
+        : row.instrumentIds.filter((_, i) => i !== instrumentIndex);
+      return { ...row, instrumentIds: next };
+    });
+
+  const addInstrument = (uid: string, instrumentId: string | null) => {
+    if (!instrumentId) return;
+    updateRow(uid, (row) => ({ ...row, instrumentIds: [...row.instrumentIds, instrumentId] }));
+  };
+
+  const addRow = () =>
+    commit([...rowsRef.current, { uid: makeUid(), musicianId: "", present: true, instrumentIds: [], autoOpen: true }]);
+  const removeRow = (uid: string) => commit(rowsRef.current.filter((row) => row.uid !== uid));
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className={formLabelClass}>Performer changes</span>
+        <Button type="button" variant="secondary" size="sm" aria-label="Add performer" onClick={addRow}>
+          <Plus className="mr-1 h-4 w-4" />
+          Add
+        </Button>
+      </div>
+      {rows.length === 0 ? (
+        <p className="text-sm text-content-text-tertiary">No sit-ins or sat-outs for this track.</p>
+      ) : (
+        <ul className="space-y-2 sm:space-y-1.5">
+          {rows.map((row) => (
+            <li
+              key={row.uid}
+              className="flex flex-wrap items-center gap-1.5 rounded-md border border-glass-border/30 p-2 sm:rounded-none sm:border-0 sm:p-0"
+            >
+              <MusicianSearch
+                value={row.musicianId || null}
+                onValueChange={(id) => setMusician(row.uid, id)}
+                onItemChange={(musician) => prefillInstrument(row.uid, musician)}
+                allowCreate
+                autoOpen={row.autoOpen}
+                className="h-8 w-full sm:w-48"
+              />
+              <GlassSelect
+                value={row.present ? "present" : "out"}
+                onValueChange={(value) => setPresent(row.uid, value === "present")}
+                options={STATUS_OPTIONS}
+                ariaLabel="Performer status"
+                className="h-8 w-full sm:w-32"
+              />
+              {row.present && row.musicianId && (
+                <>
+                  {row.instrumentIds.map((instrumentId, instrumentIndex) => (
+                    <InstrumentSearch
+                      key={instrumentId}
+                      value={instrumentId}
+                      onValueChange={(id) => replaceInstrument(row.uid, instrumentIndex, id)}
+                      allowCreate
+                      className="h-8 w-full sm:w-36"
+                    />
+                  ))}
+                  <InstrumentSearch
+                    value={null}
+                    onValueChange={(id) => addInstrument(row.uid, id)}
+                    allowCreate
+                    placeholder="+ instrument"
+                    className="h-8 w-full sm:w-32"
+                  />
+                </>
+              )}
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Remove performer"
+                onClick={() => removeRow(row.uid)}
+                className="ml-auto h-8 w-8 shrink-0 sm:ml-0"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/components/track/use-track-api.test.tsx
+++ b/apps/web/app/components/track/use-track-api.test.tsx
@@ -297,6 +297,48 @@ describe("useTrackApi", () => {
     });
   });
 
+  describe("setPerformers", () => {
+    // Saves a track's performer deltas through the dedicated endpoint, separate
+    // from the track PUT so the cheap note save never touches performers.
+    test("PUTs /api/tracks/:id/performers with the deltas and returns the fresh deltas", async () => {
+      const fresh = [{ trackId: "t-1", musician: { id: "m-mike" }, present: true, instruments: [{ id: "i-guitar" }] }];
+      fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true, deltas: fresh }) });
+      const { hook } = setupHook();
+      const deltas = [
+        { musicianId: "m-mike", present: true, instrumentIds: ["i-guitar"] },
+        { musicianId: "m-marc", present: false, instrumentIds: [] },
+      ];
+
+      let result: unknown;
+      await act(async () => {
+        result = await hook.result.current.setPerformers("t-1", deltas);
+      });
+
+      const [url, options] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/tracks/t-1/performers");
+      expect(options.method).toBe("PUT");
+      expect(JSON.parse(options.body)).toEqual({ deltas });
+      expect(result).toEqual(fresh);
+    });
+
+    // The service rejects a sit-in for a lineup member with a 400 + message;
+    // that message surfaces to the admin as a toast and the call returns null.
+    test("surfaces the server error message and returns null on failure", async () => {
+      fetchMock.mockResolvedValueOnce({ ok: false, text: async () => "already in lineup" });
+      const { hook } = setupHook();
+
+      let result: unknown;
+      await act(async () => {
+        result = await hook.result.current.setPerformers("t-1", [
+          { musicianId: "m-1", present: true, instrumentIds: [] },
+        ]);
+      });
+
+      expect(toastError).toHaveBeenCalledWith("already in lineup");
+      expect(result).toBeNull();
+    });
+  });
+
   describe("loadTracks", () => {
     // Initial-load helper: hits /api/tracks?showId=…, fills local state,
     // and swallows errors with a toast so the form doesn't blow up if the

--- a/apps/web/app/components/track/use-track-api.ts
+++ b/apps/web/app/components/track/use-track-api.ts
@@ -1,4 +1,4 @@
-import type { Track } from "@bip/domain";
+import type { Track, TrackMusicianDelta } from "@bip/domain";
 import { parseDuration } from "@bip/domain";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
@@ -21,6 +21,14 @@ export interface TrackFormData {
 }
 
 type SetTracks = (updater: (prev: Track[]) => Track[]) => void;
+
+/** One per-track performer change as the performers endpoint expects it:
+ *  `present: true` is a sit-in (also played), `false` a sat-out. */
+export interface TrackPerformerDelta {
+  musicianId: string;
+  present: boolean;
+  instrumentIds: string[];
+}
 
 function sortTracks(tracks: Track[]): Track[] {
   return [...tracks].sort((a, b) => {
@@ -56,6 +64,7 @@ export function useTrackApi(showId: string, setTracks: SetTracks) {
   const [isCreating, setIsCreating] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isSavingPerformers, setIsSavingPerformers] = useState(false);
 
   const loadTracks = useCallback(async () => {
     try {
@@ -154,6 +163,34 @@ export function useTrackApi(showId: string, setTracks: SetTracks) {
     [setTracks],
   );
 
+  // Returns the saved deltas (resolved with names) so the caller can refresh
+  // its read-only footnotes, or null when the save failed.
+  const setPerformers = useCallback(
+    async (trackId: string, deltas: TrackPerformerDelta[]): Promise<TrackMusicianDelta[] | null> => {
+      setIsSavingPerformers(true);
+      try {
+        const response = await fetch(`/api/tracks/${trackId}/performers`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ deltas }),
+        });
+        // The endpoint returns a 400 with a human-readable message (e.g. a
+        // sit-in for a musician already in the lineup); surface it verbatim.
+        if (!response.ok) {
+          throw new Error(await response.text());
+        }
+        const data = (await response.json()) as { deltas: TrackMusicianDelta[] };
+        return data.deltas;
+      } catch (error) {
+        toast.error(error instanceof Error && error.message ? error.message : "Failed to save performers");
+        return null;
+      } finally {
+        setIsSavingPerformers(false);
+      }
+    },
+    [],
+  );
+
   const reorderTracks = useCallback(
     async (updates: { id: string; position: number; set: string }[]): Promise<void> => {
       try {
@@ -187,8 +224,10 @@ export function useTrackApi(showId: string, setTracks: SetTracks) {
     updateTrack,
     deleteTrack,
     reorderTracks,
+    setPerformers,
     isCreating,
     isUpdating,
     isDeleting,
+    isSavingPerformers,
   };
 }

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -117,6 +117,7 @@ export default [
     route("reviews", "routes/api/reviews.tsx"),
     route("ratings", "routes/api/ratings.tsx"),
     route("tracks/:trackId", "routes/api/tracks/$trackId.tsx"),
+    route("tracks/:trackId/performers", "routes/api/tracks/$trackId.performers.tsx"),
     route("attendances", "routes/api/attendances.tsx"),
     route("shows/user-data", "routes/api/shows/user-data.tsx"),
     route("shows/reorder", "routes/api/shows/reorder.tsx"),

--- a/apps/web/app/routes/api/tracks/$trackId.performers.test.ts
+++ b/apps/web/app/routes/api/tracks/$trackId.performers.test.ts
@@ -1,0 +1,96 @@
+import type { ActionFunctionArgs } from "react-router-dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// adminAction normally wraps the inner function with auth. For action-level
+// unit tests we bypass auth and run the inner function directly so we can
+// exercise body parsing, validation, and service delegation in isolation.
+vi.mock("~/lib/base-loaders", () => ({
+  adminAction: <T>(fn: (args: ActionFunctionArgs) => Promise<T>) => fn,
+}));
+
+const setTrackMusicianDeltas = vi.fn();
+const getTrackMusicianDeltas = vi.fn();
+vi.mock("~/server/services", () => ({
+  services: { tracks: { setTrackMusicianDeltas, getTrackMusicianDeltas } },
+}));
+
+vi.mock("~/lib/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn() },
+}));
+
+const { action } = await import("./$trackId.performers");
+
+function makeRequest(body: unknown, method = "PUT", trackId = "track-1"): ActionFunctionArgs {
+  const init: RequestInit = { method, headers: { "Content-Type": "application/json" } };
+  if (method !== "GET" && method !== "HEAD") {
+    init.body = JSON.stringify(body);
+  }
+  return {
+    request: new Request(`http://localhost/api/tracks/${trackId}/performers`, init),
+    params: { trackId },
+    context: {},
+  } as unknown as ActionFunctionArgs;
+}
+
+describe("PUT /api/tracks/:trackId/performers", () => {
+  beforeEach(() => {
+    setTrackMusicianDeltas.mockReset().mockResolvedValue(undefined);
+    getTrackMusicianDeltas.mockReset().mockResolvedValue([]);
+  });
+
+  // Happy path: parsed deltas delegate straight to setTrackMusicianDeltas,
+  // keyed by the trackId route param, and the resolved deltas come back so the
+  // editor can refresh its footnotes without a reload.
+  test("delegates parsed deltas to TrackService.setTrackMusicianDeltas and returns the fresh deltas", async () => {
+    const deltas = [
+      { musicianId: "m-mike", present: true, instrumentIds: ["i-guitar", "i-vocals"] },
+      { musicianId: "m-marc", present: false },
+    ];
+    const fresh = [
+      { trackId: "track-1", musician: { id: "m-mike" }, present: true, instruments: [{ id: "i-guitar" }] },
+    ];
+    getTrackMusicianDeltas.mockResolvedValue(fresh);
+
+    const result = await action(makeRequest({ deltas }));
+
+    expect(setTrackMusicianDeltas).toHaveBeenCalledWith("track-1", deltas);
+    expect(getTrackMusicianDeltas).toHaveBeenCalledWith("track-1");
+    expect(result).toEqual({ ok: true, deltas: fresh });
+  });
+
+  // A sat-out delta legitimately carries no instruments.
+  test("accepts a delta with no instrumentIds", async () => {
+    await action(makeRequest({ deltas: [{ musicianId: "m-marc", present: false }] }));
+    expect(setTrackMusicianDeltas).toHaveBeenCalledWith("track-1", [{ musicianId: "m-marc", present: false }]);
+  });
+
+  // Method guard: only PUT writes the deltas.
+  test("rejects non-PUT methods with 405", async () => {
+    await expect(action(makeRequest({ deltas: [] }, "GET"))).rejects.toMatchObject({ status: 405 });
+    expect(setTrackMusicianDeltas).not.toHaveBeenCalled();
+  });
+
+  // Validation: deltas must be an array of objects with a string musicianId, a
+  // boolean present, and (if present) a string-array instrumentIds.
+  test("rejects malformed deltas with 400", async () => {
+    await expect(action(makeRequest({ deltas: "nope" }))).rejects.toMatchObject({ status: 400 });
+    await expect(action(makeRequest({ deltas: [{ present: true }] }))).rejects.toMatchObject({ status: 400 });
+    await expect(action(makeRequest({ deltas: [{ musicianId: "m-1" }] }))).rejects.toMatchObject({ status: 400 });
+    await expect(action(makeRequest({ deltas: [{ musicianId: 7, present: true }] }))).rejects.toMatchObject({
+      status: 400,
+    });
+    await expect(
+      action(makeRequest({ deltas: [{ musicianId: "m-1", present: true, instrumentIds: [9] }] })),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(setTrackMusicianDeltas).not.toHaveBeenCalled();
+  });
+
+  // The service rejects a sit-in for a musician already in the show lineup; that
+  // surfaces as a 400 with the service message rather than a generic 500.
+  test("translates service errors into 400 responses", async () => {
+    setTrackMusicianDeltas.mockRejectedValueOnce(new Error("already in lineup"));
+    await expect(action(makeRequest({ deltas: [{ musicianId: "m-1", present: true }] }))).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+});

--- a/apps/web/app/routes/api/tracks/$trackId.performers.tsx
+++ b/apps/web/app/routes/api/tracks/$trackId.performers.tsx
@@ -1,0 +1,58 @@
+import { adminAction } from "~/lib/base-loaders";
+import { logger } from "~/lib/logger";
+import { services } from "~/server/services";
+
+interface TrackMusicianDeltaInput {
+  musicianId: string;
+  present: boolean;
+  instrumentIds?: string[];
+}
+
+function parseDeltas(raw: unknown): TrackMusicianDeltaInput[] {
+  if (!Array.isArray(raw)) {
+    throw new Response("deltas must be an array", { status: 400 });
+  }
+  return raw.map((delta) => {
+    if (typeof delta !== "object" || delta === null) {
+      throw new Response("each delta must be an object", { status: 400 });
+    }
+    const { musicianId, present, instrumentIds } = delta as Record<string, unknown>;
+    if (typeof musicianId !== "string" || !musicianId) {
+      throw new Response("each delta needs a string musicianId", { status: 400 });
+    }
+    if (typeof present !== "boolean") {
+      throw new Response("each delta needs a boolean present", { status: 400 });
+    }
+    if (instrumentIds !== undefined) {
+      if (!Array.isArray(instrumentIds) || !instrumentIds.every((id) => typeof id === "string")) {
+        throw new Response("instrumentIds must be an array of strings", { status: 400 });
+      }
+      return { musicianId, present, instrumentIds: instrumentIds as string[] };
+    }
+    return { musicianId, present };
+  });
+}
+
+// PUT /api/tracks/:trackId/performers - Full-set replace of a track's per-track
+// performer deltas (sit-ins / sat-outs).
+export const action = adminAction(async ({ request, params }) => {
+  if (request.method !== "PUT") {
+    throw new Response("Method not allowed", { status: 405 });
+  }
+
+  const trackId = params.trackId as string;
+  const { deltas } = (await request.json()) as { deltas?: unknown };
+  const parsed = parseDeltas(deltas);
+
+  try {
+    await services.tracks.setTrackMusicianDeltas(trackId, parsed);
+    logger.info("Set track performer deltas", { trackId, count: parsed.length });
+    // Return the resolved deltas (with names) so the edit page can re-derive its
+    // read-only footnotes without a reload.
+    const deltas = await services.tracks.getTrackMusicianDeltas(trackId);
+    return { ok: true, deltas };
+  } catch (error) {
+    logger.error("Error setting track performer deltas", { error });
+    throw new Response(error instanceof Error ? error.message : "Failed to set performers", { status: 400 });
+  }
+});

--- a/packages/core/src/setlists/setlist-service.ts
+++ b/packages/core/src/setlists/setlist-service.ts
@@ -456,7 +456,7 @@ export function mapShowMusicianToLineupMember(db: DbShowMusicianWithRelations): 
   };
 }
 
-function mapTrackMusicianToDelta(db: DbTrackMusicianWithRelations, trackId: string): TrackMusicianDelta {
+export function mapTrackMusicianToDelta(db: DbTrackMusicianWithRelations, trackId: string): TrackMusicianDelta {
   return {
     trackId,
     musician: mapMusicianRefToDomainEntity(db.musician),
@@ -674,7 +674,7 @@ const SINGLE_SHOW_PERFORMER_INCLUDE = {
   },
 } as const;
 
-const TRACK_PERFORMER_INCLUDE = {
+export const TRACK_PERFORMER_INCLUDE = {
   trackMusicians: {
     include: {
       musician: { include: { defaultInstrument: true } },

--- a/packages/core/src/tracks/track-service.test.ts
+++ b/packages/core/src/tracks/track-service.test.ts
@@ -225,3 +225,57 @@ describe("TrackService.setTrackMusicianDeltas", () => {
     expect(db.trackMusician.create).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("TrackService.getTrackMusicianDeltas", () => {
+  const created = new Date("2020-01-01");
+
+  // Reads a single track's saved performer rows back as domain deltas (resolved
+  // musician + instrument names), so the editor can refresh its footnotes after
+  // a save without reloading the page.
+  test("maps the track's performer rows to domain deltas", async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const db: any = {
+      track: {
+        findUnique: vi.fn().mockResolvedValue({
+          trackMusicians: [
+            {
+              present: true,
+              musician: {
+                id: "m-mike",
+                name: "Mike Gordon",
+                slug: "mike-gordon",
+                knownFrom: null,
+                defaultInstrument: null,
+              },
+              instruments: [
+                { instrument: { id: "i-bass", name: "Bass", slug: "bass", createdAt: created, updatedAt: created } },
+              ],
+            },
+          ],
+        }),
+      },
+    };
+    const service = new TrackService(db as never, logger, makeCacheInvalidationStub());
+
+    const deltas = await service.getTrackMusicianDeltas("track-id");
+
+    expect(deltas).toEqual([
+      {
+        trackId: "track-id",
+        present: true,
+        musician: { id: "m-mike", name: "Mike Gordon", slug: "mike-gordon", knownFrom: null, defaultInstrument: null },
+        instruments: [{ id: "i-bass", name: "Bass", slug: "bass", createdAt: created, updatedAt: created }],
+      },
+    ]);
+  });
+
+  // A track with no performer rows (or no track) yields an empty list, not a
+  // throw, so the caller can blindly replace its local deltas.
+  test("returns an empty list when the track has no performer rows", async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const db: any = { track: { findUnique: vi.fn().mockResolvedValue(null) } };
+    const service = new TrackService(db as never, logger, makeCacheInvalidationStub());
+
+    expect(await service.getTrackMusicianDeltas("missing")).toEqual([]);
+  });
+});

--- a/packages/core/src/tracks/track-service.ts
+++ b/packages/core/src/tracks/track-service.ts
@@ -1,9 +1,10 @@
-import type { Annotation, Logger, Track } from "@bip/domain";
+import type { Annotation, Logger, Track, TrackMusicianDelta as TrackMusicianDeltaView } from "@bip/domain";
 import { type CacheInvalidationService, yearFromShowDate } from "../_shared/cache";
 import type { DbAnnotation, DbClient, DbSong, DbTrack } from "../_shared/database/models";
 import { buildIncludeClause, buildOrderByClause, buildWhereClause } from "../_shared/database/query-utils";
 import type { QueryOptions } from "../_shared/database/types";
 import { slugify } from "../_shared/utils/slugify";
+import { mapTrackMusicianToDelta, TRACK_PERFORMER_INCLUDE } from "../setlists/setlist-service";
 import { recomputeShowDuration } from "./show-duration";
 
 export interface TrackMusicianDelta {
@@ -387,5 +388,18 @@ export class TrackService {
     ]);
 
     await this.invalidateShowCaches(track.showId);
+  }
+
+  /**
+   * Reads a track's saved performer deltas back as domain entities (resolved
+   * musician + instrument names), so the show-edit page can refresh its
+   * read-only footnotes right after a save instead of waiting for a reload.
+   */
+  async getTrackMusicianDeltas(trackId: string): Promise<TrackMusicianDeltaView[]> {
+    const track = await this.db.track.findUnique({
+      where: { id: trackId },
+      include: TRACK_PERFORMER_INCLUDE,
+    });
+    return (track?.trackMusicians ?? []).map((trackMusician) => mapTrackMusicianToDelta(trackMusician, trackId));
   }
 }


### PR DESCRIPTION
Admins can edit a track's performers (sit-ins and sat-outs) directly from the show edit page. Each track's edit form gains a "Performer changes" section: pick a musician, choose "Also played" or "Sat out", and for a sit-in pick one or more instruments (defaulting to the musician's primary). The track's Update/Add button saves the performers alongside the track, and the track's read-only footnotes update in place, no reload.

### How

- New `PUT /api/tracks/:trackId/performers` (admin) wraps the existing `TrackService.setTrackMusicianDeltas` (full-set replace; rejects a sit-in for a musician already in the show lineup). It's separate from the track save so a plain note edit doesn't touch performers or bust extra caches, and works for brand-new tracks via the created id.
- `TrackPerformerEditor` is a controlled section rendered inside the track edit form; `TrackManager` seeds it from the show's deltas, saves on submit, and skips the write when there's nothing to save.

### Notes for review

- The endpoint returns the saved deltas (resolved with musician/instrument names) so the edit page re-derives its read-only footnotes from local state instead of waiting for a reload. `TrackService.getTrackMusicianDeltas` reads them back, reusing the now-exported `mapTrackMusicianToDelta` + `TRACK_PERFORMER_INCLUDE` from setlist-service.
- The editor keeps a `rowsRef` to compose the two synchronous state updates a musician pick fires (set the id, then prefill the default instrument); without it the second update clobbers the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
