### PR TITLE
Mirror prod performer data, track flags, and completions in the local sync

### DIFF
--- a/MCP_README.md
+++ b/MCP_README.md
@@ -1,6 +1,6 @@
 # BIP MCP Server - User Guide
 
-The BIP setlist database is now available as a Model Context Protocol (MCP) server! This allows LLMs like Claude to directly query our comprehensive database of show information, setlists, songs, and venues.
+The BIP setlist database is available as a Model Context Protocol (MCP) server. This lets LLMs like Claude directly query our comprehensive database of show information, setlists, songs, and venues.
 
 ## What is MCP?
 
@@ -8,266 +8,324 @@ Model Context Protocol (MCP) is an open standard that allows AI assistants to se
 
 ## Requirements
 
-- Claude Pro, Team, Max, or Enterprise subscription (for remote MCP servers)
-- Or Claude Code (supports MCP)
+- Claude Pro, Team, Max, or Enterprise subscription (for remote MCP servers), or
+- Claude Code, Cursor, or any other MCP-capable client
+
+The server is public and read-only — no account, API key, or authentication is required.
 
 ## Setup
 
-### For Claude Desktop
+The server endpoint is `https://discobiscuits.net/mcp` (HTTP transport).
 
-Add the BIP MCP server to your Claude Desktop configuration:
+### Claude Code (CLI)
 
-**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+```bash
+claude mcp add discobiscuits --transport http https://discobiscuits.net/mcp
+```
+
+### Claude Desktop
+
+Add the server to your config file:
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
 
 ```json
 {
   "mcpServers": {
-    "bip-setlist": {
-      "url": "https://biscuits.app/mcp",
-      "transport": "http"
+    "discobiscuits": {
+      "type": "http",
+      "url": "https://discobiscuits.net/mcp"
     }
   }
 }
 ```
 
-### For Claude Code
+Restart Claude Desktop to enable the server.
 
-```bash
-claude mcp add https://biscuits.app/mcp --transport http
-```
+### Cursor
+
+Add the same block to `.cursor/mcp.json`, or use **Settings → Features → MCP Servers → Add Server** with type `HTTP` and URL `https://discobiscuits.net/mcp`.
 
 ## Available Tools
 
-The MCP server provides 14 specialized tools for querying the setlist database:
+The server exposes 23 tools: 17 for querying the database (below) and 6 internal Sync / Replication tools (documented at the end of this section) used to mirror prod into local dev environments.
 
 ### 🔍 Search Tools
 
 #### `search_shows`
-Search for shows by song names, venue, date, or any combination.
 
-**Example queries:**
-- "fillmore swell" - Shows at Fillmore featuring Swell
-- "12/30/99" - Shows on December 30, 1999
-- "red rocks 2022" - Shows at Red Rocks in 2022
+Search for shows by song, venue, date, or any combination.
+
+**Input:** `query` (required), `limit` (default 50, max 100)
+
+**Returns:** `results`, each `{ slug, date, venue, location }`.
+
+**Example queries:** "fillmore swell", "12/30/99", "red rocks 2022"
 
 #### `search_songs`
+
 Search the song catalog by title.
 
-**Example:** "basis", "shimmy"
+**Input:** `query` (required), `limit` (default 50)
+
+**Returns:** `results`, each `{ slug, title, author }`.
 
 #### `search_venues`
+
 Find venues by name, city, state, or country.
 
-**Example:** "fillmore", "colorado venues", "red rocks"
+**Input:** `query` (required), `limit` (default 50)
+
+**Returns:** `results`, each `{ slug, name, city, state }`.
 
 #### `search_segues`
-Find specific song sequences using ">" notation.
 
-**Example:** "Shimmy > Basis > Woody"
+Find specific song sequences using `>` notation.
+
+**Input:** `sequence` (required, e.g. "Shimmy > Basis > Woody"), `venueFilter` (optional)
+
+**Returns:** `results`, each `{ showSlug, showDate, venueName, set, matchedSequence }`.
 
 #### `search_by_date`
+
 Find shows by exact date, month, or year.
 
-**Examples:**
-- Exact: "12/30/1999"
-- Month: "December"
-- Year: "1999"
+**Input:** `date` (required, e.g. "1999-12-31", "1999-12", "1999"), `dateType` (required: `exact` | `month` | `year`)
+
+**Returns:** `results`, each `{ slug, date, venueName, venueCity }`.
 
 ### 📊 Data Retrieval Tools
 
-#### `get_shows`
-Get detailed information for multiple shows at once.
+#### `get_setlist`
 
-**Input:** Array of show slugs (e.g., ["1999-12-30", "2000-01-01"])
+Get a single show's setlist in a compact, human-readable shape.
 
-**Returns:** Show metadata including venue, ratings, counts
+**Input:** `slug` (required, e.g. "1999-12-31")
 
-#### `get_songs`
-Get detailed song information including lyrics, tabs, and history.
-
-**Input:** Array of song slugs
-
-**Returns:** Full song details, play statistics, author info
-
-#### `get_venues`
-Get venue details including location and show history.
-
-**Input:** Array of venue slugs
-
-**Returns:** Venue information with contact details and coordinates
+**Returns:** `{ date, venue, location, sets }` — each set `{ name, tracks }`, each track `{ position, song, segue, notes }`. For the full structured payload (ids, performer lineup, flags, completions), use `get_setlists`.
 
 #### `get_setlists`
-Get complete setlists organized by sets.
 
-**Input:** Array of show slugs
+Get complete setlists for multiple shows at once, with the full structured payload.
 
-**Returns:** Full setlists with songs, segues, notes, and annotations
+**Input:** `showSlugs` (required, array of show slugs)
+
+**Returns:** `setlists`, each with `showSlug`, `showDate`, `venue`, and `sets`. Per track: `id`, `position`, `songTitle`, `songSlug`, `segue`, `note`, `allTimer`, `duration`, `durationSource`, `annotations`, plus the structured performer data the local sync mirrors:
+
+- `lineup` (per show): the whole-show performer lineup — each member `{ musicianSlug, musicianName, knownFrom, defaultInstrument, instruments }`, with musicians and instruments carried by slug (the stable cross-environment id) plus name.
+- `trackMusicians` (per track): sit-in / sat-out deltas `{ musicianSlug, musicianName, present, defaultInstrument, instruments }` (`present: true` = sit-in, `false` = sat-out).
+- `flags` (per track): structured flag enum names (e.g. `DYSLEXIC`, `INVERTED`, `UNFINISHED`, `ENDING_ONLY`). Derived recurrence columns are excluded — the consumer recomputes them.
+- `completes` (per track): completion links where this is the later (completing) track, each pointing at the earlier track by natural key `{ showSlug, set, position }`.
+
+Unknown slugs come back in an `errors` array.
+
+#### `get_song`
+
+Get a single song's lyrics and headline play info.
+
+**Input:** `slug` (required)
+
+**Returns:** `{ title, author, lyrics, notes, timesPlayed, debut, lastPlayed }`. Use `get_songs` for the full curated field set.
+
+#### `get_songs`
+
+Get detailed information for multiple songs at once.
+
+**Input:** `slugs` (required, array of song slugs)
+
+**Returns:** `songs`, each with `slug`, `title`, `author`, `lyrics`, `timesPlayed`, `dateFirstPlayed`, `dateLastPlayed`, plus the curated admin fields `kind` (original / cover / mashup / improvisation), `legacyAuthor`, `featuredLyric`, `tabs`, `notes`, `history`, and `guitarTabsUrl`. Unknown slugs come back in an `errors` array.
+
+#### `get_shows`
+
+Get detailed information for multiple shows at once.
+
+**Input:** `slugs` (required, array of show slugs, e.g. ["1999-12-30", "2000-01-01"])
+
+**Returns:** `shows`, each with `id`, `slug`, `date`, `venueName`, `venueCity`, `averageRating`, `ratingsCount`, `notes`, `relistenUrl`, the admin-curated stat flags `countForStats` and `dayOrder`, and `rockOperaSlugs` (full-album performances tagged on the show). Unknown slugs come back in an `errors` array.
+
+#### `get_venues`
+
+Get venue details including location and contact info.
+
+**Input:** `slugs` (required, array of venue slugs)
+
+**Returns:** `venues`, each with `slug`, `name`, `city`, `state`, `country`, `timesPlayed`, and the geocode/contact columns `street`, `postalCode`, `phone`, `website`, `latitude`, `longitude`. Unknown slugs come back in an `errors` array.
+
+#### `get_rock_operas`
+
+List the rock operas / full-album performances the catalog tracks.
+
+**Input:** None
+
+**Returns:** `rockOperas`, each `{ slug, name, shortName }`. The slugs match `rockOperaSlugs` from `get_shows`.
 
 #### `get_song_performances`
+
 Get all performances of a specific song across all shows.
 
-**Input:** Song slug, optional limit and sort preferences
+**Input:** `songSlug` (required), `limit` (default 50, max 500), `sortBy` (`date` | `rating`, default `date`)
 
-**Returns:** List of shows where the song was played with ratings and context
+**Returns:** `{ song, performances }` — each performance `{ showSlug, showDate, venueName, venueCity, set, position, averageRating, allTimer }`.
 
 ### 📈 Analytics Tools
 
 #### `get_trending_songs`
+
 See which songs have been played most frequently in recent shows.
 
-**Input:** Number of recent shows to analyze (default: 50)
+**Input:** `lastXShows` (default 50, max 200), `limit` (default 50, max 100)
 
-**Returns:** Songs sorted by play frequency
+**Returns:** `songs`, each `{ slug, title, playCount, lastPlayed }`.
 
 #### `get_song_statistics`
-Get detailed analytics for any song.
 
-**Input:** Song slug
+Get detailed analytics for a song.
 
-**Returns:**
-- Times played
-- First/last played dates
-- Yearly play data
-- Longest gaps between performances
-- Most/least common years
+**Input:** `songSlug` (required)
+
+**Returns:** `{ song, statistics }` — statistics include `timesPlayed`, `dateFirstPlayed`, `dateLastPlayed`, `yearlyPlayData`, `longestGapsData`, `mostCommonYear`, `leastCommonYear`.
 
 #### `get_venue_history`
+
 Get all shows performed at a specific venue.
 
-**Input:** Venue slug, optional limit and sort
+**Input:** `venueSlug` (required), `limit` (default 50, max 500), `sortBy` (`date` | `rating`, default `date`)
 
-**Returns:** List of shows at that venue with dates and ratings
+**Returns:** `{ venue, shows }` — each show `{ slug, date, averageRating, ratingsCount }`.
 
 #### `get_shows_by_year`
+
 List all shows from a specific year.
 
-**Input:** Year (e.g., 1999)
+**Input:** `year` (required), `limit` (default 50, max 500), `sortBy` (`date` | `rating`, default `date`)
 
-**Returns:** All shows from that year with venue info and ratings
+**Returns:** `{ year, shows }` — each show `{ slug, date, venueName, venueCity, averageRating }`.
+
+### 🔄 Sync / Replication Tools (internal)
+
+These tools mirror prod's user-activity tables into local dev databases (see `packages/core/scripts/sync-missing-shows.ts`); they are not meant for general LLM querying. They expose a PII-free projection only — the service-layer `select` allowlist enforces the shape.
+
+#### `list_users_since`, `list_ratings_since`, `list_attendances_since`
+
+Cursor-paginated pulls of rows changed since a timestamp.
+
+**Input:** `since` (required, ISO-8601 timestamp), `cursor` (optional, opaque base64 of `updatedAt|id`), `limit` (default 2000, max 5000)
+
+**Returns:** A `users` / `ratings` / `attendances` array plus `nextCursor` (null when the page isn't full). Users carry no email or password — only the fields needed to attach activity (`id`, `username`, avatar references, timestamps). Ratings carry `id`, `userId`, `value`, `rateableType`, `rateableId`, timestamps; attendances carry `id`, `userId`, `showId`, timestamps.
+
+#### `list_all_user_ids`, `list_all_rating_ids`, `list_all_attendance_ids`
+
+Full id dumps used by the sync's `--full-users` / prune reconcile to delete local rows no longer present on prod.
+
+**Input:** None
+
+**Returns:** `{ ids: string[] }`
 
 ## Example Queries
 
 Once configured, you can ask Claude questions like:
 
 ### Show Information
+
 - "Show me the setlist from the 12/30/99 show"
 - "Find all shows at the Fillmore in 1999 where they played Swell"
 - "What were the highest rated shows in 2022?"
 
 ### Song Information
+
 - "What are the lyrics to 'Basis'?"
 - "When was the last time they played 'Aceetobee'?"
 - "Show me all performances of 'Swell' sorted by rating"
 - "What songs have been trending in the last 50 shows?"
 
 ### Venue Information
+
 - "What venues in Colorado have they played?"
 - "Show me all shows at Red Rocks"
 - "Find venues in Philadelphia"
 
 ### Advanced Queries
+
 - "Find all shows where they played 'Shimmy > Basis > Woody'"
 - "What are the song statistics for 'The Devil's Waltz'?"
 - "List all shows from 1999 sorted by rating"
 - "Get me the setlists for both 12/30/99 and 12/31/99"
 
 ### Cross-referencing
+
 - "Compare the setlists from the top 3 rated shows in 2023"
 - "What songs appeared in multiple shows at the Fillmore in 1999?"
 - "Show me lyrics for all songs that were trending in 2022"
 
-## API Endpoints
+## Protocol
 
-For developers, all tools are accessible as HTTP POST endpoints:
+The server speaks [JSON-RPC 2.0](https://www.jsonrpc.org/specification) over a single HTTP endpoint:
 
-```bash
-# Base URL
-https://biscuits.app/mcp/
-
-# Endpoints
-POST /mcp/search-shows
-POST /mcp/search-songs
-POST /mcp/search-venues
-POST /mcp/search-segues
-POST /mcp/search-by-date
-POST /mcp/get-shows
-POST /mcp/get-songs
-POST /mcp/get-venues
-POST /mcp/get-setlists
-POST /mcp/get-song-performances
-POST /mcp/get-trending-songs
-POST /mcp/get-song-statistics
-POST /mcp/get-venue-history
-POST /mcp/get-shows-by-year
+```text
+POST https://discobiscuits.net/mcp
 ```
 
-### Example API Call
+(A `GET` on the same URL returns server identity metadata.)
+
+Three methods are supported:
+
+- `initialize` — handshake; returns `protocolVersion`, `capabilities`, and `serverInfo`.
+- `tools/list` — returns the full `tools` array with names, descriptions, and input schemas.
+- `tools/call` — invokes a tool. `params` is `{ name, arguments }`, where `arguments` matches the tool's input schema.
+
+A `tools/call` result wraps the tool's JSON payload as text:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "content": [{ "type": "text", "text": "{ ...the tool's JSON output... }" }]
+  }
+}
+```
+
+On a tool error the same shape is returned with `"isError": true` and an `Error: …` message in the text.
+
+### Example Call
 
 ```bash
-curl -X POST https://biscuits.app/mcp/search-shows \
+curl -X POST https://discobiscuits.net/mcp \
   -H "Content-Type: application/json" \
   -d '{
-    "query": "fillmore swell",
-    "limit": 10
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "search_shows",
+      "arguments": { "query": "red rocks 2022", "limit": 10 }
+    }
   }'
 ```
 
 ## Data Coverage
 
 The database includes:
+
 - **2,400+** shows dating back to the 1990s
 - **700+** songs including lyrics, tabs, and history
 - **500+** venues worldwide
-- Complete setlists with song positions and segues
-- User ratings and reviews
-- Show photos and videos
+- Complete setlists with song positions, segues, and per-track performer/flag/completion data
+- User ratings and attendance
 - Annotations and performance notes
-
-## Response Format
-
-All endpoints return JSON with consistent formatting:
-
-```json
-{
-  "results": [...],
-  // or
-  "shows": [...],
-  "songs": [...],
-  etc.
-}
-```
-
-Errors are returned with descriptive messages:
-
-```json
-{
-  "error": "Description of error",
-  "details": "Additional context"
-}
-```
 
 ## Rate Limits
 
-Currently no rate limits are enforced, but please use the API responsibly. If you're building an integration, consider caching responses.
-
-## Support
-
-Questions or issues?
-- GitHub: [bip-turbo repository](https://github.com/...)
-- Contact: [Your contact info]
+No rate limits are currently enforced, but please use the server responsibly. If you're building an integration, consider caching responses.
 
 ## Privacy
 
-The MCP server only accesses publicly available show and song data. No user account information is exposed through these endpoints.
+The query tools expose only publicly available show, song, and venue data. The Sync / Replication tools expose a deliberately PII-free user projection (id, username, avatar reference, timestamps) plus ratings and attendance rows — no emails, passwords, or other account details are ever returned.
 
-## Future Enhancements
+## Support
 
-Planned features:
-- SSE (Server-Sent Events) support for streaming responses
-- Authentication for API access
-- Webhooks for new show announcements
-- Advanced filtering and aggregation tools
+Questions or issues? Open an issue on the [bip-turbo repository](https://github.com/biscuits-internet-project/bip-turbo).
 
 ---
 

--- a/apps/web/app/routes/mcp/index.tsx
+++ b/apps/web/app/routes/mcp/index.tsx
@@ -1,8 +1,26 @@
+import type { Instrument, TrackMusicianDelta } from "@bip/domain";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { services } from "~/server/services";
 
 // MCP JSON-RPC Protocol Handler
 // Implements Model Context Protocol for Claude Code and other MCP clients
+
+// Performer wire mappers for get_setlists. Musicians + instruments travel by
+// slug (the stable cross-environment id) plus name, so sync-missing-shows can
+// resolve an existing row or seed a missing one idempotently.
+function instrumentToWire(instrument: Instrument | null): { slug: string; name: string } | null {
+  return instrument ? { slug: instrument.slug, name: instrument.name } : null;
+}
+
+function mapDeltaToWire(delta: TrackMusicianDelta) {
+  return {
+    musicianSlug: delta.musician.slug,
+    musicianName: delta.musician.name,
+    present: delta.present,
+    defaultInstrument: instrumentToWire(delta.musician.defaultInstrument),
+    instruments: delta.instruments.map((i) => ({ slug: i.slug, name: i.name })),
+  };
+}
 
 interface JsonRpcRequest {
   jsonrpc: "2.0";
@@ -589,10 +607,28 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
               list.push(ann.desc ?? "");
               annotationsByTrackId.set(ann.trackId, list);
             }
+            // Per-track musician deltas (sit-ins / sat-outs). Grouped by trackId
+            // so each track carries its own; sync's diffTrackMusicians replaces
+            // local-by-trackId. Musicians + instruments travel by slug (stable
+            // cross-env id) plus name (so sync can seed a missing row).
+            const trackMusiciansByTrackId = new Map<string, ReturnType<typeof mapDeltaToWire>[]>();
+            for (const delta of setlist.trackMusicianDeltas) {
+              const list = trackMusiciansByTrackId.get(delta.trackId) ?? [];
+              list.push(mapDeltaToWire(delta));
+              trackMusiciansByTrackId.set(delta.trackId, list);
+            }
             setlists.push({
               showSlug: setlist.show.slug,
               showDate: setlist.show.date,
               venue: { name: setlist.venue.name, city: setlist.venue.city, state: setlist.venue.state },
+              // Whole-show performer lineup. Sync's diffShowMusicians mirrors it.
+              lineup: setlist.lineup.map((member) => ({
+                musicianSlug: member.musician.slug,
+                musicianName: member.musician.name,
+                knownFrom: member.musician.knownFrom,
+                defaultInstrument: instrumentToWire(member.musician.defaultInstrument),
+                instruments: member.instruments.map((i) => ({ slug: i.slug, name: i.name })),
+              })),
               sets: setlist.sets.map((set) => ({
                 label: set.label,
                 tracks: set.tracks.map((t) => ({
@@ -616,6 +652,17 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
                   duration: t.duration ?? null,
                   durationSource: t.durationSource ?? null,
                   annotations: annotationsByTrackId.get(t.id) ?? [],
+                  // Structured flags (enum names) — sync's diffTrackFlags
+                  // mirrors them; the derived recurrence columns stay local.
+                  flags: t.flags,
+                  trackMusicians: trackMusiciansByTrackId.get(t.id) ?? [],
+                  // Completion links where this is the later (completing) track.
+                  // The earlier track travels by natural key (slug/set/position)
+                  // so sync resolves it even across id drift. completionShowsFromDb
+                  // only populates set/position on `completes`, so both are present.
+                  completes: t.completes
+                    .filter((c) => c.set !== undefined && c.position !== undefined)
+                    .map((c) => ({ showSlug: c.slug, set: c.set as string, position: c.position as number })),
                 })),
               })),
             });

--- a/packages/core/scripts/sync-missing-shows.test.ts
+++ b/packages/core/scripts/sync-missing-shows.test.ts
@@ -11,7 +11,12 @@ import {
   buildVenueDriftUpdate,
   collectSongSlugs,
   collectVenueKeys,
+  diffCompletions,
+  diffShowMusicians,
   diffTrackAnnotations,
+  diffTrackFlags,
+  diffTrackMusicians,
+  resolveCompletionLinks,
   isStubSlug,
   matchVenue,
   parseYearsArg,
@@ -1677,6 +1682,196 @@ describe("buildRockOperaAssignmentDiff", () => {
   });
 });
 
+// diffShowMusicians mirrors a show's lineup the way diffTrackAnnotations
+// mirrors annotations: identity by musician slug (the
+// stable cross-env id), replace-not-merge, `undefined` = no opinion. The wrinkle
+// is the second level — the instruments each musician played — which is diffed
+// per retained musician so an unchanged re-run produces zero instrument writes.
+describe("diffShowMusicians", () => {
+  // Canonical case: prod adds Aron on keys, drops Marc. Sammy stays but picks
+  // up a second instrument. Create Aron, delete Marc's row, add the new
+  // instrument to Sammy without recreating his lineup row.
+  test("returns create/delete plus per-musician instrument deltas", () => {
+    const local = [
+      { showMusicianId: "sm-marc", musicianSlug: "marc-brownstein", instrumentSlugs: ["bass"] },
+      { showMusicianId: "sm-sammy", musicianSlug: "sam-altman", instrumentSlugs: ["drums"] },
+    ];
+    const remote = [
+      { musicianSlug: "sam-altman", instrumentSlugs: ["drums", "percussion"] },
+      { musicianSlug: "aron-magner", instrumentSlugs: ["keys"] },
+    ];
+    expect(diffShowMusicians(local, remote)).toEqual({
+      toCreate: [{ musicianSlug: "aron-magner", instrumentSlugs: ["keys"] }],
+      toDeleteShowMusicianIds: ["sm-marc"],
+      toUpdateInstruments: [{ showMusicianId: "sm-sammy", addInstrumentSlugs: ["percussion"], removeInstrumentSlugs: [] }],
+    });
+  });
+
+  // No drift: same musicians + instruments in any order. Zero ops keeps a
+  // re-run from churning row ids or updatedAt on the lineup.
+  test("returns empty deltas when local matches remote (order-insensitive)", () => {
+    const local = [{ showMusicianId: "sm-1", musicianSlug: "jon-gutwillig", instrumentSlugs: ["guitar", "vocals"] }];
+    const remote = [{ musicianSlug: "jon-gutwillig", instrumentSlugs: ["vocals", "guitar"] }];
+    expect(diffShowMusicians(local, remote)).toEqual({
+      toCreate: [],
+      toDeleteShowMusicianIds: [],
+      toUpdateInstruments: [],
+    });
+  });
+
+  // Pre-deploy MCP omits lineup entirely → no opinion, never wipe local.
+  test("returns empty deltas when remote is undefined", () => {
+    const local = [{ showMusicianId: "sm-1", musicianSlug: "jon-gutwillig", instrumentSlugs: ["guitar"] }];
+    expect(diffShowMusicians(local, undefined)).toEqual({
+      toCreate: [],
+      toDeleteShowMusicianIds: [],
+      toUpdateInstruments: [],
+    });
+  });
+
+  // Explicit empty array means prod cleared the lineup — delete every local row.
+  test("deletes all lineup rows when remote is explicitly empty", () => {
+    const local = [
+      { showMusicianId: "sm-1", musicianSlug: "jon-gutwillig", instrumentSlugs: ["guitar"] },
+      { showMusicianId: "sm-2", musicianSlug: "marc-brownstein", instrumentSlugs: ["bass"] },
+    ];
+    expect(diffShowMusicians(local, [])).toEqual({
+      toCreate: [],
+      toDeleteShowMusicianIds: ["sm-1", "sm-2"],
+      toUpdateInstruments: [],
+    });
+  });
+});
+
+// diffTrackMusicians is diffShowMusicians plus a `present` boolean (sit-in vs
+// sat-out). A flipped `present` on a retained musician is an update, not a
+// delete+create, so the row id survives.
+describe("diffTrackMusicians", () => {
+  // Sammy was a sat-out (present=false), prod now records him as a sit-in
+  // (present=true) on drums. Patch present, no row churn.
+  test("patches present when a retained musician's sit-in/sat-out flips", () => {
+    const local = [{ trackMusicianId: "tm-sammy", musicianSlug: "sam-altman", present: false, instrumentSlugs: [] }];
+    const remote = [{ musicianSlug: "sam-altman", present: true, instrumentSlugs: ["drums"] }];
+    expect(diffTrackMusicians(local, remote)).toEqual({
+      toCreate: [],
+      toDeleteTrackMusicianIds: [],
+      toUpdate: [{ trackMusicianId: "tm-sammy", present: true, addInstrumentSlugs: ["drums"], removeInstrumentSlugs: [] }],
+    });
+  });
+
+  // New sit-in inserted, stale delta removed, untouched delta produces nothing.
+  test("creates new deltas and deletes ones prod dropped", () => {
+    const local = [{ trackMusicianId: "tm-old", musicianSlug: "allen-aucoin", present: true, instrumentSlugs: ["drums"] }];
+    const remote = [{ musicianSlug: "sam-altman", present: true, instrumentSlugs: ["drums"] }];
+    expect(diffTrackMusicians(local, remote)).toEqual({
+      toCreate: [{ musicianSlug: "sam-altman", present: true, instrumentSlugs: ["drums"] }],
+      toDeleteTrackMusicianIds: ["tm-old"],
+      toUpdate: [],
+    });
+  });
+
+  // No drift → no ops; omits `present` from the update when only instruments
+  // (here: nothing) would change.
+  test("returns empty deltas when local matches remote", () => {
+    const local = [{ trackMusicianId: "tm-1", musicianSlug: "sam-altman", present: true, instrumentSlugs: ["drums"] }];
+    const remote = [{ musicianSlug: "sam-altman", present: true, instrumentSlugs: ["drums"] }];
+    expect(diffTrackMusicians(local, remote)).toEqual({ toCreate: [], toDeleteTrackMusicianIds: [], toUpdate: [] });
+  });
+
+  test("returns empty deltas when remote is undefined", () => {
+    const local = [{ trackMusicianId: "tm-1", musicianSlug: "sam-altman", present: true, instrumentSlugs: ["drums"] }];
+    expect(diffTrackMusicians(local, undefined)).toEqual({ toCreate: [], toDeleteTrackMusicianIds: [], toUpdate: [] });
+  });
+});
+
+// diffTrackFlags is the diffTrackAnnotations contract over the flag enum names.
+describe("diffTrackFlags", () => {
+  test("returns the add/remove delta to reach the remote flag set", () => {
+    expect(diffTrackFlags(["DYSLEXIC"], ["DYSLEXIC", "INVERTED"])).toEqual({ toAdd: ["INVERTED"], toRemove: [] });
+    expect(diffTrackFlags(["DYSLEXIC", "UNFINISHED"], ["DYSLEXIC"])).toEqual({ toAdd: [], toRemove: ["UNFINISHED"] });
+  });
+
+  test("returns empty deltas when remote is undefined (pre-deploy MCP)", () => {
+    expect(diffTrackFlags(["DYSLEXIC"], undefined)).toEqual({ toAdd: [], toRemove: [] });
+  });
+
+  test("removes all flags when remote is explicitly empty", () => {
+    expect(diffTrackFlags(["DYSLEXIC", "INVERTED"], [])).toEqual({ toAdd: [], toRemove: ["DYSLEXIC", "INVERTED"] });
+  });
+});
+
+// Completions cross shows and reference tracks by natural key. resolveCompletionLinks
+// turns the (slug,set,position) endpoints into local track ids, dropping links
+// whose other end isn't in the synced scope; diffCompletions then computes the
+// upsert/delete set keyed by the UNIQUE earlier track.
+describe("resolveCompletionLinks", () => {
+  const keyMap = new Map([
+    ["2026-01-01-show|S1|3", "track-earlier"],
+    ["2026-01-01-show|S2|1", "track-later"],
+  ]);
+
+  // Both endpoints local → resolved to their local track ids.
+  test("resolves links whose both endpoints are local", () => {
+    const links = [
+      {
+        later: { showSlug: "2026-01-01-show", set: "S2", position: 1 },
+        earlier: { showSlug: "2026-01-01-show", set: "S1", position: 3 },
+      },
+    ];
+    expect(resolveCompletionLinks(links, keyMap)).toEqual({
+      resolved: [{ earlierTrackId: "track-earlier", laterTrackId: "track-later" }],
+      skipped: [],
+    });
+  });
+
+  // Earlier track in an un-synced show → skipped, never a dangling FK.
+  test("skips links whose earlier track is out of scope", () => {
+    const links = [
+      {
+        later: { showSlug: "2026-01-01-show", set: "S2", position: 1 },
+        earlier: { showSlug: "1999-12-31-other", set: "S1", position: 5 },
+      },
+    ];
+    expect(resolveCompletionLinks(links, keyMap)).toEqual({ resolved: [], skipped: links });
+  });
+});
+
+describe("diffCompletions", () => {
+  // Re-point: the earlier track already has a completer locally, prod moved it
+  // to a different later track. Keyed by earlierTrackId, that's an upsert (one
+  // entry), not a second insert that would violate the unique constraint.
+  test("upserts a re-pointed completion rather than duplicating it", () => {
+    const local = [{ earlierTrackId: "e1", laterTrackId: "old-later" }];
+    const desired = [{ earlierTrackId: "e1", laterTrackId: "new-later" }];
+    expect(diffCompletions(local, desired)).toEqual({
+      toUpsert: [{ earlierTrackId: "e1", laterTrackId: "new-later" }],
+      toDeleteEarlierTrackIds: [],
+    });
+  });
+
+  // A chain A→B→C: B completes A, C completes B. Two distinct earlier tracks,
+  // two upserts, nothing deleted.
+  test("upserts each link of a completion chain independently", () => {
+    const desired = [
+      { earlierTrackId: "track-a", laterTrackId: "track-b" },
+      { earlierTrackId: "track-b", laterTrackId: "track-c" },
+    ];
+    expect(diffCompletions([], desired)).toEqual({ toUpsert: desired, toDeleteEarlierTrackIds: [] });
+  });
+
+  // Prod dropped a completion that exists locally → delete by earlier track id.
+  test("deletes local completions prod no longer reports", () => {
+    const local = [{ earlierTrackId: "e1", laterTrackId: "l1" }];
+    expect(diffCompletions(local, [])).toEqual({ toUpsert: [], toDeleteEarlierTrackIds: ["e1"] });
+  });
+
+  // No drift → no ops.
+  test("returns empty deltas when local matches desired", () => {
+    const same = [{ earlierTrackId: "e1", laterTrackId: "l1" }];
+    expect(diffCompletions(same, same)).toEqual({ toUpsert: [], toDeleteEarlierTrackIds: [] });
+  });
+});
+
 // buildSongDriftUpdate diffs an existing local Song row against the latest
 // MCP response and returns a patch — only the curated admin fields (title,
 // lyrics, cover, legacyAuthor, featuredLyric, tabs, notes, history,
@@ -2533,6 +2728,142 @@ describe("syncUserActivity — compound-key upserts", () => {
     expect(state.ratings).toHaveLength(1);
     expect(state.ratings[0].id).toBe("r-local-stale-id");
     expect(state.ratings[0].value).toBe(5);
+  });
+});
+
+// The show-id-drift fix: prod ratings/attendances reference prod's show/track
+// id, but a local show seeded from an old dump can carry a DIFFERENT id under
+// the same slug. The show/track passes build prodShowIdToLocalId /
+// prodTrackIdToLocalId; the user-activity loops resolve through them before the
+// FK check + upsert, mirroring the existing user prodIdToLocalId remap. Without
+// it, the rating/attendance FK-skips against the prod id that isn't local.
+describe("syncUserActivity — show/track id-drift remap", () => {
+  const driftUser = (): StubUserRow => ({
+    id: "u-marc",
+    email: "stub-u-marc@local.invalid",
+    passwordDigest: "STUB",
+    username: "trance-marc",
+    avatarFileId: null,
+    avatarFileUrl: null,
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    updatedAt: new Date("2024-01-01T00:00:00Z"),
+  });
+
+  test("lands a Show rating that would FK-skip, remapped onto the drifted local show id", async () => {
+    // Local show carries id "local-show"; prod's id for the same slug is
+    // "prod-show". The rating references "prod-show".
+    const { db, state } = makeStubDb({
+      users: [driftUser()],
+      shows: [{ id: "local-show", slug: "2026-01-01-show" }],
+    });
+    const mcp = makeStubMcp({
+      list_users_since: [{ users: [], nextCursor: null }],
+      list_ratings_since: [
+        {
+          ratings: [
+            {
+              id: "r-1",
+              userId: "u-marc",
+              value: 5,
+              rateableType: "Show",
+              rateableId: "prod-show",
+              createdAt: "2026-01-02T00:00:00Z",
+              updatedAt: "2026-01-02T00:00:00Z",
+            },
+          ],
+          nextCursor: null,
+        },
+      ],
+      list_attendances_since: [{ attendances: [], nextCursor: null }],
+    });
+
+    await syncUserActivity(db as never, {
+      isDryRun: false,
+      pullFromEpoch: false,
+      pruneOrphans: false,
+      ratingService: stubRatingService(),
+      cacheInvalidation: null,
+      changedSlugs: new Set(),
+      now: new Date(),
+      prodShowIdToLocalId: new Map([["prod-show", "local-show"]]),
+      mcp,
+    });
+
+    // Without the remap this rating skips (prod-show isn't a local id). With it,
+    // the rating lands on the local show id.
+    expect(state.ratings).toHaveLength(1);
+    expect(state.ratings[0].rateableId).toBe("local-show");
+  });
+
+  test("lands an attendance remapped onto the drifted local show id", async () => {
+    const { db, state } = makeStubDb({
+      users: [driftUser()],
+      shows: [{ id: "local-show", slug: "2026-01-01-show" }],
+    });
+    const mcp = makeStubMcp({
+      list_users_since: [{ users: [], nextCursor: null }],
+      list_ratings_since: [{ ratings: [], nextCursor: null }],
+      list_attendances_since: [
+        {
+          attendances: [
+            { id: "a-1", userId: "u-marc", showId: "prod-show", createdAt: "2026-01-02T00:00:00Z", updatedAt: "2026-01-02T00:00:00Z" },
+          ],
+          nextCursor: null,
+        },
+      ],
+    });
+
+    await syncUserActivity(db as never, {
+      isDryRun: false,
+      pullFromEpoch: false,
+      pruneOrphans: false,
+      ratingService: stubRatingService(),
+      cacheInvalidation: null,
+      changedSlugs: new Set(),
+      now: new Date(),
+      prodShowIdToLocalId: new Map([["prod-show", "local-show"]]),
+      mcp,
+    });
+
+    expect(state.attendances).toHaveLength(1);
+    expect(state.attendances[0].showId).toBe("local-show");
+  });
+
+  test("still FK-skips when the show is genuinely absent (no remap entry)", async () => {
+    const { db, state } = makeStubDb({ users: [driftUser()], shows: [] });
+    const mcp = makeStubMcp({
+      list_users_since: [{ users: [], nextCursor: null }],
+      list_ratings_since: [
+        {
+          ratings: [
+            {
+              id: "r-1",
+              userId: "u-marc",
+              value: 5,
+              rateableType: "Show",
+              rateableId: "prod-show",
+              createdAt: "2026-01-02T00:00:00Z",
+              updatedAt: "2026-01-02T00:00:00Z",
+            },
+          ],
+          nextCursor: null,
+        },
+      ],
+      list_attendances_since: [{ attendances: [], nextCursor: null }],
+    });
+
+    await syncUserActivity(db as never, {
+      isDryRun: false,
+      pullFromEpoch: false,
+      pruneOrphans: false,
+      ratingService: stubRatingService(),
+      cacheInvalidation: null,
+      changedSlugs: new Set(),
+      now: new Date(),
+      mcp,
+    });
+
+    expect(state.ratings).toHaveLength(0);
   });
 });
 

--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -16,10 +16,11 @@
  * We therefore write directly via Prisma with the prod-supplied slugs.
  */
 
-import { Prisma } from "@prisma/client";
+import { Prisma, type TrackFlag } from "@prisma/client";
 import { CacheInvalidationService, CacheService } from "../src/_shared/cache";
 import prisma from "../src/_shared/prisma/client";
 import { RedisService } from "../src/_shared/redis";
+import { InstrumentService, MusicianService } from "../src/musicians/musician-service";
 import { RatingService } from "../src/ratings/rating-service";
 import { SegueRunGeneratorService } from "../src/segue-run/segue-run-generator-service";
 import { StatsService } from "../src/stats/stats-service";
@@ -100,6 +101,59 @@ export interface McpSetlistTrack {
   // "no opinion" (pre-deploy MCP); an explicit empty array means "prod has
   // zero". Replace-not-merge semantics on sync — see diffTrackAnnotations.
   annotations?: string[];
+  // Per-track musician deltas (sit-ins / sat-outs). Each carries the
+  // musician + the instruments played, keyed by slug (the stable cross-env
+  // id). `undefined` = no opinion (pre-deploy MCP); explicit empty = "prod
+  // has zero deltas on this track". See diffTrackMusicians.
+  trackMusicians?: McpTrackMusician[];
+  // Structured track flags (DYSLEXIC / INVERTED / UNFINISHED / *_ONLY).
+  // Wire shape is the enum name strings. `undefined` = no opinion; explicit
+  // empty = "prod cleared this track's flags". The recurrence columns
+  // (flag_gap / flag_version_gap / flag_previous_show_id) are DERIVED locally
+  // by the end-of-batch stats rebuild and never travel on the wire.
+  flags?: string[];
+  // Completion links where THIS track is the later (completing) one. Each
+  // entry is the natural key of the earlier (unfinished) track it completes.
+  // `undefined` = no opinion; explicit empty = "prod cleared this track's
+  // completions". See resolveCompletionLinks / diffCompletions.
+  completes?: McpTrackCompletion[];
+}
+
+// An instrument carried by slug (the stable cross-env id) plus its name, so
+// the sync can idempotently create the row when the local DB lacks it.
+export interface McpInstrumentRef {
+  slug: string;
+  name: string;
+}
+
+// One lineup member (whole-show performer) on the wire. Name + knownFrom +
+// default instrument are carried so the sync can seed a missing Musician row.
+export interface McpLineupMember {
+  musicianSlug: string;
+  musicianName: string;
+  knownFrom: string | null;
+  defaultInstrument: McpInstrumentRef | null;
+  instruments: McpInstrumentRef[];
+}
+
+// One per-track musician delta on the wire. `present` distinguishes a sit-in
+// (true) from a sat-out (false).
+export interface McpTrackMusician {
+  musicianSlug: string;
+  musicianName: string;
+  present: boolean;
+  defaultInstrument: McpInstrumentRef | null;
+  instruments: McpInstrumentRef[];
+}
+
+// The earlier (unfinished) track a completion points at, by natural key.
+// Tracks are matched cross-environment by (show slug, set, position) — the
+// same key buildSetlistReconciliation uses — not by id, so a completion
+// resolves even when the earlier track's local id drifted from prod.
+export interface McpTrackCompletion {
+  showSlug: string;
+  set: string;
+  position: number;
 }
 
 export interface McpSetlistSet {
@@ -112,6 +166,10 @@ export interface McpSetlist {
   showDate: string;
   venue: { name: string | null; city: string | null; state: string | null };
   sets: McpSetlistSet[];
+  // Whole-show performer lineup. Same optional + replace-not-merge semantics
+  // as the per-track fields: `undefined` = pre-deploy MCP (no opinion),
+  // explicit empty = "prod has no lineup for this show". See diffShowMusicians.
+  lineup?: McpLineupMember[];
 }
 
 export interface McpSong {
@@ -875,6 +933,183 @@ export function diffTrackAnnotations(
   return { toCreateDescs, toDeleteIds };
 }
 
+// --- Performer / flag / completion diffs ---
+//
+// All four share the diffTrackAnnotations contract: identity is by a stable
+// slug / enum / natural key (never a per-env row id), `undefined` remote means
+// "no opinion" (pre-deploy MCP) and yields empty deltas, and an explicit array
+// (including empty) is authoritative replace-not-merge. The performer diffs add
+// a second level — the many-to-many instruments a musician played — which is
+// diffed per retained musician rather than cascade-replaced, so a re-run with
+// unchanged instruments produces zero writes and doesn't churn row ids.
+
+export interface LocalShowMusician {
+  showMusicianId: string;
+  musicianSlug: string;
+  instrumentSlugs: string[];
+}
+
+export interface RemoteShowMusician {
+  musicianSlug: string;
+  instrumentSlugs: string[];
+}
+
+export interface ShowMusicianDiff {
+  toCreate: Array<{ musicianSlug: string; instrumentSlugs: string[] }>;
+  toDeleteShowMusicianIds: string[];
+  toUpdateInstruments: Array<{ showMusicianId: string; addInstrumentSlugs: string[]; removeInstrumentSlugs: string[] }>;
+}
+
+export function diffShowMusicians(
+  local: LocalShowMusician[],
+  remote: RemoteShowMusician[] | undefined,
+): ShowMusicianDiff {
+  if (remote === undefined) return { toCreate: [], toDeleteShowMusicianIds: [], toUpdateInstruments: [] };
+  const localBySlug = new Map(local.map((m) => [m.musicianSlug, m]));
+  const remoteBySlug = new Map(remote.map((m) => [m.musicianSlug, m]));
+  const toCreate = remote
+    .filter((m) => !localBySlug.has(m.musicianSlug))
+    .map((m) => ({ musicianSlug: m.musicianSlug, instrumentSlugs: m.instrumentSlugs }));
+  const toDeleteShowMusicianIds = local.filter((m) => !remoteBySlug.has(m.musicianSlug)).map((m) => m.showMusicianId);
+  const toUpdateInstruments: ShowMusicianDiff["toUpdateInstruments"] = [];
+  for (const m of local) {
+    const r = remoteBySlug.get(m.musicianSlug);
+    if (!r) continue;
+    const { add, remove } = diffSlugSets(m.instrumentSlugs, r.instrumentSlugs);
+    if (add.length > 0 || remove.length > 0) {
+      toUpdateInstruments.push({ showMusicianId: m.showMusicianId, addInstrumentSlugs: add, removeInstrumentSlugs: remove });
+    }
+  }
+  return { toCreate, toDeleteShowMusicianIds, toUpdateInstruments };
+}
+
+export interface LocalTrackMusician {
+  trackMusicianId: string;
+  musicianSlug: string;
+  present: boolean;
+  instrumentSlugs: string[];
+}
+
+export interface RemoteTrackMusician {
+  musicianSlug: string;
+  present: boolean;
+  instrumentSlugs: string[];
+}
+
+export interface TrackMusicianDiff {
+  toCreate: Array<{ musicianSlug: string; present: boolean; instrumentSlugs: string[] }>;
+  toDeleteTrackMusicianIds: string[];
+  toUpdate: Array<{
+    trackMusicianId: string;
+    present?: boolean;
+    addInstrumentSlugs: string[];
+    removeInstrumentSlugs: string[];
+  }>;
+}
+
+export function diffTrackMusicians(
+  local: LocalTrackMusician[],
+  remote: RemoteTrackMusician[] | undefined,
+): TrackMusicianDiff {
+  if (remote === undefined) return { toCreate: [], toDeleteTrackMusicianIds: [], toUpdate: [] };
+  const localBySlug = new Map(local.map((m) => [m.musicianSlug, m]));
+  const remoteBySlug = new Map(remote.map((m) => [m.musicianSlug, m]));
+  const toCreate = remote
+    .filter((m) => !localBySlug.has(m.musicianSlug))
+    .map((m) => ({ musicianSlug: m.musicianSlug, present: m.present, instrumentSlugs: m.instrumentSlugs }));
+  const toDeleteTrackMusicianIds = local.filter((m) => !remoteBySlug.has(m.musicianSlug)).map((m) => m.trackMusicianId);
+  const toUpdate: TrackMusicianDiff["toUpdate"] = [];
+  for (const m of local) {
+    const r = remoteBySlug.get(m.musicianSlug);
+    if (!r) continue;
+    const { add, remove } = diffSlugSets(m.instrumentSlugs, r.instrumentSlugs);
+    const presentChanged = m.present !== r.present;
+    if (presentChanged || add.length > 0 || remove.length > 0) {
+      toUpdate.push({
+        trackMusicianId: m.trackMusicianId,
+        ...(presentChanged ? { present: r.present } : {}),
+        addInstrumentSlugs: add,
+        removeInstrumentSlugs: remove,
+      });
+    }
+  }
+  return { toCreate, toDeleteTrackMusicianIds, toUpdate };
+}
+
+// Set add/remove over slug arrays — the shared instrument-sub-bridge diff for
+// both performer helpers, so a musician kept across runs only churns the
+// instrument rows that actually changed.
+function diffSlugSets(local: string[], remote: string[]): { add: string[]; remove: string[] } {
+  const localSet = new Set(local);
+  const remoteSet = new Set(remote);
+  return { add: remote.filter((s) => !localSet.has(s)), remove: local.filter((s) => !remoteSet.has(s)) };
+}
+
+// Track flags mirror diffTrackAnnotations exactly: identity by the flag enum
+// string, replace-not-merge, `undefined` = no opinion. The derived recurrence
+// columns are never part of this diff (see McpSetlistTrack.flags).
+export function diffTrackFlags(local: string[], remote: string[] | undefined): { toAdd: string[]; toRemove: string[] } {
+  if (remote === undefined) return { toAdd: [], toRemove: [] };
+  const localSet = new Set(local);
+  const remoteSet = new Set(remote);
+  return { toAdd: remote.filter((f) => !localSet.has(f)), toRemove: local.filter((f) => !remoteSet.has(f)) };
+}
+
+export interface CompletionKey {
+  showSlug: string;
+  set: string;
+  position: number;
+}
+
+export interface RemoteCompletionLink {
+  // The later (completing) track — the one carrying the `completes` entry.
+  later: CompletionKey;
+  // The earlier (unfinished) track it completes.
+  earlier: CompletionKey;
+}
+
+const completionKeyOf = (k: CompletionKey): string => `${k.showSlug}|${k.set}|${k.position}`;
+
+/**
+ * Resolve each completion link's two natural-key endpoints to local track ids.
+ * A link whose earlier OR later track isn't local (e.g. a narrow --years window
+ * synced one show of a cross-show completion) lands in `skipped`, not resolved —
+ * the caller logs it and moves on rather than inserting a dangling FK.
+ */
+export function resolveCompletionLinks(
+  links: RemoteCompletionLink[],
+  trackKeyToLocalId: Map<string, string>,
+): { resolved: Array<{ earlierTrackId: string; laterTrackId: string }>; skipped: RemoteCompletionLink[] } {
+  const resolved: Array<{ earlierTrackId: string; laterTrackId: string }> = [];
+  const skipped: RemoteCompletionLink[] = [];
+  for (const link of links) {
+    const earlierTrackId = trackKeyToLocalId.get(completionKeyOf(link.earlier));
+    const laterTrackId = trackKeyToLocalId.get(completionKeyOf(link.later));
+    if (earlierTrackId && laterTrackId) resolved.push({ earlierTrackId, laterTrackId });
+    else skipped.push(link);
+  }
+  return { resolved, skipped };
+}
+
+/**
+ * Diff local completion rows against the desired (already-resolved) set, keyed
+ * by `earlierTrackId` — the UNIQUE column, so one earlier track has at most one
+ * completer. A re-pointed completion (same earlier, new later) is an upsert, not
+ * an insert, so it overwrites cleanly instead of hitting the unique constraint.
+ * `local` MUST be scoped to completions whose earlier track is in the sync's
+ * scope, or out-of-scope links would be spuriously deleted.
+ */
+export function diffCompletions(
+  local: Array<{ earlierTrackId: string; laterTrackId: string }>,
+  desired: Array<{ earlierTrackId: string; laterTrackId: string }>,
+): { toUpsert: Array<{ earlierTrackId: string; laterTrackId: string }>; toDeleteEarlierTrackIds: string[] } {
+  const localByEarlier = new Map(local.map((c) => [c.earlierTrackId, c.laterTrackId]));
+  const desiredByEarlier = new Map(desired.map((c) => [c.earlierTrackId, c.laterTrackId]));
+  const toUpsert = desired.filter((c) => localByEarlier.get(c.earlierTrackId) !== c.laterTrackId);
+  const toDeleteEarlierTrackIds = local.filter((c) => !desiredByEarlier.has(c.earlierTrackId)).map((c) => c.earlierTrackId);
+  return { toUpsert, toDeleteEarlierTrackIds };
+}
+
 // --- JSON-RPC transport ---
 
 // Bun's default fetch timeout has been observed to abort the bigger sync
@@ -1005,6 +1240,13 @@ interface SyncUserActivityOptions {
   cacheInvalidation: CacheInvalidationService | null;
   changedSlugs: Set<string>;
   now: Date;
+  // prod show/track id → local id, for rows whose local id drifted from prod
+  // (seeded by an old dump under a different id, then matched by slug/natural
+  // key in the show/track passes). Rating + attendance references resolve
+  // through these before the FK check + upsert so an id-drifted show/track
+  // doesn't orphan its user activity. Absent entry = ids already match.
+  prodShowIdToLocalId?: Map<string, string>;
+  prodTrackIdToLocalId?: Map<string, string>;
   // Injected to keep the function unit-testable without mocking globals.
   // Defaults to the real mcpCall in the production wiring below.
   mcp?: <T>(toolName: string, args: Record<string, unknown>) => Promise<T>;
@@ -1036,6 +1278,8 @@ export async function syncUserActivity(
 ): Promise<UserActivityStats> {
   const { isDryRun, pullFromEpoch, pruneOrphans, ratingService, now, changedSlugs } = options;
   const mcp = options.mcp ?? mcpCall;
+  const prodShowIdToLocalId = options.prodShowIdToLocalId ?? new Map<string, string>();
+  const prodTrackIdToLocalId = options.prodTrackIdToLocalId ?? new Map<string, string>();
   const stats: UserActivityStats = {
     usersCreated: 0,
     usersUpdated: 0,
@@ -1200,16 +1444,25 @@ export async function syncUserActivity(
     const resolvedRatings = ratings.map((r) => ({
       ...r,
       localUserId: prodIdToLocalId.get(r.userId) ?? r.userId,
+      // Resolve the rateable through the show/track drift maps so a rating that
+      // references prod's show/track id lands on the local row even when that
+      // row was seeded under a different id. No-drift case = the same id back.
+      localRateableId:
+        r.rateableType === "Show"
+          ? prodShowIdToLocalId.get(r.rateableId) ?? r.rateableId
+          : r.rateableType === "Track"
+            ? prodTrackIdToLocalId.get(r.rateableId) ?? r.rateableId
+            : r.rateableId,
     }));
     // Batched FK existence check per page. The realistic miss is show/track:
     // a dev DB synced for a narrow --years window legitimately lacks older
     // shows that older ratings reference.
     const ratingUserIds = Array.from(new Set(resolvedRatings.map((r) => r.localUserId)));
     const ratingShowIds = Array.from(
-      new Set(resolvedRatings.filter((r) => r.rateableType === "Show").map((r) => r.rateableId)),
+      new Set(resolvedRatings.filter((r) => r.rateableType === "Show").map((r) => r.localRateableId)),
     );
     const ratingTrackIds = Array.from(
-      new Set(resolvedRatings.filter((r) => r.rateableType === "Track").map((r) => r.rateableId)),
+      new Set(resolvedRatings.filter((r) => r.rateableType === "Track").map((r) => r.localRateableId)),
     );
     const [existingRatingUsers, existingRatingShows, existingRatingTracks] = await Promise.all([
       ratingUserIds.length > 0
@@ -1232,19 +1485,19 @@ export async function syncUserActivity(
         console.warn(`  ⚠️  rating ${r.id}: skipping — user ${r.localUserId} not local`);
         continue;
       }
-      if (r.rateableType === "Show" && !localRatingShowSet.has(r.rateableId)) {
+      if (r.rateableType === "Show" && !localRatingShowSet.has(r.localRateableId)) {
         stats.ratingsFkSkipped++;
-        console.warn(`  ⚠️  rating ${r.id}: skipping — show ${r.rateableId} not local`);
+        console.warn(`  ⚠️  rating ${r.id}: skipping — show ${r.localRateableId} not local`);
         continue;
       }
-      if (r.rateableType === "Track" && !localRatingTrackSet.has(r.rateableId)) {
+      if (r.rateableType === "Track" && !localRatingTrackSet.has(r.localRateableId)) {
         stats.ratingsFkSkipped++;
-        console.warn(`  ⚠️  rating ${r.id}: skipping — track ${r.rateableId} not local`);
+        console.warn(`  ⚠️  rating ${r.id}: skipping — track ${r.localRateableId} not local`);
         continue;
       }
       if (isDryRun) {
         stats.ratingsUpserted++;
-        touchedRateables.set(`${r.rateableType}|${r.rateableId}`, { rateableId: r.rateableId, rateableType: r.rateableType });
+        touchedRateables.set(`${r.rateableType}|${r.localRateableId}`, { rateableId: r.localRateableId, rateableType: r.rateableType });
         continue;
       }
       try {
@@ -1261,7 +1514,7 @@ export async function syncUserActivity(
           where: {
             userId_rateableId_rateableType: {
               userId: r.localUserId,
-              rateableId: r.rateableId,
+              rateableId: r.localRateableId,
               rateableType: r.rateableType,
             },
           },
@@ -1274,14 +1527,14 @@ export async function syncUserActivity(
             userId: r.localUserId,
             value: r.value,
             rateableType: r.rateableType,
-            rateableId: r.rateableId,
+            rateableId: r.localRateableId,
             createdAt: new Date(r.createdAt),
             updatedAt: new Date(r.updatedAt),
           },
         });
         stats.ratingsUpserted++;
-        touchedRateables.set(`${r.rateableType}|${r.rateableId}`, {
-          rateableId: r.rateableId,
+        touchedRateables.set(`${r.rateableType}|${r.localRateableId}`, {
+          rateableId: r.localRateableId,
           rateableType: r.rateableType,
         });
       } catch (err) {
@@ -1307,9 +1560,11 @@ export async function syncUserActivity(
     const resolvedAttendances = attendances.map((a) => ({
       ...a,
       localUserId: prodIdToLocalId.get(a.userId) ?? a.userId,
+      // Same show-id drift remap as the rating loop.
+      localShowId: prodShowIdToLocalId.get(a.showId) ?? a.showId,
     }));
     const attUserIds = Array.from(new Set(resolvedAttendances.map((a) => a.localUserId)));
-    const attShowIds = Array.from(new Set(resolvedAttendances.map((a) => a.showId)));
+    const attShowIds = Array.from(new Set(resolvedAttendances.map((a) => a.localShowId)));
     const [existingAttUsers, existingAttShows] = await Promise.all([
       attUserIds.length > 0
         ? db.user.findMany({ where: { id: { in: attUserIds } }, select: { id: true } })
@@ -1327,12 +1582,12 @@ export async function syncUserActivity(
         console.warn(`  ⚠️  attendance ${a.id}: skipping — user ${a.localUserId} not local`);
         continue;
       }
-      if (!localAttShowBySlug.has(a.showId)) {
+      if (!localAttShowBySlug.has(a.localShowId)) {
         stats.attendancesFkSkipped++;
-        console.warn(`  ⚠️  attendance ${a.id}: skipping — show ${a.showId} not local`);
+        console.warn(`  ⚠️  attendance ${a.id}: skipping — show ${a.localShowId} not local`);
         continue;
       }
-      const showSlug = localAttShowBySlug.get(a.showId) ?? null;
+      const showSlug = localAttShowBySlug.get(a.localShowId) ?? null;
       if (isDryRun) {
         stats.attendancesUpserted++;
         if (showSlug) changedSlugs.add(showSlug);
@@ -1345,12 +1600,12 @@ export async function syncUserActivity(
         // on an id-keyed insert. --full-users converges the local id back
         // to prod's over two runs.
         await db.attendance.upsert({
-          where: { userId_showId: { userId: a.localUserId, showId: a.showId } },
+          where: { userId_showId: { userId: a.localUserId, showId: a.localShowId } },
           update: { updatedAt: new Date(a.updatedAt) },
           create: {
             id: a.id,
             userId: a.localUserId,
-            showId: a.showId,
+            showId: a.localShowId,
             createdAt: new Date(a.createdAt),
             updatedAt: new Date(a.updatedAt),
           },
@@ -1512,6 +1767,17 @@ interface SyncStats {
   rockOperasUpserted: number;
   rockOperaAssignmentsAdded: number;
   rockOperaAssignmentsRemoved: number;
+  musiciansCreated: number;
+  instrumentsCreated: number;
+  showMusiciansUpserted: number;
+  showMusiciansDeleted: number;
+  trackMusiciansUpserted: number;
+  trackMusiciansDeleted: number;
+  trackFlagsAdded: number;
+  trackFlagsRemoved: number;
+  completionsUpserted: number;
+  completionsDeleted: number;
+  completionsSkipped: number;
   userActivity: UserActivityStats | null;
   errors: number;
 }
@@ -1644,6 +1910,10 @@ async function syncMissingShows(): Promise<void> {
   // setlist reconcile inserts or deletes a track, those arrays go stale; we
   // call generateSegueRunsForShow per structurally-changed show to rebuild.
   const segueRunService = new SegueRunGeneratorService(prisma, logger);
+  // Both dedupe-by-slug on create (return the existing row), so the performer
+  // mirroring pass can resolve-or-seed musicians/instruments idempotently.
+  const instrumentService = new InstrumentService(prisma, logger);
+  const musicianService = new MusicianService(prisma, logger);
   if (redis) await redis.connect();
 
   // Track every show whose row materially changed this run — used at the end
@@ -1655,6 +1925,13 @@ async function syncMissingShows(): Promise<void> {
   // the same as chronologically, so `<` works directly.
   let earliestInsertedDate: string | null = null;
   let songsChanged = false;
+  // prod row id → local row id, for shows/tracks whose local id drifted from
+  // prod (seeded under a different id by an old dump, then matched by slug).
+  // The user-activity pass falls back through these so a rating/attendance that
+  // references prod's show/track id still lands on the local row — mirroring the
+  // existing prodIdToLocalId remap for users. Empty entry = ids already match.
+  const prodShowIdToLocalId = new Map<string, string>();
+  const prodTrackIdToLocalId = new Map<string, string>();
 
   const stats: SyncStats = {
     yearsSynced: years,
@@ -1685,6 +1962,17 @@ async function syncMissingShows(): Promise<void> {
     rockOperasUpserted: 0,
     rockOperaAssignmentsAdded: 0,
     rockOperaAssignmentsRemoved: 0,
+    musiciansCreated: 0,
+    instrumentsCreated: 0,
+    showMusiciansUpserted: 0,
+    showMusiciansDeleted: 0,
+    trackMusiciansUpserted: 0,
+    trackMusiciansDeleted: 0,
+    trackFlagsAdded: 0,
+    trackFlagsRemoved: 0,
+    completionsUpserted: 0,
+    completionsDeleted: 0,
+    completionsSkipped: 0,
     userActivity: null,
     errors: 0,
   };
@@ -2428,6 +2716,438 @@ async function syncMissingShows(): Promise<void> {
       }
     }
 
+    // Build prodShowIdToLocalId for any show whose local id drifted from prod's
+    // (matched by slug above, kept its old local id). The user-activity pass
+    // remaps rating/attendance show references through this so they don't FK-skip.
+    {
+      const remoteIdBySlug = new Map(remoteFullShows.map((s) => [s.slug, s.id]));
+      for (const [slug, local] of existingBySlug) {
+        if (String(local.id).startsWith("dry-run-show-")) continue;
+        const prodId = remoteIdBySlug.get(slug);
+        if (prodId && prodId !== local.id) prodShowIdToLocalId.set(prodId, local.id);
+      }
+    }
+
+    // Step 8c: mirror performer data (whole-show lineup + per-track sit-ins /
+    // sat-outs), track flags, and completion links for every in-scope show.
+    // Runs after the setlist reconcile so every track exists locally under its
+    // prod id. The diffs key musicians by slug and tracks by (slug, set,
+    // position) — never a per-env row id — so they survive id drift. Each
+    // per-entity diff treats `undefined` remote as "no opinion" (pre-deploy
+    // MCP), so this whole step is a no-op until the MCP route change deploys.
+    const performerShowIds = Array.from(existingBySlug.values())
+      .filter((s) => !String(s.id).startsWith("dry-run-show-"))
+      .map((s) => s.id);
+    if (performerShowIds.length > 0 || isDryRun) {
+      // 8c.1 — resolve every musician + instrument referenced across the
+      // in-scope setlists to a local id, seeding missing rows idempotently by
+      // slug. Instruments first so a musician's defaultInstrument FK resolves.
+      const instrumentNameBySlug = new Map<string, string>();
+      const musicianRefBySlug = new Map<string, { name: string; knownFrom: string | null; defaultInstrumentSlug: string | null }>();
+      const noteInstrument = (i: { slug: string; name: string } | null | undefined): void => {
+        if (i) instrumentNameBySlug.set(i.slug, i.name);
+      };
+      for (const setlist of setlistBySlug.values()) {
+        for (const member of setlist.lineup ?? []) {
+          noteInstrument(member.defaultInstrument);
+          for (const i of member.instruments) noteInstrument(i);
+          if (!musicianRefBySlug.has(member.musicianSlug)) {
+            musicianRefBySlug.set(member.musicianSlug, {
+              name: member.musicianName,
+              knownFrom: member.knownFrom,
+              defaultInstrumentSlug: member.defaultInstrument?.slug ?? null,
+            });
+          }
+        }
+        for (const set of setlist.sets) {
+          for (const track of set.tracks) {
+            for (const tm of track.trackMusicians ?? []) {
+              noteInstrument(tm.defaultInstrument);
+              for (const i of tm.instruments) noteInstrument(i);
+              if (!musicianRefBySlug.has(tm.musicianSlug)) {
+                musicianRefBySlug.set(tm.musicianSlug, {
+                  name: tm.musicianName,
+                  knownFrom: null,
+                  defaultInstrumentSlug: tm.defaultInstrument?.slug ?? null,
+                });
+              }
+            }
+          }
+        }
+      }
+
+      const instrumentSlugToId = new Map<string, string>();
+      const musicianSlugToId = new Map<string, string>();
+      if (instrumentNameBySlug.size > 0) {
+        const existing = await db.instrument.findMany({
+          where: { slug: { in: Array.from(instrumentNameBySlug.keys()) } },
+          select: { id: true, slug: true },
+        });
+        for (const row of existing) instrumentSlugToId.set(row.slug, row.id);
+        for (const [slug, name] of instrumentNameBySlug) {
+          if (instrumentSlugToId.has(slug)) continue;
+          if (isDryRun) {
+            instrumentSlugToId.set(slug, `dry-run-instrument-${slug}`);
+          } else {
+            const created = await instrumentService.create({ name });
+            instrumentSlugToId.set(created.slug, created.id);
+          }
+          stats.instrumentsCreated++;
+        }
+      }
+      if (musicianRefBySlug.size > 0) {
+        const existing = await db.musician.findMany({
+          where: { slug: { in: Array.from(musicianRefBySlug.keys()) } },
+          select: { id: true, slug: true },
+        });
+        for (const row of existing) musicianSlugToId.set(row.slug, row.id);
+        for (const [slug, ref] of musicianRefBySlug) {
+          if (musicianSlugToId.has(slug)) continue;
+          if (isDryRun) {
+            musicianSlugToId.set(slug, `dry-run-musician-${slug}`);
+          } else {
+            const created = await musicianService.create({
+              name: ref.name,
+              knownFrom: ref.knownFrom,
+              defaultInstrumentId: ref.defaultInstrumentSlug ? instrumentSlugToId.get(ref.defaultInstrumentSlug) ?? null : null,
+            });
+            musicianSlugToId.set(created.slug, created.id);
+          }
+          stats.musiciansCreated++;
+        }
+      }
+      const instrumentIdsFor = (slugs: string[]): string[] =>
+        slugs.map((s) => instrumentSlugToId.get(s)).filter((id): id is string => id !== undefined);
+
+      // 8c.2 — re-load local tracks (fresh, post-reconcile) and build the
+      // (slug, set, position) → local track id map plus prodTrackIdToLocalId.
+      const showIdToSlug = new Map<string, string>();
+      for (const [slug, local] of existingBySlug) {
+        if (!String(local.id).startsWith("dry-run-show-")) showIdToSlug.set(local.id, slug);
+      }
+      const localTrackRows = performerShowIds.length === 0
+        ? []
+        : await db.track.findMany({
+            where: { showId: { in: performerShowIds } },
+            select: { id: true, showId: true, set: true, position: true },
+          });
+      const trackKeyToLocalId = new Map<string, string>();
+      const allTrackIds: string[] = [];
+      for (const row of localTrackRows) {
+        const slug = showIdToSlug.get(row.showId);
+        if (!slug) continue;
+        trackKeyToLocalId.set(`${slug}|${row.set}|${row.position}`, row.id);
+        allTrackIds.push(row.id);
+      }
+      // prodTrackIdToLocalId: where a remote track's prod id differs from the
+      // local id at the same (slug, set, position) — residual drift the step-8
+      // id-rebuild didn't converge (e.g. a track only ever ratings-referenced).
+      for (const [slug, setlist] of setlistBySlug) {
+        for (const set of setlist.sets) {
+          for (const track of set.tracks) {
+            if (!track.id) continue;
+            const localId = trackKeyToLocalId.get(`${slug}|${set.label}|${track.position}`);
+            if (localId && localId !== track.id) prodTrackIdToLocalId.set(track.id, localId);
+          }
+        }
+      }
+
+      // 8c.3 — load local performer + flag rows for the in-scope shows/tracks.
+      const localShowMusicianRows = performerShowIds.length === 0
+        ? []
+        : await db.showMusician.findMany({
+            where: { showId: { in: performerShowIds } },
+            select: {
+              id: true,
+              showId: true,
+              musician: { select: { slug: true } },
+              instruments: { select: { instrument: { select: { slug: true } } } },
+            },
+          });
+      const localShowMusiciansByShowId = new Map<string, LocalShowMusician[]>();
+      for (const row of localShowMusicianRows) {
+        const entry: LocalShowMusician = {
+          showMusicianId: row.id,
+          musicianSlug: row.musician.slug,
+          instrumentSlugs: row.instruments.map((r) => r.instrument.slug),
+        };
+        const arr = localShowMusiciansByShowId.get(row.showId);
+        if (arr) arr.push(entry);
+        else localShowMusiciansByShowId.set(row.showId, [entry]);
+      }
+
+      const localTrackMusicianRows = allTrackIds.length === 0
+        ? []
+        : await db.trackMusician.findMany({
+            where: { trackId: { in: allTrackIds } },
+            select: {
+              id: true,
+              trackId: true,
+              present: true,
+              musician: { select: { slug: true } },
+              instruments: { select: { instrument: { select: { slug: true } } } },
+            },
+          });
+      const localTrackMusiciansByTrackId = new Map<string, LocalTrackMusician[]>();
+      for (const row of localTrackMusicianRows) {
+        const entry: LocalTrackMusician = {
+          trackMusicianId: row.id,
+          musicianSlug: row.musician.slug,
+          present: row.present,
+          instrumentSlugs: row.instruments.map((r) => r.instrument.slug),
+        };
+        const arr = localTrackMusiciansByTrackId.get(row.trackId);
+        if (arr) arr.push(entry);
+        else localTrackMusiciansByTrackId.set(row.trackId, [entry]);
+      }
+
+      const localFlagRows = allTrackIds.length === 0
+        ? []
+        : await db.trackFlagAssignment.findMany({ where: { trackId: { in: allTrackIds } }, select: { trackId: true, flag: true } });
+      const localFlagsByTrackId = new Map<string, string[]>();
+      for (const row of localFlagRows) {
+        const arr = localFlagsByTrackId.get(row.trackId);
+        if (arr) arr.push(row.flag);
+        else localFlagsByTrackId.set(row.trackId, [row.flag]);
+      }
+
+      // 8c.4 — per show: apply the lineup diff, then per track the musician +
+      // flag diffs. A flag change also widens the stats-rebuild window so the
+      // derived recurrence columns recompute (the structural-only gate in step 8
+      // would otherwise miss a flag-only edit on an already-local show).
+      for (const [slug, local] of existingBySlug) {
+        const setlist = setlistBySlug.get(slug);
+        if (!setlist) continue;
+        const isDryRunShow = String(local.id).startsWith("dry-run-show-");
+
+        const localSM = localShowMusiciansByShowId.get(local.id) ?? [];
+        const remoteSM = setlist.lineup?.map((m) => ({ musicianSlug: m.musicianSlug, instrumentSlugs: m.instruments.map((i) => i.slug) }));
+        const smDiff = diffShowMusicians(localSM, remoteSM);
+
+        type TrackPerformerWork = {
+          trackId: string;
+          tmDiff: TrackMusicianDiff;
+          flagDiff: { toAdd: string[]; toRemove: string[] };
+        };
+        const trackWork: TrackPerformerWork[] = [];
+        for (const set of setlist.sets) {
+          for (const track of set.tracks) {
+            const trackId = trackKeyToLocalId.get(`${slug}|${set.label}|${track.position}`);
+            if (!trackId) continue;
+            const localTM = localTrackMusiciansByTrackId.get(trackId) ?? [];
+            const remoteTM = track.trackMusicians?.map((tm) => ({
+              musicianSlug: tm.musicianSlug,
+              present: tm.present,
+              instrumentSlugs: tm.instruments.map((i) => i.slug),
+            }));
+            const tmDiff = diffTrackMusicians(localTM, remoteTM);
+            const flagDiff = diffTrackFlags(localFlagsByTrackId.get(trackId) ?? [], track.flags);
+            if (
+              tmDiff.toCreate.length > 0 ||
+              tmDiff.toDeleteTrackMusicianIds.length > 0 ||
+              tmDiff.toUpdate.length > 0 ||
+              flagDiff.toAdd.length > 0 ||
+              flagDiff.toRemove.length > 0
+            ) {
+              trackWork.push({ trackId, tmDiff, flagDiff });
+            }
+          }
+        }
+
+        const lineupChanged =
+          smDiff.toCreate.length > 0 || smDiff.toDeleteShowMusicianIds.length > 0 || smDiff.toUpdateInstruments.length > 0;
+        if (!lineupChanged && trackWork.length === 0) continue;
+
+        const flagChanged = trackWork.some((w) => w.flagDiff.toAdd.length > 0 || w.flagDiff.toRemove.length > 0);
+        // Tally before the write so dry runs report the same numbers.
+        stats.showMusiciansUpserted += smDiff.toCreate.length + smDiff.toUpdateInstruments.length;
+        stats.showMusiciansDeleted += smDiff.toDeleteShowMusicianIds.length;
+        for (const w of trackWork) {
+          stats.trackMusiciansUpserted += w.tmDiff.toCreate.length + w.tmDiff.toUpdate.length;
+          stats.trackMusiciansDeleted += w.tmDiff.toDeleteTrackMusicianIds.length;
+          stats.trackFlagsAdded += w.flagDiff.toAdd.length;
+          stats.trackFlagsRemoved += w.flagDiff.toRemove.length;
+        }
+
+        if (isDryRun || isDryRunShow) {
+          console.log(`  🎙️  ${slug}: lineup ±${smDiff.toCreate.length + smDiff.toDeleteShowMusicianIds.length}, ${trackWork.length} track delta(s) (dry run)`);
+          changedSlugs.add(slug);
+          continue;
+        }
+
+        try {
+          await db.$transaction(async (tx) => {
+            if (smDiff.toDeleteShowMusicianIds.length > 0) {
+              await tx.showMusician.deleteMany({ where: { id: { in: smDiff.toDeleteShowMusicianIds } } });
+            }
+            for (const c of smDiff.toCreate) {
+              const musicianId = musicianSlugToId.get(c.musicianSlug);
+              if (!musicianId) continue;
+              const instrumentIds = instrumentIdsFor(c.instrumentSlugs);
+              await tx.showMusician.create({
+                data: {
+                  showId: local.id,
+                  musicianId,
+                  createdAt: now,
+                  updatedAt: now,
+                  instruments:
+                    instrumentIds.length > 0 ? { create: instrumentIds.map((instrumentId) => ({ instrumentId })) } : undefined,
+                },
+              });
+            }
+            for (const u of smDiff.toUpdateInstruments) {
+              const removeIds = instrumentIdsFor(u.removeInstrumentSlugs);
+              const addIds = instrumentIdsFor(u.addInstrumentSlugs);
+              if (removeIds.length > 0) {
+                await tx.showMusicianInstrument.deleteMany({
+                  where: { showMusicianId: u.showMusicianId, instrumentId: { in: removeIds } },
+                });
+              }
+              if (addIds.length > 0) {
+                await tx.showMusicianInstrument.createMany({
+                  data: addIds.map((instrumentId) => ({ showMusicianId: u.showMusicianId, instrumentId })),
+                });
+              }
+            }
+            for (const w of trackWork) {
+              if (w.tmDiff.toDeleteTrackMusicianIds.length > 0) {
+                await tx.trackMusician.deleteMany({ where: { id: { in: w.tmDiff.toDeleteTrackMusicianIds } } });
+              }
+              for (const c of w.tmDiff.toCreate) {
+                const musicianId = musicianSlugToId.get(c.musicianSlug);
+                if (!musicianId) continue;
+                const instrumentIds = instrumentIdsFor(c.instrumentSlugs);
+                await tx.trackMusician.create({
+                  data: {
+                    trackId: w.trackId,
+                    musicianId,
+                    present: c.present,
+                    createdAt: now,
+                    updatedAt: now,
+                    instruments:
+                      instrumentIds.length > 0 ? { create: instrumentIds.map((instrumentId) => ({ instrumentId })) } : undefined,
+                  },
+                });
+              }
+              for (const u of w.tmDiff.toUpdate) {
+                if (u.present !== undefined) {
+                  await tx.trackMusician.update({ where: { id: u.trackMusicianId }, data: { present: u.present, updatedAt: now } });
+                }
+                const removeIds = instrumentIdsFor(u.removeInstrumentSlugs);
+                const addIds = instrumentIdsFor(u.addInstrumentSlugs);
+                if (removeIds.length > 0) {
+                  await tx.trackMusicianInstrument.deleteMany({
+                    where: { trackMusicianId: u.trackMusicianId, instrumentId: { in: removeIds } },
+                  });
+                }
+                if (addIds.length > 0) {
+                  await tx.trackMusicianInstrument.createMany({
+                    data: addIds.map((instrumentId) => ({ trackMusicianId: u.trackMusicianId, instrumentId })),
+                  });
+                }
+              }
+              if (w.flagDiff.toRemove.length > 0) {
+                await tx.trackFlagAssignment.deleteMany({
+                  where: { trackId: w.trackId, flag: { in: w.flagDiff.toRemove as TrackFlag[] } },
+                });
+              }
+              if (w.flagDiff.toAdd.length > 0) {
+                await tx.trackFlagAssignment.createMany({
+                  data: w.flagDiff.toAdd.map((flag) => ({ trackId: w.trackId, flag: flag as TrackFlag, createdAt: now, updatedAt: now })),
+                });
+              }
+            }
+          });
+          changedSlugs.add(slug);
+          // A flag add/remove shifts the derived recurrence columns; widen the
+          // rebuild window to this show's date so the end-of-batch recompute
+          // picks it up (step 8 only widens on structural setlist changes).
+          if (flagChanged) {
+            const showDate = String(local.date);
+            if (earliestInsertedDate === null || showDate < earliestInsertedDate) earliestInsertedDate = showDate;
+          }
+          console.log(`  🎙️  ${slug}: lineup ±${smDiff.toCreate.length + smDiff.toDeleteShowMusicianIds.length}, ${trackWork.length} track delta(s)`);
+        } catch (err) {
+          console.error(`  ❌ failed to mirror performers for ${slug}:`, err);
+          stats.errors++;
+        }
+      }
+
+      // Step 8d: completion links. Cross-show, so resolved after all tracks
+      // exist, keyed by the UNIQUE earlier track. Gated on prod having served
+      // completion data for at least one in-scope track — pre-deploy MCP omits
+      // `completes` entirely (no opinion), and without the gate the empty
+      // desired set would wrongly delete every local completion.
+      const completionLinks: RemoteCompletionLink[] = [];
+      let completionsServed = false;
+      for (const [slug, setlist] of setlistBySlug) {
+        for (const set of setlist.sets) {
+          for (const track of set.tracks) {
+            if (track.completes === undefined) continue;
+            completionsServed = true;
+            for (const c of track.completes) {
+              completionLinks.push({
+                later: { showSlug: slug, set: set.label, position: track.position },
+                earlier: { showSlug: c.showSlug, set: c.set, position: c.position },
+              });
+            }
+          }
+        }
+      }
+      if (completionsServed && allTrackIds.length > 0) {
+        const { resolved, skipped } = resolveCompletionLinks(completionLinks, trackKeyToLocalId);
+        stats.completionsSkipped += skipped.length;
+        // Only completions with BOTH ends in scope are authoritatively managed
+        // here. A completion whose later track is in an un-synced show would
+        // otherwise be absent from `resolved` (its link rides the later track's
+        // payload, which we never fetched) and get wrongly deleted.
+        const localCompletionRows = await db.trackCompletion.findMany({
+          where: { earlierTrackId: { in: allTrackIds }, laterTrackId: { in: allTrackIds } },
+          select: { earlierTrackId: true, laterTrackId: true },
+        });
+        const compDiff = diffCompletions(localCompletionRows, resolved);
+        stats.completionsUpserted += compDiff.toUpsert.length;
+        stats.completionsDeleted += compDiff.toDeleteEarlierTrackIds.length;
+        if (!isDryRun && (compDiff.toUpsert.length > 0 || compDiff.toDeleteEarlierTrackIds.length > 0)) {
+          try {
+            await db.$transaction(async (tx) => {
+              if (compDiff.toDeleteEarlierTrackIds.length > 0) {
+                await tx.trackCompletion.deleteMany({ where: { earlierTrackId: { in: compDiff.toDeleteEarlierTrackIds } } });
+              }
+              for (const link of compDiff.toUpsert) {
+                await tx.trackCompletion.upsert({
+                  where: { earlierTrackId: link.earlierTrackId },
+                  update: { laterTrackId: link.laterTrackId, updatedAt: now },
+                  create: { earlierTrackId: link.earlierTrackId, laterTrackId: link.laterTrackId, createdAt: now, updatedAt: now },
+                });
+              }
+            });
+            // Invalidate the show on each end of every touched link (both
+            // upserts and deletes — the deleted link's later track lives in the
+            // localCompletionRows snapshot).
+            const showIdByTrackId = new Map(localTrackRows.map((t) => [t.id, t.showId]));
+            const deletedSet = new Set(compDiff.toDeleteEarlierTrackIds);
+            const touchedTrackIds = [
+              ...compDiff.toUpsert.flatMap((l) => [l.earlierTrackId, l.laterTrackId]),
+              ...localCompletionRows.filter((c) => deletedSet.has(c.earlierTrackId)).flatMap((c) => [c.earlierTrackId, c.laterTrackId]),
+            ];
+            for (const trackId of touchedTrackIds) {
+              const slug = showIdToSlug.get(showIdByTrackId.get(trackId) ?? "");
+              if (slug) changedSlugs.add(slug);
+            }
+          } catch (err) {
+            console.error("  ❌ failed to mirror completion links:", err);
+            stats.errors++;
+          }
+        }
+        if (compDiff.toUpsert.length > 0 || compDiff.toDeleteEarlierTrackIds.length > 0) {
+          console.log(
+            `  🔗 completions: ~${compDiff.toUpsert.length} -${compDiff.toDeleteEarlierTrackIds.length}${skipped.length > 0 ? ` (skipped ${skipped.length} out-of-scope)` : ""}`,
+          );
+        }
+      }
+    }
+
     // Step 8b: ghost-show detection. Local shows in the synced years whose
     // slug isn't in prod's per-year list are renames / merges / deletes
     // upstream — the step 8 reconcile loop never touches them because it
@@ -2600,6 +3320,8 @@ async function syncMissingShows(): Promise<void> {
           cacheInvalidation,
           changedSlugs,
           now,
+          prodShowIdToLocalId,
+          prodTrackIdToLocalId,
         });
         stats.userActivity = userActivityStats;
       } catch (err) {
@@ -2687,6 +3409,11 @@ function printSummary(stats: SyncStats, isDryRun: boolean): void {
   console.log(`Unresolved song slugs: ${stats.unresolvedSongSlugs}`);
   console.log(`Rock operas upserted: ${stats.rockOperasUpserted}`);
   console.log(`Rock opera assignments added / removed: ${stats.rockOperaAssignmentsAdded} / ${stats.rockOperaAssignmentsRemoved}`);
+  console.log(`Musicians / instruments created: ${stats.musiciansCreated} / ${stats.instrumentsCreated}`);
+  console.log(`Show lineup (upserted / deleted): ${stats.showMusiciansUpserted} / ${stats.showMusiciansDeleted}`);
+  console.log(`Track musicians (upserted / deleted): ${stats.trackMusiciansUpserted} / ${stats.trackMusiciansDeleted}`);
+  console.log(`Track flags (added / removed): ${stats.trackFlagsAdded} / ${stats.trackFlagsRemoved}`);
+  console.log(`Completions (upserted / deleted / skipped): ${stats.completionsUpserted} / ${stats.completionsDeleted} / ${stats.completionsSkipped}`);
   if (stats.userActivity) {
     const ua = stats.userActivity;
     console.log(`Users (created / updated / deleted): ${ua.usersCreated} / ${ua.usersUpdated} / ${ua.usersDeleted}`);

--- a/packages/core/src/setlists/setlist-service.ts
+++ b/packages/core/src/setlists/setlist-service.ts
@@ -94,7 +94,12 @@ type DbTrackLight = {
     previousShow: { date: string; slug: string | null } | null;
   }[];
   completionsAsLater?: {
-    earlierTrack: { show: { date: string; slug: string | null }; song: { title: string } | null };
+    earlierTrack: {
+      set: string;
+      position: number;
+      show: { date: string; slug: string | null };
+      song: { title: string } | null;
+    };
   }[];
   completionAsEarlier?: {
     laterTrack: { show: { date: string; slug: string | null }; song: { title: string } | null };
@@ -197,16 +202,28 @@ function mapAnnotationToDomainEntity(dbAnnotation: DbAnnotation): Annotation {
 // reads "… version of <name>".
 function completionShowsFromDb(
   currentSongTitle: string | null | undefined,
-  rows: Array<{ show: { date: string; slug: string | null }; songTitle: string | null }> | null | undefined,
-): Array<{ date: string; slug: string; otherSongTitle?: string }> {
+  rows:
+    | Array<{ show: { date: string; slug: string | null }; songTitle: string | null; set?: string; position?: number }>
+    | null
+    | undefined,
+): Array<{ date: string; slug: string; otherSongTitle?: string; set?: string; position?: number }> {
   return (rows ?? [])
-    .filter((row): row is { show: { date: string; slug: string }; songTitle: string | null } => Boolean(row.show.slug))
+    .filter(
+      (
+        row,
+      ): row is { show: { date: string; slug: string }; songTitle: string | null; set?: string; position?: number } =>
+        Boolean(row.show.slug),
+    )
     .map((row) => {
       const differs = Boolean(row.songTitle) && row.songTitle !== currentSongTitle;
       return {
         date: String(row.show.date),
         slug: row.show.slug,
         ...(differs ? { otherSongTitle: row.songTitle as string } : {}),
+        // Carried only for the completed (earlier) track so sync can natural-key
+        // match it; undefined elsewhere (e.g. completedBy).
+        ...(row.set !== undefined ? { set: row.set } : {}),
+        ...(row.position !== undefined ? { position: row.position } : {}),
       };
     })
     .sort((a, b) => a.date.localeCompare(b.date));
@@ -323,7 +340,12 @@ export function mapTrackToDomainEntity(
       previousShow: { date: string; slug: string | null } | null;
     }[];
     completionsAsLater?: {
-      earlierTrack: { show: { date: string; slug: string | null }; song: { title: string } | null };
+      earlierTrack: {
+        set: string;
+        position: number;
+        show: { date: string; slug: string | null };
+        song: { title: string } | null;
+      };
     }[];
     completionAsEarlier?: {
       laterTrack: { show: { date: string; slug: string | null }; song: { title: string } | null };
@@ -365,6 +387,8 @@ export function mapTrackToDomainEntity(
       completionsAsLater?.map((row) => ({
         show: row.earlierTrack.show,
         songTitle: row.earlierTrack.song?.title ?? null,
+        set: row.earlierTrack.set,
+        position: row.earlierTrack.position,
       })),
     ),
     completedBy: completionShowsFromDb(
@@ -580,6 +604,8 @@ function mapTrackLightToDomainEntity(track: DbTrackLight): TrackLight {
       track.completionsAsLater?.map((row) => ({
         show: row.earlierTrack.show,
         songTitle: row.earlierTrack.song?.title ?? null,
+        set: row.earlierTrack.set,
+        position: row.earlierTrack.position,
       })),
     ),
     completedBy: completionShowsFromDb(
@@ -700,7 +726,14 @@ const TRACK_FLAGS_AND_COMPLETIONS_INCLUDE = {
   },
   completionsAsLater: {
     select: {
-      earlierTrack: { select: { show: { select: { date: true, slug: true } }, song: { select: { title: true } } } },
+      earlierTrack: {
+        select: {
+          set: true,
+          position: true,
+          show: { select: { date: true, slug: true } },
+          song: { select: { title: true } },
+        },
+      },
     },
   },
   completionAsEarlier: {

--- a/packages/domain/src/models/track.ts
+++ b/packages/domain/src/models/track.ts
@@ -68,6 +68,11 @@ const completionShowsSchema = z
       date: z.string(),
       slug: z.string(),
       otherSongTitle: z.string().optional(),
+      // The completed track's set + position, carried so the prod→local sync
+      // can match it by natural key (show slug, set, position). Footnote
+      // rendering ignores these; only `completes` populates them.
+      set: z.string().optional(),
+      position: z.number().optional(),
     }),
   )
   .default([]);


### PR DESCRIPTION
## What this does

A local prod-sync now reproduces the structured performer data admins manage
in prod, so a freshly-synced dev DB matches prod instead of rendering empty
lineups and missing footnotes:

- Per-show **lineups** and per-track **sit-ins / sat-outs** (with the
  instruments each musician played)
- Track **flags** (dyslexic / inverted / unfinished / section-only)
- **Completion** links between tracks

It also fixes a latent bug where ratings and attendance were silently dropped
on shows whose local id had drifted from prod's.

## How it works

- `get_setlists` (MCP route) gains `lineup`, `trackMusicians`, `flags`, and
  `completes`. All optional on the wire, so a sync against a pre-deploy server
  is a no-op; every diff treats `undefined` as "no opinion".
- Musicians/instruments resolve by slug (plus name to seed missing rows);
  completion links resolve by the earlier track's natural key
  `(show slug, set, position)`, so both survive id drift.
- The id-drift fix builds `prodShowIdToLocalId` / `prodTrackIdToLocalId` during
  the show/track passes and resolves rating/attendance references through them
  before the FK check, mirroring the existing user-id remap.

## Reviewer notes

- **Deploy ordering:** the MCP route change must reach prod before a local
  sync can pull the new fields. It's additive and `undefined`-tolerant, so the
  order is safe either way.
- **Completion deletion** is scoped to links with both endpoints in-scope, so
  a narrow `--years` window can't delete a half-synced completion.
- **Flag edits** widen the stats-rebuild window so the derived recurrence
  columns recompute (the structural-only gate would otherwise miss a flag-only
  change). The window stays bounded by the sync's year scope.
- Derived columns (`Track.gap`, flag recurrence) are never synced; they're
  recomputed locally.
- The PR also brings `MCP_README.md` current (it had drifted to the v1
  server): adds the tools and fields added since, and replaces the fictional
  REST endpoints section with the real JSON-RPC protocol.

## Test plan

- `make tc` clean; 523 core + 1204 web tests pass.
- New unit tests for the five diff helpers + completion resolution, and
  stub-db tests proving the id-drift remap lands a rating/attendance that would
  otherwise FK-skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
