### PR TITLE
Collapse "E1" to "E" on cross-show Set columns for single-encore shows

### DIFF
--- a/apps/web/app/components/performance/performance-columns.test.tsx
+++ b/apps/web/app/components/performance/performance-columns.test.tsx
@@ -33,6 +33,7 @@ function makePerformance(overrides: Partial<SongPagePerformance> = {}): SongPage
     segue: null,
     annotations: [],
     set: "S1",
+    encoresInSet: 0,
     position: 3,
     gap: 5,
     previousPerformanceShowId: "prev-show",
@@ -317,6 +318,23 @@ describe("createPerformanceColumns", () => {
     const withoutSong = createPerformanceColumns(defaultOptions);
     await setupWithRouter(<DataTable columns={withoutSong} data={performances} hideSearch hidePagination />);
     expect(screen.queryByText("Song")).not.toBeInTheDocument();
+  });
+
+  // The Set column collapses "E1" → "E" when the row's show had a single
+  // encore (encoresInSet === 1), matching the single-show setlist views, but
+  // keeps the numeral when the show had multiple encores.
+  test("Set column collapses E1 to E for single-encore shows, keeps numeral otherwise", async () => {
+    const columns = createPerformanceColumns({ ...defaultOptions, showSongColumn: true });
+
+    const single = [makePerformance({ set: "E1", encoresInSet: 1 })];
+    const { unmount } = await setupWithRouter(<DataTable columns={columns} data={single} hideSearch hidePagination />);
+    expect(screen.getByText("E")).toBeInTheDocument();
+    expect(screen.queryByText("E1")).not.toBeInTheDocument();
+    unmount();
+
+    const multi = [makePerformance({ set: "E1", encoresInSet: 2 })];
+    await setupWithRouter(<DataTable columns={columns} data={multi} hideSearch hidePagination />);
+    expect(screen.getByText("E1")).toBeInTheDocument();
   });
 
   // The AllTimer flame marks standout performances. Renders twice in the

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -409,7 +409,7 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
           const set = info.getValue();
           return (
             <NumberCell width="2ch" className={set ? "text-content-text-secondary" : "text-content-text-tertiary"}>
-              {set ? formatSetLabel(set) : "—"}
+              {set ? formatSetLabel(set, { encoresInSet: info.row.original.encoresInSet }) : "—"}
             </NumberCell>
           );
         },

--- a/apps/web/app/components/performance/performance-table.test.tsx
+++ b/apps/web/app/components/performance/performance-table.test.tsx
@@ -53,6 +53,7 @@ function makePerformance(overrides: Partial<SongPagePerformance> = {}): SongPage
     segue: null,
     annotations: [],
     set: "S1",
+    encoresInSet: 0,
     position: 3,
     tags: {
       setOpener: false,

--- a/apps/web/app/components/setlist/set-label.ts
+++ b/apps/web/app/components/setlist/set-label.ts
@@ -1,15 +1,15 @@
 /**
  * Compact display of a track's `set` value across any table that shows a
  * Set column. Drops the "S" prefix on regular sets ("S1" → "1") because the
- * column header already says "Set". Encores keep their letter; if the
- * caller knows the surrounding setlist has only one encore (single-show
- * tables), pass `encoresInSet: 1` to collapse "E1" → "E". Anything else
+ * column header already says "Set". Encores keep their numeral unless the
+ * caller passes `encoresInSet: 1`, which collapses "E1" → "E". Anything else
  * (e.g. "Soundcheck") renders verbatim.
  *
  * @param raw The raw set label as stored on the Track row.
- * @param opts.encoresInSet Optional count of distinct encores that share
- *   the same setlist as this track. Only meaningful when the caller knows
- *   the full setlist (e.g. SetlistTable); cross-show tables omit it.
+ * @param opts.encoresInSet Count of distinct encores in this track's show.
+ *   Single-show tables derive it from the setlist in scope; cross-show
+ *   tables carry it per-row on the performance DTO. Omit it only when the
+ *   show's encore count is genuinely unknown.
  */
 export function formatSetLabel(raw: string, opts?: { encoresInSet?: number }): string {
   const upper = raw.toUpperCase();

--- a/apps/web/app/hooks/use-performance-page-filters.test.ts
+++ b/apps/web/app/hooks/use-performance-page-filters.test.ts
@@ -335,6 +335,7 @@ function makePerformance(overrides: Partial<SongPagePerformance> = {}): SongPage
     segue: null,
     annotations: [],
     set: "S1",
+    encoresInSet: 0,
     position: 3,
     gap: 5,
     previousPerformanceShowId: "prev-show",

--- a/packages/core/src/page-composers/song-page-composer.test.ts
+++ b/packages/core/src/page-composers/song-page-composer.test.ts
@@ -28,6 +28,7 @@ function makePerformance(overrides: Partial<SongPagePerformance> = {}): SongPage
       countForStats: true,
     },
     set: "S1",
+    encoresInSet: 0,
     position: 3,
     segue: null,
     allTimer: false,
@@ -75,6 +76,7 @@ function makeDto(overrides: Partial<PerformanceDto> = {}): PerformanceDto {
     duration: null,
     duration_source: null,
     previous_performance_show_id: null,
+    encores_in_set: 0,
     previous_show_slug: null,
     previous_show_date: null,
     // Next/Prev track segues
@@ -700,7 +702,7 @@ describe("CacheKeys.songs.jamCharts", () => {
   // Mirrors the cache-key shape of `allTimers`. Versioned suffix is
   // bumped together with the rest of the songs cache family.
   test("returns a stable, versioned key string", () => {
-    expect(CacheKeys.songs.jamCharts()).toBe("songs:jam-charts:v8");
+    expect(CacheKeys.songs.jamCharts()).toBe("songs:jam-charts:v9");
   });
 });
 
@@ -781,6 +783,7 @@ describe("assignFilteredGaps", () => {
       },
       position: overrides.position ?? 1,
       set: "S1",
+      encoresInSet: 0,
       segue: null,
       allTimer: false,
       annotations: [],
@@ -1072,7 +1075,7 @@ describe("CacheKeys", () => {
   // The on-this-day all-timers cache key must embed the monthDay so each
   // calendar day gets its own cache entry.
   test("allTimersOnThisDay includes the monthDay in the key", () => {
-    expect(CacheKeys.songs.allTimersOnThisDay("04-08")).toBe("songs:all-timers:on-this-day:04-08:v7");
+    expect(CacheKeys.songs.allTimersOnThisDay("04-08")).toBe("songs:all-timers:on-this-day:04-08:v8");
   });
 
   // The on-this-day counts cache key is used by the home page to cache

--- a/packages/core/src/page-composers/song-page-composer.ts
+++ b/packages/core/src/page-composers/song-page-composer.ts
@@ -633,6 +633,12 @@ export class SongPageComposer {
         tracks.duration,
         tracks.duration_source,
         tracks.previous_performance_show_id,
+        (
+          SELECT COUNT(DISTINCT encoreTracks.set)
+          FROM tracks encoreTracks
+          WHERE encoreTracks.show_id = tracks.show_id
+            AND encoreTracks.set ~* '^E[0-9]+$'
+        ) as encores_in_set,
         prevShows.slug as previous_show_slug,
         prevShows.date as previous_show_date
         ${songColumns},
@@ -936,6 +942,7 @@ export function transformToSongPagePerformanceView(row: PerformanceDto): SongPag
     duration: row.duration ?? null,
     durationSource: row.duration_source ?? null,
     gap: row.gap,
+    encoresInSet: Number(row.encores_in_set),
     previousPerformanceShowId: row.previous_performance_show_id,
     previousShow:
       row.previous_show_slug && row.previous_show_date
@@ -1020,6 +1027,9 @@ export type PerformanceDto = {
   duration: number | null;
   duration_source: string | null;
   previous_performance_show_id: string | null;
+  // Distinct encore count for this track's show, so cross-show tables can
+  // collapse "E1" → "E" when the show had a single encore.
+  encores_in_set: bigint | number;
   previous_show_slug: string | null;
   previous_show_date: string | null;
 

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -83,13 +83,13 @@ export const CacheKeys = {
     /** Full songs index page data */
     index: () => "songs:index:full:v6",
     /** All-timers page data */
-    allTimers: () => "songs:all-timers:v7",
+    allTimers: () => "songs:all-timers:v8",
     /** Jam Charts page data (tracks that are all-timers OR carry a curated note) */
-    jamCharts: () => "songs:jam-charts:v8",
+    jamCharts: () => "songs:jam-charts:v9",
     /** Songs with history content */
     histories: () => "songs:histories:v6",
     /** All-timers for a specific calendar day (On This Day page) */
-    allTimersOnThisDay: (monthDay: string) => `songs:all-timers:on-this-day:${monthDay}:v7`,
+    allTimersOnThisDay: (monthDay: string) => `songs:all-timers:on-this-day:${monthDay}:v8`,
     /** Every On-This-Day all-timer cache across all calendar days (for pattern deletion). */
     allTimersOnThisDayAll: () => "songs:all-timers:on-this-day:*",
     /** Filtered song results by era/author/kind/musician/tags/attended */
@@ -97,9 +97,9 @@ export const CacheKeys = {
       const filterHash = hashFilters(filters);
       const attendedUserId = filters.attended;
       if (attendedUserId) {
-        return `songs:filtered:user:${attendedUserId}:${filterHash}:v10`;
+        return `songs:filtered:user:${attendedUserId}:${filterHash}:v11`;
       }
-      return `songs:filtered:${filterHash}:v10`;
+      return `songs:filtered:${filterHash}:v11`;
     },
     /** All filtered song caches (for pattern deletion) */
     allFiltered: () => "songs:filtered:*",
@@ -112,7 +112,7 @@ export const CacheKeys = {
    */
   musicians: {
     /** Full musician profile payload (appearances, songs played/written, performances). */
-    page: (slug: string) => `musician:${slug}:data:v2`,
+    page: (slug: string) => `musician:${slug}:data:v3`,
     /** Every musician profile cache (for pattern deletion on broad mutations). */
     allPages: () => "musician:*:data:*",
   },

--- a/packages/domain/src/views/song-page.ts
+++ b/packages/domain/src/views/song-page.ts
@@ -32,6 +32,11 @@ export type SongPagePerformance = {
   duration?: number | null;
   durationSource?: string | null;
   gap?: number | null;
+  // Distinct encore count for this performance's show. Required so any code
+  // building a performance row must supply it, which keeps the Set column's
+  // "E1" → "E" collapse (single-encore shows) working on every cross-show
+  // table without a silent fallback. Mirrors the single-show setlist views.
+  encoresInSet: number;
   // Gap measured against the previous performance of this song within the
   // currently-applied filter scope. Populated server-side only when a
   // narrowing filter is active.


### PR DESCRIPTION
Song-performance tables that span many shows (the musician page's "All Song
Performances", /songs/all-timers, /songs/jam-charts, /on-this-day, and the song
detail page) now display "E" in the Set column for encores from single-encore
shows, instead of "E1". Shows with multiple encores still display "E1", "E2".
This matches what the single-show setlist views and the user-profile ratings
table already did.

The collapse lives in `formatSetLabel`, which only drops the numeral when told
the show had exactly one encore. The single-show views pass that count; the
cross-show tables never had it on the row, so every encore rendered "E1".

This wires the count end-to-end: a per-row `encores_in_set` subquery on the
performance query, carried through `PerformanceDto` → `SongPagePerformance` →
the Set column cell.

### Notes for the reviewer

`encoresInSet` is now a **required** field on `SongPagePerformance` (not
optional). The bug was silent precisely because a caller could omit the count
and fall back to "E1" with no error. Making it required means any new query or
table that builds a performance row fails to compile until it supplies the
count.

Bumped the cache-key versions for every key that stores `SongPagePerformance`
(`musician:…:data` v2→v3, `songs:all-timers` v7→v8, `songs:jam-charts` v8→v9,
`songs:all-timers:on-this-day` v7→v8, `songs:filtered` v10→v11) so deployed
instances don't serve stale-shape payloads after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
