### PR TITLE
Performer sync follow-ups: all-years crash fix, instrument sort, Spraypaint flag

### DIFF
--- a/apps/web/app/components/setlist/footnotes.tsx
+++ b/apps/web/app/components/setlist/footnotes.tsx
@@ -6,6 +6,7 @@ import {
   gapFootnoteSuppressed,
   LAST_TIME_PLAYED_GAP_THRESHOLD,
 } from "~/lib/footnote-constants";
+import { formatInstrumentNames } from "~/lib/instruments";
 import { deriveShowLineupNotes, elevatedGuestIds } from "~/lib/lineup-notes";
 import { formatDateShort } from "~/lib/utils";
 
@@ -208,8 +209,9 @@ export function annotationFootnoteSources(annotations: Annotation[]): FootnoteSo
 }
 
 function instrumentNames(delta: TrackMusicianDelta): string {
-  // Display instrument names with the casing stored in the DB.
-  return delta.instruments.map((instrument) => instrument.name).join(", ");
+  // Display instrument names with the casing stored in the DB, sorted
+  // alphabetically so a multi-instrument list reads consistently.
+  return formatInstrumentNames(delta.instruments);
 }
 
 function musicianLink(delta: TrackMusicianDelta): ReactNode {

--- a/apps/web/app/components/show/show-lineup-note.tsx
+++ b/apps/web/app/components/show/show-lineup-note.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from "react";
 import { Link } from "react-router-dom";
+import { sortInstrumentNames } from "~/lib/instruments";
 import { groupWholeShowGuests, type ShowLineupNotes } from "~/lib/lineup-notes";
 
 /** A musician name linked to their profile, rendered un-italicized inside the note. */
@@ -55,14 +56,14 @@ export function ShowLineupNote({ notes }: { notes: ShowLineupNotes }) {
       ))}
       {offInstrument.map((member) => (
         <div key={`off-${member.slug}`}>
-          <MusicianLink name={member.name} slug={member.slug} /> on {member.instruments.join(", ")} instead of{" "}
-          {member.defaultInstrument}
+          <MusicianLink name={member.name} slug={member.slug} /> on {sortInstrumentNames(member.instruments).join(", ")}{" "}
+          instead of {member.defaultInstrument}
         </div>
       ))}
       {guestGroups.map((group) => (
         <div key={`guest-${group.members.map((member) => member.slug).join("-")}`}>
           with <MusicianList members={group.members} />
-          {group.instruments.length > 0 ? ` on ${group.instruments.join(", ")}` : ""}
+          {group.instruments.length > 0 ? ` on ${sortInstrumentNames(group.instruments).join(", ")}` : ""}
           {group.exceptWhereNoted ? ", except where noted" : ""}
         </div>
       ))}

--- a/apps/web/app/components/show/show-lineup-section.tsx
+++ b/apps/web/app/components/show/show-lineup-section.tsx
@@ -1,5 +1,6 @@
 import type { ShowLineupMember } from "@bip/domain";
 import { Link } from "react-router-dom";
+import { formatInstrumentNames } from "~/lib/instruments";
 import { sortLineup } from "~/lib/musicians-constants";
 
 /**
@@ -15,7 +16,7 @@ export function ShowLineupSection({ lineup, bare = false }: { lineup: ShowLineup
   const list = (
     <ul className="space-y-1">
       {sortLineup(lineup).map((member) => {
-        const instruments = member.instruments.map((instrument) => instrument.name).join(", ");
+        const instruments = formatInstrumentNames(member.instruments);
         return (
           <li key={member.musician.id} className="text-sm text-content-text-secondary">
             <Link

--- a/apps/web/app/lib/instruments.test.ts
+++ b/apps/web/app/lib/instruments.test.ts
@@ -1,0 +1,38 @@
+import type { Instrument } from "@bip/domain";
+import { describe, expect, test } from "vitest";
+import { formatInstrumentNames, sortInstrumentNames } from "./instruments";
+
+const instrument = (name: string): Instrument => ({
+  id: name,
+  name,
+  slug: name,
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+});
+
+describe("formatInstrumentNames", () => {
+  // The DB stores instruments in attach order, which floats "vocals" wherever it
+  // was added (e.g. Jon Gutwillig saved as [vocals, guitar]). Display sorts so the
+  // list reads the same regardless: "guitar, vocals".
+  test("joins instrument names alphabetically, not in array order", () => {
+    expect(formatInstrumentNames([instrument("vocals"), instrument("guitar")])).toBe("guitar, vocals");
+  });
+
+  test("sorts case-insensitively", () => {
+    expect(formatInstrumentNames([instrument("Vocals"), instrument("guitar"), instrument("Bass")])).toBe(
+      "Bass, guitar, Vocals",
+    );
+  });
+
+  test("returns an empty string for no instruments", () => {
+    expect(formatInstrumentNames([])).toBe("");
+  });
+});
+
+describe("sortInstrumentNames", () => {
+  test("sorts a name list alphabetically without mutating the input", () => {
+    const input = ["vocals", "guitar", "keys"];
+    expect(sortInstrumentNames(input)).toEqual(["guitar", "keys", "vocals"]);
+    expect(input).toEqual(["vocals", "guitar", "keys"]);
+  });
+});

--- a/apps/web/app/lib/instruments.ts
+++ b/apps/web/app/lib/instruments.ts
@@ -1,0 +1,22 @@
+import type { Instrument } from "@bip/domain";
+
+// Case-insensitive name sort so multi-instrument lists read the same regardless
+// of the order instruments were attached in the DB.
+const byName = (a: string, b: string) => a.localeCompare(b, undefined, { sensitivity: "base" });
+
+/**
+ * A musician's instruments joined for display, sorted alphabetically by name.
+ * Stored order reflects DB insertion (which floats "vocals" wherever it was
+ * added); sorting keeps the rendered list stable, e.g. "guitar, vocals".
+ */
+export function formatInstrumentNames(instruments: Instrument[]): string {
+  return [...instruments]
+    .map((instrument) => instrument.name)
+    .sort(byName)
+    .join(", ");
+}
+
+/** Same alphabetical ordering for instrument names already reduced to strings. */
+export function sortInstrumentNames(names: string[]): string[] {
+  return [...names].sort(byName);
+}

--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -2876,10 +2876,14 @@ async function syncMissingShows(): Promise<void> {
         else localShowMusiciansByShowId.set(row.showId, [entry]);
       }
 
+      // Filter the per-track rows by the show relation (showId IN performerShowIds,
+      // bounded by show count) rather than `trackId IN allTrackIds`: an all-years
+      // sync has tens of thousands of track ids, which blows past the database's
+      // bound-parameter limit.
       const localTrackMusicianRows = allTrackIds.length === 0
         ? []
         : await db.trackMusician.findMany({
-            where: { trackId: { in: allTrackIds } },
+            where: { track: { showId: { in: performerShowIds } } },
             select: {
               id: true,
               trackId: true,
@@ -2903,7 +2907,10 @@ async function syncMissingShows(): Promise<void> {
 
       const localFlagRows = allTrackIds.length === 0
         ? []
-        : await db.trackFlagAssignment.findMany({ where: { trackId: { in: allTrackIds } }, select: { trackId: true, flag: true } });
+        : await db.trackFlagAssignment.findMany({
+            where: { track: { showId: { in: performerShowIds } } },
+            select: { trackId: true, flag: true },
+          });
       const localFlagsByTrackId = new Map<string, string[]>();
       for (const row of localFlagRows) {
         const arr = localFlagsByTrackId.get(row.trackId);
@@ -2958,6 +2965,9 @@ async function syncMissingShows(): Promise<void> {
           smDiff.toCreate.length > 0 || smDiff.toDeleteShowMusicianIds.length > 0 || smDiff.toUpdateInstruments.length > 0;
         if (!lineupChanged && trackWork.length === 0) continue;
 
+        // +adds -deletes ~instrument-only-updates, so a lineup change that only
+        // re-instruments an existing member still shows in the log.
+        const lineupSummary = `lineup +${smDiff.toCreate.length} -${smDiff.toDeleteShowMusicianIds.length} ~${smDiff.toUpdateInstruments.length}, ${trackWork.length} track delta(s)`;
         const flagChanged = trackWork.some((w) => w.flagDiff.toAdd.length > 0 || w.flagDiff.toRemove.length > 0);
         // Tally before the write so dry runs report the same numbers.
         stats.showMusiciansUpserted += smDiff.toCreate.length + smDiff.toUpdateInstruments.length;
@@ -2970,7 +2980,7 @@ async function syncMissingShows(): Promise<void> {
         }
 
         if (isDryRun || isDryRunShow) {
-          console.log(`  🎙️  ${slug}: lineup ±${smDiff.toCreate.length + smDiff.toDeleteShowMusicianIds.length}, ${trackWork.length} track delta(s) (dry run)`);
+          console.log(`  🎙️  ${slug}: ${lineupSummary} (dry run)`);
           changedSlugs.add(slug);
           continue;
         }
@@ -3066,7 +3076,7 @@ async function syncMissingShows(): Promise<void> {
             const showDate = String(local.date);
             if (earliestInsertedDate === null || showDate < earliestInsertedDate) earliestInsertedDate = showDate;
           }
-          console.log(`  🎙️  ${slug}: lineup ±${smDiff.toCreate.length + smDiff.toDeleteShowMusicianIds.length}, ${trackWork.length} track delta(s)`);
+          console.log(`  🎙️  ${slug}: ${lineupSummary}`);
         } catch (err) {
           console.error(`  ❌ failed to mirror performers for ${slug}:`, err);
           stats.errors++;
@@ -3102,7 +3112,10 @@ async function syncMissingShows(): Promise<void> {
         // otherwise be absent from `resolved` (its link rides the later track's
         // payload, which we never fetched) and get wrongly deleted.
         const localCompletionRows = await db.trackCompletion.findMany({
-          where: { earlierTrackId: { in: allTrackIds }, laterTrackId: { in: allTrackIds } },
+          where: {
+            earlierTrack: { showId: { in: performerShowIds } },
+            laterTrack: { showId: { in: performerShowIds } },
+          },
           select: { earlierTrackId: true, laterTrackId: true },
         });
         const compDiff = diffCompletions(localCompletionRows, resolved);

--- a/packages/core/src/_shared/prisma/migrations/20260610000000_spraypaint_inverted_2014_08_01/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260610000000_spraypaint_inverted_2014_08_01/migration.sql
@@ -1,0 +1,37 @@
+-- 2014-08-01-9-30-club-washington-dc — S2.3 Spraypaint is an inverted version.
+-- The other inverted tracks on this show (Abraxas, Bombs, The Great Abyss) were
+-- already flagged INVERTED; Spraypaint was missed and still carries the manual
+-- "Last Time Inverted 12/6/06 (420 shows)" annotation. Replace the prose with the
+-- structured INVERTED flag — the recurrence engine regenerates the equivalent
+-- "last time inverted" footnote from the flag.
+--
+-- Idempotent: the track is resolved by (show slug, set, position); the flag
+-- insert is ON CONFLICT DO NOTHING; the annotation DELETE is scoped to that exact
+-- track and text (btrim guards trailing/double whitespace). Replay after any prod
+-- sync that resurrects the annotation.
+
+DELETE FROM "annotations" a
+USING "tracks" t, "shows" s
+WHERE a."track_id" = t."id"
+  AND t."show_id" = s."id"
+  AND s."slug" = '2014-08-01-9-30-club-washington-dc'
+  AND t."set" = 'S2' AND t."position" = 3
+  AND btrim(a."desc") = 'Last Time Inverted 12/6/06 (420 shows)';
+
+INSERT INTO "track_flags" ("track_id", "flag", "updated_at")
+SELECT t."id", 'INVERTED'::track_flag, now() FROM "tracks" t
+JOIN "shows" s ON s."id" = t."show_id"
+WHERE s."slug" = '2014-08-01-9-30-club-washington-dc' AND t."set" = 'S2' AND t."position" = 3
+ON CONFLICT ("track_id", "flag") DO NOTHING;
+
+-- Recompute recurrence for Spraypaint from its earliest performance so the
+-- INVERTED flag's gap / previous-show columns populate. HAVING dedups against
+-- already-queued dates (a NULL MIN would otherwise insert a NOT-NULL-violating row).
+INSERT INTO "stats_recompute_requests" ("id", "since_date")
+SELECT gen_random_uuid(), MIN(s."date")::date
+FROM "shows" s
+JOIN "tracks" t ON t."show_id" = s."id"
+JOIN "songs" so ON so."id" = t."song_id"
+WHERE so."slug" = 'spraypaint' AND s."date" IS NOT NULL
+HAVING MIN(s."date")::date IS NOT NULL
+   AND MIN(s."date")::date NOT IN (SELECT "since_date" FROM "stats_recompute_requests");


### PR DESCRIPTION
Three follow-ups from verifying the performer-data sync against prod.

## Lineup instruments display alphabetically

Instruments were shown in DB attach order, which floated "vocals" wherever it
was added (e.g. a member stored as "vocals, guitar"). A shared
`formatInstrumentNames` / `sortInstrumentNames` helper now sorts them
case-insensitively everywhere they render (setlist footnotes, the show lineup
block, and the lineup note), so a multi-instrument list reads consistently as
"guitar, vocals".

## Fix prod data for 2014-08-01 Spraypaint (migration)

Spraypaint (S2.3) is an inverted version like the show's other inverted tracks,
but was missed: it lacked the `INVERTED` flag and still carried the manual
"Last Time Inverted 12/6/06 (420 shows)" annotation. The migration removes the
prose, adds the structured `INVERTED` flag, and enqueues a recurrence recompute
so the flag's gap columns populate. It's natural-key matched (show slug, set,
position), idempotent, and a new forward migration (the existing backfill
migrations are already deployed).

## Fix the all-years sync crash

The performer/flag/completion mirroring loaded its local rows with
`trackId IN (…)` over every in-scope track. A full-catalog sync has tens of
thousands of track ids, exceeding the database's bound-parameter limit; the
completions query used the list twice and failed first with `P2029`. The
queries now filter on the show relation (`showId IN performerShowIds`, bounded
by show count). The per-show lineup log line also surfaces instrument-only
updates (`+adds -deletes ~instrument-updates`) instead of hiding them as
`±0, 0`.

## Reviewer notes

- The `P2029` fix is a bug in the just-merged performer-sync PR: an all-years
  dry-run (`YEARS=1995-2026`) crashed before the fix and completes clean after.
- The migration's computed gap is 412 shows vs the manual note's "420"; the
  structured/recomputed value is authoritative.

## Test plan

- `make tc` clean; 523 core + 1204 web + 4 new instrument-sort tests pass.
- Migration applied locally via `prisma migrate deploy`; verified Spraypaint ends
  up `INVERTED` with recurrence populated and the annotation gone (idempotent,
  since local already matched the target state).
- Full `YEARS=1995-2026` dry-run completes with 0 errors after the query fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
