### PR TITLE
Enforce repo-wide formatting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,5 +56,8 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      - name: Format Check
+        run: bun run format:check
+
       - name: Test
         run: bun run test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ bun run lint                         # Lint all code with Biome
 make lint                            # Same as bun run lint
 ```
 
-**Formatting:** Always run `make format FILES="file1.ts file2.tsx"` on files you changed before committing. Only format files you modified — never run project-wide formatting. Biome handles formatting, import sorting, and lint fixes — never use Prettier or other formatters.
+**Formatting:** The whole repo is Biome-formatted and CI fails on unformatted files (`bun run format:check`). Run `bun run format` (`make format-all`) to format everything, or `make format FILES="file1.ts file2.tsx"` to fix just the files you touched. Biome handles formatting, import sorting, and lint fixes — never use Prettier or other formatters.
 
 **Testing:**
 ```bash

--- a/apps/web/app/components/layout/header.tsx
+++ b/apps/web/app/components/layout/header.tsx
@@ -160,59 +160,59 @@ export function Header() {
             {/* Mobile Auth & User Menu */}
             <div className="border-t border-border/10 pt-4 mt-4">
               {user ? (
-                  <div className="space-y-1">
-                    {/* User Info */}
-                    <div className="flex items-center space-x-3 px-4 py-3 rounded-md bg-brand-primary/5">
-                      <Avatar className="h-10 w-10">
-                        <AvatarImage src={user.avatarUrl ?? undefined} />
-                        <AvatarFallback className="bg-brand-primary/20 text-brand-primary text-sm font-medium">
-                          {username?.slice(0, 2).toUpperCase()}
-                        </AvatarFallback>
-                      </Avatar>
-                      <div className="flex flex-col">
-                        <span className="text-sm font-medium text-foreground">{username}</span>
-                        <span className="text-xs text-content-text-secondary">{user.email}</span>
-                      </div>
+                <div className="space-y-1">
+                  {/* User Info */}
+                  <div className="flex items-center space-x-3 px-4 py-3 rounded-md bg-brand-primary/5">
+                    <Avatar className="h-10 w-10">
+                      <AvatarImage src={user.avatarUrl ?? undefined} />
+                      <AvatarFallback className="bg-brand-primary/20 text-brand-primary text-sm font-medium">
+                        {username?.slice(0, 2).toUpperCase()}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="flex flex-col">
+                      <span className="text-sm font-medium text-foreground">{username}</span>
+                      <span className="text-xs text-content-text-secondary">{user.email}</span>
                     </div>
-
-                    {/* User Menu Items */}
-                    <Link
-                      to={`/users/${username}`}
-                      onClick={() => setMobileMenuOpen(false)}
-                      className="flex items-center rounded-md px-4 py-3 text-base font-medium text-content-text-secondary transition-all duration-200 hover:text-brand-primary hover:bg-hover-glass"
-                    >
-                      <Eye className="h-5 w-5 mr-3" />
-                      View Profile
-                    </Link>
-
-                    <Link
-                      to="/profile/edit"
-                      onClick={() => setMobileMenuOpen(false)}
-                      className="flex items-center rounded-md px-4 py-3 text-base font-medium text-content-text-secondary transition-all duration-200 hover:text-brand-secondary hover:bg-hover-glass"
-                    >
-                      <Edit className="h-5 w-5 mr-3" />
-                      Edit Profile
-                    </Link>
-
-                    <Link
-                      to="/auth/logout"
-                      onClick={() => setMobileMenuOpen(false)}
-                      className="flex items-center rounded-md px-4 py-3 text-base font-medium text-red-400 transition-all duration-200 hover:text-red-300 hover:bg-red-500/10"
-                    >
-                      <LogOut className="h-5 w-5 mr-3" />
-                      Sign out
-                    </Link>
                   </div>
-                ) : (
+
+                  {/* User Menu Items */}
                   <Link
-                    to="/auth/login"
+                    to={`/users/${username}`}
                     onClick={() => setMobileMenuOpen(false)}
                     className="flex items-center rounded-md px-4 py-3 text-base font-medium text-content-text-secondary transition-all duration-200 hover:text-brand-primary hover:bg-hover-glass"
                   >
-                    <User className="h-5 w-5 mr-3" />
-                    Sign in
+                    <Eye className="h-5 w-5 mr-3" />
+                    View Profile
                   </Link>
-                )}
+
+                  <Link
+                    to="/profile/edit"
+                    onClick={() => setMobileMenuOpen(false)}
+                    className="flex items-center rounded-md px-4 py-3 text-base font-medium text-content-text-secondary transition-all duration-200 hover:text-brand-secondary hover:bg-hover-glass"
+                  >
+                    <Edit className="h-5 w-5 mr-3" />
+                    Edit Profile
+                  </Link>
+
+                  <Link
+                    to="/auth/logout"
+                    onClick={() => setMobileMenuOpen(false)}
+                    className="flex items-center rounded-md px-4 py-3 text-base font-medium text-red-400 transition-all duration-200 hover:text-red-300 hover:bg-red-500/10"
+                  >
+                    <LogOut className="h-5 w-5 mr-3" />
+                    Sign out
+                  </Link>
+                </div>
+              ) : (
+                <Link
+                  to="/auth/login"
+                  onClick={() => setMobileMenuOpen(false)}
+                  className="flex items-center rounded-md px-4 py-3 text-base font-medium text-content-text-secondary transition-all duration-200 hover:text-brand-primary hover:bg-hover-glass"
+                >
+                  <User className="h-5 w-5 mr-3" />
+                  Sign in
+                </Link>
+              )}
             </div>
           </nav>
         </div>

--- a/apps/web/app/components/track/track-manager.test.tsx
+++ b/apps/web/app/components/track/track-manager.test.tsx
@@ -525,7 +525,10 @@ describe("TrackManager", () => {
     // the earlier-track id); saving PUTs those earlier-track ids so a full-set
     // replace preserves the existing links.
     test("seeds the selection from the server and PUTs earlierTrackIds on save", async () => {
-      const fetchMock = routeFetch(["e1"], { ok: true, completes: [{ date: "2010-01-01", slug: "2010-01-01-shimmy" }] });
+      const fetchMock = routeFetch(["e1"], {
+        ok: true,
+        completes: [{ date: "2010-01-01", slug: "2010-01-01-shimmy" }],
+      });
       globalThis.fetch = fetchMock as never;
 
       const { user } = await setup(

--- a/apps/web/app/components/ui/sortable-header.test.tsx
+++ b/apps/web/app/components/ui/sortable-header.test.tsx
@@ -1,4 +1,11 @@
-import { type ColumnDef, createColumnHelper, flexRender, getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
+import {
+  type ColumnDef,
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, test } from "vitest";

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "cd apps/web && bun run build",
     "lint": "biome lint --error-on-warnings .",
     "format": "biome format . --write",
+    "format:check": "biome format .",
     "typecheck": "cd apps/web && bun react-router typegen && cd ../.. && bun tsc --noEmit",
     "typecheck:all": "bun run -F '*' typecheck",
     "test": "bun run -F '*' test",

--- a/packages/core/src/stats/stats-service.test.ts
+++ b/packages/core/src/stats/stats-service.test.ts
@@ -333,10 +333,7 @@ describe("StatsService.recomputeSongRecurrence", () => {
   // exactly those two track ids (proves it doesn't touch the whole catalog).
   test("recomputes only the given song's tracks and writes their flag recurrence", async () => {
     const statsShows = ["2003-01-01", "2003-01-10", "2003-01-20"];
-    const tracks = [
-      stubTrack("a", "A", "2003-01-01", ["DYSLEXIC"]),
-      stubTrack("b", "B", "2003-01-20", ["DYSLEXIC"]),
-    ];
+    const tracks = [stubTrack("a", "A", "2003-01-01", ["DYSLEXIC"]), stubTrack("b", "B", "2003-01-20", ["DYSLEXIC"])];
     const service = makeService(tracks, statsShows);
     const replaceFlag = vi.spyOn(
       service as unknown as { replaceFlagRecurrence: (ids: string[], recs: unknown[]) => Promise<void> },


### PR DESCRIPTION
CI now fails when any file isn't Biome-formatted, so unformatted code can't merge.

- Adds a `format:check` script (`biome format .`, no `--write`) and a "Format Check" step to the CI workflow.
- Reformats the 4 files that were already out of compliance (`header.tsx`, `track-manager.test.tsx`, `sortable-header.test.tsx`, `stats-service.test.ts`).
- Updates the formatting note in CLAUDE.md: the repo is uniformly formatted and CI enforces it, so project-wide `bun run format` is now the norm rather than something to avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)