### PR TITLE
Shard CI tests across parallel runners

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,33 @@
+name: Setup
+description: Install toolchain, restore the dependency cache, install packages, and generate the Prisma client.
+
+runs:
+  using: composite
+  steps:
+    # Node.js is required for native modules like lightningcss.
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+
+    - uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: 1.3.5
+
+    - name: Cache Bun dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.bun/install/cache
+          node_modules
+          **/node_modules
+        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+        restore-keys: |
+          ${{ runner.os }}-bun-
+
+    - name: Install dependencies
+      shell: bash
+      run: bun install
+
+    - name: Generate Prisma Client
+      shell: bash
+      run: cd packages/core && bun prisma:generate:prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,39 +10,12 @@ on:
       - '!README.md'
 
 jobs:
-  lint-typecheck-test:
-    name: Lint, Type Check & Test
+  checks:
+    name: Lint, Type Check, Format & Core Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      # Setup Node.js (required for native modules like lightningcss)
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      # Setup Bun
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.5
-
-      # Cache Bun dependencies
-      - name: Cache Bun dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.bun/install/cache
-            node_modules
-            **/node_modules
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Generate Prisma Client
-        run: cd packages/core && bun prisma:generate:prod
+      - uses: ./.github/actions/setup
 
       - name: Build packages
         run: |
@@ -59,5 +32,24 @@ jobs:
       - name: Format Check
         run: bun run format:check
 
-      - name: Test
-        run: bun run test
+      # Core tests run in the node environment and finish in a couple of
+      # seconds, so they ride along here instead of paying a separate runner.
+      # The web suite is the slow one and is sharded in `web-test` below.
+      - name: Core tests
+        run: cd packages/core && bun run test
+
+  web-test:
+    name: Web Tests (shard ${{ matrix.shard }}/3)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+
+      # Web tests resolve @bip/core and @bip/domain from source via
+      # vite-tsconfig-paths, so they need neither package built.
+      - name: Web tests
+        run: cd apps/web && bun run vitest run --shard=${{ matrix.shard }}/3


### PR DESCRIPTION
CI now finishes in roughly a quarter of the time. The single serial job
(~193s, dominated by a 116s test step) is split into parallel jobs:

- **checks** — build, type check, lint, format, and the fast node-env
  core tests (~1s).
- **web-test** — a 3-way matrix running the web suite with
  `vitest run --shard=N/3`, ~40s per shard instead of 116s in one pass.

Shared setup (toolchain, dependency cache, install, Prisma generate)
moves into a `.github/actions/setup` composite action so the two jobs
don't repeat it.

Net: ~193s → ~50s wall-clock, at the cost of running 4 runners instead
of 1.

## Detail worth knowing

The web shards intentionally skip the package build step. Web tests
resolve `@bip/core` and `@bip/domain` from source through
vite-tsconfig-paths, so neither package needs a `dist`. Verified by
running the full web suite with the built `dist` directories removed.
Core tests still run in `checks`, which keeps the build, because the
core suite resolves `@bip/domain` from its built output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
