### PR TITLE
Label all song kinds and fix show/venue edit save redirects

### DIFF
--- a/apps/web/app/routes/shows/$slug.edit.render.test.tsx
+++ b/apps/web/app/routes/shows/$slug.edit.render.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// Mock `useNavigate` so we can assert where the form sends the user after save,
+// without needing a Routes definition.
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+// Strip server modules + auth wrappers; this test only drives the component.
+vi.mock("~/server/services", () => ({ services: {} }));
+vi.mock("~/lib/base-loaders", () => ({
+  adminLoader: (fn: unknown) => fn,
+  adminAction: (fn: unknown) => fn,
+}));
+vi.mock("~/lib/errors", () => ({ notFound: (msg: string) => new Response(msg, { status: 404 }) }));
+vi.mock("sonner", () => ({ toast: { loading: vi.fn(() => "toast-id"), success: vi.fn(), error: vi.fn() } }));
+
+// Stub heavy children. ShowForm exposes a button that fires onSubmit with fixed
+// values, standing in for a real edit (here: a venue change that re-slugs).
+vi.mock("~/components/show/show-form", () => ({
+  ShowForm: ({ onSubmit }: { onSubmit: (values: Record<string, unknown>) => void }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onSubmit({
+          date: "2017-07-22",
+          venueId: "venue-2",
+          bandId: "none",
+          notes: "",
+          relistenUrl: "",
+          countForStats: true,
+          rockOperaIds: [],
+        })
+      }
+    >
+      Update Show
+    </button>
+  ),
+}));
+vi.mock("~/components/show/show-lineup-manager", () => ({ ShowLineupManager: () => null }));
+vi.mock("~/components/show/show-day-order-manager", () => ({ ShowDayOrderManager: () => null }));
+vi.mock("~/components/track/track-manager", () => ({ TrackManager: () => null }));
+vi.mock("~/components/admin/delete-entity-button", () => ({ DeleteEntityButton: () => null }));
+vi.mock("~/components/ui/page-header", () => ({ PageHeader: () => null }));
+
+const loaderData = {
+  show: {
+    id: "show-1",
+    slug: "2017-07-22-red-rocks",
+    date: "2017-07-22",
+    venueId: "venue-1",
+    bandId: null,
+    notes: "",
+    relistenUrl: "",
+    countForStats: true,
+  },
+  bands: [],
+  tracks: [],
+  footnoteSetlist: null,
+  sameDateShows: [],
+  rockOperas: [],
+  currentRockOperaIds: [],
+  initialLineup: [],
+};
+vi.mock("~/hooks/use-serialized-loader-data", () => ({
+  useSerializedLoaderData: vi.fn(() => loaderData),
+}));
+
+import EditShow from "./$slug.edit";
+
+describe("shows/$slug.edit redirect", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // Changing date/venue re-slugs the show. The action redirects to the new
+  // slug; fetch follows it, so response.url carries the canonical path. The
+  // form must navigate there, not to the stale loader slug, or the user 404s.
+  test("navigates to the redirect target (re-slugged URL), not the loader slug", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      url: "http://localhost/shows/2017-07-22-new-venue",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const user = userEvent.setup();
+    render(<EditShow />);
+
+    await user.click(await screen.findByRole("button", { name: /update show/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/shows/2017-07-22-new-venue");
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith("/shows/2017-07-22-red-rocks");
+  });
+});

--- a/apps/web/app/routes/shows/$slug.edit.tsx
+++ b/apps/web/app/routes/shows/$slug.edit.tsx
@@ -1,6 +1,6 @@
 import type { Band, RockOpera, Setlist, Show, ShowLineupMember, Track, Venue } from "@bip/domain";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { redirect, useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { DeleteEntityButton } from "~/components/admin/delete-entity-button";
 import { ShowDayOrderManager, type ShowDayOrderRow } from "~/components/show/show-day-order-manager";
@@ -106,10 +106,12 @@ export const action = adminAction(async ({ request, params }) => {
     rockOperaIds: formData.getAll("rockOperaIds").map(String),
   };
 
-  // Update the show
+  // Update the show. A date/venue change re-slugs it, so redirect to the new
+  // slug (the client navigates to the redirect target) rather than returning
+  // the show, which a plain fetch would receive as an HTML document.
   const show = await services.shows.update(slug as string, data);
 
-  return { show };
+  return redirect(`/shows/${show.slug}`);
 });
 
 export default function EditShow() {
@@ -156,8 +158,11 @@ export default function EditShow() {
       });
 
       if (response.ok) {
+        // The action redirects to the (possibly re-slugged) show URL; fetch
+        // follows it, so response.url is the canonical slug. Navigate there
+        // instead of the stale loader slug, which 404s on a date/venue change.
         toast.success("Show updated successfully!", { id: loadingToast });
-        navigate(`/shows/${show.slug}`);
+        navigate(new URL(response.url).pathname);
       } else {
         toast.error("Failed to update show. Please try again.", { id: loadingToast });
       }

--- a/apps/web/app/routes/songs/$slug.test.tsx
+++ b/apps/web/app/routes/songs/$slug.test.tsx
@@ -414,4 +414,50 @@ describe("SongPage", () => {
     expect(value.className).toContain("text-xl");
     expect(value.className).toContain("sm:text-3xl");
   });
+
+  // The song's kind (original/cover/mashup/improvisation) is editable in the
+  // admin form, so the public page must surface it for every value — not just
+  // mashup — or an admin can set a kind and never see it reflected.
+  function loaderDataWithKind(kind: string | null) {
+    return {
+      song: {
+        title: "Basis for a Day",
+        slug: "basis-for-a-day",
+        timesPlayed: 100,
+        dateFirstPlayed: null,
+        dateLastPlayed: null,
+        kind,
+        history: null,
+        lyrics: null,
+        tabs: null,
+        guitarTabsUrl: null,
+        notes: null,
+        yearlyPlayData: {},
+      },
+      performances: [],
+      showsByYear: {},
+    };
+  }
+
+  test.each([
+    "original",
+    "cover",
+    "mashup",
+    "improvisation",
+  ])("renders the '%s' kind label on the song page", (kind) => {
+    vi.mocked(useSerializedLoaderData).mockReturnValueOnce(loaderDataWithKind(kind));
+    renderSongPage();
+
+    expect(screen.getByText(kind)).toBeInTheDocument();
+  });
+
+  // A song with no kind and no author must not render an empty subtitle row.
+  test("renders no kind label when kind is null", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValueOnce(loaderDataWithKind(null));
+    renderSongPage();
+
+    for (const kind of ["original", "cover", "mashup", "improvisation"]) {
+      expect(screen.queryByText(kind)).not.toBeInTheDocument();
+    }
+  });
 });

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -262,14 +262,14 @@ export default function SongPage() {
             </AdminOnly>
           }
         />
-        {(song.authorName || song.kind === "mashup") && (
+        {(song.authorName || song.kind) && (
           <div className="flex flex-wrap items-baseline justify-center gap-x-3 text-content-text-secondary text-lg">
             {song.authorName && (
               <span>
                 by <span className="text-brand-primary">{song.authorName}</span>
               </span>
             )}
-            {song.kind === "mashup" && <span className="text-content-text-tertiary">mashup</span>}
+            {song.kind && <span className="text-content-text-tertiary">{song.kind}</span>}
           </div>
         )}
       </div>

--- a/apps/web/app/routes/venues/$slug.edit.render.test.tsx
+++ b/apps/web/app/routes/venues/$slug.edit.render.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// Mock `useNavigate` so we can assert where the form sends the user after save.
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("~/server/services", () => ({ services: {} }));
+vi.mock("~/lib/base-loaders", () => ({
+  adminLoader: (fn: unknown) => fn,
+  adminAction: (fn: unknown) => fn,
+}));
+vi.mock("~/lib/errors", () => ({ notFound: (msg: string) => new Response(msg, { status: 404 }) }));
+
+// VenueForm fires onSubmit with fixed values, standing in for a rename.
+vi.mock("~/components/venue/venue-form", () => ({
+  VenueForm: ({ onSubmit }: { onSubmit: (values: Record<string, unknown>) => void }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onSubmit({ name: "Red Rocks Amphitheater", city: "Morrison", state: "CO", country: "United States" })
+      }
+    >
+      Update Venue
+    </button>
+  ),
+}));
+vi.mock("~/components/ui/page-header", () => ({ PageHeader: () => null }));
+
+const loaderData = {
+  venue: { slug: "the-caverns", name: "The Caverns", city: "Pelham", state: "TN", country: "United States" },
+};
+vi.mock("~/hooks/use-serialized-loader-data", () => ({
+  useSerializedLoaderData: vi.fn(() => loaderData),
+}));
+
+import EditVenue from "./$slug.edit";
+
+describe("venues/$slug.edit redirect", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // Renaming a venue re-slugs it, so the form must land on the slug the action
+  // redirects to (carried by response.url), not the stale loader slug → 404.
+  test("navigates to the redirect target (re-slugged URL), not the loader slug", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      url: "http://localhost/venues/red-rocks-amphitheater",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const user = userEvent.setup();
+    render(<EditVenue />);
+
+    await user.click(await screen.findByRole("button", { name: /update venue/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/venues/red-rocks-amphitheater");
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith("/venues/the-caverns");
+  });
+});

--- a/apps/web/app/routes/venues/$slug.edit.tsx
+++ b/apps/web/app/routes/venues/$slug.edit.tsx
@@ -1,6 +1,6 @@
 import type { Venue } from "@bip/domain";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { redirect, useNavigate } from "react-router-dom";
 import { Card, CardContent } from "~/components/ui/card";
 import { PageHeader } from "~/components/ui/page-header";
 import { VenueForm, type VenueFormValues } from "~/components/venue/venue-form";
@@ -32,7 +32,9 @@ export const action = adminAction(async ({ request, params }) => {
   const state = (formData.get("state") as string) || null;
   const country = formData.get("country") as string;
 
-  // Update the venue
+  // Update the venue. A name/city/state change re-slugs it, so redirect to the
+  // new slug (the client navigates to the redirect target) rather than returning
+  // the venue, which a plain fetch would receive as an HTML document.
   const venue = await services.venues.update(slug as string, {
     name,
     city,
@@ -40,7 +42,7 @@ export const action = adminAction(async ({ request, params }) => {
     country,
   });
 
-  return { venue };
+  return redirect(`/venues/${venue.slug}`);
 });
 
 export default function EditVenue() {
@@ -75,7 +77,10 @@ export default function EditVenue() {
     });
 
     if (response.ok) {
-      navigate(`/venues/${venue.slug}`);
+      // The action redirects to the (possibly re-slugged) venue URL; fetch
+      // follows it, so response.url is the canonical slug. Navigate there
+      // instead of the stale loader slug, which 404s on a rename.
+      navigate(new URL(response.url).pathname);
     }
   };
 

--- a/packages/core/src/venues/venue-service.test.ts
+++ b/packages/core/src/venues/venue-service.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test, vi } from "vitest";
+import { VenueService } from "./venue-service";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+
+type VenueRow = { id: string; name: string; slug: string; city: string; state: string; country: string };
+
+// The admin edit route passes the slug from the URL, so update must resolve the
+// venue by slug — not by id (passing the slug as an id matches nothing and throws).
+function makeVenueDb(bySlug: Record<string, VenueRow>) {
+  return {
+    venue: {
+      findFirst: vi.fn(({ where }: { where: { slug?: string; id?: { not?: string } } }) => {
+        const match = where.slug ? bySlug[where.slug] : null;
+        if (!match) return Promise.resolve(null);
+        // generateVenueSlug excludes the current venue when checking collisions.
+        if (where.id?.not && match.id === where.id.not) return Promise.resolve(null);
+        return Promise.resolve(match);
+      }),
+      update: vi.fn(({ where, data }: { where: { id: string }; data: Record<string, unknown> }) =>
+        Promise.resolve({
+          id: where.id,
+          name: "",
+          slug: "",
+          city: null,
+          state: null,
+          country: null,
+          createdAt: new Date("2020-01-01"),
+          updatedAt: new Date("2020-01-01"),
+          ...data,
+        }),
+      ),
+    },
+  };
+}
+
+describe("VenueService.update — resolves by slug", () => {
+  test("looks the venue up by slug and regenerates the slug on rename", async () => {
+    const db = makeVenueDb({
+      "the-caverns": {
+        id: "cav",
+        name: "The Caverns",
+        slug: "the-caverns",
+        city: "Pelham",
+        state: "TN",
+        country: "United States",
+      },
+    });
+    const service = new VenueService(db as never, logger);
+
+    const result = await service.update("the-caverns", {
+      name: "Red Rocks Amphitheater",
+      city: "Morrison",
+      state: "CO",
+      country: "United States",
+    });
+
+    expect(db.venue.update).toHaveBeenCalledWith(expect.objectContaining({ where: { id: "cav" } }));
+    expect(result.slug).toBe("red-rocks-amphitheater");
+  });
+
+  test("throws when no venue matches the slug", async () => {
+    const db = makeVenueDb({});
+    const service = new VenueService(db as never, logger);
+
+    await expect(
+      service.update("nobody", { name: "Somewhere", city: "Town", state: "TN", country: "United States" }),
+    ).rejects.toThrow('Venue with slug "nobody" not found');
+  });
+});

--- a/packages/core/src/venues/venue-service.ts
+++ b/packages/core/src/venues/venue-service.ts
@@ -147,17 +147,17 @@ export class VenueService {
   }
 
   async update(
-    id: string,
+    slug: string,
     data: Partial<Omit<Venue, "id" | "slug" | "createdAt" | "updatedAt" | "timesPlayed">>,
   ): Promise<Venue> {
-    // Get current venue for validation and fallback values
-    const current = await this.db.venue.findUnique({
-      where: { id },
-      select: { name: true, city: true, state: true, country: true },
+    // Resolve by slug — that's what the admin edit route passes in (the URL param).
+    const current = await this.db.venue.findFirst({
+      where: { slug },
+      select: { id: true, name: true, city: true, state: true, country: true },
     });
 
     if (!current) {
-      throw new Error(`Venue with id "${id}" not found`);
+      throw new Error(`Venue with slug "${slug}" not found`);
     }
 
     // Validate required fields (using current values as fallback)
@@ -230,11 +230,11 @@ export class VenueService {
       const name = cleanData.name || current.name || "";
       const city = cleanData.city || current.city;
       const state = cleanData.state !== undefined ? cleanData.state : current.state;
-      updateData.slug = await this.generateVenueSlug(name, city, state, id);
+      updateData.slug = await this.generateVenueSlug(name, city, state, current.id);
     }
 
     const result = await this.db.venue.update({
-      where: { id },
+      where: { id: current.id },
       data: updateData,
     });
     return mapVenueToDomainEntity(result);


### PR DESCRIPTION
## What changed

- **Song pages show the kind.** The kind (cover, mashup, improvisation, or original) now renders next to the song title. Previously only mashups were labeled, so a kind set in the admin form was invisible everywhere else.
- **Show and venue edits redirect correctly.** Changing a show's date/venue, or a venue's name/city/state, re-slugs the record; the edit form now lands on the new URL instead of a 404.
- **Venue editing works again.** Saving any venue edit previously threw a 500: `VenueService.update` looked the venue up by `id` while the route passed its `slug`, so every save failed. It now resolves by slug (mirroring `AuthorService.update`).

## Tests

Red/green for each change: per-kind song label rendering, show/venue navigate-to-redirect-target, and `VenueService.update` slug resolution. Full suite green (core 499, web 1190). Browser-verified the song labels, both edit redirects, and (separately) the track flag and completion editors end-to-end.

## Implementation note

The show/venue edit forms submit via a manual `fetch` and then `navigate`. A plain `fetch` POST to a React Router page-route action receives the rendered HTML document, not the action's return value as JSON, so `response.json()` throws. The actions now `redirect()` to the canonical URL and the client navigates to `new URL(response.url).pathname` (the followed-redirect target). This is the only reliable way to get the server-computed slug, which can append a disambiguating city or early/late suffix the client can't reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
