### PR TITLE
Harden prod sync: id bindings, show renames, venue search

### DIFF
--- a/packages/core/scripts/sync-missing-shows.test.ts
+++ b/packages/core/scripts/sync-missing-shows.test.ts
@@ -24,6 +24,7 @@ import {
   type McpShow,
   matchVenue,
   parseYearsArg,
+  planShowRenames,
   planVenueOrphans,
   resolveCompletionLinks,
   STUB_USER_PASSWORD_DIGEST,
@@ -570,6 +571,38 @@ describe("collectVenueKeys", () => {
   });
 });
 
+// planShowRenames detects prod shows that look "missing" (no local row under
+// their slug) but already exist locally by id, i.e. the slug was renamed on
+// prod. Matching by id (stable cross-env) lets the caller update the slug in
+// place instead of insert-colliding on the primary key + FK-failing the ghost
+// delete. The Disco Biscuits 9-30 Club / 930 Club rename is the live case.
+describe("planShowRenames", () => {
+  test("pairs a missing prod slug with the local row that shares its id", () => {
+    const missingRemote = [
+      { id: "show-fca", slug: "2009-10-02-930-club-washington-dc" },
+      { id: "show-new", slug: "2024-08-12-cap-theatre" }, // genuinely new — no local row
+    ];
+    const localById = new Map([["show-fca", { slug: "2009-10-02-9-30-club-washington-dc" }]]);
+    expect(planShowRenames(missingRemote, localById)).toEqual([
+      {
+        id: "show-fca",
+        oldSlug: "2009-10-02-9-30-club-washington-dc",
+        newSlug: "2009-10-02-930-club-washington-dc",
+      },
+    ]);
+  });
+
+  test("ignores remotes with no id (can't match cross-env)", () => {
+    const localById = new Map([["show-fca", { slug: "old-slug" }]]);
+    expect(planShowRenames([{ slug: "new-slug" }], localById)).toEqual([]);
+  });
+
+  test("skips a row whose local slug already equals the prod slug", () => {
+    const localById = new Map([["show-fca", { slug: "same-slug" }]]);
+    expect(planShowRenames([{ id: "show-fca", slug: "same-slug" }], localById)).toEqual([]);
+  });
+});
+
 // matchVenue disambiguates search_venues results. Name alone is insufficient —
 // "Fox Theatre" appears in multiple cities. We only return a match when city AND
 // state both agree (case-insensitive). Anything else is null so the caller can
@@ -631,6 +664,38 @@ describe("matchVenue", () => {
     ];
     expect(matchVenue(candidates, { name: "Brooklyn Bowl Las Vegas", city: "Las Vegas", state: "NV" })).toBe(
       "brooklyn-bowl-las-vegas",
+    );
+  });
+
+  // Many venues share the exact name "House of Blues" across different cities.
+  // Disambiguation must hold no matter how many same-name rows the search
+  // returns — the bug was the *caller* truncating search_venues to 10 results
+  // so the wanted city never reached matchVenue; given the full set it picks
+  // the right one. Guards the city+state discriminator at scale.
+  test("picks the right city among many same-name venues", () => {
+    const cities = [
+      ["West Hollywood", "CA"],
+      ["Chicago", "IL"],
+      ["Las Vegas", "NV"],
+      ["Anaheim", "CA"],
+      ["Atlantic City", "NJ"],
+      ["San Diego", "CA"],
+      ["Orlando", "FL"],
+      ["New Orleans", "LA"],
+      ["Boston", "MA"],
+      ["Cleveland", "OH"],
+      ["Myrtle Beach", "SC"],
+      ["Dallas", "TX"],
+      ["Houston", "TX"],
+    ];
+    const candidates: McpSearchVenueResult[] = cities.map(([city, state]) => ({
+      slug: `house-of-blues-${city.toLowerCase().replace(/ /g, "-")}`,
+      name: "House of Blues",
+      city,
+      state,
+    }));
+    expect(matchVenue(candidates, { name: "House of Blues", city: "Atlantic City", state: "NJ" })).toBe(
+      "house-of-blues-atlantic-city",
     );
   });
 });

--- a/packages/core/scripts/sync-missing-shows.test.ts
+++ b/packages/core/scripts/sync-missing-shows.test.ts
@@ -16,6 +16,7 @@ import {
   diffTrackAnnotations,
   diffTrackFlags,
   diffTrackMusicians,
+  findSquatterIds,
   isStubSlug,
   type LocalTrackForReconcile,
   type McpSearchVenueResult,
@@ -30,6 +31,13 @@ import {
   stubUserEmail,
   syncUserActivity,
 } from "./sync-missing-shows";
+
+// Mirrors Prisma's P2002 on the ratings/attendances primary key — thrown by the
+// stub db when a create reuses an id already held by a different compound-key
+// row, the exact failure the epoch id-binding reconcile resolves.
+function prismaUniqueIdError(): Error {
+  return Object.assign(new Error("Unique constraint failed on the fields: (`id`)"), { code: "P2002" });
+}
 
 // parseYearsArg governs the "what years to sync" decision. Default (no flag)
 // must be the current calendar year per the user's chosen behavior; explicit
@@ -2241,7 +2249,7 @@ function makeStubDb(seed: {
     rating: {
       findFirst: vi.fn(async () => findFirstByMaxUpdatedAt(ratings)),
       findMany: vi.fn(async () =>
-        ratings.map((r) => ({ id: r.id, rateableId: r.rateableId, rateableType: r.rateableType })),
+        ratings.map((r) => ({ id: r.id, userId: r.userId, rateableId: r.rateableId, rateableType: r.rateableType })),
       ),
       upsert: vi.fn(
         async (args: {
@@ -2270,6 +2278,10 @@ function makeStubDb(seed: {
             Object.assign(existing, args.update);
             return existing;
           }
+          // Mirror the primary-key constraint: a create whose id is already
+          // taken by a different (compound-key) row throws P2002, exactly as
+          // Postgres does on the id-preserving insert path.
+          if (ratings.some((r) => r.id === args.create.id)) throw prismaUniqueIdError();
           ratings.push(args.create);
           return args.create;
         },
@@ -2284,7 +2296,7 @@ function makeStubDb(seed: {
     },
     attendance: {
       findFirst: vi.fn(async () => findFirstByMaxUpdatedAt(attendances)),
-      findMany: vi.fn(async () => attendances.map((a) => ({ id: a.id, showId: a.showId }))),
+      findMany: vi.fn(async () => attendances.map((a) => ({ id: a.id, userId: a.userId, showId: a.showId }))),
       upsert: vi.fn(
         async (args: {
           where: { id?: string; userId_showId?: { userId: string; showId: string } };
@@ -2302,6 +2314,7 @@ function makeStubDb(seed: {
             Object.assign(existing, args.update);
             return existing;
           }
+          if (attendances.some((a) => a.id === args.create.id)) throw prismaUniqueIdError();
           attendances.push(args.create);
           return args.create;
         },
@@ -2329,14 +2342,16 @@ function makeStubDb(seed: {
         const t = tracks.find((row) => row.id === args.where.id);
         return t ? { id: t.id } : null;
       }),
-      findMany: vi.fn(async (args: { where: { id: { in: string[] } } }) => {
+      findMany: vi.fn(async (args: { where: { id: { in: string[] } }; select?: { id?: boolean } }) => {
         const ids = new Set(args.where.id.in);
-        return tracks
-          .filter((t) => ids.has(t.id))
-          .map((t) => {
-            const show = shows.find((s) => s.id === t.showId);
-            return { show: { slug: show?.slug ?? null } };
-          });
+        const matching = tracks.filter((t) => ids.has(t.id));
+        // The FK existence check selects { id }; the aggregate-rebuild slug
+        // lookup selects { show: { slug } }. Return the requested shape.
+        if (args.select?.id) return matching.map((t) => ({ id: t.id }));
+        return matching.map((t) => {
+          const show = shows.find((s) => s.id === t.showId);
+          return { show: { slug: show?.slug ?? null } };
+        });
       }),
     },
   };
@@ -2852,6 +2867,200 @@ describe("syncUserActivity — compound-key upserts", () => {
     expect(state.ratings).toHaveLength(1);
     expect(state.ratings[0].id).toBe("r-local-stale-id");
     expect(state.ratings[0].value).toBe(5);
+  });
+});
+
+describe("findSquatterIds", () => {
+  // A local row whose id prod binds to a DIFFERENT compound key is a squatter:
+  // it occupies an id prod needs for other content. Only those ids are returned.
+  test("flags local ids prod binds to a different compound key", () => {
+    const prodKeyById = new Map([
+      ["id-1", "user-a rate-cap Show"],
+      ["id-2", "user-a rate-starland Show"],
+    ]);
+    const local = [
+      { id: "id-1", key: "user-a rate-starland Show" }, // squatter: prod says id-1 is the cap rating
+      { id: "id-2", key: "user-a rate-starland Show" }, // matches prod — not a squatter
+    ];
+    expect(findSquatterIds(local, prodKeyById)).toEqual(["id-1"]);
+  });
+
+  // A local id absent from prod's map is the prune's job (id not on prod at
+  // all), not a binding conflict — the reconcile leaves it alone.
+  test("ignores local ids prod doesn't have", () => {
+    const prodKeyById = new Map([["id-1", "user-a rate-cap Show"]]);
+    const local = [{ id: "id-orphan", key: "user-a rate-cap Show" }];
+    expect(findSquatterIds(local, prodKeyById)).toEqual([]);
+  });
+
+  test("returns nothing when every binding matches", () => {
+    const prodKeyById = new Map([["id-1", "user-a rate-cap Show"]]);
+    expect(findSquatterIds([{ id: "id-1", key: "user-a rate-cap Show" }], prodKeyById)).toEqual([]);
+  });
+});
+
+// The epoch id-binding reconcile: prod owns the rating/attendance id namespace.
+// A local DB can hold an id prod has since rebound to different content; the
+// id-preserving create then collides on the primary key (the compound-key
+// upsert can't help — different key → falls to create). Epoch mode deletes the
+// squatter first, so prod's real row inserts under its id and the squatter's own
+// content re-inserts under ITS prod id in the same pass. Without it, the prod
+// row that wanted the squatted id is silently dropped (the live-run failure).
+describe("syncUserActivity — epoch id-binding reconcile", () => {
+  test("rebinds a rating whose id prod now assigns to a different show", async () => {
+    const { db, state } = makeStubDb({
+      users: [
+        {
+          id: "u-marc",
+          email: "stub-u-marc@local.invalid",
+          passwordDigest: "STUB",
+          username: "trance-marc",
+          avatarFileId: null,
+          avatarFileUrl: null,
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-01-01T00:00:00Z"),
+        },
+      ],
+      shows: [
+        { id: "show-cap", slug: "2024-08-12-cap-theatre" },
+        { id: "show-starland", slug: "2025-03-15-starland-ballroom" },
+      ],
+      ratings: [
+        {
+          id: "r-shared",
+          userId: "u-marc",
+          value: 3,
+          rateableType: "Show",
+          rateableId: "show-starland",
+          createdAt: new Date("2023-01-01T00:00:00Z"),
+          updatedAt: new Date("2023-01-01T00:00:00Z"),
+        },
+      ],
+    });
+    const mcp = makeStubMcp({
+      list_users_since: [{ users: [], nextCursor: null }],
+      list_ratings_since: [
+        {
+          ratings: [
+            {
+              id: "r-shared",
+              userId: "u-marc",
+              value: 5,
+              rateableType: "Show",
+              rateableId: "show-cap",
+              createdAt: "2024-08-12T00:00:00Z",
+              updatedAt: "2024-08-12T00:00:00Z",
+            },
+            {
+              id: "r-starland-real",
+              userId: "u-marc",
+              value: 4,
+              rateableType: "Show",
+              rateableId: "show-starland",
+              createdAt: "2025-03-15T00:00:00Z",
+              updatedAt: "2025-03-15T00:00:00Z",
+            },
+          ],
+          nextCursor: null,
+        },
+      ],
+      list_attendances_since: [{ attendances: [], nextCursor: null }],
+      list_all_attendance_ids: [{ ids: [] }],
+      list_all_rating_ids: [{ ids: ["r-shared", "r-starland-real"] }],
+      list_all_user_ids: [{ ids: ["u-marc"] }],
+    });
+
+    const result = await syncUserActivity(db as never, {
+      isDryRun: false,
+      pullFromEpoch: true,
+      pruneOrphans: true,
+      ratingService: stubRatingService(),
+      cacheInvalidation: null,
+      changedSlugs: new Set(),
+      now: new Date(),
+      mcp,
+    });
+
+    expect(result.ratingsReconciled).toBe(1);
+    const byId = new Map(state.ratings.map((r) => [r.id, r]));
+    expect(byId.get("r-shared")).toMatchObject({ rateableId: "show-cap", value: 5 });
+    expect(byId.get("r-starland-real")).toMatchObject({ rateableId: "show-starland", value: 4 });
+    expect(state.ratings).toHaveLength(2);
+  });
+
+  test("rebinds an attendance whose id prod now assigns to a different show", async () => {
+    const { db, state } = makeStubDb({
+      users: [
+        {
+          id: "u-marc",
+          email: "stub-u-marc@local.invalid",
+          passwordDigest: "STUB",
+          username: "trance-marc",
+          avatarFileId: null,
+          avatarFileUrl: null,
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-01-01T00:00:00Z"),
+        },
+      ],
+      shows: [
+        { id: "show-cap", slug: "2024-08-12-cap-theatre" },
+        { id: "show-starland", slug: "2025-03-15-starland-ballroom" },
+      ],
+      attendances: [
+        {
+          id: "a-shared",
+          userId: "u-marc",
+          showId: "show-starland",
+          createdAt: new Date("2023-01-01T00:00:00Z"),
+          updatedAt: new Date("2023-01-01T00:00:00Z"),
+        },
+      ],
+    });
+    const mcp = makeStubMcp({
+      list_users_since: [{ users: [], nextCursor: null }],
+      list_ratings_since: [{ ratings: [], nextCursor: null }],
+      list_attendances_since: [
+        {
+          attendances: [
+            {
+              id: "a-shared",
+              userId: "u-marc",
+              showId: "show-cap",
+              createdAt: "2024-08-12T00:00:00Z",
+              updatedAt: "2024-08-12T00:00:00Z",
+            },
+            {
+              id: "a-starland-real",
+              userId: "u-marc",
+              showId: "show-starland",
+              createdAt: "2025-03-15T00:00:00Z",
+              updatedAt: "2025-03-15T00:00:00Z",
+            },
+          ],
+          nextCursor: null,
+        },
+      ],
+      list_all_attendance_ids: [{ ids: ["a-shared", "a-starland-real"] }],
+      list_all_rating_ids: [{ ids: [] }],
+      list_all_user_ids: [{ ids: ["u-marc"] }],
+    });
+
+    const result = await syncUserActivity(db as never, {
+      isDryRun: false,
+      pullFromEpoch: true,
+      pruneOrphans: true,
+      ratingService: stubRatingService(),
+      cacheInvalidation: null,
+      changedSlugs: new Set(),
+      now: new Date(),
+      mcp,
+    });
+
+    expect(result.attendancesReconciled).toBe(1);
+    const byId = new Map(state.attendances.map((a) => [a.id, a]));
+    expect(byId.get("a-shared")).toMatchObject({ showId: "show-cap" });
+    expect(byId.get("a-starland-real")).toMatchObject({ showId: "show-starland" });
+    expect(state.attendances).toHaveLength(2);
   });
 });
 

--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -1249,6 +1249,46 @@ async function mcpBulkChunked<TItem, TRow>(
 
 // --- User activity sync (users + ratings + attendances) ---
 
+// Compound-key strings mirroring the rating / attendance unique constraints
+// (ratings_user_id_rateable_id_rateable_type_unique,
+// attendances_user_id_show_id_unique). The space separator can't appear in a
+// uuid or rateableType, so distinct tuples never collide. Detects id↔content
+// divergence
+// between local and prod — see findSquatterIds.
+export function ratingBindingKey(userId: string, rateableId: string, rateableType: string): string {
+  return `${userId} ${rateableId} ${rateableType}`;
+}
+
+export function attendanceBindingKey(userId: string, showId: string): string {
+  return `${userId} ${showId}`;
+}
+
+/**
+ * Local rows that squat on an id prod has assigned to DIFFERENT content.
+ *
+ * Prod owns the rating/attendance id namespace. A local row whose id maps (on
+ * prod) to a different (user, rateable) binding blocks the id-preserving insert
+ * of prod's real row — the compound-key upsert misses, falls to create, and
+ * collides on the primary key. Such squatters must be deleted before the upsert
+ * pass; the squatter's own content is re-created under its correct prod id later
+ * in the same pass (or correctly dropped if prod no longer has it).
+ *
+ * Only sound with prod's complete id→binding map (epoch full-reconcile), where
+ * every prod row is appliable so deleting a squatter never strands local data.
+ * Returns the local ids to delete.
+ */
+export function findSquatterIds(
+  localRows: Array<{ id: string; key: string }>,
+  prodKeyById: Map<string, string>,
+): string[] {
+  const stale: string[] = [];
+  for (const row of localRows) {
+    const prodKey = prodKeyById.get(row.id);
+    if (prodKey !== undefined && prodKey !== row.key) stale.push(row.id);
+  }
+  return stale;
+}
+
 interface UserActivityStats {
   usersCreated: number;
   usersUpdated: number;
@@ -1259,6 +1299,11 @@ interface UserActivityStats {
   usersDeleted: number;
   ratingsDeleted: number;
   attendancesDeleted: number;
+  // Squatter rows deleted by the epoch id-binding reconcile (re-inserted under
+  // their correct prod id during the same upsert pass). Separate from the
+  // prune's *Deleted counters, which remove rows prod no longer has at all.
+  ratingsReconciled: number;
+  attendancesReconciled: number;
   aggregatesRebuilt: number;
 }
 
@@ -1331,6 +1376,8 @@ export async function syncUserActivity(
     usersDeleted: 0,
     ratingsDeleted: 0,
     attendancesDeleted: 0,
+    ratingsReconciled: 0,
+    attendancesReconciled: 0,
     aggregatesRebuilt: 0,
   };
 
@@ -1472,6 +1519,11 @@ export async function syncUserActivity(
   const touchedRateables = new Map<string, { rateableId: string; rateableType: string }>();
   const ratingCursor = await localMaxUpdatedAt("rating");
   console.log(`⭐ Ratings: ${pullFromEpoch ? "full epoch pull" : `incremental since ${ratingCursor.toISOString()}`}`);
+
+  // Buffer the whole prod stream before writing. Epoch mode needs prod's
+  // complete id→(user, rateable) picture to reconcile stale id bindings up
+  // front; incremental mode just buffers its small delta.
+  const prodRatings: McpSyncRating[] = [];
   pageCursor = null;
   do {
     const args: Record<string, unknown> = { since: ratingCursor.toISOString(), limit: SYNC_PAGE_LIMIT };
@@ -1480,32 +1532,80 @@ export async function syncUserActivity(
       "list_ratings_since",
       args,
     );
-    // Resolve each rating's userId through prodIdToLocalId. The map is
-    // populated above for every prod user we saw this run; rows owned by
-    // users we didn't see fall through to their prod id (which equals the
-    // local id in the common case where local was seeded from prod).
-    const resolvedRatings = ratings.map((r) => ({
-      ...r,
-      localUserId: prodIdToLocalId.get(r.userId) ?? r.userId,
-      // Resolve the rateable through the show/track drift maps so a rating that
-      // references prod's show/track id lands on the local row even when that
-      // row was seeded under a different id. No-drift case = the same id back.
-      localRateableId:
-        r.rateableType === "Show"
-          ? (prodShowIdToLocalId.get(r.rateableId) ?? r.rateableId)
-          : r.rateableType === "Track"
-            ? (prodTrackIdToLocalId.get(r.rateableId) ?? r.rateableId)
-            : r.rateableId,
-    }));
-    // Batched FK existence check per page. The realistic miss is show/track:
-    // a dev DB synced for a narrow --years window legitimately lacks older
-    // shows that older ratings reference.
-    const ratingUserIds = Array.from(new Set(resolvedRatings.map((r) => r.localUserId)));
+    prodRatings.push(...ratings);
+    pageCursor = nextCursor;
+  } while (pageCursor !== null);
+
+  // Resolve each rating's userId through prodIdToLocalId. The map is populated
+  // above for every prod user we saw this run; rows owned by users we didn't
+  // see fall through to their prod id (which equals the local id in the common
+  // case where local was seeded from prod). The rateable resolves through the
+  // show/track drift maps so a rating referencing prod's show/track id lands on
+  // the local row even when that row was seeded under a different id. No-drift
+  // case = the same id back.
+  const resolvedRatings = prodRatings.map((r) => ({
+    ...r,
+    localUserId: prodIdToLocalId.get(r.userId) ?? r.userId,
+    localRateableId:
+      r.rateableType === "Show"
+        ? (prodShowIdToLocalId.get(r.rateableId) ?? r.rateableId)
+        : r.rateableType === "Track"
+          ? (prodTrackIdToLocalId.get(r.rateableId) ?? r.rateableId)
+          : r.rateableId,
+  }));
+
+  // Epoch id-binding reconcile. Prod owns the rating id namespace, so a local
+  // row holding an id prod now binds to different content squats the slot the
+  // id-preserving create below needs — and the compound-key upsert can't fix it
+  // (different key → falls to create → primary-key collision). Delete those
+  // squatters; each re-inserts under its correct prod id in the upsert pass.
+  // Mark the squatter's old rateable touched so one whose content prod dropped
+  // still gets its aggregate rebuilt. Epoch-only: the full picture guarantees a
+  // deleted squatter's content is re-created (or rightly gone), never stranded.
+  if (pullFromEpoch && !isDryRun) {
+    const prodKeyById = new Map<string, string>();
+    for (const r of resolvedRatings) {
+      prodKeyById.set(r.id, ratingBindingKey(r.localUserId, r.localRateableId, r.rateableType));
+    }
+    const localRatings = await db.rating.findMany({
+      select: { id: true, userId: true, rateableId: true, rateableType: true },
+    });
+    const squatterIds = new Set(
+      findSquatterIds(
+        localRatings.map((r) => ({
+          id: r.id,
+          key: ratingBindingKey(r.userId, r.rateableId, r.rateableType),
+        })),
+        prodKeyById,
+      ),
+    );
+    if (squatterIds.size > 0) {
+      for (const r of localRatings) {
+        if (!squatterIds.has(r.id)) continue;
+        touchedRateables.set(`${r.rateableType}|${r.rateableId}`, {
+          rateableId: r.rateableId,
+          rateableType: r.rateableType,
+        });
+      }
+      await db.rating.deleteMany({ where: { id: { in: Array.from(squatterIds) } } });
+      stats.ratingsReconciled = squatterIds.size;
+      console.log(`🧩 Ratings: reconciled ${squatterIds.size} stale id binding(s)`);
+    }
+  }
+
+  // Apply in chunks so the FK existence IN-lists stay bounded (same shape the
+  // paged pull used). The realistic FK miss is show/track: a dev DB synced for
+  // a narrow --years window legitimately lacks older shows that older ratings
+  // reference. Squatters are gone, so the id-preserving create can't collide in
+  // epoch mode.
+  for (let offset = 0; offset < resolvedRatings.length; offset += SYNC_PAGE_LIMIT) {
+    const chunk = resolvedRatings.slice(offset, offset + SYNC_PAGE_LIMIT);
+    const ratingUserIds = Array.from(new Set(chunk.map((r) => r.localUserId)));
     const ratingShowIds = Array.from(
-      new Set(resolvedRatings.filter((r) => r.rateableType === "Show").map((r) => r.localRateableId)),
+      new Set(chunk.filter((r) => r.rateableType === "Show").map((r) => r.localRateableId)),
     );
     const ratingTrackIds = Array.from(
-      new Set(resolvedRatings.filter((r) => r.rateableType === "Track").map((r) => r.localRateableId)),
+      new Set(chunk.filter((r) => r.rateableType === "Track").map((r) => r.localRateableId)),
     );
     const [existingRatingUsers, existingRatingShows, existingRatingTracks] = await Promise.all([
       ratingUserIds.length > 0
@@ -1522,7 +1622,7 @@ export async function syncUserActivity(
     const localRatingShowSet = new Set(existingRatingShows.map((s) => s.id));
     const localRatingTrackSet = new Set(existingRatingTracks.map((t) => t.id));
 
-    for (const r of resolvedRatings) {
+    for (const r of chunk) {
       if (!localRatingUserSet.has(r.localUserId)) {
         stats.ratingsFkSkipped++;
         console.warn(`  ⚠️  rating ${r.id}: skipping — user ${r.localUserId} not local`);
@@ -1548,14 +1648,11 @@ export async function syncUserActivity(
       }
       try {
         // Upsert by the compound unique (userId, rateableId, rateableType)
-        // instead of id. Local DBs seeded from older prod dumps can hold a
-        // row with the same compound key but a different id; upserting by
-        // id would then hit ratings_user_id_rateable_id_rateable_type_unique
-        // on insert. Using the compound key as the upsert target lets the
-        // existing local row absorb the new value cleanly. The local id may
-        // drift from prod; --full-users converges by deleting the stale-id
-        // local row, after which the next incremental run inserts with the
-        // prod id.
+        // instead of id. A local row with the same compound key but a different
+        // id (older dump) absorbs the new value in place — upserting by id would
+        // hit ratings_user_id_rateable_id_rateable_type_unique on insert. The
+        // inverse — a local row with this id bound to a DIFFERENT compound key —
+        // is cleared by the epoch reconcile above before we reach create.
         await db.rating.upsert({
           where: {
             userId_rateableId_rateableType: {
@@ -1587,13 +1684,14 @@ export async function syncUserActivity(
         console.error(`  ❌ rating ${r.id} upsert failed:`, err);
       }
     }
-    pageCursor = nextCursor;
-  } while (pageCursor !== null);
+  }
   console.log(`⭐ Ratings: +${stats.ratingsUpserted} (skipped ${stats.ratingsFkSkipped} on missing FK)`);
 
   // --- Attendances ---
+  // Same buffer → resolve → epoch-reconcile → chunked-apply shape as ratings.
   const attCursor = await localMaxUpdatedAt("attendance");
   console.log(`🎫 Attendances: ${pullFromEpoch ? "full epoch pull" : `incremental since ${attCursor.toISOString()}`}`);
+  const prodAttendances: McpSyncAttendance[] = [];
   pageCursor = null;
   do {
     const args: Record<string, unknown> = { since: attCursor.toISOString(), limit: SYNC_PAGE_LIMIT };
@@ -1602,15 +1700,50 @@ export async function syncUserActivity(
       "list_attendances_since",
       args,
     );
-    // Same userId remap + batched FK check as the ratings loop.
-    const resolvedAttendances = attendances.map((a) => ({
-      ...a,
-      localUserId: prodIdToLocalId.get(a.userId) ?? a.userId,
-      // Same show-id drift remap as the rating loop.
-      localShowId: prodShowIdToLocalId.get(a.showId) ?? a.showId,
-    }));
-    const attUserIds = Array.from(new Set(resolvedAttendances.map((a) => a.localUserId)));
-    const attShowIds = Array.from(new Set(resolvedAttendances.map((a) => a.localShowId)));
+    prodAttendances.push(...attendances);
+    pageCursor = nextCursor;
+  } while (pageCursor !== null);
+
+  // Same userId + show-id drift remap as the ratings loop.
+  const resolvedAttendances = prodAttendances.map((a) => ({
+    ...a,
+    localUserId: prodIdToLocalId.get(a.userId) ?? a.userId,
+    localShowId: prodShowIdToLocalId.get(a.showId) ?? a.showId,
+  }));
+
+  // Epoch id-binding reconcile — same rationale as ratings: clear local rows
+  // squatting an id prod now binds to a different (user, show) before the
+  // id-preserving create runs. Show slugs of cleared squatters land in
+  // changedSlugs so the affected listings get their cache invalidated.
+  if (pullFromEpoch && !isDryRun) {
+    const prodKeyById = new Map<string, string>();
+    for (const a of resolvedAttendances) {
+      prodKeyById.set(a.id, attendanceBindingKey(a.localUserId, a.localShowId));
+    }
+    const localAttendances = await db.attendance.findMany({ select: { id: true, userId: true, showId: true } });
+    const squatterIds = new Set(
+      findSquatterIds(
+        localAttendances.map((a) => ({ id: a.id, key: attendanceBindingKey(a.userId, a.showId) })),
+        prodKeyById,
+      ),
+    );
+    if (squatterIds.size > 0) {
+      const squatterShowIds = new Set(localAttendances.filter((a) => squatterIds.has(a.id)).map((a) => a.showId));
+      const squatterShows = await db.show.findMany({
+        where: { id: { in: Array.from(squatterShowIds) } },
+        select: { slug: true },
+      });
+      for (const s of squatterShows) if (s.slug) changedSlugs.add(s.slug);
+      await db.attendance.deleteMany({ where: { id: { in: Array.from(squatterIds) } } });
+      stats.attendancesReconciled = squatterIds.size;
+      console.log(`🧩 Attendances: reconciled ${squatterIds.size} stale id binding(s)`);
+    }
+  }
+
+  for (let offset = 0; offset < resolvedAttendances.length; offset += SYNC_PAGE_LIMIT) {
+    const chunk = resolvedAttendances.slice(offset, offset + SYNC_PAGE_LIMIT);
+    const attUserIds = Array.from(new Set(chunk.map((a) => a.localUserId)));
+    const attShowIds = Array.from(new Set(chunk.map((a) => a.localShowId)));
     const [existingAttUsers, existingAttShows] = await Promise.all([
       attUserIds.length > 0
         ? db.user.findMany({ where: { id: { in: attUserIds } }, select: { id: true } })
@@ -1622,7 +1755,7 @@ export async function syncUserActivity(
     const localAttUserSet = new Set(existingAttUsers.map((u) => u.id));
     const localAttShowBySlug = new Map(existingAttShows.map((s) => [s.id, s.slug]));
 
-    for (const a of resolvedAttendances) {
+    for (const a of chunk) {
       if (!localAttUserSet.has(a.localUserId)) {
         stats.attendancesFkSkipped++;
         console.warn(`  ⚠️  attendance ${a.id}: skipping — user ${a.localUserId} not local`);
@@ -1640,11 +1773,10 @@ export async function syncUserActivity(
         continue;
       }
       try {
-        // Same compound-key upsert reasoning as the rating loop above —
-        // local DBs from old prod dumps can hold (userId, showId) with a
-        // different id, which would violate attendances_user_id_show_id_unique
-        // on an id-keyed insert. --full-users converges the local id back
-        // to prod's over two runs.
+        // Compound-key upsert: a local row with the same (userId, showId) but a
+        // different id (older dump) absorbs the update in place. The inverse —
+        // this id bound to a different (userId, showId) — is cleared by the
+        // epoch reconcile above before we reach create.
         await db.attendance.upsert({
           where: { userId_showId: { userId: a.localUserId, showId: a.localShowId } },
           update: { updatedAt: new Date(a.updatedAt) },
@@ -1662,8 +1794,7 @@ export async function syncUserActivity(
         console.error(`  ❌ attendance ${a.id} upsert failed:`, err);
       }
     }
-    pageCursor = nextCursor;
-  } while (pageCursor !== null);
+  }
   console.log(`🎫 Attendances: +${stats.attendancesUpserted} (skipped ${stats.attendancesFkSkipped} on missing FK)`);
 
   // --- Full-mode reconciliation: delete local rows not on prod ---
@@ -3579,10 +3710,10 @@ function printSummary(stats: SyncStats, isDryRun: boolean): void {
     const ua = stats.userActivity;
     console.log(`Users (created / updated / deleted): ${ua.usersCreated} / ${ua.usersUpdated} / ${ua.usersDeleted}`);
     console.log(
-      `Ratings (upserted / deleted / FK skipped): ${ua.ratingsUpserted} / ${ua.ratingsDeleted} / ${ua.ratingsFkSkipped}`,
+      `Ratings (upserted / deleted / reconciled / FK skipped): ${ua.ratingsUpserted} / ${ua.ratingsDeleted} / ${ua.ratingsReconciled} / ${ua.ratingsFkSkipped}`,
     );
     console.log(
-      `Attendances (upserted / deleted / FK skipped): ${ua.attendancesUpserted} / ${ua.attendancesDeleted} / ${ua.attendancesFkSkipped}`,
+      `Attendances (upserted / deleted / reconciled / FK skipped): ${ua.attendancesUpserted} / ${ua.attendancesDeleted} / ${ua.attendancesReconciled} / ${ua.attendancesFkSkipped}`,
     );
     console.log(`Rating aggregates rebuilt: ${ua.aggregatesRebuilt}`);
   } else {

--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -409,6 +409,30 @@ export function buildShowCreateInput(
   };
 }
 
+/**
+ * Pair prod shows that look "missing" (no local row under their slug) against
+ * local rows carrying the same prod id under a DIFFERENT slug. Those are slug
+ * renames (an admin changed the show slug on prod), not new shows: handling
+ * them as insert-new would collide on the primary key, and the stale-slug local
+ * row would then trip the ghost-delete (FK from its ratings/attendances).
+ * Match by id (the stable cross-environment key) since the slug is exactly what
+ * drifted. Returns the (oldSlug to newSlug) updates to apply in place.
+ */
+export function planShowRenames(
+  missingRemote: Array<{ id?: string; slug: string }>,
+  localById: Map<string, { slug: string | null }>,
+): Array<{ id: string; oldSlug: string | null; newSlug: string }> {
+  const renames: Array<{ id: string; oldSlug: string | null; newSlug: string }> = [];
+  for (const remote of missingRemote) {
+    if (!remote.id) continue;
+    const local = localById.get(remote.id);
+    if (!local) continue; // genuinely new show — leave it for the insert path
+    if (local.slug === remote.slug) continue; // already aligned (defensive)
+    renames.push({ id: remote.id, oldSlug: local.slug, newSlug: remote.slug });
+  }
+  return renames;
+}
+
 // Shape-minimal view of a local Show row (only the aggregate fields we mirror)
 // — used as the left operand to showNeedsUpdate.
 export interface LocalShowAggregates {
@@ -1923,6 +1947,9 @@ interface SyncStats {
   showsUpdated: number;
   showsUnchanged: number;
   showsCreated: number;
+  // Local shows whose slug was realigned to prod's after an admin renamed the
+  // show on prod (matched by id). See planShowRenames.
+  showsRenamed: number;
   songsFetched: number;
   songsCreated: number;
   songsOrphanedDeleted: number;
@@ -2120,6 +2147,7 @@ async function syncMissingShows(): Promise<void> {
     showsUpdated: 0,
     showsUnchanged: 0,
     showsCreated: 0,
+    showsRenamed: 0,
     songsFetched: 0,
     songsCreated: 0,
     songsOrphanedDeleted: 0,
@@ -2206,21 +2234,19 @@ async function syncMissingShows(): Promise<void> {
     // Step 2c: partition into missing-locally vs already-local. We pull venueId
     // for existing rows so the drift-update branch can back-fill venues that
     // landed NULL under an older sync (caused 404s on /shows/:slug).
-    const existingLocal = await db.show.findMany({
-      where: { slug: { in: realSlugs } },
-      select: {
-        id: true,
-        slug: true,
-        date: true,
-        averageRating: true,
-        ratingsCount: true,
-        notes: true,
-        relistenUrl: true,
-        venueId: true,
-        countForStats: true,
-        dayOrder: true,
-      },
-    });
+    const localShowSelect = {
+      id: true,
+      slug: true,
+      date: true,
+      averageRating: true,
+      ratingsCount: true,
+      notes: true,
+      relistenUrl: true,
+      venueId: true,
+      countForStats: true,
+      dayOrder: true,
+    } as const;
+    const existingLocal = await db.show.findMany({ where: { slug: { in: realSlugs } }, select: localShowSelect });
     // Local Show.slug is nullable in the schema, but every show this script
     // touches has a slug (we filter the prod summary by slug earlier in step
     // 2). Narrowing here keeps `existingBySlug` keyed by `string` so every
@@ -2229,13 +2255,44 @@ async function syncMissingShows(): Promise<void> {
     const existingBySlug = new Map(
       existingLocal.filter((s): s is typeof s & { slug: string } => s.slug !== null).map((s) => [s.slug, s]),
     );
+
+    // Step 2d: realign renamed shows. A prod show with no local row under its
+    // slug, but whose prod id already exists locally under a different slug, is
+    // a slug rename (admin renamed it on prod), not a new show. Update the local
+    // row's slug in place and fold it into existingBySlug so it flows through
+    // the drift/setlist reconcile as an existing show. Without this the show
+    // would insert-collide on the primary key and then FK-fail when the
+    // stale-slug ghost is pruned.
+    const slugRenameCandidates = remoteFullShows.filter((s) => !existingBySlug.has(s.slug));
+    const renameCandidateIds = slugRenameCandidates.flatMap((s) => (s.id ? [s.id] : []));
+    const renameLocalRows =
+      renameCandidateIds.length > 0
+        ? await db.show.findMany({ where: { id: { in: renameCandidateIds } }, select: localShowSelect })
+        : [];
+    const renameLocalById = new Map(renameLocalRows.map((r) => [r.id, r]));
+    for (const rename of planShowRenames(slugRenameCandidates, renameLocalById)) {
+      const localRow = renameLocalById.get(rename.id);
+      if (!localRow) continue;
+      if (!isDryRun) {
+        await db.show.update({ where: { id: rename.id }, data: { slug: rename.newSlug, updatedAt: now } });
+      }
+      if (rename.oldSlug) changedSlugs.add(rename.oldSlug);
+      changedSlugs.add(rename.newSlug);
+      existingBySlug.set(rename.newSlug, { ...localRow, slug: rename.newSlug });
+      stats.showsRenamed++;
+      console.log(`  🔀 show slug realigned ${rename.oldSlug ?? "(null)"} → ${rename.newSlug}`);
+    }
+
     stats.showsAlreadyLocal = existingBySlug.size;
     const missingShows = remoteFullShows.filter((s) => !existingBySlug.has(s.slug));
     const existingRemoteShows = remoteFullShows.filter((s) => existingBySlug.has(s.slug));
     // Existing shows whose venue we still need to resolve so the drift loop
     // can back-fill venueId. Their setlists MUST be fetched alongside missing
-    // shows so we know the (name, city, state) tuple to search by.
-    const needsVenueSlugs = existingLocal.filter((s) => s.venueId === null).map((s) => s.slug);
+    // shows so we know the (name, city, state) tuple to search by. Sourced from
+    // existingBySlug (not existingLocal) so realigned renames are covered too.
+    const needsVenueSlugs = Array.from(existingBySlug.values())
+      .filter((s) => s.venueId === null)
+      .map((s) => s.slug);
     console.log(
       `📥 ${missingShows.length} missing locally (${stats.showsAlreadyLocal} already present, ${needsVenueSlugs.length} need venue back-fill)`,
     );
@@ -2329,9 +2386,14 @@ async function syncMissingShows(): Promise<void> {
     const venueKeyToSlug = new Map<string, string>(); // "name|city|state" -> slug
     for (const key of venueKeys) {
       try {
+        // Query by name only, then disambiguate on city+state in matchVenue.
+        // The limit must exceed the largest count of venues sharing a name, or
+        // the exact city+state match can be truncated away (16 "House of Blues"
+        // rows overflowed the old limit of 10, leaving those shows venue-less).
+        // 50 is the prod search default and comfortably covers real name reuse.
         const { results } = await mcpCall<{ results: McpSearchVenueResult[] }>("search_venues", {
           query: key.name,
-          limit: 10,
+          limit: 50,
         });
         const slug = matchVenue(results, key);
         if (slug) {
@@ -3673,6 +3735,7 @@ function printSummary(stats: SyncStats, isDryRun: boolean): void {
   console.log(`Shows updated (drift): ${stats.showsUpdated}`);
   console.log(`Shows unchanged: ${stats.showsUnchanged}`);
   console.log(`Shows created: ${stats.showsCreated}`);
+  console.log(`Shows renamed (slug realigned): ${stats.showsRenamed}`);
   console.log(`Songs fetched: ${stats.songsFetched}`);
   console.log(`Songs created: ${stats.songsCreated}`);
   console.log(


### PR DESCRIPTION
Makes a full-reconcile sync (`make db-sync-missing-shows ... FULL_USERS=1
PRUNE_GHOST_SHOWS=1`) converge cleanly instead of logging errors and
dropping or mis-slugging rows. Three independent failure modes, all from
the same root cause: prod is the source of truth, but the reconcile matched
rows by slug / absorbed by compound key without reconciling the underlying
ids.

## 1. Stale rating/attendance id bindings (was dropping ~96 rows)

Prod owns the rating/attendance row-id namespace. A local DB can hold an id
prod has since rebound to a different `(user, rateable)`: e.g. local rating
`8b0872cb` pointed at a Starland Ballroom show while prod assigns that id to
a different rating. The compound-key upsert misses, falls to `create`, and
collides on the primary key; the prune can't help (the id IS on prod, just
bound to other content) and runs after the upsert anyway.

`syncUserActivity` now runs an epoch-only id-binding reconcile first: build
prod's complete `id -> (user, rateable)` map, delete local rows squatting an
id under a different binding (`findSquatterIds`), then upsert. Prod's rows
insert under their ids; each squatter's content re-inserts under its correct
prod id in the same pass. On the live run this rebound 42 ratings + 54
attendances; upsert failures went from ~96 to 0.

## 2. Renamed show slugs (was logging 2 errors, leaving slug stale)

A show whose slug changed on prod looked like insert-new + delete-ghost: the
insert collided on the primary key (same prod id already local) and the
ghost delete FK-failed on the show's ratings/attendances. The show pass now
detects a "missing" prod show whose id already exists locally under a
different slug (`planShowRenames`) and updates that row's slug in place,
folding it into the existing-show reconcile. Healed the 9-30 Club / 930 Club
rename; errors went from 2 to 0.

## 3. Venue search truncation (cosmetic, but a latent miss)

`search_venues` used `limit: 10`, but 16 venues share the name "House of
Blues"; the exact city+state match could be truncated before reaching the
disambiguator, leaving those shows venue-less. Raised the limit to 50 (the
prod search default). No data to heal (0 shows are currently venue-less),
but a future show at a high-collision venue would have landed with no venue.

## Notes for the reviewer

The id-preserving create can collide two ways: same compound key /
different id (a local row absorbs the update in place via the compound-key
upsert, unchanged) versus different compound key / same id (a squatter,
handled by the new reconcile). The test stub previously never modeled the
primary-key constraint, so the collision was invisible to tests; it now
throws `P2002` on a create whose id is already taken, which is what makes
the new regression tests meaningful. The id-binding reconcile is gated to
epoch mode (`--full-users`), where prod's complete picture guarantees a
deleted squatter's content is re-created (or rightly gone), never stranded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
