### PR TITLE
Add a "played by musician" filter to the song and show pages

### DIFF
--- a/apps/web/app/components/performance/performance-filter-controls.test.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.test.tsx
@@ -254,6 +254,37 @@ describe("PerformanceFilterControls", () => {
     expect(toggle.textContent).toMatch(/3/);
   });
 
+  // The Musician picker is opt-in via the selectedMusician prop (mirrors the
+  // Author picker). Rendering the label confirms the control is wired in.
+  test("renders the Musician picker when selectedMusician is provided", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} selectedMusician={null} />);
+
+    expect(screen.getByText("Musician")).toBeInTheDocument();
+  });
+
+  test("does not render the Musician picker when selectedMusician is omitted", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} />);
+
+    expect(screen.queryByText("Musician")).not.toBeInTheDocument();
+  });
+
+  // A selected musician counts toward the active-filter badge so the collapsed
+  // mobile chrome reflects the hidden filter.
+  test("Filters toggle counts a selected musician toward the active-filter badge", async () => {
+    await setup(
+      <PerformanceFilterControls
+        {...defaultProps}
+        searchValue=""
+        onSearchChange={() => {}}
+        hasActiveFilters
+        selectedMusician="sam-altman"
+      />,
+    );
+
+    const toggle = screen.getByRole("button", { name: /^Search & Filters/ });
+    expect(toggle.textContent).toMatch(/1/);
+  });
+
   // Clicking Clear All delegates to the parent's clearFilters callback, which
   // resets all URL params and search text in the hook.
   test("clicking Clear All calls clearFilters", async () => {

--- a/apps/web/app/components/performance/performance-filter-controls.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown, Filter } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import { AuthorSearch } from "~/components/author/author-search";
+import { MusicianSearch } from "~/components/musician/musician-search";
 import { SelectFilter } from "~/components/ui/filters";
 import { ToggleFilterGroup } from "~/components/ui/filters/toggle-filter-group";
 import { Input } from "~/components/ui/input";
@@ -31,6 +32,7 @@ interface PerformanceFilterControlsProps {
   hideTimeRange?: boolean;
   kindFilter?: string;
   selectedAuthor?: string | null;
+  selectedMusician?: string | null;
   playedFilter?: string;
   searchValue?: string;
   onSearchChange?: (value: string) => void;
@@ -49,6 +51,7 @@ export function PerformanceFilterControls({
   hideTimeRange = false,
   kindFilter,
   selectedAuthor,
+  selectedMusician,
   playedFilter,
   searchValue,
   onSearchChange,
@@ -77,6 +80,7 @@ export function PerformanceFilterControls({
     (!hideTimeRange && selectedTimeRange !== "all" ? 1 : 0) +
     (kindFilter && kindFilter !== "all" ? 1 : 0) +
     (selectedAuthor ? 1 : 0) +
+    (selectedMusician ? 1 : 0) +
     (playedFilter && playedFilter !== "all" ? 1 : 0) +
     activeToggleSet.size;
 
@@ -134,6 +138,26 @@ export function PerformanceFilterControls({
               groups={TIME_RANGE_GROUPS}
               width="w-[200px]"
             />
+          )}
+          {selectedMusician !== undefined && (
+            <div className="flex flex-col">
+              <label htmlFor="musician-search" className={labelClass}>
+                Musician
+              </label>
+              <MusicianSearch
+                value={selectedMusician}
+                onValueChange={(value) => updateFilter({ musician: value === "none" ? null : value })}
+                // Carry the slug (not the id) in the URL so a shared
+                // ?musician= link is readable. The /api/musicians endpoint
+                // resolves the slug back to a record for pre-fill.
+                itemId={(musician) => musician.slug ?? musician.id}
+                // Show a deep open-list (the roster is 130+) so most names are
+                // visible without typing.
+                topLimit={40}
+                placeholder="All Musicians"
+                className="w-[150px] sm:w-[200px] h-[34px] text-sm"
+              />
+            </div>
           )}
           {kindFilter !== undefined && (
             <SelectFilter

--- a/apps/web/app/components/song/filtered-songs-table.tsx
+++ b/apps/web/app/components/song/filtered-songs-table.tsx
@@ -19,6 +19,7 @@ export function FilteredSongsTable({ songs, extraParams, hideTimeRange }: Filter
     selectedTimeRange,
     kindFilter,
     selectedAuthor,
+    selectedMusician,
     playedFilter,
     activeToggleSet,
     hasActiveFilters,
@@ -39,16 +40,18 @@ export function FilteredSongsTable({ songs, extraParams, hideTimeRange }: Filter
   });
 
   // Show the Filtered Plays column only when a narrowing filter is active
-  // (date range, attended, or a toggle like Set Opener/Encore). Cover and
-  // author aren't narrowing — they pick which songs appear but every
-  // matching song still surfaces its full play history. Tab-baked
+  // (date range, attended, a toggle like Set Opener/Encore, or a musician).
+  // Cover and author aren't narrowing — they pick which songs appear but every
+  // matching song still surfaces its full play history. A musician IS narrowing
+  // (like the time range), so it surfaces the filtered columns. Tab-baked
   // extraParams (e.g. /songs/this-year) always carry a time range, so they
   // count as a date range here.
   const hasDateRange = selectedTimeRange !== "all" || !!extraParams;
   const hasAttendedUser = activeToggleSet.has("attended");
   const hasToggleFilters = [...activeToggleSet].some((key) => key !== "attended");
   const showFilteredPlays =
-    hasNarrowingFilter({ hasDateRange, hasAttendedUser, hasToggleFilters }) && playedFilter !== "notPlayed";
+    hasNarrowingFilter({ hasDateRange, hasAttendedUser, hasToggleFilters, hasMusician: !!selectedMusician }) &&
+    playedFilter !== "notPlayed";
 
   const filterControls = (
     <PerformanceFilterControls
@@ -59,6 +62,7 @@ export function FilteredSongsTable({ songs, extraParams, hideTimeRange }: Filter
       clearFilters={clearFilters}
       kindFilter={kindFilter}
       selectedAuthor={selectedAuthor}
+      selectedMusician={selectedMusician}
       playedFilter={playedFilter}
       searchValue={searchText}
       onSearchChange={setSearchText}

--- a/apps/web/app/components/ui/entity-search.tsx
+++ b/apps/web/app/components/ui/entity-search.tsx
@@ -10,6 +10,19 @@ export interface EntityPickerProps {
   allowCreate?: boolean;
   /** Start open with the search input focused — for a freshly added picker row. */
   autoOpen?: boolean;
+  /**
+   * The token used as the picker's value (in the URL / form). Defaults to the
+   * record id. The public musician filter overrides this to the slug so its
+   * URL is shareable; the record must still be fetchable by that token.
+   */
+  itemId?: (item: { id: string; slug?: string }) => string;
+  /**
+   * How many records the open-on-focus list shows before the user types.
+   * Defaults to 10 (fine for the small admin vocabularies); the public
+   * musician filter raises it so most of the 130+ roster is visible at a
+   * glance. The API caps this at 50.
+   */
+  topLimit?: number;
 }
 
 interface EntitySearchProps<T extends { id: string }> extends EntityPickerProps {
@@ -40,6 +53,8 @@ export function EntitySearch<T extends { id: string }>({
   resource,
   noneLabel,
   itemLabel,
+  itemId = (item) => item.id,
+  topLimit = 10,
 }: EntitySearchProps<T>) {
   const searchPlaceholder = placeholder ?? `Search ${resource}...`;
   return (
@@ -54,14 +69,14 @@ export function EntitySearch<T extends { id: string }>({
       emptyMessage={`No ${resource} found.`}
       loadingMessage="Loading..."
       loadOnOpen
-      itemId={(item) => item.id}
+      itemId={itemId}
       itemLabel={itemLabel}
       noneLabel={noneLabel}
       fetchResults={async (query) => {
         const url =
           query && query.length >= 2
             ? `/api/${resource}?q=${encodeURIComponent(query)}&limit=20`
-            : `/api/${resource}?top=10`;
+            : `/api/${resource}?top=${topLimit}`;
         const response = await fetch(url);
         if (!response.ok) return [];
         return (await response.json()) as T[];

--- a/apps/web/app/hooks/use-performance-page-filters.test.ts
+++ b/apps/web/app/hooks/use-performance-page-filters.test.ts
@@ -142,6 +142,40 @@ describe("usePerformancePageFilters", () => {
     expect(result.current.hasFilters).toBe(true);
   });
 
+  test("hasFilters is true when musician is set", () => {
+    mockSearchParams = new URLSearchParams("musician=sam-altman");
+
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    expect(result.current.hasFilters).toBe(true);
+    expect(result.current.selectedMusician).toBe("sam-altman");
+  });
+
+  // selectedMusician is null when the param is absent (mirrors selectedAuthor).
+  test("selectedMusician is null when the param is absent", () => {
+    const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    expect(result.current.selectedMusician).toBeNull();
+  });
+
+  // The musician param threads into the client fetch URL so the filtered
+  // API call narrows to that musician.
+  test("fetch URL carries the musician param", async () => {
+    mockSearchParams = new URLSearchParams("musician=sam-altman");
+    const fetchMock = vi.fn().mockImplementation(() => new Promise(() => {}));
+    globalThis.fetch = fetchMock;
+
+    renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("musician=sam-altman");
+  });
+
   test("hasFilters is true when toggle filters are set", () => {
     mockSearchParams = new URLSearchParams("filters=encore,setOpener");
 
@@ -250,7 +284,7 @@ describe("usePerformancePageFilters", () => {
   // need to confirm the function produces the right params.
   test("clearFilters resets all params", () => {
     mockSearchParams = new URLSearchParams(
-      "timeRange=2024&kind=cover&author=Trey&filters=encore&attended=attended&played=notPlayed",
+      "timeRange=2024&kind=cover&author=Trey&musician=sam-altman&filters=encore&attended=attended&played=notPlayed",
     );
 
     const { result } = renderHook(() => usePerformancePageFilters({ initialData: EMPTY, apiUrl: "/api/test" }));
@@ -263,12 +297,15 @@ describe("usePerformancePageFilters", () => {
 
     const updaterFn = mockSetSearchParams.mock.calls[0][0];
     const nextParams = updaterFn(
-      new URLSearchParams("timeRange=2024&kind=cover&author=Trey&filters=encore&attended=attended&played=notPlayed"),
+      new URLSearchParams(
+        "timeRange=2024&kind=cover&author=Trey&musician=sam-altman&filters=encore&attended=attended&played=notPlayed",
+      ),
     );
 
     expect(nextParams.get("timeRange")).toBeNull();
     expect(nextParams.get("kind")).toBeNull();
     expect(nextParams.get("author")).toBeNull();
+    expect(nextParams.get("musician")).toBeNull();
     expect(nextParams.get("filters")).toBeNull();
     expect(nextParams.get("attended")).toBeNull();
     expect(nextParams.get("played")).toBeNull();

--- a/apps/web/app/hooks/use-performance-page-filters.ts
+++ b/apps/web/app/hooks/use-performance-page-filters.ts
@@ -39,6 +39,7 @@ export function usePerformancePageFilters<T>({
   const selectedTimeRange = getTimeRangeParam(searchParams) || "all";
   const kindFilter = (searchParams.get("kind") as "all" | "original" | "cover" | "mashup" | "improvisation") || "all";
   const selectedAuthor = searchParams.get("author") || null;
+  const selectedMusician = searchParams.get("musician") || null;
   const filtersParam = searchParams.get("filters") || "";
   const attendedParam = searchParams.get("attended") || "";
   const playedParam = searchParams.get("played") || "";
@@ -58,6 +59,7 @@ export function usePerformancePageFilters<T>({
     selectedTimeRange !== "all" ||
     kindFilter !== "all" ||
     !!selectedAuthor ||
+    !!selectedMusician ||
     filtersParam !== "" ||
     attendedParam !== "" ||
     playedParam !== "";
@@ -87,6 +89,7 @@ export function usePerformancePageFilters<T>({
     if (selectedTimeRange !== "all") params.set("timeRange", selectedTimeRange);
     if (kindFilter !== "all") params.set("kind", kindFilter);
     if (selectedAuthor) params.set("author", selectedAuthor);
+    if (selectedMusician) params.set("musician", selectedMusician);
     if (filtersParam) params.set("filters", filtersParam);
     if (attendedParam) params.set("attended", attendedParam);
     if (playedParam) params.set("played", playedParam);
@@ -131,6 +134,7 @@ export function usePerformancePageFilters<T>({
     selectedTimeRange,
     kindFilter,
     selectedAuthor,
+    selectedMusician,
     filtersParam,
     attendedParam,
     playedParam,
@@ -197,6 +201,7 @@ export function usePerformancePageFilters<T>({
       era: null,
       kind: null,
       author: null,
+      musician: null,
       filters: null,
       attended: null,
       played: null,
@@ -211,6 +216,7 @@ export function usePerformancePageFilters<T>({
     selectedTimeRange,
     kindFilter,
     selectedAuthor,
+    selectedMusician,
     playedFilter: playedParam || "all",
     activeToggleSet,
     hasFilters,

--- a/apps/web/app/lib/noteworthy-performance-page.tsx
+++ b/apps/web/app/lib/noteworthy-performance-page.tsx
@@ -33,6 +33,7 @@ export function NoteworthyPerformancePage({
     selectedTimeRange,
     kindFilter,
     selectedAuthor,
+    selectedMusician,
     activeToggleSet,
     hasActiveFilters,
     searchText,
@@ -64,6 +65,7 @@ export function NoteworthyPerformancePage({
             clearFilters={clearFilters}
             kindFilter={kindFilter}
             selectedAuthor={selectedAuthor}
+            selectedMusician={selectedMusician}
             showAllTimerToggle={!hideAllTimerToggle}
             showJamChartToggle={!hideJamChartToggle}
             searchValue={searchText}

--- a/apps/web/app/lib/performance-filter-params.test.ts
+++ b/apps/web/app/lib/performance-filter-params.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test, vi } from "vitest";
+import type { PublicContext } from "~/lib/base-loaders";
+
+// The module imports `~/server/services`, which validates server env at
+// import time. Stub it with just the musician lookup the filter needs.
+const findBySlug = vi.fn();
+vi.mock("~/server/services", () => ({ services: { musicians: { findBySlug } } }));
+
+const { buildFilteredCacheKey, parsePerformanceFilters } = await import("./performance-filter-params");
+
+// A context with no logged-in user. The musician/author/cache-key paths under
+// test never touch the user service (only the `attended` param does).
+const emptyContext = { currentUser: undefined } as unknown as PublicContext;
+
+const MUSICIAN_ID = "11111111-1111-1111-1111-111111111111";
+
+describe("parsePerformanceFilters — musician", () => {
+  // The URL carries a readable slug; parse resolves it to the id the composer
+  // filters on (mirrors how the attended username resolves to a user id).
+  test("resolves a musician slug to playedByMusicianId", async () => {
+    findBySlug.mockResolvedValueOnce({ id: MUSICIAN_ID, slug: "sam-altman" });
+    const url = new URL("https://x.test/songs?musician=sam-altman");
+
+    const filters = await parsePerformanceFilters(url, emptyContext);
+
+    expect(findBySlug).toHaveBeenCalledWith("sam-altman");
+    expect(filters.playedByMusicianId).toBe(MUSICIAN_ID);
+  });
+
+  // An unknown slug resolves to nothing, so the filter is simply inactive
+  // rather than erroring or matching everything.
+  test("leaves the filter inactive when the slug resolves to no musician", async () => {
+    findBySlug.mockResolvedValueOnce(null);
+    const url = new URL("https://x.test/songs?musician=not-a-real-musician");
+
+    const filters = await parsePerformanceFilters(url, emptyContext);
+
+    expect(filters.playedByMusicianId).toBeUndefined();
+  });
+});
+
+describe("buildFilteredCacheKey — musician", () => {
+  // The musician slug must be part of the cache key, or two different musician
+  // filters would collide on one cached payload.
+  test("a musician filter changes the cache key", () => {
+    const base = buildFilteredCacheKey(new URL("https://x.test/songs"), "songs-index");
+    const withMusician = buildFilteredCacheKey(new URL("https://x.test/songs?musician=sam-altman"), "songs-index");
+    expect(withMusician).not.toBe(base);
+  });
+
+  // Different musicians produce different keys.
+  test("different musicians produce different cache keys", () => {
+    const a = buildFilteredCacheKey(new URL("https://x.test/songs?musician=sam-altman"), "songs-index");
+    const b = buildFilteredCacheKey(new URL("https://x.test/songs?musician=allen-aucoin"), "songs-index");
+    expect(a).not.toBe(b);
+  });
+});

--- a/apps/web/app/lib/performance-filter-params.ts
+++ b/apps/web/app/lib/performance-filter-params.ts
@@ -68,6 +68,7 @@ export async function parsePerformanceFilters(url: URL, context: PublicContext):
   const filtersParam = url.searchParams.get("filters");
   const attendedParam = url.searchParams.get("attended");
   const monthDayParam = url.searchParams.get("monthDay");
+  const musicianParam = url.searchParams.get("musician");
 
   const filters: PerformanceFilterOptions = {};
 
@@ -84,6 +85,14 @@ export async function parsePerformanceFilters(url: URL, context: PublicContext):
   }
   if (authorParam && UUID_REGEX.test(authorParam)) filters.authorId = authorParam;
   if (monthDayParam) filters.monthDay = monthDayParam;
+
+  // The musician filter carries a readable slug (e.g. ?musician=sam-altman)
+  // for shareable URLs; resolve it to the id the composer filters on. An
+  // unknown slug resolves to nothing and the filter is simply inactive.
+  if (musicianParam) {
+    const musician = await services.musicians.findBySlug(musicianParam);
+    if (musician) filters.playedByMusicianId = musician.id;
+  }
 
   const attendedUserId = await resolveAttendedUserId(attendedParam, context);
   if (attendedUserId) filters.attendedUserId = attendedUserId;
@@ -106,6 +115,7 @@ export function buildFilteredCacheKey(url: URL, scope: string, attendedUserId?: 
   const timeRange = getTimeRangeParam(url.searchParams);
   const kindParam = url.searchParams.get("kind");
   const authorParam = url.searchParams.get("author");
+  const musicianParam = url.searchParams.get("musician");
   const filtersParam = url.searchParams.get("filters");
   const monthDay = url.searchParams.get("monthDay");
 
@@ -114,6 +124,7 @@ export function buildFilteredCacheKey(url: URL, scope: string, attendedUserId?: 
     timeRange: timeRange || null,
     kind: kindParam || null,
     author: authorParam || null,
+    musician: musicianParam || null,
     filters: filtersParam || null,
     attended: attendedUserId || null,
     monthDay: monthDay || null,

--- a/apps/web/app/lib/played-filter.test.ts
+++ b/apps/web/app/lib/played-filter.test.ts
@@ -6,23 +6,28 @@ const defaults = {
   hasDateRange: false,
   hasAttendedUser: false,
   hasToggleFilters: false,
+  hasMusician: false,
 };
 
 describe("hasNarrowingFilter", () => {
-  // None of date range / attended / toggles → no narrowing happening.
+  // None of date range / attended / toggles / musician → no narrowing.
   // (Cover and author are deliberately not "narrowing" — they pick which
   // songs appear but don't restrict which performances contribute to a
-  // count, so they stay out of this predicate.)
+  // count. Musician IS narrowing: it restricts performances to the ones that
+  // player appeared on, like the time range, so it surfaces filtered columns.)
   test("returns false when no narrowing input is set", () => {
-    expect(hasNarrowingFilter({ hasDateRange: false, hasAttendedUser: false, hasToggleFilters: false })).toBe(false);
+    expect(
+      hasNarrowingFilter({ hasDateRange: false, hasAttendedUser: false, hasToggleFilters: false, hasMusician: false }),
+    ).toBe(false);
   });
 
-  // Each of the three narrowing inputs is sufficient on its own. Parameterized
-  // to keep the rule visible in one place if a fourth narrowing kind is added.
+  // Each narrowing input is sufficient on its own. Parameterized to keep the
+  // rule visible in one place if another narrowing kind is added.
   test.each([
-    ["hasDateRange", { hasDateRange: true, hasAttendedUser: false, hasToggleFilters: false }],
-    ["hasAttendedUser", { hasDateRange: false, hasAttendedUser: true, hasToggleFilters: false }],
-    ["hasToggleFilters", { hasDateRange: false, hasAttendedUser: false, hasToggleFilters: true }],
+    ["hasDateRange", { hasDateRange: true, hasAttendedUser: false, hasToggleFilters: false, hasMusician: false }],
+    ["hasAttendedUser", { hasDateRange: false, hasAttendedUser: true, hasToggleFilters: false, hasMusician: false }],
+    ["hasToggleFilters", { hasDateRange: false, hasAttendedUser: false, hasToggleFilters: true, hasMusician: false }],
+    ["hasMusician", { hasDateRange: false, hasAttendedUser: false, hasToggleFilters: false, hasMusician: true }],
   ])("returns true when %s is set", (_label, input) => {
     expect(hasNarrowingFilter(input)).toBe(true);
   });
@@ -58,5 +63,11 @@ describe("shouldShowNotPlayed", () => {
   // never had a matching performance.
   test("returns true when notPlayed with toggle filters", () => {
     expect(shouldShowNotPlayed({ ...defaults, playedParam: "notPlayed", hasToggleFilters: true })).toBe(true);
+  });
+
+  // Musician narrows the view to a player's performances, so "not played" =
+  // songs that player has never performed.
+  test("returns true when notPlayed with a musician filter", () => {
+    expect(shouldShowNotPlayed({ ...defaults, playedParam: "notPlayed", hasMusician: true })).toBe(true);
   });
 });

--- a/apps/web/app/lib/played-filter.ts
+++ b/apps/web/app/lib/played-filter.ts
@@ -2,18 +2,21 @@ interface NarrowingFilterInputs {
   hasDateRange: boolean;
   hasAttendedUser: boolean;
   hasToggleFilters: boolean;
+  hasMusician: boolean;
 }
 
 /**
  * True when at least one filter is active that restricts which performances
- * contribute to a count (date range, attended-shows, or a toggle like
- * encore/setOpener). Cover and author filters intentionally don't count —
- * they pick which songs appear but every matching song still surfaces its
- * full play history. Used by the "not played" gate and by the /songs UI to
- * decide whether the Filtered Plays column is meaningful.
+ * contribute to a count (date range, attended-shows, a toggle like
+ * encore/setOpener, or a musician). Cover and author filters intentionally
+ * don't count — they pick which songs appear but every matching song still
+ * surfaces its full play history. A musician DOES count: it restricts the
+ * performances to that player's, just like the time range. Used by the "not
+ * played" gate and by the /songs UI to decide whether the filtered columns
+ * are meaningful.
  */
 export function hasNarrowingFilter(inputs: NarrowingFilterInputs): boolean {
-  return inputs.hasDateRange || inputs.hasAttendedUser || inputs.hasToggleFilters;
+  return inputs.hasDateRange || inputs.hasAttendedUser || inputs.hasToggleFilters || inputs.hasMusician;
 }
 
 /**

--- a/apps/web/app/lib/song-utilities.test.ts
+++ b/apps/web/app/lib/song-utilities.test.ts
@@ -42,6 +42,7 @@ const mockBuildFilteredSongRarity = vi.fn().mockResolvedValue(new Map());
 const mockCacheGetOrSet = vi.fn().mockImplementation((_key: string, fn: () => Promise<unknown>) => fn());
 const mockFindByEmail = vi.fn();
 const mockFindByUsername = vi.fn();
+const mockMusicianFindBySlug = vi.fn();
 const mockGetShowsByYear = vi.fn();
 const mockGetShowsSinceLastPlayedBySongIds = vi.fn();
 const mockGetAverageGapShowsBySongIds = vi.fn();
@@ -66,6 +67,9 @@ vi.mock("~/server/services", () => ({
     users: {
       findByEmail: (...args: unknown[]) => mockFindByEmail(...args),
       findByUsername: (...args: unknown[]) => mockFindByUsername(...args),
+    },
+    musicians: {
+      findBySlug: (...args: unknown[]) => mockMusicianFindBySlug(...args),
     },
     stats: {
       getShowsByYear: (...args: unknown[]) => mockGetShowsByYear(...args),
@@ -174,6 +178,24 @@ describe("fetchFilteredSongs", () => {
     expect(result[0].id).toBe("2");
     expect(result[0].timesPlayed).toBe(50); // Home Again all-time
     expect(result[0].filteredTimesPlayed).toBe(4);
+  });
+
+  // The musician filter is a per-performance predicate, so — like toggles —
+  // it routes through buildSongPerformanceCounts (with the slug resolved to an
+  // id) to narrow the song list and attach filteredTimesPlayed, rather than the
+  // non-narrowing song-level treatment that author/kind get.
+  test("musician filter: resolves the slug, narrows via buildSongPerformanceCounts, attaches filteredTimesPlayed", async () => {
+    mockMusicianFindBySlug.mockResolvedValue({ id: "musician-1", slug: "sam-altman" });
+    mockBuildSongPerformanceCounts.mockResolvedValueOnce({ "3": 9 }); // only Crickets
+
+    const result = await fetchFilteredSongs(new URL("http://test/songs?musician=sam-altman"), ctx);
+
+    expect(mockMusicianFindBySlug).toHaveBeenCalledWith("sam-altman");
+    expect(mockBuildSongPerformanceCounts).toHaveBeenCalledWith(
+      expect.objectContaining({ playedByMusicianId: "musician-1" }),
+    );
+    expect(result.map((s) => s.id)).toEqual(["3"]);
+    expect(result[0].filteredTimesPlayed).toBe(9);
   });
 
   // played=notPlayed combined with a narrowing filter returns songs that

--- a/apps/web/app/lib/song-utilities.ts
+++ b/apps/web/app/lib/song-utilities.ts
@@ -28,7 +28,7 @@ interface BaseFilter {
  * The canonical all-time list comes from `services.songs.findMany` keyed
  * only on cover/author — those filters pick which songs appear, not which
  * performances contribute to a count. Narrowing filters (date range,
- * attended, toggle flags) compute scope counts as a separate
+ * attended, toggle flags, musician) compute scope counts as a separate
  * `Map<songId, count>` and attach as `filteredTimesPlayed`. `timesPlayed`
  * always means the all-time count from the denormalized song column.
  */
@@ -40,6 +40,7 @@ export async function fetchFilteredSongs(url: URL, context: PublicContext): Prom
   const kindParam = params.get("kind");
   const attendedParam = params.get("attended");
   const filtersParam = params.get("filters");
+  const musicianParam = params.get("musician");
 
   const kindFilter =
     kindParam === "original" || kindParam === "cover" || kindParam === "mashup" || kindParam === "improvisation"
@@ -50,12 +51,14 @@ export async function fetchFilteredSongs(url: URL, context: PublicContext): Prom
 
   const hasDateRange = timeRangeParam === "last10shows" || (timeRangeParam !== null && timeRangeParam in SONG_FILTERS);
   const hasToggleFilters = !!filtersParam;
+  const hasMusician = !!musicianParam;
   const hasAttendedUser = !!attendedUserId;
   const showNotPlayed = shouldShowNotPlayed({
     playedParam,
     hasDateRange,
     hasAttendedUser,
     hasToggleFilters,
+    hasMusician,
   });
 
   const baseFilter: BaseFilter = {};
@@ -67,6 +70,7 @@ export async function fetchFilteredSongs(url: URL, context: PublicContext): Prom
     played: playedParam || null,
     author: authorId || null,
     kind: kindParam || null,
+    musician: musicianParam || null,
     attended: attendedUserId || null,
     filters: filtersParam || null,
   });
@@ -85,6 +89,7 @@ export async function fetchFilteredSongs(url: URL, context: PublicContext): Prom
         hasDateRange,
         hasAttendedUser,
         hasToggleFilters,
+        hasMusician,
       });
 
       let result: Song[];
@@ -165,22 +170,37 @@ interface ScopeContext {
   hasDateRange: boolean;
   hasAttendedUser: boolean;
   hasToggleFilters: boolean;
+  hasMusician: boolean;
 }
 
 /**
  * Returns scope counts as a `Map<songId, count>` for whichever narrowing
  * filter is active, or `null` when no narrowing is happening. Dispatch:
  * `buildSongPerformanceCounts` is the only counter that understands toggle
- * flags, so any toggle wins; otherwise date range or attended routes
- * through the song service. The two paths count differently on same-show
- * repeats (distinct-tracks vs distinct-shows-with-track) — call sites
- * surface whichever the active filter selects.
+ * flags and the musician predicate, so either of those wins; otherwise date
+ * range or attended routes through the song service. Both paths count distinct
+ * shows (matching `Song.timesPlayed`), so a filtered count never exceeds the
+ * all-time count.
  */
 async function computeScopeCounts(scope: ScopeContext): Promise<Map<string, number> | null> {
-  const { url, context, baseFilter, attendedUserId, timeRangeParam, hasDateRange, hasAttendedUser, hasToggleFilters } =
-    scope;
+  const {
+    url,
+    context,
+    baseFilter,
+    attendedUserId,
+    timeRangeParam,
+    hasDateRange,
+    hasAttendedUser,
+    hasToggleFilters,
+    hasMusician,
+  } = scope;
 
-  if (hasToggleFilters) {
+  // buildSongPerformanceCounts is the per-performance counter — it understands
+  // both the toggle chips (?filters=) and the musician predicate (?musician=)
+  // via FILTER_BUILDERS, so either routes here. They stay separate flags
+  // because they're separate params and separate kinds of filter (a musician
+  // isn't a toggle); date range and attended count through the song service.
+  if (hasToggleFilters || hasMusician) {
     const performanceFilters = await parsePerformanceFilters(url, context);
     const counts = await services.songPageComposer.buildSongPerformanceCounts(performanceFilters);
     return new Map(Object.entries(counts).filter(([, c]) => c > 0));

--- a/apps/web/app/routes/api/musicians.test.ts
+++ b/apps/web/app/routes/api/musicians.test.ts
@@ -6,9 +6,9 @@ vi.mock("~/lib/base-loaders", () => ({
 }));
 
 const search = vi.fn();
-const findMany = vi.fn();
+const findTopBySongCount = vi.fn();
 vi.mock("~/server/services", () => ({
-  services: { musicians: { search, findMany } },
+  services: { musicians: { search, findTopBySongCount } },
 }));
 
 vi.mock("~/lib/logger", () => ({
@@ -24,19 +24,20 @@ function makeArgs(url: string): LoaderFunctionArgs & { context: unknown } {
 describe("GET /api/musicians", () => {
   beforeEach(() => {
     search.mockReset();
-    findMany.mockReset();
+    findTopBySongCount.mockReset();
   });
 
-  // The picker's loadOnOpen hits ?top=N for the initial list.
-  test("returns the top musicians (alphabetical) for ?top=N, without searching", async () => {
+  // The picker's loadOnOpen hits ?top=N for the initial list, ordered by song
+  // count (most-played first) rather than alphabetically.
+  test("returns the top musicians by song count for ?top=N, without searching", async () => {
     const top = [{ id: "jg", name: "Jon Gutwillig", slug: "jon-gutwillig" }];
-    findMany.mockResolvedValue(top);
+    findTopBySongCount.mockResolvedValue(top);
 
     const response = (await loader(makeArgs("http://localhost/api/musicians?top=5"))) as Response;
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(top);
-    expect(findMany).toHaveBeenCalledWith({ pagination: { limit: 5 } });
+    expect(findTopBySongCount).toHaveBeenCalledWith(5);
     expect(search).not.toHaveBeenCalled();
   });
 

--- a/apps/web/app/routes/api/musicians.tsx
+++ b/apps/web/app/routes/api/musicians.tsx
@@ -24,11 +24,13 @@ export const loader = publicLoader(async ({ request }) => {
   const limit = parseBoundedPositiveInt(url.searchParams.get("limit"), DEFAULT_LIMIT);
   const topParam = url.searchParams.get("top");
 
-  // The picker's loadOnOpen asks for the top list; return musicians alphabetically.
+  // The picker's loadOnOpen asks for the top list; most-played musicians first
+  // (track count desc, ties alphabetical) so the core lineup and frequent
+  // guests sit at the top rather than being buried in an alphabetical list.
   if (topParam) {
     const topLimit = parseBoundedPositiveInt(topParam, DEFAULT_TOP_LIMIT);
     try {
-      const musicians = await services.musicians.findMany({ pagination: { limit: topLimit } });
+      const musicians = await services.musicians.findTopBySongCount(topLimit);
       logger.info(`Fetched top ${musicians.length} musicians`);
       return json(musicians, 200);
     } catch (error) {

--- a/apps/web/app/routes/api/musicians/$id.test.ts
+++ b/apps/web/app/routes/api/musicians/$id.test.ts
@@ -6,8 +6,9 @@ vi.mock("~/lib/base-loaders", () => ({
 }));
 
 const findById = vi.fn();
+const findBySlug = vi.fn();
 vi.mock("~/server/services", () => ({
-  services: { musicians: { findById } },
+  services: { musicians: { findById, findBySlug } },
 }));
 
 vi.mock("~/lib/logger", () => ({
@@ -24,23 +25,43 @@ function makeArgs(id: string | undefined): LoaderFunctionArgs & { context: unkno
   } as unknown as LoaderFunctionArgs & { context: unknown };
 }
 
+const MUSICIAN_UUID = "11111111-1111-1111-1111-111111111111";
+
 describe("GET /api/musicians/:id", () => {
   beforeEach(() => {
     findById.mockReset();
+    findBySlug.mockReset();
   });
 
-  test("returns the musician when found", async () => {
-    const musician = { id: "am", name: "Aron Magner", slug: "aron-magner", defaultInstrumentId: "keys-id" };
+  // A uuid-shaped param looks up by id (admin editors pre-fill this way).
+  test("looks up by id when the param is a uuid", async () => {
+    const musician = { id: MUSICIAN_UUID, name: "Aron Magner", slug: "aron-magner", defaultInstrumentId: "keys-id" };
     findById.mockResolvedValue(musician);
 
-    const response = (await loader(makeArgs("am"))) as Response;
+    const response = (await loader(makeArgs(MUSICIAN_UUID))) as Response;
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(musician);
+    expect(findById).toHaveBeenCalledWith(MUSICIAN_UUID);
+    expect(findBySlug).not.toHaveBeenCalled();
   });
 
-  test("returns 404 when no musician matches the id", async () => {
-    findById.mockResolvedValue(null);
+  // A non-uuid param looks up by slug — the shareable ?musician= filter
+  // pre-fills the picker this way.
+  test("looks up by slug when the param is not a uuid", async () => {
+    const musician = { id: MUSICIAN_UUID, name: "Aron Magner", slug: "aron-magner", defaultInstrumentId: "keys-id" };
+    findBySlug.mockResolvedValue(musician);
+
+    const response = (await loader(makeArgs("aron-magner"))) as Response;
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(musician);
+    expect(findBySlug).toHaveBeenCalledWith("aron-magner");
+    expect(findById).not.toHaveBeenCalled();
+  });
+
+  test("returns 404 when no musician matches", async () => {
+    findBySlug.mockResolvedValue(null);
 
     const response = (await loader(makeArgs("nobody"))) as Response;
 

--- a/apps/web/app/routes/api/musicians/$id.tsx
+++ b/apps/web/app/routes/api/musicians/$id.tsx
@@ -5,7 +5,13 @@ import { services } from "~/server/services";
 const json = (body: unknown, status: number) =>
   new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 // GET /api/musicians/:id - the picker's fetchById, used to pre-fill a selection.
+// Accepts either a musician id or a slug: admin editors pre-fill by id, while
+// the public "played by musician" filter pre-fills by the slug it carries in
+// the URL. A uuid-shaped param looks up by id (the id column rejects non-uuids),
+// anything else by the unique slug.
 export const loader = publicLoader(async ({ params }) => {
   const { id } = params;
 
@@ -14,7 +20,9 @@ export const loader = publicLoader(async ({ params }) => {
   }
 
   try {
-    const musician = await services.musicians.findById(id);
+    const musician = UUID_REGEX.test(id)
+      ? await services.musicians.findById(id)
+      : await services.musicians.findBySlug(id);
     if (!musician) {
       return json({ error: "Musician not found" }, 404);
     }

--- a/apps/web/app/routes/musicians/$slug.tsx
+++ b/apps/web/app/routes/musicians/$slug.tsx
@@ -35,7 +35,7 @@ interface ShowRow {
 interface LoaderData {
   musician: MusicianWithInstrument;
   tier: MusicianTier;
-  stats: { showCount: number; trackCount: number };
+  stats: { showCount: number; songCount: number };
   firstShow: MusicianAppearanceShow | null;
   lastShow: MusicianAppearanceShow | null;
   // Empty for core members (counts only); for drummers, shows outside their
@@ -58,7 +58,7 @@ export const loader = publicLoader(async ({ params }): Promise<LoaderData> => {
     ? await services.instruments.findById(musician.defaultInstrumentId)
     : null;
 
-  const { showIds, trackCount, firstShow, lastShow } = await services.musicians.findAppearances(musician.id);
+  const { showIds, songCount, firstShow, lastShow } = await services.musicians.findAppearances(musician.id);
   const tier = classifyMusician(slug);
 
   // Core members appear on essentially every show, so their tables are omitted;
@@ -96,7 +96,7 @@ export const loader = publicLoader(async ({ params }): Promise<LoaderData> => {
   return {
     musician: { ...musician, defaultInstrument },
     tier,
-    stats: { showCount: showIds.length, trackCount },
+    stats: { showCount: showIds.length, songCount },
     firstShow,
     lastShow,
     shows,
@@ -287,7 +287,7 @@ export default function MusicianPage() {
       <div className="space-y-8">
         <dl className="grid grid-cols-2 lg:grid-cols-4 gap-4">
           <StatBox label="Shows Played" value={stats.showCount} />
-          <StatBox label="Songs Played" value={stats.trackCount} />
+          <StatBox label="Songs Played" value={stats.songCount} />
           <PerformanceStatBox label="First Performance" show={firstShow} />
           <PerformanceStatBox label="Last Performance" show={lastShow} />
         </dl>

--- a/apps/web/app/routes/musicians/index.tsx
+++ b/apps/web/app/routes/musicians/index.tsx
@@ -65,7 +65,7 @@ const columns: ColumnDef<MusicianWithStats>[] = [
     header: ({ column }) => <SortableHeader column={column} label="Shows" />,
   },
   {
-    accessorKey: "trackCount",
+    accessorKey: "songCount",
     meta: { fixedWidth: "5rem", cellClassName: "tabular-nums" },
     header: ({ column }) => <SortableHeader column={column} label="Songs" />,
   },

--- a/apps/web/app/routes/on-this-day.$monthDay.tsx
+++ b/apps/web/app/routes/on-this-day.$monthDay.tsx
@@ -124,15 +124,8 @@ clientLoader.hydrate = true;
 const ALL_TIMERS_PAGE_SIZE = 10;
 
 export default function OnThisDay() {
-  const {
-    setlists,
-    performances,
-    displayLabel,
-    monthDay,
-    previousMonthDay,
-    nextMonthDay,
-    externalSources,
-  } = useSerializedLoaderData<LoaderData>();
+  const { setlists, performances, displayLabel, monthDay, previousMonthDay, nextMonthDay, externalSources } =
+    useSerializedLoaderData<LoaderData>();
 
   const {
     filteredData: filteredPerformances,
@@ -140,6 +133,7 @@ export default function OnThisDay() {
     selectedTimeRange,
     kindFilter,
     selectedAuthor,
+    selectedMusician,
     activeToggleSet,
     hasActiveFilters,
     searchText,
@@ -216,6 +210,7 @@ export default function OnThisDay() {
                     clearFilters={clearFilters}
                     kindFilter={kindFilter}
                     selectedAuthor={selectedAuthor}
+                    selectedMusician={selectedMusician}
                     showAllTimerToggle={false}
                     searchValue={searchText}
                     onSearchChange={setSearchText}

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -185,6 +185,7 @@ export default function SongPage() {
     filteredData: filteredPerformances,
     isLoading,
     selectedTimeRange,
+    selectedMusician,
     activeToggleSet,
     hasActiveFilters,
     searchText,
@@ -215,7 +216,7 @@ export default function SongPage() {
   // Server-narrowing filter active = any UI filter that affects the
   // performance set the server returned. Excludes `searchText` (client-only).
   // Used to render the Filtered Gap column in the performances table.
-  const hasServerNarrowingFilter = selectedTimeRange !== "all" || activeToggleSet.size > 0;
+  const hasServerNarrowingFilter = selectedTimeRange !== "all" || !!selectedMusician || activeToggleSet.size > 0;
   // Tab-specific noteworthy-toggle suppression: when the active tab is
   // already scoped to "all-timers" or "jam-charts", the matching chip
   // (and the chip that strictly subsets it) shouldn't reappear in the
@@ -225,6 +226,7 @@ export default function SongPage() {
   const renderFilterContent = (overrides?: { hideAllTimerToggle?: boolean; hideJamChartToggle?: boolean }) => (
     <PerformanceFilterControls
       selectedTimeRange={selectedTimeRange}
+      selectedMusician={selectedMusician}
       activeToggleSet={activeToggleSet}
       updateFilter={updateFilter}
       toggleFilter={toggleFilter}

--- a/packages/core/src/musicians/musician-service.test.ts
+++ b/packages/core/src/musicians/musician-service.test.ts
@@ -58,6 +58,30 @@ describe("MusicianService.create — dedupe by slug", () => {
   });
 });
 
+describe("MusicianService.findTopBySongCount", () => {
+  // The picker's default list surfaces the most-played musicians first (the
+  // core lineup + frequent guests) so the common picks aren't buried under an
+  // alphabetical list. Ties break alphabetically for a stable order.
+  test("orders by song count desc, breaking ties alphabetically, and caps at the limit", async () => {
+    const service = new MusicianService({} as never, logger);
+    vi.spyOn(service, "findAllWithStats").mockResolvedValue([
+      { id: "1", name: "Allen Aucoin", slug: "allen-aucoin", songCount: 5 },
+      { id: "2", name: "Marc Brownstein", slug: "marc-brownstein", songCount: 40 },
+      { id: "3", name: "Aron Magner", slug: "aron-magner", songCount: 40 },
+      { id: "4", name: "Sam Altman", slug: "sam-altman", songCount: 12 },
+    ] as never);
+
+    const result = await service.findTopBySongCount(3);
+
+    expect(result.map((m) => m.slug)).toEqual([
+      // 40 (Aron < Marc alphabetically), then 40, then 12 — Allen's 5 is cut.
+      "aron-magner",
+      "marc-brownstein",
+      "sam-altman",
+    ]);
+  });
+});
+
 describe("InstrumentService.create — dedupe by slug", () => {
   test("returns the existing instrument when the slug already exists, without creating", async () => {
     const existing = {
@@ -350,8 +374,7 @@ describe("MusicianService.findAppearances", () => {
   function makeAppearancesDb(args: {
     lineupShowIds: string[];
     presentDeltaShowIds: string[];
-    absentDeltaCount: number;
-    lineupTrackCount: number;
+    songCount: number;
     firstShowDate?: string;
     lastShowDate?: string;
   }) {
@@ -361,11 +384,9 @@ describe("MusicianService.findAppearances", () => {
       },
       trackMusician: {
         findMany: vi.fn(() => Promise.resolve(args.presentDeltaShowIds.map((showId) => ({ track: { showId } })))),
-        count: vi.fn(() => Promise.resolve(args.absentDeltaCount)),
       },
-      track: {
-        count: vi.fn(() => Promise.resolve(args.lineupTrackCount)),
-      },
+      // findAppearances counts distinct (song, show) via a raw query.
+      $queryRaw: vi.fn(() => Promise.resolve([{ song_count: BigInt(args.songCount) }])),
       show: {
         findFirst: vi.fn(({ orderBy }: { orderBy: { date: "asc" | "desc" } }) => {
           const date = orderBy.date === "asc" ? (args.firstShowDate ?? null) : (args.lastShowDate ?? null);
@@ -381,8 +402,7 @@ describe("MusicianService.findAppearances", () => {
     const db = makeAppearancesDb({
       lineupShowIds: ["show-1", "show-2"],
       presentDeltaShowIds: ["show-2", "show-3"],
-      absentDeltaCount: 0,
-      lineupTrackCount: 20,
+      songCount: 0,
     });
     const service = new MusicianService(db as never, logger);
 
@@ -391,28 +411,24 @@ describe("MusicianService.findAppearances", () => {
     expect([...result.showIds].sort()).toEqual(["show-1", "show-2", "show-3"]);
   });
 
-  test("track count is lineup tracks minus sat-outs plus sit-ins on non-lineup shows", async () => {
-    // 20 lineup tracks, 3 sat-outs, one sit-in on a lineup show (not added
-    // again) and one on a non-lineup show (added). 20 - 3 + 1 = 18.
+  test("song count comes from the distinct (song, show) query", async () => {
     const db = makeAppearancesDb({
       lineupShowIds: ["show-1"],
-      presentDeltaShowIds: ["show-1", "show-9"],
-      absentDeltaCount: 3,
-      lineupTrackCount: 20,
+      presentDeltaShowIds: ["show-9"],
+      songCount: 42,
     });
     const service = new MusicianService(db as never, logger);
 
     const result = await service.findAppearances("musician-1");
 
-    expect(result.trackCount).toBe(18);
+    expect(result.songCount).toBe(42);
   });
 
   test("surfaces first and last show dates from the appearance show set", async () => {
     const db = makeAppearancesDb({
       lineupShowIds: ["show-1"],
       presentDeltaShowIds: [],
-      absentDeltaCount: 0,
-      lineupTrackCount: 5,
+      songCount: 5,
       firstShowDate: "2003-04-12",
       lastShowDate: "2019-09-01",
     });

--- a/packages/core/src/musicians/musician-service.ts
+++ b/packages/core/src/musicians/musician-service.ts
@@ -273,32 +273,47 @@ export class MusicianService {
    * filter work.
    */
   async findAppearances(musicianId: string): Promise<MusicianAppearances> {
-    const [lineupRows, presentDeltas, absentDeltaCount, lineupTrackCount] = await Promise.all([
+    const [lineupRows, presentDeltas, songCountRows] = await Promise.all([
       this.db.showMusician.findMany({ where: { musicianId }, select: { showId: true } }),
       this.db.trackMusician.findMany({
         where: { musicianId, present: true },
         select: { track: { select: { showId: true } } },
       }),
-      this.db.trackMusician.count({ where: { musicianId, present: false } }),
-      this.db.track.count({ where: { show: { showMusicians: { some: { musicianId } } } } }),
+      // Distinct (song, show) the musician played on count_for_stats=true shows —
+      // the same "a song twice in one show counts once" math as Song.timesPlayed
+      // and the /musicians index, so the profile's "Songs Played" stays consistent.
+      this.db.$queryRaw<[{ song_count: bigint }]>`
+        WITH appearances AS (
+          SELECT t.show_id, t.song_id
+          FROM show_musicians sm
+          JOIN tracks t ON t.show_id = sm.show_id
+          WHERE sm.musician_id = ${musicianId}::uuid
+            AND NOT EXISTS (
+              SELECT 1 FROM track_musicians tm
+              WHERE tm.track_id = t.id AND tm.musician_id = ${musicianId}::uuid AND tm.present = false
+            )
+          UNION
+          SELECT t.show_id, t.song_id
+          FROM track_musicians tm
+          JOIN tracks t ON t.id = tm.track_id
+          WHERE tm.musician_id = ${musicianId}::uuid AND tm.present = true
+        )
+        SELECT COUNT(DISTINCT (a.song_id, a.show_id)) FILTER (WHERE s.count_for_stats) AS song_count
+        FROM appearances a
+        JOIN shows s ON s.id = a.show_id
+      `,
     ]);
 
     const lineupShowIds = lineupRows.map((row) => row.showId);
-    const lineupShowIdSet = new Set(lineupShowIds);
     const sitInShowIds = presentDeltas.map((delta) => delta.track.showId);
     const showIds = Array.from(new Set([...lineupShowIds, ...sitInShowIds]));
-
-    // Tracks of their lineup shows, minus their sat-outs, plus sit-ins on shows
-    // they were not in the lineup for (a sit-in on a lineup show is already
-    // counted by lineupTrackCount).
-    const sitInOnNonLineupCount = presentDeltas.filter((delta) => !lineupShowIdSet.has(delta.track.showId)).length;
-    const trackCount = lineupTrackCount - absentDeltaCount + sitInOnNonLineupCount;
+    const songCount = Number(songCountRows[0]?.song_count ?? 0);
 
     const [firstShow, lastShow] = showIds.length
       ? await Promise.all([this.findAppearanceShow(showIds, "asc"), this.findAppearanceShow(showIds, "desc")])
       : [null, null];
 
-    return { showIds, trackCount, firstShow, lastShow };
+    return { showIds, songCount, firstShow, lastShow };
   }
 
   /** Earliest/latest appearance show (with venue) for the first/last cards. */
@@ -323,9 +338,11 @@ export class MusicianService {
    * Every musician with their appearance aggregates in one query, for the
    * /musicians index table. A musician "plays" a track when they are in that
    * show's lineup and have no sat-out delta for the track, OR they have a
-   * present=true sit-in delta for it. Track count, distinct show count, and
-   * first/last show dates all derive from that single per-track predicate, so
-   * they agree with each other and with the per-musician findAppearances math.
+   * present=true sit-in delta for it. The song count counts distinct
+   * (song, show) pairs on count_for_stats=true shows — the same "a song played
+   * twice in one show counts once" math as Song.timesPlayed — so it never
+   * exceeds the per-song totals. Distinct show count and first/last dates span
+   * all of the musician's appearance shows.
    */
   async findAllWithStats(): Promise<MusicianWithStats[]> {
     const rows = await this.db.$queryRaw<
@@ -336,14 +353,14 @@ export class MusicianService {
         known_from: string | null;
         default_instrument_id: string | null;
         default_instrument_name: string | null;
-        track_count: bigint;
+        song_count: bigint;
         show_count: bigint;
         first_show_date: string | null;
         last_show_date: string | null;
       }>
     >`
       WITH appearances AS (
-        SELECT t.id AS track_id, t.show_id, sm.musician_id
+        SELECT t.show_id, t.song_id, sm.musician_id
         FROM show_musicians sm
         JOIN tracks t ON t.show_id = sm.show_id
         WHERE NOT EXISTS (
@@ -351,7 +368,7 @@ export class MusicianService {
           WHERE tm.track_id = t.id AND tm.musician_id = sm.musician_id AND tm.present = false
         )
         UNION
-        SELECT tm.track_id, t.show_id, tm.musician_id
+        SELECT t.show_id, t.song_id, tm.musician_id
         FROM track_musicians tm
         JOIN tracks t ON t.id = tm.track_id
         WHERE tm.present = true
@@ -359,7 +376,7 @@ export class MusicianService {
       stats AS (
         SELECT
           a.musician_id,
-          COUNT(*) AS track_count,
+          COUNT(DISTINCT (a.song_id, a.show_id)) FILTER (WHERE s.count_for_stats) AS song_count,
           COUNT(DISTINCT a.show_id) AS show_count,
           to_char(MIN(s.date::date), 'YYYY-MM-DD') AS first_show_date,
           to_char(MAX(s.date::date), 'YYYY-MM-DD') AS last_show_date
@@ -374,7 +391,7 @@ export class MusicianService {
         m.known_from,
         m.default_instrument_id,
         i.name AS default_instrument_name,
-        COALESCE(stats.track_count, 0) AS track_count,
+        COALESCE(stats.song_count, 0) AS song_count,
         COALESCE(stats.show_count, 0) AS show_count,
         stats.first_show_date,
         stats.last_show_date
@@ -390,11 +407,22 @@ export class MusicianService {
       slug: row.slug,
       knownFrom: row.known_from ?? null,
       defaultInstrumentName: row.default_instrument_name ?? null,
-      trackCount: Number(row.track_count),
+      songCount: Number(row.song_count),
       showCount: Number(row.show_count),
       firstShowDate: row.first_show_date,
       lastShowDate: row.last_show_date,
     }));
+  }
+
+  /**
+   * The most-played musicians first (song count desc, ties alphabetical), for
+   * the picker's default list — surfacing the core lineup and frequent guests
+   * ahead of one-off sit-ins. Reuses the findAllWithStats song-count metric so
+   * "how much a musician played" stays defined in one place.
+   */
+  async findTopBySongCount(limit: number): Promise<MusicianWithStats[]> {
+    const all = await this.findAllWithStats();
+    return all.sort((a, b) => b.songCount - a.songCount || a.name.localeCompare(b.name)).slice(0, limit);
   }
 
   /**

--- a/packages/core/src/page-composers/song-page-composer.test.ts
+++ b/packages/core/src/page-composers/song-page-composer.test.ts
@@ -380,6 +380,27 @@ describe("buildFilterQuery", () => {
     expect(sql).not.toContain("annotations");
   });
 
+  // The "played by musician" filter resolves to an EXISTS condition (not a
+  // JOIN — a JOIN over the bridge tables would multiply track rows). It must
+  // express lineup-minus-sat-outs OR sit-ins: a track counts when the
+  // musician is in the show lineup and has no sat-out delta, OR has a
+  // present=true delta on that track.
+  test("playedByMusicianId produces an EXISTS condition over the lineup and delta tables", () => {
+    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery([], {
+      playedByMusicianId: "11111111-1111-1111-1111-111111111111",
+    });
+
+    expect(conditions).toHaveLength(1);
+    expect(extraJoins).toHaveLength(0);
+    const sql = conditions[0].strings.join(" ");
+    // In-lineup branch over show_musicians, sat-out exclusion + sit-in branch
+    // over track_musicians (present), ORed together.
+    expect(sql).toContain("show_musicians");
+    expect(sql).toContain("track_musicians");
+    expect(sql).toContain("present");
+    expect(sql).toMatch(/EXISTS.*OR.*EXISTS/s);
+  });
+
   // The attended filter is special: it produces a JOIN (on the attendances
   // table) rather than a WHERE condition. Important because JOINs and
   // conditions are injected at different points in the SQL template.
@@ -481,6 +502,21 @@ describe("buildSongPerformanceCounts", () => {
     await composer.buildSongPerformanceCounts({ encore: true, segueIn: true });
 
     expect(mockDb.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  // The "Filtered Plays" count must count distinct SHOWS, matching
+  // Song.timesPlayed (which counts unique shows — a song played twice in one
+  // show counts once). Counting distinct tracks would let same-show repeats
+  // push a filtered count above the all-time total, which is impossible for a
+  // subset of those plays.
+  test("counts distinct shows, not distinct tracks, to stay consistent with timesPlayed", async () => {
+    const { composer, mockDb } = createComposer([]);
+
+    await composer.buildSongPerformanceCounts({ playedByMusicianId: "musician-1" });
+
+    const sql = (mockDb.$queryRaw.mock.calls[0][0] as readonly string[]).join("");
+    expect(sql).toContain("COUNT(DISTINCT tracks.show_id)");
+    expect(sql).not.toContain("COUNT(DISTINCT tracks.id)");
   });
 });
 
@@ -646,6 +682,7 @@ describe("isNarrowingFilter", () => {
     ["unfinished", { unfinished: true }],
     ["allTimer", { allTimer: true }],
     ["monthDay", { monthDay: "07-26" }],
+    ["playedByMusicianId", { playedByMusicianId: "musician-1" }],
   ])("returns true when %s is set", (_label, options) => {
     expect(isNarrowingFilter(options)).toBe(true);
   });

--- a/packages/core/src/page-composers/song-page-composer.ts
+++ b/packages/core/src/page-composers/song-page-composer.ts
@@ -50,6 +50,11 @@ export interface PerformanceFilterOptions {
   jamChart?: boolean;
   allTimer?: boolean;
   monthDay?: string;
+  /**
+   * Narrow to tracks a given musician played: in the show lineup with no
+   * sat-out delta, OR carrying a present=true sit-in delta on the track.
+   */
+  playedByMusicianId?: string;
 }
 
 export class SongPageComposer {
@@ -319,7 +324,10 @@ export class SongPageComposer {
 
   /**
    * Count matching performances per song, grouped by song_id.
-   * Used by /songs to show per-song counts when toggle filters are active.
+   * Used by /songs to show per-song counts when narrowing filters are active.
+   * Counts distinct SHOWS (not tracks) so the "Filtered Plays" value shares the
+   * all-time `Song.timesPlayed` semantic — unique shows, a song played twice in
+   * one show counting once — and so stays at or below the all-time total.
    */
   async buildSongPerformanceCounts(options?: PerformanceFilterOptions): Promise<Record<string, number>> {
     // Always exclude count_for_stats=false shows so the "filtered plays"
@@ -331,7 +339,7 @@ export class SongPageComposer {
     const extraJoinsSql = extraJoins.length > 0 ? Prisma.sql`${Prisma.join(extraJoins, "\n      ")}` : Prisma.empty;
 
     const rows = await this.db.$queryRaw<Array<{ song_id: string; count: string }>>`
-      SELECT tracks.song_id, COUNT(DISTINCT tracks.id)::text as count
+      SELECT tracks.song_id, COUNT(DISTINCT tracks.show_id)::text as count
       FROM tracks
       JOIN shows ON tracks.show_id = shows.id
       JOIN songs ON tracks.song_id = songs.id
@@ -521,6 +529,25 @@ export class SongPageComposer {
       o.unfinished
         ? {
             condition: Prisma.sql`EXISTS (SELECT 1 FROM track_flags WHERE track_flags.track_id = tracks.id AND track_flags.flag = 'UNFINISHED'::track_flag)`,
+          }
+        : null,
+    // "Played by musician": the track matches when the musician is in the
+    // show lineup AND has no sat-out delta on this track, OR has a sit-in
+    // (present=true) delta on this track. EXISTS (not a JOIN) so the track
+    // row isn't multiplied. Parenthesized — it contains a top-level OR.
+    playedByMusicianId: (o) =>
+      o.playedByMusicianId
+        ? {
+            condition: Prisma.sql`(
+              (
+                EXISTS (SELECT 1 FROM show_musicians sm
+                        WHERE sm.show_id = tracks.show_id AND sm.musician_id = ${o.playedByMusicianId}::uuid)
+                AND NOT EXISTS (SELECT 1 FROM track_musicians tm
+                        WHERE tm.track_id = tracks.id AND tm.musician_id = ${o.playedByMusicianId}::uuid AND tm.present = false)
+              )
+              OR EXISTS (SELECT 1 FROM track_musicians tm
+                        WHERE tm.track_id = tracks.id AND tm.musician_id = ${o.playedByMusicianId}::uuid AND tm.present = true)
+            )`,
           }
         : null,
   };
@@ -729,7 +756,8 @@ export function isNarrowingFilter(options: PerformanceFilterOptions | undefined)
       options.unfinished ||
       options.jamChart ||
       options.allTimer ||
-      options.monthDay,
+      options.monthDay ||
+      options.playedByMusicianId,
   );
 }
 

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -92,14 +92,14 @@ export const CacheKeys = {
     allTimersOnThisDay: (monthDay: string) => `songs:all-timers:on-this-day:${monthDay}:v5`,
     /** Every On-This-Day all-timer cache across all calendar days (for pattern deletion). */
     allTimersOnThisDayAll: () => "songs:all-timers:on-this-day:*",
-    /** Filtered song results by era/author/kind/tags/attended */
+    /** Filtered song results by era/author/kind/musician/tags/attended */
     filtered: (filters: CacheFilters) => {
       const filterHash = hashFilters(filters);
       const attendedUserId = filters.attended;
       if (attendedUserId) {
-        return `songs:filtered:user:${attendedUserId}:${filterHash}:v5`;
+        return `songs:filtered:user:${attendedUserId}:${filterHash}:v7`;
       }
-      return `songs:filtered:${filterHash}:v5`;
+      return `songs:filtered:${filterHash}:v7`;
     },
     /** All filtered song caches (for pattern deletion) */
     allFiltered: () => "songs:filtered:*",

--- a/packages/domain/src/models/musician.ts
+++ b/packages/domain/src/models/musician.ts
@@ -74,7 +74,7 @@ export type MusicianWithStats = {
   slug: string;
   knownFrom: string | null;
   defaultInstrumentName: string | null;
-  trackCount: number;
+  songCount: number;
   showCount: number;
   firstShowDate: string | null;
   lastShowDate: string | null;
@@ -93,7 +93,7 @@ export type MusicianAppearanceShow = {
 /** A musician's appearance summary for their profile header and tables. */
 export type MusicianAppearances = {
   showIds: string[];
-  trackCount: number;
+  songCount: number;
   firstShow: MusicianAppearanceShow | null;
   lastShow: MusicianAppearanceShow | null;
 };


### PR DESCRIPTION
Filter songs and performances by which musician played them. A **Musician**
dropdown now appears everywhere the Time Range filter does — the /songs index,
a song's performance list (e.g. /songs/i-man), All-Timers, Jam Charts, and On
This Day. Pick a player and the list narrows to their performances, with the
filtered columns (Filtered Plays / Gap) shown just like a time range. The URL
carries the readable slug (`?musician=sam-altman`) so a filtered view is
shareable, and the dropdown is ordered most-played-first.

This completes the "see what a given musician played" goal of the
musicians/performers feature (the structured lineup + sit-in data shipped
earlier); this PR makes it filterable across the app.

## Count corrections (standard site math everywhere)
Building the filter surfaced two places where musician/performance counts drifted
from the rest of the site, both fixed here:
- **Filtered Plays** on /songs counted distinct *tracks*, so same-show repeats
  could push it above the all-time Plays count (most visible for core members
  who play nearly everything). It now counts distinct *shows*, matching
  `Song.timesPlayed`.
- The **/musicians "Songs"** column and a profile's **"Songs Played"** counted
  raw track rows; they now count distinct `(song, show)` pairs on
  count_for_stats=true shows — the same "a song twice in one show counts once"
  math as the rest of the site.

## Notes for the reviewer
- The filter URL carries the musician **slug**, not an id. `parsePerformanceFilters`
  resolves slug→id (mirroring how `attended=<username>` resolves to a user id);
  the shared picker gained an optional `itemId` override and the `/api/musicians/:id`
  endpoint resolves either an id or a slug so the picker pre-fills from a shared link.
- The `songs:filtered` cache key was bumped (the `filteredTimesPlayed` semantic
  changed from distinct-tracks to distinct-shows).
- Musician is a per-performance predicate, so it routes through
  `buildSongPerformanceCounts` alongside the toggle chips; date range and
  attended still count through the song service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
