### PR TITLE
Show-page Lineup: collapsible card with deviation sparkles

### DIFF
--- a/apps/web/app/components/show/show-lineup-section.test.tsx
+++ b/apps/web/app/components/show/show-lineup-section.test.tsx
@@ -1,7 +1,8 @@
 import type { Instrument, ShowLineupMember } from "@bip/domain";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, test } from "vitest";
+import type { ShowLineupNotes } from "~/lib/lineup-notes";
 import { ShowLineupSection } from "./show-lineup-section";
 
 function makeInstrument(name: string): Instrument {
@@ -15,10 +16,14 @@ function makeMember(name: string, slug: string, instruments: Instrument[]): Show
   };
 }
 
-function renderSection(lineup: ShowLineupMember[]) {
+function makeNotes(overrides: Partial<ShowLineupNotes> = {}): ShowLineupNotes {
+  return { missing: [], guests: [], offInstrument: [], milestones: [], ...overrides };
+}
+
+function renderSection(lineup: ShowLineupMember[], notes?: ShowLineupNotes) {
   return render(
     <MemoryRouter>
-      <ShowLineupSection lineup={lineup} />
+      <ShowLineupSection lineup={lineup} notes={notes} />
     </MemoryRouter>,
   );
 }
@@ -47,5 +52,91 @@ describe("ShowLineupSection", () => {
   test("renders nothing for an empty lineup", () => {
     const { container } = renderSection([]);
     expect(container).toBeEmptyDOMElement();
+  });
+
+  test("marks a deviating member (whole-show guest) with a sparkle, leaves core members unmarked", () => {
+    renderSection(
+      [
+        makeMember("Jon Gutwillig", "jon-gutwillig", [makeInstrument("Guitar")]),
+        makeMember("Tom Hamilton", "tom-hamilton", [makeInstrument("Guitar")]),
+      ],
+      makeNotes({
+        guests: [
+          {
+            musicianId: "m-tom-hamilton",
+            name: "Tom Hamilton",
+            slug: "tom-hamilton",
+            instruments: ["guitar"],
+            absentTrackIds: [],
+          },
+        ],
+      }),
+    );
+
+    const guestRow = screen.getByText("Tom Hamilton").closest("li");
+    const coreRow = screen.getByText("Jon Gutwillig").closest("li");
+    expect(within(guestRow as HTMLElement).getByTestId("lineup-member-sparkle")).toBeInTheDocument();
+    expect(within(coreRow as HTMLElement).queryByTestId("lineup-member-sparkle")).not.toBeInTheDocument();
+  });
+
+  test("marks an off-instrument core member with a sparkle", () => {
+    renderSection(
+      [makeMember("Jon Gutwillig", "jon-gutwillig", [makeInstrument("Keys")])],
+      makeNotes({
+        offInstrument: [
+          { slug: "jon-gutwillig", name: "Jon Gutwillig", instruments: ["keys"], defaultInstrument: "guitar" },
+        ],
+      }),
+    );
+
+    const row = screen.getByText("Jon Gutwillig").closest("li");
+    expect(within(row as HTMLElement).getByTestId("lineup-member-sparkle")).toBeInTheDocument();
+  });
+
+  test("shows a header deviation indicator when a core member is missing, even with no listed member marked", () => {
+    renderSection(
+      [makeMember("Jon Gutwillig", "jon-gutwillig", [makeInstrument("Guitar")])],
+      makeNotes({ missing: [{ slug: "marc-brownstein", name: "Marc Brownstein", instrument: "bass" }] }),
+    );
+
+    expect(screen.getByTestId("lineup-deviation-indicator")).toBeInTheDocument();
+    expect(screen.queryByTestId("lineup-member-sparkle")).not.toBeInTheDocument();
+  });
+
+  test("shows no indicators when notes report no deviations", () => {
+    renderSection([makeMember("Jon Gutwillig", "jon-gutwillig", [makeInstrument("Guitar")])], makeNotes());
+    expect(screen.queryByTestId("lineup-deviation-indicator")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("lineup-member-sparkle")).not.toBeInTheDocument();
+  });
+
+  test("shows no indicators when notes are omitted", () => {
+    renderSection([makeMember("Jon Gutwillig", "jon-gutwillig", [makeInstrument("Guitar")])]);
+    expect(screen.queryByTestId("lineup-deviation-indicator")).not.toBeInTheDocument();
+  });
+
+  test("bare mode renders just the member list with no card heading or indicators", () => {
+    render(
+      <MemoryRouter>
+        <ShowLineupSection
+          lineup={[makeMember("Jon Gutwillig", "jon-gutwillig", [makeInstrument("Guitar")])]}
+          notes={makeNotes({
+            guests: [
+              {
+                musicianId: "m-tom-hamilton",
+                name: "Tom Hamilton",
+                slug: "tom-hamilton",
+                instruments: ["guitar"],
+                absentTrackIds: [],
+              },
+            ],
+          })}
+          bare
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("heading", { name: "Lineup" })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("lineup-deviation-indicator")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("lineup-member-sparkle")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/components/show/show-lineup-section.tsx
+++ b/apps/web/app/components/show/show-lineup-section.tsx
@@ -1,31 +1,72 @@
 import type { ShowLineupMember } from "@bip/domain";
+import { ChevronDown, Sparkles } from "lucide-react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
+import { Card, CardContent, CardHeader } from "~/components/ui/card";
 import { formatInstrumentNames } from "~/lib/instruments";
+import type { ShowLineupNotes } from "~/lib/lineup-notes";
 import { sortLineup } from "~/lib/musicians-constants";
+import { cn } from "~/lib/utils";
+
+/** Slugs of lineup members who deviate from the expected core lineup — a
+ *  whole-show guest/sit-in, or a core member on a non-default instrument.
+ *  Missing members aren't in the list, so they only drive the header indicator. */
+function deviatingMemberSlugs(notes: ShowLineupNotes): Set<string> {
+  return new Set([...notes.guests, ...notes.offInstrument].map((member) => member.slug));
+}
+
+/** True when anything about the lineup differs from the expected core lineup:
+ *  a missing core member, a whole-show guest, or an off-instrument play. */
+function hasDeviation(notes: ShowLineupNotes): boolean {
+  return notes.missing.length > 0 || notes.guests.length > 0 || notes.offInstrument.length > 0;
+}
 
 /**
- * The show's default performer lineup, shown below the setlist. Each member's
- * name links to their profile page, followed by the instruments they played.
+ * The show's default performer lineup, shown below the setlist as a card. Each
+ * member's name links to their profile, followed by the instruments they
+ * played. A sparkle marks any member who differs from the expected core lineup
+ * (a sit-in, or a core member on an off-instrument), and a matching header
+ * indicator surfaces that the lineup is non-standard while the card is
+ * collapsed on mobile. The card starts collapsed on mobile (tap the header to
+ * expand) and is always expanded at >= md.
+ *
  * Renders nothing when no lineup is recorded. Pass `bare` to render just the
- * member list (no heading or top divider) when the caller supplies its own
- * chrome — e.g. the admin edit page's read-only lineup card.
+ * member list (no card, heading, or indicators) when the caller supplies its
+ * own chrome — e.g. the admin edit page's read-only lineup card; `notes` is
+ * ignored in that mode.
  */
-export function ShowLineupSection({ lineup, bare = false }: { lineup: ShowLineupMember[]; bare?: boolean }) {
+export function ShowLineupSection({
+  lineup,
+  notes,
+  bare = false,
+}: {
+  lineup: ShowLineupMember[];
+  notes?: ShowLineupNotes;
+  bare?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
   if (lineup.length === 0) return null;
+
+  const deviating = !bare && notes ? deviatingMemberSlugs(notes) : null;
 
   const list = (
     <ul className="space-y-1">
       {sortLineup(lineup).map((member) => {
         const instruments = formatInstrumentNames(member.instruments);
         return (
-          <li key={member.musician.id} className="text-sm text-content-text-secondary">
-            <Link
-              to={`/musicians/${member.musician.slug}`}
-              className="text-brand-primary hover:text-brand-secondary hover:underline"
-            >
-              {member.musician.name}
-            </Link>
-            {instruments ? <span className="lowercase"> · {instruments}</span> : ""}
+          <li key={member.musician.id} className="flex items-center gap-1.5 text-sm text-content-text-secondary">
+            <span>
+              <Link
+                to={`/musicians/${member.musician.slug}`}
+                className="text-brand-primary hover:text-brand-secondary hover:underline"
+              >
+                {member.musician.name}
+              </Link>
+              {instruments ? <span className="lowercase"> · {instruments}</span> : ""}
+            </span>
+            {deviating?.has(member.musician.slug) && (
+              <Sparkles data-testid="lineup-member-sparkle" className="h-3.5 w-3.5 shrink-0 text-brand-primary" />
+            )}
           </li>
         );
       })}
@@ -35,9 +76,32 @@ export function ShowLineupSection({ lineup, bare = false }: { lineup: ShowLineup
   if (bare) return list;
 
   return (
-    <div className="mt-6 pt-4 border-t border-glass-border/30">
-      <h3 className="text-base font-medium text-content-text-tertiary mb-2">Lineup</h3>
-      {list}
-    </div>
+    <Card className="card-premium relative overflow-hidden mt-4">
+      <CardHeader
+        onClick={() => setOpen((value) => !value)}
+        className="flex flex-row items-center justify-between gap-2 px-3 py-2 md:px-6 md:py-3 cursor-pointer md:cursor-default"
+      >
+        <h3 className="flex items-center gap-1.5 text-base font-medium text-content-text-tertiary">
+          Lineup
+          {notes && hasDeviation(notes) && (
+            <Sparkles data-testid="lineup-deviation-indicator" className="h-4 w-4 text-brand-primary" />
+          )}
+        </h3>
+        <ChevronDown
+          aria-hidden
+          className={cn("h-4 w-4 shrink-0 transition-transform md:hidden", open && "rotate-180")}
+        />
+      </CardHeader>
+      <div
+        className={cn(
+          "grid transition-[grid-template-rows] duration-300 ease-out md:grid-rows-[1fr]",
+          open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+        )}
+      >
+        <div className="overflow-hidden md:overflow-visible">
+          <CardContent className="px-3 pb-3 pt-0 md:px-6 md:pb-5">{list}</CardContent>
+        </div>
+      </div>
+    </Card>
   );
 }

--- a/apps/web/app/routes/shows/$slug.tsx
+++ b/apps/web/app/routes/shows/$slug.tsx
@@ -25,6 +25,7 @@ import { useShowUserData } from "~/hooks/use-show-user-data";
 import { publicLoader } from "~/lib/base-loaders";
 import { notFound } from "~/lib/errors";
 import { EXTERNAL_SOURCE_DOMAINS } from "~/lib/favicon";
+import { deriveShowLineupNotes } from "~/lib/lineup-notes";
 import { logger } from "~/lib/logger";
 import { showUserDataQueryKey } from "~/lib/query-keys";
 import { createPrefetchClient } from "~/lib/query-prefetch";
@@ -310,7 +311,15 @@ export default function Show() {
             defaultView={setlistView}
             onViewChange={setSetlistView}
           />
-          <ShowLineupSection lineup={setlist.lineup} />
+          <ShowLineupSection
+            lineup={setlist.lineup}
+            notes={deriveShowLineupNotes(
+              setlist.show.date,
+              setlist.lineup,
+              setlist.trackMusicianDeltas,
+              setlist.sets.flatMap((set) => set.tracks).map((track) => track.id),
+            )}
+          />
           {/* Note when count_for_stats=false (soundchecks, radio sessions,
               cancelled stubs, late-night Tractorbeam sets). Yellow accent on
               the left edge for attention, no full background so it doesn't


### PR DESCRIPTION
The Lineup section on a show page is now a card with the standard background instead of a bare list, and it calls out unusual lineups at a glance.

- **Card styling** — the Lineup renders in a `card-premium` card, matching the setlist, reviews, and rail sections.
- **Mobile collapse** — on phones the card starts collapsed with a chevron, and tapping the header expands it. On desktop (≥ md) it's always expanded with no chevron.
- **Deviation sparkles** — a sparkle trails any member who differs from the expected core lineup (a whole-show guest/sit-in, or a core member on an off-instrument), plus a header sparkle so the deviation shows while the card is collapsed. "Different than expected" covers a missing core member, a guest, or an off-instrument play, derived from the existing `deriveShowLineupNotes`.

The admin show-edit read-only lineup (`bare` mode) is unchanged: still a plain list, no card or sparkles.

### Implementation note

The mobile-only collapse is CSS-driven: a `grid-template-rows` transition toggled by React state on mobile, pinned open at `md:` via `md:grid-rows-[1fr]`. Desktop is therefore always expanded regardless of the toggle state, so server and first client render agree and there's no hydration flash from a JS breakpoint check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
