### PR TITLE
Unify collapsible sections behind a shared component

### DIFF
--- a/apps/web/app/components/filter-nav.test.tsx
+++ b/apps/web/app/components/filter-nav.test.tsx
@@ -23,29 +23,6 @@ describe("FilterNav", () => {
     expect(countSpan.className).toContain("sm:inline");
   });
 
-  // The panel always collapses on mobile (so the long year list doesn't
-  // push the rest of the page out of the viewport) but stays expanded at
-  // sm+ by default. The mobile toggle button is `sm:hidden`; desktop gets
-  // a static heading.
-  test("renders a mobile toggle button (sm:hidden)", async () => {
-    await setupWithRouter(<FilterNav title="Filter by Year" filters={["2024"]} basePath="/shows/year/" />);
-
-    const trigger = screen.getByRole("button", { name: /Filter by Year/ });
-    expect(trigger.className).toContain("sm:hidden");
-  });
-
-  // On desktop the panel renders a non-button heading so the panel is
-  // always expanded and there is no functional toggle visible.
-  test("renders a static heading at sm+ (hidden sm:flex)", async () => {
-    const { container } = await setupWithRouter(
-      <FilterNav title="Filter by Year" filters={["2024"]} basePath="/shows/year/" />,
-    );
-
-    const desktopHeading = container.querySelector("h2");
-    expect(desktopHeading?.className).toContain("hidden");
-    expect(desktopHeading?.className).toContain("sm:flex");
-  });
-
   // The "All" button's count should follow the same hide-on-mobile rule
   // so it does not overlap the "All" label on phones.
   test("allCount span uses 'hidden sm:inline' so it hides on mobile", async () => {
@@ -58,42 +35,39 @@ describe("FilterNav", () => {
     expect(countSpan.className).toContain("sm:inline");
   });
 
-  // Phone-landscape collapse: a rotated phone has the same vertical-space
-  // crunch as a narrow portrait phone, so we re-show the mobile toggle
-  // button and re-hide the desktop heading when `short:` (max-height:
-  // 640px) matches. Without this, the filter chrome eats most of the
-  // landscape viewport.
-  test("mobile toggle re-shows on short viewports via short:!flex", async () => {
+  // The title is the collapsible toggle (a heading wrapping a button), so it's
+  // reachable both as a heading and as a clickable control.
+  test("renders the title as a collapsible toggle heading", async () => {
     await setupWithRouter(<FilterNav title="Filter by Year" filters={["2024"]} basePath="/shows/year/" />);
 
-    const trigger = screen.getByRole("button", { name: /Filter by Year/ });
-    expect(trigger.className).toContain("short:!flex");
+    expect(screen.getByRole("heading", { name: /Filter by Year/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Filter by Year/ })).toBeInTheDocument();
   });
 
-  test("desktop heading re-hides on short viewports via short:hidden", async () => {
-    const { container } = await setupWithRouter(
-      <FilterNav title="Filter by Year" filters={["2024"]} basePath="/shows/year/" />,
-    );
+  // Each filter is a link to its year route, preserving any active URL params.
+  test("renders each filter as a link to its route", async () => {
+    await setupWithRouter(<FilterNav title="Filter by Year" filters={["2024", "2025"]} basePath="/shows/year/" />);
 
-    const desktopHeading = container.querySelector("h2");
-    expect(desktopHeading?.className).toContain("short:hidden");
+    expect(screen.getByRole("link", { name: "2024" })).toHaveAttribute("href", "/shows/year/2024");
+    expect(screen.getByRole("link", { name: "2025" })).toHaveAttribute("href", "/shows/year/2025");
   });
 
-  // Collapsed body carries the short:! overrides so a desktop-style force-
-  // open (sm:!max-h-[1000px]) doesn't keep the panel expanded on a phone
-  // in landscape. When the user has already expanded the panel, the
-  // overrides drop out so the panel stays open at any viewport size.
-  test("collapsed body re-collapses on short viewports via short:!max-h-0", async () => {
-    const { container } = await setupWithRouter(
-      <FilterNav title="Filter by Year" filters={["2024"]} basePath="/shows/year/" />,
-    );
+  // The panel collapses on phones but force-opens from sm+ (it's filter chrome,
+  // which only crowds small screens — hence sm, not the md content default).
+  test("force-opens from sm+ via sm:grid-rows-[1fr]", async () => {
+    await setupWithRouter(<FilterNav title="Filter by Year" filters={["2024"]} basePath="/shows/year/" />);
 
-    // Body is the inner overflow-hidden + transition-all wrapper around the
-    // filter grid — distinct from the outer card-premium wrapper which also
-    // has overflow-hidden.
-    const body = container.querySelector("div.transition-all");
-    expect(body?.className).toContain("short:!max-h-0");
-    expect(body?.className).toContain("short:!opacity-0");
-    expect(body?.className).toContain("short:!pointer-events-none");
+    const body = screen.getByTestId("collapsible-section-body");
+    expect(body.className).toContain("sm:grid-rows-[1fr]");
+    expect(body.className).not.toContain("md:grid-rows-[1fr]");
+  });
+
+  // Phone-landscape collapse: a rotated phone has the same vertical-space crunch
+  // as portrait, so the panel re-collapses on short viewports even above sm.
+  test("re-collapses on short (landscape) viewports via short:!grid-rows-[0fr]", async () => {
+    await setupWithRouter(<FilterNav title="Filter by Year" filters={["2024"]} basePath="/shows/year/" />);
+
+    const body = screen.getByTestId("collapsible-section-body");
+    expect(body.className).toContain("short:!grid-rows-[0fr]");
   });
 });

--- a/apps/web/app/components/filter-nav.tsx
+++ b/apps/web/app/components/filter-nav.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
 import { Link } from "react-router-dom";
+import { CollapsibleSection } from "~/components/ui/collapsible-section";
 import { cn } from "~/lib/utils";
 
 function getLink(filter: string, basePath: string, currentURLParameters: URLSearchParams) {
@@ -45,11 +45,6 @@ export function FilterNav({
   filterCounts,
   allCount,
 }: FilterNavProps) {
-  // The panel always collapses on mobile (`<sm`); on desktop it stays
-  // expanded unless the caller opts in with `defaultExpanded={false}`.
-  const [expanded, setExpanded] = useState(false);
-  const desktopCollapsible = !defaultExpanded;
-
   const subtitleCSS = cn(
     "text-xs font-normal text-content-text-tertiary",
     "bg-content-bg-secondary px-2 py-0.5 rounded-full",
@@ -77,157 +72,105 @@ export function FilterNav({
   const allSelected = currentFilter === null || currentFilter === undefined;
   const actualAllURL = allURL || basePath;
 
-  const headingContent = (
-    <>
-      {title}
-      {subtitle && <span className={subtitleCSS}>{subtitle}</span>}
-      {additionalText && <span className={subtitleCSS}>{additionalText}</span>}
-    </>
-  );
-
-  // The mobile toggle button is always rendered (`sm:hidden`). On desktop
-  // we render either a static h2 (always expanded) or the same toggle
-  // button (collapsible) depending on `defaultExpanded`. On phone-landscape
-  // viewports we re-show the toggle so the filter chrome doesn't eat the
-  // already-shallow row count.
-  const ToggleButton = (
-    <button
-      type="button"
-      className={cn(
-        "w-full flex items-center gap-2 text-sm font-semibold text-white cursor-pointer select-none transition-colors",
-        expanded ? "mb-3" : "mb-0",
-        !desktopCollapsible && "sm:hidden short:!flex",
-        {
-          "hover:text-brand-primary": expanded,
-          "hover:text-brand-secondary": !expanded,
-        },
-      )}
-      onClick={() => setExpanded((v) => !v)}
-      aria-expanded={expanded}
-    >
-      {headingContent}
-      <span
-        className={cn("transition-transform duration-300 ml-2", {
-          "rotate-90": expanded,
-          "rotate-0": !expanded,
-        })}
-        aria-hidden
-      >
-        ▶
-      </span>
-    </button>
-  );
-
+  // The filter chrome only needs collapsing on phones, so it force-opens from
+  // `sm` (not the `md` content default) and re-collapses on landscape phones.
+  // `defaultExpanded={false}` makes it collapsible on desktop too.
   return (
-    <div className="card-premium rounded-lg overflow-hidden">
-      <div className="px-4 py-3">
-        {ToggleButton}
-        {!desktopCollapsible && (
-          <h2 className="hidden sm:flex short:hidden text-sm font-semibold text-white mb-3 items-center gap-2">
-            {headingContent}
-          </h2>
-        )}
-        <div
-          className={cn(
-            "overflow-hidden transition-all duration-300",
-            expanded ? "max-h-[1000px] opacity-100" : "max-h-0 opacity-0 pointer-events-none",
-            // Desktop is always visible unless the caller opted into a
-            // desktop-collapsible variant via `defaultExpanded={false}`.
-            !desktopCollapsible && "sm:!max-h-[1000px] sm:!opacity-100 sm:!pointer-events-auto",
-            // …but on phone-landscape viewports we follow the user's
-            // toggle state instead of force-open: filter chrome eats too
-            // much vertical space on a rotated phone. The user can still
-            // click to expand; this just changes the default.
-            !desktopCollapsible &&
-              !expanded &&
-              "short:!max-h-0 short:!opacity-0 short:!pointer-events-none short:transition-none",
-          )}
-        >
-          <div className={cn("grid gap-1.5", columnCSS)}>
-            {filters.map((filter) => {
-              const count = filterCounts?.[filter];
-              const disabled = count === 0;
-              const label = filterCounts ? (
-                <>
-                  {filter}
-                  <span className="ml-1 text-xs opacity-70 hidden sm:inline">({count ?? 0})</span>
-                </>
-              ) : (
-                filter
-              );
+    <CollapsibleSection
+      className="card-premium rounded-lg overflow-hidden"
+      title={title}
+      titleClassName="text-sm font-semibold text-white"
+      headerExtra={
+        subtitle || additionalText ? (
+          <>
+            {subtitle && <span className={subtitleCSS}>{subtitle}</span>}
+            {additionalText && <span className={subtitleCSS}>{additionalText}</span>}
+          </>
+        ) : undefined
+      }
+      headerClassName="px-4 py-3"
+      contentClassName="px-4 pb-3"
+      breakpoint="sm"
+      collapseOnLandscape
+      collapsibleOnDesktop={!defaultExpanded}
+    >
+      <div className={cn("grid gap-1.5", columnCSS)}>
+        {filters.map((filter) => {
+          const count = filterCounts?.[filter];
+          const disabled = count === 0;
+          const label = filterCounts ? (
+            <>
+              {filter}
+              <span className="ml-1 text-xs opacity-70 hidden sm:inline">({count ?? 0})</span>
+            </>
+          ) : (
+            filter
+          );
 
-              if (disabled) {
-                return (
-                  <span
-                    key={filter}
-                    className={cn(itemCSS, "text-content-text-tertiary bg-transparent cursor-not-allowed opacity-40")}
-                  >
-                    {label}
-                  </span>
-                );
-              }
-
-              const link = getLink(filter, basePath, currentURLParameters);
-              return (
-                <Link
-                  key={filter}
-                  to={link}
-                  className={cn(itemCSS, filter === currentFilter ? highlightedItemCSS : nonHighlightedItemCSS)}
-                >
-                  {label}
-                </Link>
-              );
-            })}
-            {showAllButton && (
-              <Link
-                to={actualAllURL}
-                className={cn(itemCSS, {
-                  [highlightedItemCSS]: allSelected,
-                  [nonHighlightedItemCSS]: !allSelected,
-                })}
+          if (disabled) {
+            return (
+              <span
+                key={filter}
+                className={cn(itemCSS, "text-content-text-tertiary bg-transparent cursor-not-allowed opacity-40")}
               >
-                All
-                {allCount !== undefined && (
-                  <span className="ml-1 text-xs opacity-70 hidden sm:inline">({allCount})</span>
-                )}
-              </Link>
-            )}
-          </div>
-          {/* Parameter toggles rendered separately below the grid */}
-          {!allSelected && parameters.length > 0 && (
-            <div className="flex flex-wrap gap-2 mt-3 pt-3 border-t border-content-bg-secondary">
-              <span className="text-xs text-content-text-tertiary self-center">Filters:</span>
-              {parameters.map((parameter) => {
-                const newParams = new URLSearchParams(currentURLParameters.toString());
-                const hasParam = currentURLParameters.has(parameter);
-                if (hasParam) {
-                  newParams.delete(parameter);
-                } else {
-                  newParams.append(parameter, "true");
-                }
-                const link = getLink(currentFilter || "", basePath, newParams);
-                return (
-                  <Link
-                    key={parameter}
-                    to={link}
-                    className={cn(toggleCSS, hasParam ? toggleActiveCSS : toggleInactiveCSS)}
-                  >
-                    <span
-                      className={cn(
-                        "w-3.5 h-3.5 rounded-sm border flex items-center justify-center text-[10px]",
-                        hasParam ? "bg-brand-primary border-brand-primary text-white" : "border-content-text-tertiary",
-                      )}
-                    >
-                      {hasParam && "✓"}
-                    </span>
-                    {parameter}
-                  </Link>
-                );
-              })}
-            </div>
-          )}
-        </div>
+                {label}
+              </span>
+            );
+          }
+
+          const link = getLink(filter, basePath, currentURLParameters);
+          return (
+            <Link
+              key={filter}
+              to={link}
+              className={cn(itemCSS, filter === currentFilter ? highlightedItemCSS : nonHighlightedItemCSS)}
+            >
+              {label}
+            </Link>
+          );
+        })}
+        {showAllButton && (
+          <Link
+            to={actualAllURL}
+            className={cn(itemCSS, {
+              [highlightedItemCSS]: allSelected,
+              [nonHighlightedItemCSS]: !allSelected,
+            })}
+          >
+            All
+            {allCount !== undefined && <span className="ml-1 text-xs opacity-70 hidden sm:inline">({allCount})</span>}
+          </Link>
+        )}
       </div>
-    </div>
+      {/* Parameter toggles rendered separately below the grid */}
+      {!allSelected && parameters.length > 0 && (
+        <div className="flex flex-wrap gap-2 mt-3 pt-3 border-t border-content-bg-secondary">
+          <span className="text-xs text-content-text-tertiary self-center">Filters:</span>
+          {parameters.map((parameter) => {
+            const newParams = new URLSearchParams(currentURLParameters.toString());
+            const hasParam = currentURLParameters.has(parameter);
+            if (hasParam) {
+              newParams.delete(parameter);
+            } else {
+              newParams.append(parameter, "true");
+            }
+            const link = getLink(currentFilter || "", basePath, newParams);
+            return (
+              <Link key={parameter} to={link} className={cn(toggleCSS, hasParam ? toggleActiveCSS : toggleInactiveCSS)}>
+                <span
+                  className={cn(
+                    "w-3.5 h-3.5 rounded-sm border flex items-center justify-center text-[10px]",
+                    hasParam ? "bg-brand-primary border-brand-primary text-white" : "border-content-text-tertiary",
+                  )}
+                >
+                  {hasParam && "✓"}
+                </span>
+                {parameter}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </CollapsibleSection>
   );
 }

--- a/apps/web/app/components/performance/performance-filter-controls.test.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.test.tsx
@@ -184,59 +184,51 @@ describe("PerformanceFilterControls", () => {
     expect(handleUpdateFilter).not.toHaveBeenCalled();
   });
 
-  // On mobile the entire filter block is collapsed behind a "Search & Filters"
-  // toggle button so it doesn't eat the viewport before any results show, and
-  // the label hints that the search box lives inside the expansion. The wrapper
-  // carries `hidden` until expanded; sm+ breakpoints keep it visible regardless
-  // via `sm:flex`/`sm:block`.
-  test("renders a mobile-only Search & Filters toggle button (sm:hidden)", async () => {
+  // The filter chrome is a "Search & Filters" collapsible toggle (chevron +
+  // slide). It's force-open from sm+ (it only crowds phones) so desktop users
+  // see filters by default; on phones it starts collapsed behind the toggle.
+  test("renders a Search & Filters toggle that force-opens the body from sm+", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} searchValue="" onSearchChange={() => {}} />);
+
+    expect(screen.getByRole("button", { name: /^Search & Filters/ })).toBeInTheDocument();
+    const body = screen.getByTestId("collapsible-section-body");
+    expect(body.className).toContain("sm:grid-rows-[1fr]");
+  });
+
+  // On desktop the toggle itself is hidden (the filters render bare); the header
+  // wrapper carries sm:hidden so only phones/landscape show the toggle.
+  test("hides the toggle entirely at sm+ (filters render bare on desktop)", async () => {
     await setup(<PerformanceFilterControls {...defaultProps} searchValue="" onSearchChange={() => {}} />);
 
     const toggle = screen.getByRole("button", { name: /^Search & Filters/ });
-    expect(toggle.className).toContain("sm:hidden");
+    expect(toggle.parentElement?.className).toContain("sm:hidden");
   });
 
-  // The filter content wrapper starts hidden on mobile and becomes visible
-  // when the toggle is clicked. At sm+ it is always visible regardless of
-  // the toggle state so desktop users see filters by default.
-  test("filter content is hidden on mobile by default and revealed when Filters is clicked", async () => {
-    const { user, container } = await setup(
+  // On phones the body starts collapsed (grid-rows-[0fr]) and opens to
+  // grid-rows-[1fr] when the toggle is clicked.
+  test("filter body is collapsed by default and opens when the toggle is clicked", async () => {
+    const { user } = await setup(
       <PerformanceFilterControls {...defaultProps} searchValue="" onSearchChange={() => {}} />,
     );
 
-    const wrapper = container.querySelector("[data-testid='filter-content-wrapper']") as HTMLElement;
-    expect(wrapper.className).toContain("hidden");
-    expect(wrapper.className).toContain("sm:block");
+    const body = screen.getByTestId("collapsible-section-body");
+    expect(body.className).toContain("grid-rows-[0fr]");
 
     await user.click(screen.getByRole("button", { name: /^Search & Filters/ }));
-
-    // After click, mobile-collapse should release.
-    expect(wrapper.className).not.toMatch(/(^|\s)hidden(\s|$)/);
+    expect(body.className).toContain("grid-rows-[1fr]");
   });
 
-  // Phone-landscape collapse: a rotated phone has the same vertical-space
-  // crunch as a narrow portrait phone. The toggle re-shows via `short:!flex`
-  // and the content wrapper re-collapses via `short:!hidden` when the user
-  // hasn't expanded it.
-  test("Filters toggle carries short:!flex so it re-shows on phone landscape", async () => {
+  // Phone-landscape collapse: a rotated phone has the same vertical-space crunch
+  // as portrait, so the body re-collapses on short viewports even above sm.
+  test("re-collapses on landscape phones via short:!grid-rows-[0fr]", async () => {
     await setup(<PerformanceFilterControls {...defaultProps} searchValue="" onSearchChange={() => {}} />);
 
-    const toggle = screen.getByRole("button", { name: /^Search & Filters/ });
-    expect(toggle.className).toContain("short:!flex");
+    const body = screen.getByTestId("collapsible-section-body");
+    expect(body.className).toContain("short:!grid-rows-[0fr]");
   });
 
-  test("collapsed filter content carries short:!hidden so it re-collapses on phone landscape", async () => {
-    const { container } = await setup(
-      <PerformanceFilterControls {...defaultProps} searchValue="" onSearchChange={() => {}} />,
-    );
-
-    const wrapper = container.querySelector("[data-testid='filter-content-wrapper']") as HTMLElement;
-    expect(wrapper.className).toContain("short:!hidden");
-  });
-
-  // The Filters toggle shows an active-filter count when filters are
-  // applied so users know there's state hidden behind the button without
-  // having to expand it.
+  // The Filters toggle shows an active-filter count so users know there's state
+  // hidden behind it without expanding.
   test("Filters toggle shows count badge when filters are active", async () => {
     await setup(
       <PerformanceFilterControls
@@ -283,6 +275,19 @@ describe("PerformanceFilterControls", () => {
 
     const toggle = screen.getByRole("button", { name: /^Search & Filters/ });
     expect(toggle.textContent).toMatch(/1/);
+  });
+
+  // On dense pages (the musician profile) the filter chrome collapses on desktop
+  // too: with collapsibleOnDesktop the body drops its sm force-open so it stays
+  // collapsed at every width until the user opens it.
+  test("collapsibleOnDesktop collapses the filters at all widths (no sm force-open)", async () => {
+    await setup(
+      <PerformanceFilterControls {...defaultProps} searchValue="" onSearchChange={() => {}} collapsibleOnDesktop />,
+    );
+
+    const body = screen.getByTestId("collapsible-section-body");
+    expect(body.className).not.toContain("sm:grid-rows-[1fr]");
+    expect(body.className).toContain("grid-rows-[0fr]");
   });
 
   // Clicking Clear All delegates to the parent's clearFilters callback, which

--- a/apps/web/app/components/performance/performance-filter-controls.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.tsx
@@ -1,12 +1,12 @@
-import { ChevronDown, Filter } from "lucide-react";
-import { type ReactNode, useEffect, useState } from "react";
+import { Filter } from "lucide-react";
+import { type ReactNode, useEffect } from "react";
 import { AuthorSearch } from "~/components/author/author-search";
 import { MusicianSearch } from "~/components/musician/musician-search";
+import { CollapsibleSection } from "~/components/ui/collapsible-section";
 import { SelectFilter } from "~/components/ui/filters";
 import { ToggleFilterGroup } from "~/components/ui/filters/toggle-filter-group";
 import { Input } from "~/components/ui/input";
 import { TIME_RANGE_GROUPS, TOGGLE_FILTER_DEFINITIONS } from "~/lib/song-filters";
-import { cn } from "~/lib/utils";
 
 const ALL_TOGGLE_FILTERS = TOGGLE_FILTER_DEFINITIONS as unknown as Array<{ key: string; label: string }>;
 
@@ -37,6 +37,13 @@ interface PerformanceFilterControlsProps {
   searchValue?: string;
   onSearchChange?: (value: string) => void;
   hasActiveFilters?: boolean;
+  /**
+   * Collapse the filter chrome on desktop too (not just mobile). On dense pages
+   * like the musician profile the filters start collapsed behind the toggle at
+   * every width; the toggle keeps `sm:hidden` off so it stays clickable and the
+   * content wrapper keeps `sm:block` off so it follows the toggle state.
+   */
+  collapsibleOnDesktop?: boolean;
 }
 
 export function PerformanceFilterControls({
@@ -56,6 +63,7 @@ export function PerformanceFilterControls({
   searchValue,
   onSearchChange,
   hasActiveFilters = false,
+  collapsibleOnDesktop = false,
 }: PerformanceFilterControlsProps) {
   const toggleFilters = ALL_TOGGLE_FILTERS.filter((filter) => {
     if (!showAllTimerToggle && filter.key === "allTimer") return false;
@@ -84,140 +92,135 @@ export function PerformanceFilterControls({
     (playedFilter && playedFilter !== "all" ? 1 : 0) +
     activeToggleSet.size;
 
-  const [mobileOpen, setMobileOpen] = useState(false);
-
   return (
-    <div className="space-y-3">
-      <button
-        type="button"
-        onClick={() => setMobileOpen((open) => !open)}
-        // Mobile toggle re-shows on phone-landscape viewports — a
-        // rotated phone has the same vertical-space crunch as portrait,
-        // so the filter chrome collapses there too.
-        className="sm:hidden short:!flex w-full flex items-center justify-between px-3 py-2 rounded-md bg-glass-bg border border-glass-border text-sm font-medium text-content-text-primary"
-        aria-expanded={mobileOpen}
-      >
-        <span className="flex items-center gap-2">
+    <CollapsibleSection
+      // Filter chrome, not a document heading — render the toggle as a div so
+      // it stays out of the page's heading outline. Force-open from sm (it only
+      // crowds phones); on desktop the toggle is hidden entirely and the filters
+      // show bare. `collapsibleOnDesktop` keeps the toggle collapsed at every
+      // width on dense pages (the musician profile).
+      titleAs="div"
+      title={
+        <span className="inline-flex items-center gap-2">
           <Filter className="h-4 w-4" aria-hidden="true" />
           Search &amp; Filters
-          {activeFilterCount > 0 && (
-            <span className="px-2 py-0.5 rounded-full bg-brand-primary/20 text-brand-primary text-xs">
-              {activeFilterCount}
-            </span>
-          )}
         </span>
-        <ChevronDown className={cn("h-4 w-4 transition-transform", mobileOpen && "rotate-180")} />
-      </button>
-      <div
-        data-testid="filter-content-wrapper"
-        className={cn(
-          "space-y-3 sm:block",
-          mobileOpen ? "block" : "hidden",
-          // …but on phone-landscape viewports follow the toggle state
-          // instead of the sm: force-open. User can still expand by
-          // clicking the toggle button.
-          !mobileOpen && "short:!hidden",
+      }
+      titleClassName="text-sm font-medium text-content-text-primary"
+      headerExtra={
+        activeFilterCount > 0 ? (
+          <span className="px-2 py-0.5 rounded-full bg-brand-primary/20 text-brand-primary text-xs">
+            {activeFilterCount}
+          </span>
+        ) : undefined
+      }
+      // pt-3 spaces the toggle from the controls on phones; dropped at sm+ where
+      // the toggle is hidden and the controls render flush.
+      contentClassName="space-y-3 pt-3 sm:pt-0"
+      breakpoint="sm"
+      collapseOnLandscape
+      hideHeaderWhenExpanded
+      dividerWhenClosed
+      collapsibleOnDesktop={collapsibleOnDesktop}
+    >
+      <div className="flex items-end flex-wrap gap-x-3 gap-y-2">
+        {searchValue !== undefined && onSearchChange && (
+          <Input
+            placeholder="Search..."
+            value={searchValue}
+            onChange={(event) => onSearchChange(event.target.value)}
+            className="w-full sm:w-auto sm:min-w-[250px] sm:max-w-md h-[34px] text-sm bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20 placeholder:text-content-text-tertiary"
+          />
         )}
-      >
-        <div className="flex items-end flex-wrap gap-x-3 gap-y-2">
-          {searchValue !== undefined && onSearchChange && (
-            <Input
-              placeholder="Search..."
-              value={searchValue}
-              onChange={(event) => onSearchChange(event.target.value)}
-              className="w-full sm:w-auto sm:min-w-[250px] sm:max-w-md h-[34px] text-sm bg-glass-bg border border-glass-border text-white hover:bg-glass-bg/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20 placeholder:text-content-text-tertiary"
+        {!hideTimeRange && (
+          <SelectFilter
+            id="time-range-filter"
+            label="Time Range"
+            value={selectedTimeRange}
+            onValueChange={(value) => updateFilter({ timeRange: value })}
+            options={[{ value: "all", label: "All Time" }]}
+            groups={TIME_RANGE_GROUPS}
+            width="w-[200px]"
+          />
+        )}
+        {selectedMusician !== undefined && (
+          <div className="flex flex-col">
+            <label htmlFor="musician-search" className={labelClass}>
+              Musician
+            </label>
+            <MusicianSearch
+              value={selectedMusician}
+              onValueChange={(value) => updateFilter({ musician: value === "none" ? null : value })}
+              // Carry the slug (not the id) in the URL so a shared
+              // ?musician= link is readable. The /api/musicians endpoint
+              // resolves the slug back to a record for pre-fill.
+              itemId={(musician) => musician.slug ?? musician.id}
+              // Show a deep open-list (the roster is 130+) so most names are
+              // visible without typing.
+              topLimit={40}
+              placeholder="All Musicians"
+              className="w-[150px] sm:w-[200px] h-[34px] text-sm"
             />
-          )}
-          {!hideTimeRange && (
-            <SelectFilter
-              id="time-range-filter"
-              label="Time Range"
-              value={selectedTimeRange}
-              onValueChange={(value) => updateFilter({ timeRange: value })}
-              options={[{ value: "all", label: "All Time" }]}
-              groups={TIME_RANGE_GROUPS}
-              width="w-[200px]"
+          </div>
+        )}
+        {kindFilter !== undefined && (
+          <SelectFilter
+            id="kind-filter"
+            label="Type"
+            value={kindFilter}
+            onValueChange={(value) => updateFilter({ kind: value })}
+            options={[
+              { value: "all", label: "All" },
+              { value: "original", label: "Original" },
+              { value: "cover", label: "Cover" },
+              { value: "mashup", label: "Mashup" },
+              { value: "improvisation", label: "Improvisation" },
+            ]}
+            placeholder="Type"
+            width="w-[150px]"
+          />
+        )}
+        {selectedAuthor !== undefined && (
+          <div className="flex flex-col">
+            <label htmlFor="author-search" className={labelClass}>
+              Author
+            </label>
+            <AuthorSearch
+              value={selectedAuthor}
+              onValueChange={(value) => updateFilter({ author: value === "none" ? null : value })}
+              placeholder="All Authors"
+              className="w-[150px] sm:w-[200px] h-[34px] text-sm"
+              topLimit={50}
             />
-          )}
-          {selectedMusician !== undefined && (
-            <div className="flex flex-col">
-              <label htmlFor="musician-search" className={labelClass}>
-                Musician
-              </label>
-              <MusicianSearch
-                value={selectedMusician}
-                onValueChange={(value) => updateFilter({ musician: value === "none" ? null : value })}
-                // Carry the slug (not the id) in the URL so a shared
-                // ?musician= link is readable. The /api/musicians endpoint
-                // resolves the slug back to a record for pre-fill.
-                itemId={(musician) => musician.slug ?? musician.id}
-                // Show a deep open-list (the roster is 130+) so most names are
-                // visible without typing.
-                topLimit={40}
-                placeholder="All Musicians"
-                className="w-[150px] sm:w-[200px] h-[34px] text-sm"
-              />
-            </div>
-          )}
-          {kindFilter !== undefined && (
-            <SelectFilter
-              id="kind-filter"
-              label="Type"
-              value={kindFilter}
-              onValueChange={(value) => updateFilter({ kind: value })}
-              options={[
-                { value: "all", label: "All" },
-                { value: "original", label: "Original" },
-                { value: "cover", label: "Cover" },
-                { value: "mashup", label: "Mashup" },
-                { value: "improvisation", label: "Improvisation" },
-              ]}
-              placeholder="Type"
-              width="w-[150px]"
-            />
-          )}
-          {selectedAuthor !== undefined && (
-            <div className="flex flex-col">
-              <label htmlFor="author-search" className={labelClass}>
-                Author
-              </label>
-              <AuthorSearch
-                value={selectedAuthor}
-                onValueChange={(value) => updateFilter({ author: value === "none" ? null : value })}
-                placeholder="All Authors"
-                className="w-[150px] sm:w-[200px] h-[34px] text-sm"
-                topLimit={50}
-              />
-            </div>
-          )}
-          {showPlayedFilter && (
-            <SelectFilter
-              id="played-filter"
-              label="Played"
-              value={playedFilter}
-              onValueChange={(value) => updateFilter({ played: value })}
-              options={[
-                { value: "all", label: "All" },
-                { value: "notPlayed", label: "Not Played" },
-              ]}
-              width="w-[150px]"
-            />
-          )}
-          {extraSelectFilters}
-        </div>
-        <div className="flex flex-wrap gap-2 items-center">
-          <ToggleFilterGroup filters={toggleFilters} activeFilters={activeToggleSet} onToggle={toggleFilter} />
-          {hasActiveFilters && (
-            <button
-              type="button"
-              onClick={clearFilters}
-              className="px-3 py-1.5 text-sm rounded-md bg-transparent border border-glass-border text-content-text-tertiary hover:text-content-text-secondary transition-colors"
-            >
-              Clear All
-            </button>
-          )}
-        </div>
+          </div>
+        )}
+        {showPlayedFilter && (
+          <SelectFilter
+            id="played-filter"
+            label="Played"
+            value={playedFilter}
+            onValueChange={(value) => updateFilter({ played: value })}
+            options={[
+              { value: "all", label: "All" },
+              { value: "notPlayed", label: "Not Played" },
+            ]}
+            width="w-[150px]"
+          />
+        )}
+        {extraSelectFilters}
       </div>
-    </div>
+      <div className="flex flex-wrap gap-2 items-center">
+        <ToggleFilterGroup filters={toggleFilters} activeFilters={activeToggleSet} onToggle={toggleFilter} />
+        {hasActiveFilters && (
+          <button
+            type="button"
+            onClick={clearFilters}
+            className="px-3 py-1.5 text-sm rounded-md bg-transparent border border-glass-border text-content-text-tertiary hover:text-content-text-secondary transition-colors"
+          >
+            Clear All
+          </button>
+        )}
+      </div>
+    </CollapsibleSection>
   );
 }

--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -194,10 +194,13 @@ describe("SetlistCard", () => {
     expect(screen.getByText("Basis for a Day")).toBeInTheDocument();
   });
 
-  // On top-rated, each card opts into collapsed mode. The body stays mounted
-  // (so the grid-rows transition can animate it), but is marked aria-hidden
-  // and clipped to zero height via the 0fr grid row.
-  test("hides body initially when collapsible is true", async () => {
+  // On top-rated, each card opts into collapsed mode. The body wrapper stays in
+  // the DOM (so the grid-rows transition has something to animate), marked
+  // aria-hidden and clipped to zero height via the 0fr grid row — but its heavy
+  // contents (the full setlist) are lazy-mounted, so they aren't rendered until
+  // the card is first opened. This keeps 100 collapsed cards from mounting 100
+  // full setlists up front.
+  test("hides body initially and does not mount its contents when collapsible is true", async () => {
     await setupWithRouter(
       <SetlistCard setlist={makeSetlist()} collapsible userAttendance={null} userRating={null} showRating={null} />,
     );
@@ -207,24 +210,28 @@ describe("SetlistCard", () => {
     // Header content (date + venue) must still be visible.
     expect(screen.getByText("4/14/2021")).toBeInTheDocument();
     expect(screen.getByText(/The Fillmore/)).toBeInTheDocument();
+    // …but the setlist body is not mounted until first open.
+    expect(screen.queryByText("Basis for a Day")).not.toBeInTheDocument();
   });
 
-  // Clicking an empty part of the header toggles the body open. The body
-  // stays mounted throughout; opening flips aria-hidden to false and swaps
-  // the grid-rows class from 0fr to 1fr so the transition runs.
-  test("clicking the header toggles the body open when collapsible", async () => {
+  // Clicking an empty part of the header opens the card: aria-hidden flips to
+  // false, the grid-rows class swaps to 1fr for the transition, and the
+  // lazy-mounted setlist body now renders.
+  test("clicking the header opens and mounts the body when collapsible", async () => {
     const user = userEvent.setup();
     await setupWithRouter(
       <SetlistCard setlist={makeSetlist()} collapsible userAttendance={null} userRating={null} showRating={null} />,
     );
     const body = screen.getByTestId("setlist-card-body");
     expect(body).toHaveAttribute("aria-hidden", "true");
+    expect(screen.queryByText("Basis for a Day")).not.toBeInTheDocument();
 
     const header = screen.getByTestId("setlist-card-header");
     await user.click(header);
 
     expect(body).toHaveAttribute("aria-hidden", "false");
     expect(body.className).toMatch(/grid-rows-\[1fr\]/);
+    expect(screen.getByText("Basis for a Day")).toBeInTheDocument();
   });
 
   // The venue link lives inside the header. Clicking it should navigate, not

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -88,6 +88,13 @@ function SetlistCardComponent({
   const [isAttendanceAnimating, setIsAttendanceAnimating] = useState(false);
   const [localAttendance, setLocalAttendance] = useState<Attendance | null>(userAttendance);
   const [isOpen, setIsOpen] = useState(!collapsible);
+  // Lazy-mount the heavy body (the full setlist is ~20+ track links plus lineup
+  // notes and the view control). On list pages like /shows/top-rated, 100
+  // collapsible cards would otherwise mount 100 full setlists up front (~16k DOM
+  // nodes), which makes the page sluggish to click. Non-collapsible cards (the
+  // show page) render immediately. Once opened it stays mounted, so re-collapsing
+  // still animates and re-opening is instant.
+  const [hasMountedBody, setHasMountedBody] = useState(!collapsible);
 
   const attendanceMutation = useAttendanceMutation();
   const attendanceAnimationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -162,6 +169,7 @@ function SetlistCardComponent({
                 // navigate and buttons fire without collapsing the card.
                 if ((e.target as HTMLElement).closest("a, button")) return;
                 setIsOpen((v) => !v);
+                setHasMountedBody(true);
               }
             : undefined
         }
@@ -273,61 +281,63 @@ function SetlistCardComponent({
         )}
       >
         <div className={cn(collapsible && "overflow-hidden")}>
-          <CardContent className="relative z-10 px-3 py-3 md:px-6 md:py-5">
-            <RockOperaAnnotations performances={setlist.rockOperaPerformances} />
-            <ShowLineupNote
-              notes={deriveShowLineupNotes(
-                setlist.show.date,
-                setlist.lineup,
-                setlist.trackMusicianDeltas,
-                setlist.sets.flatMap((set) => set.tracks).map((track) => track.id),
-              )}
-            />
-            {setlist.show.notes && (
-              <div
-                className="mb-4 text-sm text-content-text-secondary italic border-l border-glass-border pl-3 py-1"
-                dangerouslySetInnerHTML={{ __html: setlist.show.notes }}
+          {hasMountedBody && (
+            <CardContent className="relative z-10 px-3 py-3 md:px-6 md:py-5">
+              <RockOperaAnnotations performances={setlist.rockOperaPerformances} />
+              <ShowLineupNote
+                notes={deriveShowLineupNotes(
+                  setlist.show.date,
+                  setlist.lineup,
+                  setlist.trackMusicianDeltas,
+                  setlist.sets.flatMap((set) => set.tracks).map((track) => track.id),
+                )}
               />
-            )}
+              {setlist.show.notes && (
+                <div
+                  className="mb-4 text-sm text-content-text-secondary italic border-l border-glass-border pl-3 py-1"
+                  dangerouslySetInnerHTML={{ __html: setlist.show.notes }}
+                />
+              )}
 
-            {view === "gap-chart" ? (
-              <div className="space-y-2">
-                <SetlistViewControl
-                  view={view}
-                  onChange={changeView}
-                  summary={catalogSummary}
-                  showPersonal={Boolean(user)}
-                />
-                <SetlistTable
-                  showSlug={setlist.show.slug ?? ""}
-                  showDate={setlist.show.date}
-                  tracks={setlist.sets.flatMap((s) => s.tracks)}
-                />
-              </div>
-            ) : view === "personal" && user ? (
-              <div className="space-y-2">
-                <SetlistViewControl view={view} onChange={changeView} summary={personalSummaryView} showPersonal />
-                <SetlistTablePersonal
-                  tracks={setlist.sets.flatMap((s) => s.tracks)}
-                  showSlug={setlist.show.slug ?? ""}
-                  showDate={setlist.show.date}
-                  onSummaryChange={setPersonalSummary}
-                />
-              </div>
-            ) : (
-              <>
-                <SetlistFlow setlist={setlist} />
-                <div className="mt-4">
+              {view === "gap-chart" ? (
+                <div className="space-y-2">
                   <SetlistViewControl
                     view={view}
                     onChange={changeView}
                     summary={catalogSummary}
                     showPersonal={Boolean(user)}
                   />
+                  <SetlistTable
+                    showSlug={setlist.show.slug ?? ""}
+                    showDate={setlist.show.date}
+                    tracks={setlist.sets.flatMap((s) => s.tracks)}
+                  />
                 </div>
-              </>
-            )}
-          </CardContent>
+              ) : view === "personal" && user ? (
+                <div className="space-y-2">
+                  <SetlistViewControl view={view} onChange={changeView} summary={personalSummaryView} showPersonal />
+                  <SetlistTablePersonal
+                    tracks={setlist.sets.flatMap((s) => s.tracks)}
+                    showSlug={setlist.show.slug ?? ""}
+                    showDate={setlist.show.date}
+                    onSummaryChange={setPersonalSummary}
+                  />
+                </div>
+              ) : (
+                <>
+                  <SetlistFlow setlist={setlist} />
+                  <div className="mt-4">
+                    <SetlistViewControl
+                      view={view}
+                      onChange={changeView}
+                      summary={catalogSummary}
+                      showPersonal={Boolean(user)}
+                    />
+                  </div>
+                </>
+              )}
+            </CardContent>
+          )}
         </div>
       </div>
     </Card>

--- a/apps/web/app/components/show/archive-recordings-card.tsx
+++ b/apps/web/app/components/show/archive-recordings-card.tsx
@@ -78,7 +78,8 @@ function CollapsiblePlayer({ identifier }: { identifier: string }) {
         className="w-full flex items-center justify-between text-sm font-medium text-content-text-secondary hover:text-content-text-primary transition-colors"
       >
         <span>{open ? "Hide player" : "Play recording"}</span>
-        <ChevronDown className={cn("h-4 w-4 transition-transform", open && "rotate-180")} />
+        {/* Matches the app's disclosure convention: ▶ when closed, ▼ when open. */}
+        <ChevronDown className={cn("h-4 w-4 transition-transform", !open && "-rotate-90")} />
       </button>
       {open && (
         <div className="mt-3">

--- a/apps/web/app/components/show/show-lineup-section.tsx
+++ b/apps/web/app/components/show/show-lineup-section.tsx
@@ -1,12 +1,11 @@
 import type { ShowLineupMember } from "@bip/domain";
-import { ChevronDown, Sparkles } from "lucide-react";
-import { useState } from "react";
+import { Sparkles } from "lucide-react";
 import { Link } from "react-router-dom";
-import { Card, CardContent, CardHeader } from "~/components/ui/card";
+import { Card } from "~/components/ui/card";
+import { CollapsibleSection } from "~/components/ui/collapsible-section";
 import { formatInstrumentNames } from "~/lib/instruments";
 import type { ShowLineupNotes } from "~/lib/lineup-notes";
 import { sortLineup } from "~/lib/musicians-constants";
-import { cn } from "~/lib/utils";
 
 /** Slugs of lineup members who deviate from the expected core lineup — a
  *  whole-show guest/sit-in, or a core member on a non-default instrument.
@@ -44,7 +43,6 @@ export function ShowLineupSection({
   notes?: ShowLineupNotes;
   bare?: boolean;
 }) {
-  const [open, setOpen] = useState(false);
   if (lineup.length === 0) return null;
 
   const deviating = !bare && notes ? deviatingMemberSlugs(notes) : null;
@@ -77,31 +75,20 @@ export function ShowLineupSection({
 
   return (
     <Card className="card-premium relative overflow-hidden mt-4">
-      <CardHeader
-        onClick={() => setOpen((value) => !value)}
-        className="flex flex-row items-center justify-between gap-2 px-3 py-2 md:px-6 md:py-3 cursor-pointer md:cursor-default"
-      >
-        <h3 className="flex items-center gap-1.5 text-base font-medium text-content-text-tertiary">
-          Lineup
-          {notes && hasDeviation(notes) && (
+      <CollapsibleSection
+        title="Lineup"
+        titleAs="h3"
+        titleClassName="text-base font-medium text-content-text-tertiary"
+        headerExtra={
+          notes && hasDeviation(notes) ? (
             <Sparkles data-testid="lineup-deviation-indicator" className="h-4 w-4 text-brand-primary" />
-          )}
-        </h3>
-        <ChevronDown
-          aria-hidden
-          className={cn("h-4 w-4 shrink-0 transition-transform md:hidden", open && "rotate-180")}
-        />
-      </CardHeader>
-      <div
-        className={cn(
-          "grid transition-[grid-template-rows] duration-300 ease-out md:grid-rows-[1fr]",
-          open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
-        )}
+          ) : undefined
+        }
+        headerClassName="px-3 py-2 md:px-6 md:py-3"
+        contentClassName="px-3 pb-3 pt-0 md:px-6 md:pb-5"
       >
-        <div className="overflow-hidden md:overflow-visible">
-          <CardContent className="px-3 pb-3 pt-0 md:px-6 md:pb-5">{list}</CardContent>
-        </div>
-      </div>
+        {list}
+      </CollapsibleSection>
     </Card>
   );
 }

--- a/apps/web/app/components/song/filtered-songs-table.tsx
+++ b/apps/web/app/components/song/filtered-songs-table.tsx
@@ -26,6 +26,8 @@ interface FilteredSongsTableProps {
    * musician's scoped stats, instead of pairing all-time and filtered columns.
    */
   filteredAsPrimary?: boolean;
+  /** Collapse the filter chrome on desktop too (dense pages like the musician profile). */
+  collapsibleOnDesktop?: boolean;
 }
 
 const searchFilter = (song: Song, query: string) => song.title.toLowerCase().includes(query);
@@ -36,6 +38,7 @@ export function FilteredSongsTable({
   hideTimeRange,
   presetFilters,
   filteredAsPrimary,
+  collapsibleOnDesktop,
 }: FilteredSongsTableProps) {
   const effectiveExtraParams = useMemo(
     () => (presetFilters ? { ...extraParams, ...presetFilters } : extraParams),
@@ -100,6 +103,7 @@ export function FilteredSongsTable({
       onSearchChange={setSearchText}
       hasActiveFilters={hasActiveFilters}
       hideTimeRange={hideTimeRange}
+      collapsibleOnDesktop={collapsibleOnDesktop}
     />
   );
 

--- a/apps/web/app/components/ui/collapsible-section.test.tsx
+++ b/apps/web/app/components/ui/collapsible-section.test.tsx
@@ -1,0 +1,119 @@
+import { setup } from "@test/test-utils";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { CollapsibleSection } from "./collapsible-section";
+
+describe("CollapsibleSection", () => {
+  test("renders the title heading, count badge, and headerExtra", () => {
+    render(
+      <CollapsibleSection title="Songs" count={12} headerExtra={<span data-testid="extra" />}>
+        body
+      </CollapsibleSection>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Songs" })).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByTestId("extra")).toBeInTheDocument();
+  });
+
+  // The count badge lives outside the heading element so the heading's
+  // accessible name stays exactly the title (callers query it by name).
+  test("keeps the count out of the heading's accessible name", () => {
+    render(
+      <CollapsibleSection title="Songs" count={12}>
+        body
+      </CollapsibleSection>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Songs" })).toBeInTheDocument();
+  });
+
+  // Default mode: collapsed on mobile (JS state) but force-expanded at >= md via
+  // CSS, so there's no hydration flash from a JS breakpoint hook.
+  test("expands at md via CSS and starts collapsed on mobile", () => {
+    render(<CollapsibleSection title="Songs">body</CollapsibleSection>);
+
+    const body = screen.getByTestId("collapsible-section-body");
+    expect(body.className).toContain("md:grid-rows-[1fr]");
+    expect(body.className).toContain("grid-rows-[0fr]");
+  });
+
+  test("toggling the header opens the collapsed mobile body", async () => {
+    const { user } = await setup(<CollapsibleSection title="Songs">body</CollapsibleSection>);
+
+    const body = screen.getByTestId("collapsible-section-body");
+    expect(body.className).toContain("grid-rows-[0fr]");
+
+    await user.click(screen.getByTestId("collapsible-section-toggle"));
+    expect(body.className).toContain("grid-rows-[1fr]");
+  });
+
+  // collapsibleOnDesktop drops the md: force-open so the section collapses at
+  // every width (the chevron stays visible on desktop too).
+  test("collapsibleOnDesktop collapses at all widths", () => {
+    render(
+      <CollapsibleSection title="Songs" collapsibleOnDesktop>
+        body
+      </CollapsibleSection>,
+    );
+
+    const body = screen.getByTestId("collapsible-section-body");
+    expect(body.className).not.toContain("md:grid-rows-[1fr]");
+  });
+
+  // breakpoint="sm" force-expands from the small breakpoint instead of md, for
+  // filter chrome that only needs collapsing on phones.
+  test("breakpoint='sm' force-opens at sm rather than md", () => {
+    render(
+      <CollapsibleSection title="Filter by Year" breakpoint="sm">
+        body
+      </CollapsibleSection>,
+    );
+
+    const body = screen.getByTestId("collapsible-section-body");
+    expect(body.className).toContain("sm:grid-rows-[1fr]");
+    expect(body.className).not.toContain("md:grid-rows-[1fr]");
+  });
+
+  // collapseOnLandscape re-collapses on short (landscape-phone) viewports even
+  // above the breakpoint, so the filter chrome doesn't eat a rotated phone.
+  test("collapseOnLandscape adds the short: re-collapse overrides", () => {
+    render(
+      <CollapsibleSection title="Filter by Year" breakpoint="sm" collapseOnLandscape>
+        body
+      </CollapsibleSection>,
+    );
+
+    const body = screen.getByTestId("collapsible-section-body");
+    expect(body.className).toContain("short:!grid-rows-[0fr]");
+  });
+
+  // dividerWhenClosed draws a bottom border on the header only while collapsed,
+  // so bare chrome (the filter panel) signals there's hidden content; the line
+  // drops away once opened.
+  test("dividerWhenClosed shows a bottom border only while closed", async () => {
+    const { user } = await setup(
+      <CollapsibleSection title="Filters" dividerWhenClosed>
+        body
+      </CollapsibleSection>,
+    );
+
+    const toggle = screen.getByTestId("collapsible-section-toggle");
+    expect(toggle.className).toContain("border-b");
+
+    await user.click(toggle);
+    expect(toggle.className).not.toContain("border-b");
+  });
+
+  // titleAs lets a nested card (the lineup) drop to an h3 while page sections
+  // default to h2.
+  test("renders the title as the requested heading level", () => {
+    render(
+      <CollapsibleSection title="Lineup" titleAs="h3">
+        body
+      </CollapsibleSection>,
+    );
+
+    expect(screen.getByRole("heading", { level: 3, name: "Lineup" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/ui/collapsible-section.tsx
+++ b/apps/web/app/components/ui/collapsible-section.tsx
@@ -1,0 +1,183 @@
+import { ChevronDown } from "lucide-react";
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { cn } from "~/lib/utils";
+
+/** Per-breakpoint class sets for the force-open behavior — full static strings
+ *  so Tailwind can see them (no dynamic `${bp}:` interpolation). */
+const FORCE_OPEN_AT = {
+  sm: {
+    rows: "sm:grid-rows-[1fr]",
+    overflow: "sm:overflow-visible",
+    hide: "sm:hidden",
+    cursor: "sm:cursor-default",
+  },
+  md: {
+    rows: "md:grid-rows-[1fr]",
+    overflow: "md:overflow-visible",
+    hide: "md:hidden",
+    cursor: "md:cursor-default",
+  },
+};
+
+interface CollapsibleSectionProps {
+  /** Heading text/content. Rendered in its own heading element so callers can
+   *  target it by accessible name. */
+  title: ReactNode;
+  /** Title element. Page sections use the default h2; a nested card (the show
+   *  lineup) drops to h3; chrome that shouldn't appear in the page's heading
+   *  outline (the filter panel) uses "div". */
+  titleAs?: "h2" | "h3" | "div";
+  /** Optional count badge shown beside the title (outside the heading, so the
+   *  heading's accessible name stays exactly the title). */
+  count?: number;
+  /** Extra inline header content beside the title — e.g. the lineup's deviation
+   *  sparkle or the filter chrome's subtitle pills. */
+  headerExtra?: ReactNode;
+  /**
+   * Collapse on desktop too. Default false: collapsed on mobile via JS state
+   * but force-expanded at/above `breakpoint` via pure CSS, which avoids the
+   * hydration flash a `useIsMobile`-style hook would cause (server renders
+   * desktop-open, then snaps shut on mount). When true, the section collapses
+   * at every width and the chevron stays visible on desktop.
+   */
+  collapsibleOnDesktop?: boolean;
+  /**
+   * Width at/above which the section force-expands (ignored when
+   * `collapsibleOnDesktop`). "md" (default) suits content sections; "sm" matches
+   * the filter chrome, which only needs collapsing on phones.
+   */
+  breakpoint?: "sm" | "md";
+  /**
+   * Also collapse on short (landscape-phone) viewports, even above `breakpoint`
+   * — a rotated phone has the same vertical-space crunch as portrait. The filter
+   * chrome opts in; content sections leave it off.
+   */
+  collapseOnLandscape?: boolean;
+  /**
+   * When force-expanded (at/above `breakpoint`), hide the whole header rather
+   * than just its chevron, so the expanded content shows with no title bar. The
+   * filter chrome uses this: on desktop the filters render bare (no "Search &
+   * Filters" toggle), and the toggle only appears where the panel can collapse
+   * (phones, landscape). Ignored when `collapsibleOnDesktop` (the toggle must
+   * stay visible where the panel always collapses).
+   */
+  hideHeaderWhenExpanded?: boolean;
+  /**
+   * Draw a subtle bottom divider under the header while closed (removed when
+   * open). For bare chrome with no surrounding card — the filter panel — it
+   * signals "there's collapsed content here" so the toggle doesn't blend into
+   * adjacent controls. Carded/large-heading sections don't need it.
+   */
+  dividerWhenClosed?: boolean;
+  /** Classes for the outer wrapper. */
+  className?: string;
+  /** Classes for the clickable header row. */
+  headerClassName?: string;
+  /** Classes for the heading element. */
+  titleClassName?: string;
+  /** Classes for the content padding wrapper. */
+  contentClassName?: string;
+  children: ReactNode;
+}
+
+/**
+ * A titled section whose body collapses behind a tappable header. The body uses
+ * the `grid-rows-[1fr]/[0fr]` + `transition-[grid-template-rows]` idiom (with an
+ * inner `overflow-hidden`) so the open/close animates without measuring height,
+ * and the breakpoint behavior is pure CSS (`sm:`/`md:` overrides) rather than a
+ * JS media hook. JS state drives only the manual mobile toggle.
+ */
+export function CollapsibleSection({
+  title,
+  titleAs: TitleTag = "h2",
+  count,
+  headerExtra,
+  collapsibleOnDesktop = false,
+  breakpoint = "md",
+  collapseOnLandscape = false,
+  hideHeaderWhenExpanded = false,
+  dividerWhenClosed = false,
+  className,
+  headerClassName,
+  titleClassName,
+  contentClassName,
+  children,
+}: CollapsibleSectionProps) {
+  const [open, setOpen] = useState(false);
+  const forceOpen = FORCE_OPEN_AT[breakpoint];
+
+  return (
+    <div className={className}>
+      <TitleTag
+        className={cn(
+          "m-0",
+          titleClassName,
+          // Hide the whole header where the panel is force-expanded; re-show it
+          // on landscape phones where the panel re-collapses.
+          hideHeaderWhenExpanded && !collapsibleOnDesktop && forceOpen.hide,
+          hideHeaderWhenExpanded && collapseOnLandscape && "short:!block",
+        )}
+      >
+        <button
+          type="button"
+          data-testid="collapsible-section-toggle"
+          onClick={() => setOpen((value) => !value)}
+          aria-expanded={open}
+          className={cn(
+            "w-full flex flex-row items-center justify-between gap-2 text-left font-[inherit] cursor-pointer",
+            !collapsibleOnDesktop && forceOpen.cursor,
+            collapseOnLandscape && "short:!cursor-pointer",
+            dividerWhenClosed && !open && "border-b border-glass-border pb-3",
+            headerClassName,
+          )}
+        >
+          <span className="flex items-center gap-1.5 min-w-0">
+            {title}
+            {headerExtra}
+            {/* Decorative: the same count renders elsewhere on the page, so it's
+                hidden from the heading's accessible name (which stays the title). */}
+            {count !== undefined && (
+              <span
+                aria-hidden
+                className="shrink-0 rounded-full bg-glass-bg px-2 py-0.5 text-sm font-normal text-content-text-tertiary"
+              >
+                {count}
+              </span>
+            )}
+          </span>
+          {/* Disclosure convention: points right (▶) when closed, rotates down
+              (▼) when open — the arrow points toward the content it reveals. */}
+          <ChevronDown
+            aria-hidden
+            className={cn(
+              "h-4 w-4 shrink-0 transition-transform",
+              !collapsibleOnDesktop && forceOpen.hide,
+              collapseOnLandscape && "short:!block",
+              !open && "-rotate-90",
+            )}
+          />
+        </button>
+      </TitleTag>
+      <div
+        data-testid="collapsible-section-body"
+        className={cn(
+          "grid transition-[grid-template-rows] duration-300 ease-out",
+          !collapsibleOnDesktop && forceOpen.rows,
+          open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+          collapseOnLandscape && !open && "short:!grid-rows-[0fr]",
+        )}
+      >
+        <div
+          className={cn(
+            "overflow-hidden",
+            !collapsibleOnDesktop && forceOpen.overflow,
+            collapseOnLandscape && !open && "short:!overflow-hidden",
+          )}
+        >
+          <div className={contentClassName}>{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/lib/filtered-song-performance-table.tsx
+++ b/apps/web/app/lib/filtered-song-performance-table.tsx
@@ -29,6 +29,8 @@ interface FilteredSongPerformanceTableProps {
    */
   requiresFilter?: boolean;
   emptyPrompt?: ReactNode;
+  /** Collapse the filter chrome on desktop too (dense pages like the musician profile). */
+  collapsibleOnDesktop?: boolean;
 }
 
 export function FilteredSongPerformanceTable({
@@ -37,6 +39,7 @@ export function FilteredSongPerformanceTable({
   presetFilters,
   requiresFilter = false,
   emptyPrompt = null,
+  collapsibleOnDesktop,
 }: FilteredSongPerformanceTableProps) {
   const {
     filteredData: filteredPerformances,
@@ -76,6 +79,7 @@ export function FilteredSongPerformanceTable({
       searchValue={searchText}
       onSearchChange={setSearchText}
       hasActiveFilters={hasActiveFilters}
+      collapsibleOnDesktop={collapsibleOnDesktop}
     />
   );
 

--- a/apps/web/app/routes/musicians/$slug.test.tsx
+++ b/apps/web/app/routes/musicians/$slug.test.tsx
@@ -97,11 +97,13 @@ describe("MusicianPage body", () => {
     // The "All Song Performances" tab is wired even though Radix only mounts
     // the active tab's content.
     expect(screen.getByRole("tab", { name: /all song performances/i })).toBeInTheDocument();
+    // No out-of-era note for a guest — that framing is drummer-only.
+    expect(screen.queryByText("(outside their era)")).not.toBeInTheDocument();
   });
 
   // A drummer's tables exclude their era so only out-of-era plays surface; the
   // exclude window must thread through to the table preset.
-  test("a drummer pins the era exclude window and labels the shows section accordingly", async () => {
+  test("a drummer pins the era exclude window", async () => {
     loaderData.mockReturnValue(makeData({ slug: "allen-aucoin", tier: "drummer" }));
 
     await setupWithRouter(<MusicianPage />);
@@ -112,9 +114,12 @@ describe("MusicianPage body", () => {
       excludeStart: "2005-12-28",
       excludeEnd: "2025-09-07",
     });
-    // Both sections carry the out-of-era framing for drummers.
-    expect(screen.getByRole("heading", { name: "Songs Outside Their Era" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Shows Outside Their Era" })).toBeInTheDocument();
+    // The titles read the same for every tier ("…with the band"); a drummer's
+    // two era-scoped sections append an "(outside their era)" note (which rides
+    // into the heading's accessible name, hence the substring match).
+    expect(screen.getByRole("heading", { name: /Songs played with the band/ })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Shows played with the band/ })).toBeInTheDocument();
+    expect(screen.getAllByText("(outside their era)")).toHaveLength(2);
   });
 
   // Core members appear on essentially every show, so the tables are omitted —
@@ -129,6 +134,18 @@ describe("MusicianPage body", () => {
     expect(screen.getByText(/core member/i)).toBeInTheDocument();
   });
 
+  // Each profile section is collapsible (tappable header) and carries a count
+  // badge so a dense profile collapses cleanly on mobile.
+  test("wraps the Songs and Shows sections in collapsible chrome with count badges", async () => {
+    loaderData.mockReturnValue(makeData({ slug: "mike-greenfield", tier: "guest" }));
+
+    await setupWithRouter(<MusicianPage />);
+
+    expect(screen.getAllByTestId("collapsible-section-toggle")).toHaveLength(2);
+    // One song and one show in the fixture → a "1" badge beside each heading.
+    expect(screen.getAllByText("1").length).toBeGreaterThanOrEqual(2);
+  });
+
   // Shows moved below songs: the Songs section heading precedes the Shows
   // heading in document order.
   test("the Shows section sits below the Songs section", async () => {
@@ -136,8 +153,8 @@ describe("MusicianPage body", () => {
 
     await setupWithRouter(<MusicianPage />);
 
-    const songsHeading = screen.getByRole("heading", { name: "Songs" });
-    const showsHeading = screen.getByRole("heading", { name: "Shows" });
+    const songsHeading = screen.getByRole("heading", { name: "Songs played with the band" });
+    const showsHeading = screen.getByRole("heading", { name: "Shows played with the band" });
     expect(songsHeading.compareDocumentPosition(showsHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
@@ -151,7 +168,7 @@ describe("MusicianPage body", () => {
     await setupWithRouter(<MusicianPage />);
 
     expect(screen.queryByTestId("songs-table")).not.toBeInTheDocument();
-    expect(screen.queryByRole("heading", { name: "Songs" })).not.toBeInTheDocument();
-    expect(screen.queryByText("Shows Outside Their Era")).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Songs played with the band" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Shows played with the band")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/routes/musicians/$slug.tsx
+++ b/apps/web/app/routes/musicians/$slug.tsx
@@ -9,6 +9,7 @@ import { AdminOnly } from "~/components/admin/admin-only";
 import { DateVenueCell } from "~/components/performance/date-venue-cell";
 import { ShowDate } from "~/components/show-date";
 import { FilteredSongsTable } from "~/components/song/filtered-songs-table";
+import { CollapsibleSection } from "~/components/ui/collapsible-section";
 import { DataTable } from "~/components/ui/data-table";
 import { LinkButton } from "~/components/ui/link-button";
 import { PageHeader } from "~/components/ui/page-header";
@@ -35,6 +36,9 @@ import { computeShowUserData } from "~/server/show-user-data";
 import { computeTrackUserRatings } from "~/server/track-user-ratings";
 
 export const routeParam = "slug";
+
+/** Shared heading style for the collapsible profile sections. */
+const sectionTitleClass = "text-xl font-semibold text-content-text-primary";
 
 interface MusicianWithInstrument extends Musician {
   defaultInstrument: Instrument | null;
@@ -228,10 +232,15 @@ export default function MusicianPage() {
   const { musician, tier, stats, firstShow, lastShow, shows, songs, performances, authorId, songsWritten } =
     useSerializedLoaderData<LoaderData>();
 
-  // Drummers' tables are scoped to out-of-era plays, so both section titles
-  // carry that framing.
-  const songsHeading = tier === "drummer" ? "Songs Outside Their Era" : "Songs";
-  const showsHeading = tier === "drummer" ? "Shows Outside Their Era" : "Shows";
+  // Framed by the musician's relationship to the band. Drummers' tables are
+  // scoped to out-of-era plays (their everyday in-era shows are implied), so a
+  // small note flags that the listed plays are the notable sit-ins.
+  const songsHeading = "Songs played with the band";
+  const showsHeading = "Shows played with the band";
+  const eraNote =
+    tier === "drummer" ? (
+      <span className="text-sm font-normal text-content-text-tertiary">(outside their era)</span>
+    ) : undefined;
   const songsWrittenPreset = useMemo(() => (authorId ? { author: authorId } : undefined), [authorId]);
   // Both song tables pin to this musician; drummers also exclude their era.
   const musicianPreset = useMemo(() => musicianTablePreset(musician.slug, tier), [musician.slug, tier]);
@@ -256,7 +265,7 @@ export default function MusicianPage() {
             </AdminOnly>
           }
         />
-        <div className="flex flex-wrap items-center justify-center gap-x-3 text-content-text-secondary">
+        <div className="flex flex-col items-center gap-1 text-content-text-secondary">
           {musician.defaultInstrument && <span className="lowercase">{musician.defaultInstrument.name}</span>}
           {musician.knownFrom && <span className="text-content-text-tertiary">Known from {musician.knownFrom}</span>}
         </div>
@@ -271,10 +280,14 @@ export default function MusicianPage() {
         </dl>
 
         {authorId && songsWritten.length > 0 && (
-          <section className="space-y-4">
-            <h2 className="text-xl font-semibold text-content-text-primary">Songs Written</h2>
-            <FilteredSongsTable songs={songsWritten} presetFilters={songsWrittenPreset} />
-          </section>
+          <CollapsibleSection
+            title="Songs with writing credit & performed by the band"
+            count={songsWritten.length}
+            titleClassName={sectionTitleClass}
+            contentClassName="pt-4"
+          >
+            <FilteredSongsTable songs={songsWritten} presetFilters={songsWrittenPreset} collapsibleOnDesktop />
+          </CollapsibleSection>
         )}
 
         {tier === "core" ? (
@@ -284,26 +297,45 @@ export default function MusicianPage() {
         ) : (
           <>
             {hasSongs && (
-              <section className="space-y-4">
-                <h2 className="text-xl font-semibold text-content-text-primary">{songsHeading}</h2>
+              <CollapsibleSection
+                title={songsHeading}
+                count={songs.length}
+                headerExtra={eraNote}
+                titleClassName={sectionTitleClass}
+                contentClassName="pt-4"
+              >
                 <Tabs defaultValue="by-song">
                   <TabsList>
                     <TabsTrigger value="by-song">Song Statistics</TabsTrigger>
                     <TabsTrigger value="all-performances">All Song Performances</TabsTrigger>
                   </TabsList>
                   <TabsContent value="by-song" className="mt-4">
-                    <FilteredSongsTable songs={songs} presetFilters={musicianPreset} filteredAsPrimary />
+                    <FilteredSongsTable
+                      songs={songs}
+                      presetFilters={musicianPreset}
+                      filteredAsPrimary
+                      collapsibleOnDesktop
+                    />
                   </TabsContent>
                   <TabsContent value="all-performances" className="mt-4">
-                    <FilteredSongPerformanceTable performances={performances} presetFilters={musicianPreset} />
+                    <FilteredSongPerformanceTable
+                      performances={performances}
+                      presetFilters={musicianPreset}
+                      collapsibleOnDesktop
+                    />
                   </TabsContent>
                 </Tabs>
-              </section>
+              </CollapsibleSection>
             )}
 
             {shows.length > 0 && (
-              <section className="space-y-4">
-                <h2 className="text-xl font-semibold text-content-text-primary">{showsHeading}</h2>
+              <CollapsibleSection
+                title={showsHeading}
+                count={shows.length}
+                headerExtra={eraNote}
+                titleClassName={sectionTitleClass}
+                contentClassName="pt-4"
+              >
                 <DataTable
                   columns={showColumns}
                   data={shows}
@@ -311,7 +343,7 @@ export default function MusicianPage() {
                   initialSorting={[{ id: "date", desc: true }]}
                   hideSearch
                 />
-              </section>
+              </CollapsibleSection>
             )}
           </>
         )}

--- a/apps/web/app/routes/shows/year/$year.tsx
+++ b/apps/web/app/routes/shows/year/$year.tsx
@@ -9,6 +9,7 @@ import { SetlistList } from "~/components/setlist/setlist-list";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
 import { ShowFiltersNav } from "~/components/show-filters-nav";
 import { Button } from "~/components/ui/button";
+import { CollapsibleSection } from "~/components/ui/collapsible-section";
 import { LinkButton } from "~/components/ui/link-button";
 import { YearFilterNav } from "~/components/year-filter-nav";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
@@ -195,10 +196,6 @@ export default function ShowsByYear() {
   // Months with at least one show — drives the Jump-to-Month nav active state.
   const monthsWithShows = useMemo(() => Object.keys(monthCounts).map(Number), [monthCounts]);
 
-  // Jump-to-Month collapses by default on mobile so the long month grid
-  // doesn't push the show list far below the fold; CSS forces it open at sm+.
-  const [jumpToMonthOpen, setJumpToMonthOpen] = useState(false);
-
   // Handle scroll event to show/hide back to top button
   useEffect(() => {
     const handleScroll = () => {
@@ -257,70 +254,42 @@ export default function ShowsByYear() {
               currentURLParameters={currentURLParameters}
               counts={showCountsByYear}
             />
-            <div className="card-premium rounded-lg overflow-hidden">
-              {/* Month navigation */}
-              <div className="px-4 py-3">
-                <button
-                  type="button"
-                  onClick={() => setJumpToMonthOpen((open) => !open)}
-                  aria-expanded={jumpToMonthOpen}
-                  className={cn(
-                    // Mobile-style toggle re-shows on phone-landscape
-                    // viewports so the month grid doesn't eat most of a
-                    // rotated phone's visible rows.
-                    "sm:hidden short:!flex w-full flex items-center gap-2 text-sm font-semibold text-white cursor-pointer select-none",
-                    jumpToMonthOpen ? "mb-3" : "mb-0",
-                  )}
-                >
-                  Jump to Month
-                  <span className="text-xs font-normal text-content-text-tertiary bg-content-bg-secondary px-2 py-0.5 rounded-full">
-                    {monthsWithShows.length} months
-                  </span>
-                  <span
-                    className={cn("transition-transform duration-300 ml-2", jumpToMonthOpen ? "rotate-90" : "rotate-0")}
-                    aria-hidden
-                  >
-                    ▶
-                  </span>
-                </button>
-                <h2 className="hidden sm:flex short:hidden text-sm font-semibold text-white mb-3 items-center gap-2">
-                  Jump to Month
-                  <span className="text-xs font-normal text-content-text-tertiary bg-content-bg-secondary px-2 py-0.5 rounded-full">
-                    {monthsWithShows.length} months
-                  </span>
-                </h2>
-                <div
-                  className={cn(
-                    "overflow-hidden transition-all duration-300 grid grid-cols-3 sm:grid-cols-12 gap-1.5 sm:!max-h-[1000px] sm:!opacity-100",
-                    jumpToMonthOpen ? "max-h-[1000px] opacity-100" : "max-h-0 opacity-0",
-                    // Re-collapse on phone-landscape viewports unless the
-                    // user has explicitly expanded — same density rationale
-                    // as the FilterNav short: override.
-                    !jumpToMonthOpen && "short:!max-h-0 short:!opacity-0",
-                  )}
-                >
-                  {months.map((month, index) => {
-                    const active = monthsWithShows.includes(index);
-                    const count = monthCounts[index] ?? 0;
-                    return (
-                      <a
-                        key={month}
-                        href={active ? `#month-${index}` : undefined}
-                        className={cn(
-                          "px-2 py-1.5 text-xs font-medium rounded-md transition-all duration-200 text-center",
-                          active
-                            ? "text-content-text-secondary bg-content-bg-secondary hover:bg-content-bg-tertiary hover:text-white cursor-pointer"
-                            : "text-content-text-tertiary bg-transparent cursor-not-allowed opacity-40",
-                        )}
-                      >
-                        {month}
-                        {active && count > 0 && <span className="ml-1 opacity-70 hidden sm:inline">({count})</span>}
-                      </a>
-                    );
-                  })}
-                </div>
+            <CollapsibleSection
+              className="card-premium rounded-lg overflow-hidden"
+              title="Jump to Month"
+              titleClassName="text-sm font-semibold text-white"
+              headerExtra={
+                <span className="text-xs font-normal text-content-text-tertiary bg-content-bg-secondary px-2 py-0.5 rounded-full">
+                  {monthsWithShows.length} months
+                </span>
+              }
+              headerClassName="px-4 py-3"
+              contentClassName="px-4 pb-3"
+              breakpoint="sm"
+              collapseOnLandscape
+            >
+              <div className="grid grid-cols-3 sm:grid-cols-12 gap-1.5">
+                {months.map((month, index) => {
+                  const active = monthsWithShows.includes(index);
+                  const count = monthCounts[index] ?? 0;
+                  return (
+                    <a
+                      key={month}
+                      href={active ? `#month-${index}` : undefined}
+                      className={cn(
+                        "px-2 py-1.5 text-xs font-medium rounded-md transition-all duration-200 text-center",
+                        active
+                          ? "text-content-text-secondary bg-content-bg-secondary hover:bg-content-bg-tertiary hover:text-white cursor-pointer"
+                          : "text-content-text-tertiary bg-transparent cursor-not-allowed opacity-40",
+                      )}
+                    >
+                      {month}
+                      {active && count > 0 && <span className="ml-1 opacity-70 hidden sm:inline">({count})</span>}
+                    </a>
+                  );
+                })}
               </div>
-            </div>
+            </CollapsibleSection>
           </>
         )}
 


### PR DESCRIPTION
Collapsible sections across the app now look and behave the same. Every collapsible (the musician-page sections, the show lineup card, the year/era filter, the year page's "Jump to Month", and the song/performance "Search & Filters" panel) uses one shared component: a chevron that points right when closed and down when open, a slide animation, and a clean mobile collapse.

The musician page also reads better: the three sections are now "Songs with writing credit & performed by the band", "Songs played with the band", and "Shows played with the band"; drummers get an "(outside their era)" note since their tables only list out-of-era sit-ins; and the instrument and "known from" lines stack instead of running together.

And /shows/top-rated (plus the other collapsible setlist lists) is noticeably faster to load and to click.

## Notable details

- New `CollapsibleSection` centralizes the `grid-rows` slide idiom with options for the real variations: `breakpoint` (sm/md), `collapseOnLandscape`, `collapsibleOnDesktop`, `hideHeaderWhenExpanded` (filters render bare on desktop, with the toggle only on phones), `dividerWhenClosed` (a line under the collapsed filter toggle so it doesn't blend into nearby controls), and `titleAs="div"` (keeps filter chrome out of the page's heading outline).
- Performance: a collapsed `SetlistCard` lazy-mounts its body on first open. On /shows/top-rated that dropped the page from ~16k DOM nodes to ~4k, which is what made clicks feel sluggish.
- Two collapsibles stay separate on purpose: `SetlistCard`, whose header contains interactive links and buttons that can't live inside the shared `<button>` header, and the archive "Play recording" player, which must unmount on close to stop the embedded audio. The player only adopts the new chevron direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
