### PR TITLE
Marlon percussion sit-in + Jake Brownstein profile migrations

### DIFF
--- a/packages/core/src/_shared/prisma/migrations/20260612000012_marlon_percussion_paramount_2026_06_11/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260612000012_marlon_percussion_paramount_2026_06_11/migration.sql
@@ -1,0 +1,42 @@
+-- 2026-06-11 The Paramount (Huntington, NY): Marlon Lewis sat in on percussion
+-- alongside Sam Altman's drum sit-in for the Basis -> I-Man -> Basis run. Add a
+-- per-track Marlon-on-percussion delta to every track where Sam plays drums
+-- (resolved by slug, so it tracks the actual data rather than hardcoded
+-- positions), and drop the now-redundant free-text note describing the sit-in.
+
+-- Marlon Lewis on percussion for every track where Sam Altman is on drums
+INSERT INTO "track_musicians" ("track_id", "musician_id", "present", "updated_at")
+SELECT DISTINCT t."id", mar."id", true, now()
+FROM "tracks" t
+  JOIN "shows" s ON s."id" = t."show_id"
+  JOIN "track_musicians" tm_sam ON tm_sam."track_id" = t."id"
+  JOIN "musicians" sam ON sam."id" = tm_sam."musician_id" AND sam."slug" = 'sam-altman'
+  JOIN "track_musician_instruments" tmi ON tmi."track_musician_id" = tm_sam."id"
+  JOIN "instruments" drums ON drums."id" = tmi."instrument_id" AND drums."slug" = 'drums'
+  CROSS JOIN "musicians" mar
+WHERE s."slug" = '2026-06-11-the-paramount-huntington-ny' AND mar."slug" = 'marlon-lewis'
+ON CONFLICT ("track_id", "musician_id") DO NOTHING;
+
+INSERT INTO "track_musician_instruments" ("track_musician_id", "instrument_id", "updated_at")
+SELECT tm."id", perc."id", now()
+FROM "track_musicians" tm
+  JOIN "tracks" t ON t."id" = tm."track_id"
+  JOIN "shows" s ON s."id" = t."show_id"
+  JOIN "musicians" mar ON mar."id" = tm."musician_id" AND mar."slug" = 'marlon-lewis'
+  JOIN "instruments" perc ON perc."slug" = 'percussion'
+WHERE s."slug" = '2026-06-11-the-paramount-huntington-ny'
+ON CONFLICT ("track_musician_id", "instrument_id") DO NOTHING;
+
+-- Drop the redundant Sam-on-drums sit-in note now that it is structured data
+UPDATE "shows"
+SET "notes" = 'Summer Tour Opener', "updated_at" = now()
+WHERE "slug" = '2026-06-11-the-paramount-huntington-ny'
+  AND "notes" LIKE '%Sam Altman on drums for Basis%';
+
+-- Recompute stats from this show's date forward at deploy time. The recompute
+-- drains the queue and busts the show/listing/song caches (invalidateShowListings
+-- clears CacheKeys.show.allData), which is the only cache-clear lever prod has.
+-- since_date is the most recent show date, so the rebuild scope is just this show.
+INSERT INTO "stats_recompute_requests" ("id", "since_date")
+SELECT gen_random_uuid(), '2026-06-11'
+WHERE NOT EXISTS (SELECT 1 FROM "stats_recompute_requests" WHERE "since_date" = '2026-06-11');

--- a/packages/core/src/_shared/prisma/migrations/20260613000000_jake_brownstein_guitar_eggy/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260613000000_jake_brownstein_guitar_eggy/migration.sql
@@ -1,0 +1,16 @@
+-- Set Jake Brownstein's default instrument to guitar and his "known from" to Eggy.
+-- Match by stable slugs; resolve the instrument FK via a slug subquery.
+UPDATE "musicians"
+SET "known_from" = 'Eggy',
+    "default_instrument_id" = (SELECT "id" FROM "instruments" WHERE "slug" = 'guitar'),
+    "updated_at" = now()
+WHERE "slug" = 'jake-brownstein';
+
+-- Bust the musician profile cache at deploy time. The recompute drain calls
+-- invalidateSongCaches, which delPatterns CacheKeys.musicians.allPages
+-- (musician:*:data:*) -- the only cache-clear lever a prod migration has. The
+-- since_date is after the latest show, so the gaps/song-stats rebuild is a no-op
+-- and only the cache bust runs.
+INSERT INTO "stats_recompute_requests" ("id", "since_date")
+SELECT gen_random_uuid(), '2026-06-13'
+WHERE NOT EXISTS (SELECT 1 FROM "stats_recompute_requests" WHERE "since_date" = '2026-06-13');


### PR DESCRIPTION
Marlon Lewis now shows on percussion for every track of the 2026-06-11 Paramount
Basis -> I-Man -> Basis run, alongside Sam Altman's drum sit-in, and the old
free-text note describing it is gone. Jake Brownstein's profile now lists guitar
as his default instrument and "Eggy" as where you'd know him from.

Two independent data migrations:

- `20260612000012_marlon_percussion_paramount_2026_06_11` adds a per-track
  Marlon-on-percussion delta to every track where Sam Altman is on drums
  (matched by slug, so it tracks the actual data rather than hardcoded
  positions) and replaces the redundant sit-in note.
- `20260613000000_jake_brownstein_guitar_eggy` sets `default_instrument_id`
  (via a `slug = 'guitar'` subquery) and `known_from`, matched by slug.

## Cache invalidation

The Jake migration enqueues a `stats_recompute_requests` row. A migration is
pure SQL and can't touch Redis; the deploy-time recompute drain
(`runPendingRecompute`) is the only cache-clear lever prod has, and it calls
`invalidateSongCaches`, which `delPattern`s `musician:*:data:*`. The
`since_date` is after the latest show, so the gaps/song-stats rebuild is a no-op
and only the cache bust runs. Verified locally via `make recompute-pending`:
`musician:jake-brownstein:data:v2` went from present to cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
