### PR TITLE
Show data-driven track footnotes in performance-table Notes columns

### DIFF
--- a/apps/web/app/components/performance/combined-notes.tsx
+++ b/apps/web/app/components/performance/combined-notes.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useRef, useState } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { cn } from "~/lib/utils";
 
-export function CombinedNotes({ items }: { items: string[] }) {
+export function CombinedNotes({ items }: { items: ReactNode[] }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isTruncated, setIsTruncated] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -17,8 +17,9 @@ export function CombinedNotes({ items }: { items: string[] }) {
   return (
     <div className="text-sm text-content-text-secondary">
       <div ref={contentRef} className={cn("leading-relaxed", !isExpanded && "line-clamp-2")}>
-        {items.map((item) => (
-          <div key={item} className={showBullets ? "flex" : ""}>
+        {items.map((item, index) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: items are positional ReactNodes (footnotes + notes), stable per render
+          <div key={index} className={showBullets ? "flex" : ""}>
             {showBullets && <span className="mr-1">•</span>}
             <span>{item}</span>
           </div>

--- a/apps/web/app/components/performance/performance-columns.test.tsx
+++ b/apps/web/app/components/performance/performance-columns.test.tsx
@@ -1,6 +1,7 @@
 import type { SongPagePerformance } from "@bip/domain";
 import { mockShallowComponent, setupWithRouter } from "@test/test-utils";
 import { screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { describe, expect, test, vi } from "vitest";
 import { DataTable } from "~/components/ui/data-table";
 import { createPerformanceColumns } from "./performance-columns";
@@ -8,8 +9,19 @@ import { createPerformanceColumns } from "./performance-columns";
 vi.mock("./track-rating-cell", () => ({
   TrackRatingCell: (props: object) => mockShallowComponent("TrackRatingCell", props),
 }));
+// Render the real `items` (footnote ReactNodes + free-text) so their text and
+// order are assertable, without CombinedNotes' line-clamp/measurement effects.
 vi.mock("./combined-notes", () => ({
-  CombinedNotes: (props: object) => mockShallowComponent("CombinedNotes", props),
+  CombinedNotes: ({ items }: { items: ReactNode[] }) => (
+    <div data-testid="CombinedNotes">
+      {items.map((item, index) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: positional note items in a test stub
+        <div key={index} data-testid="note-item">
+          {item}
+        </div>
+      ))}
+    </div>
+  ),
 }));
 
 function makePerformance(overrides: Partial<SongPagePerformance> = {}): SongPagePerformance {
@@ -83,6 +95,39 @@ describe("createPerformanceColumns", () => {
     const columns = createPerformanceColumns(defaultOptions);
     const notesColumn = columns.find((column) => "id" in column && column.id === "notes");
     expect(notesColumn?.meta?.hideOnMobile).toBe(true);
+  });
+
+  // The Notes cell restores the data-driven footnotes (guests, then flags /
+  // completions) ahead of any free-text annotation, mirroring the setlist.
+  test("Notes cell leads with the guest footnote, then the flag, then free-text annotations", async () => {
+    const performances = [
+      makePerformance({
+        trackId: "t1",
+        flags: ["INVERTED"],
+        annotations: [
+          { id: "a1", trackId: "t1", desc: "Tease of Munchkin Invasion", createdAt: new Date(), updatedAt: new Date() },
+        ],
+        trackMusicianDeltas: [
+          {
+            trackId: "t1",
+            present: true,
+            musician: { id: "m1", name: "Skerik", slug: "skerik", knownFrom: null, defaultInstrument: null },
+            instruments: [
+              { id: "i1", name: "saxophone", slug: "saxophone", createdAt: new Date(), updatedAt: new Date() },
+            ],
+          },
+        ],
+      }),
+    ];
+    const columns = createPerformanceColumns(defaultOptions);
+    await setupWithRouter(<DataTable columns={columns} data={performances} hideSearch hidePagination />);
+
+    const items = screen.getAllByTestId("note-item");
+    expect(items[0]).toHaveTextContent("with Skerik on saxophone");
+    expect(items[1]).toHaveTextContent("inverted");
+    expect(items[2]).toHaveTextContent("Tease of Munchkin Invasion");
+    // The Gap/Last Played columns already cover these, so no debut footnote here.
+    expect(screen.queryByText(/debut/)).not.toBeInTheDocument();
   });
 
   // Song Before / Song After visibility depends on the surface:

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -1,7 +1,9 @@
 import { compareByShowDate, type SongPagePerformance } from "@bip/domain";
 import { type Column, type ColumnDef, createColumnHelper, type Row } from "@tanstack/react-table";
 import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon, Filter, RotateCcw, Star } from "lucide-react";
+import type { ReactNode } from "react";
 import { GapIcon } from "~/components/gap-icon";
+import { buildPerformanceFootnotes } from "~/components/setlist/footnotes";
 import { formatSetLabel } from "~/components/setlist/set-label";
 import { ShowDate } from "~/components/show-date";
 import { ShowDateLink } from "~/components/show-date-link";
@@ -472,7 +474,10 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
         meta: { weight: 2.8, hideOnMobile: true },
         cell: (info) => {
           const { annotations, notes } = info.getValue();
-          const items = [];
+          // Data-driven footnotes (guests, flags, completions, recurrence
+          // clauses) lead, mirroring the setlist; then any free-text annotation
+          // descriptions, then the curated note.
+          const items: ReactNode[] = [...buildPerformanceFootnotes(info.row.original)];
 
           if (annotations && annotations.length > 0) {
             for (const annotation of annotations) {

--- a/apps/web/app/components/setlist/footnotes.test.tsx
+++ b/apps/web/app/components/setlist/footnotes.test.tsx
@@ -1,10 +1,11 @@
-import type { Annotation, Instrument, Setlist, TrackMusicianDelta } from "@bip/domain";
+import type { Annotation, Instrument, Setlist, SongPagePerformance, TrackMusicianDelta } from "@bip/domain";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, test } from "vitest";
 import {
   annotationFootnoteSources,
   buildDebutText,
+  buildPerformanceFootnotes,
   buildShowFootnotes,
   dataDrivenFootnoteSources,
   debutFootnoteSources,
@@ -835,6 +836,22 @@ describe("buildShowFootnotes", () => {
     expect(performerContent.container).toHaveTextContent("with Mike Greenfield on guitar");
   });
 
+  test("numbers a track's performer footnote before its flag footnote (guests on top)", () => {
+    // t2 keeps the guest below the whole-show elevation threshold so the sit-in
+    // stays a per-track footnote on t1 (rather than a show-level note).
+    const setlist = makeSetlist({
+      tracks: [{ id: "t1", flags: ["DYSLEXIC"] }, { id: "t2" }],
+      deltas: [makeDelta({ trackId: "t1", present: true, instruments: [makeInstrument("guitar")] })],
+    });
+
+    const { trackFootnoteIndices, orderedFootnotes } = buildShowFootnotes(setlist);
+
+    // Both footnotes hang off t1; the performer one takes the lower number.
+    expect(trackFootnoteIndices.get("t1")).toEqual([1, 2]);
+    expect(renderContent(orderedFootnotes[0].content).container).toHaveTextContent("with Mike Greenfield on guitar");
+    expect(renderContent(orderedFootnotes[1].content).container).toHaveTextContent("dyslexic");
+  });
+
   // The early-era show date predates both the debut and gap trustworthy-data
   // start dates, so debut + last-time-played + recurrence footnotes are
   // suppressed — but observed facts (flags) still render. This is the whole
@@ -886,5 +903,70 @@ describe("footnotesByTrack", () => {
     expect(byTrack.get("t2")).toHaveLength(1);
     expect(renderContent(byTrack.get("t2")?.[0]).container).toHaveTextContent("with Mike Greenfield on guitar");
     expect(byTrack.has("t3")).toBe(false);
+  });
+});
+
+// A minimal performance row carrying only the fields buildPerformanceFootnotes
+// reads. A recent show date keeps recurrence clauses out of the early-era
+// suppression window; a small non-null gap avoids the debut/last-played paths.
+function makePerformance(overrides: Partial<SongPagePerformance> & { trackId: string }): SongPagePerformance {
+  return {
+    show: { id: "show-1", slug: "2025-11-15", date: "2025-11-15", venueId: "v", dayOrder: null, countForStats: true },
+    encoresInSet: 0,
+    songSlug: "song",
+    kind: "original",
+    gap: 5,
+    flags: [],
+    flagRecurrences: [],
+    segueRecurrences: [],
+    completes: [],
+    completedBy: [],
+    trackMusicianDeltas: [],
+    ...overrides,
+  } as SongPagePerformance;
+}
+
+describe("buildPerformanceFootnotes", () => {
+  test("leads with the performer footnote, then the flag, on one row", () => {
+    const footnotes = buildPerformanceFootnotes(
+      makePerformance({
+        trackId: "t1",
+        flags: ["INVERTED"],
+        trackMusicianDeltas: [makeDelta({ trackId: "t1", present: true, instruments: [makeInstrument("guitar")] })],
+      }),
+    );
+
+    expect(footnotes).toHaveLength(2);
+    expect(renderContent(footnotes[0]).container).toHaveTextContent("with Mike Greenfield on guitar");
+    expect(renderContent(footnotes[1]).container).toHaveTextContent("inverted");
+  });
+
+  test("renders the completion clause", () => {
+    const footnotes = buildPerformanceFootnotes(
+      makePerformance({ trackId: "t1", completes: [{ date: "2021-12-30", slug: "2021-12-30-show" }] }),
+    );
+
+    expect(footnotes).toHaveLength(1);
+    expect(renderContent(footnotes[0]).container).toHaveTextContent("completes 12/30/2021 version");
+  });
+
+  test("omits the debut footnote even on a first-ever performance", () => {
+    // gap === null is a debut on the setlist; the table shows it via the Gap
+    // column, so no debut footnote here.
+    expect(buildPerformanceFootnotes(makePerformance({ trackId: "t1", gap: null }))).toEqual([]);
+  });
+
+  test("omits the last-time-played footnote for a long-gap return", () => {
+    // A gap past the threshold reads "last played …" on the setlist; the table
+    // shows it via the Last Played column, so no footnote here.
+    const footnotes = buildPerformanceFootnotes(
+      makePerformance({
+        trackId: "t1",
+        gap: 200,
+        previousShow: { slug: "2010-01-01-show", date: "2010-01-01" },
+      }),
+    );
+
+    expect(footnotes).toEqual([]);
   });
 });

--- a/apps/web/app/components/setlist/footnotes.tsx
+++ b/apps/web/app/components/setlist/footnotes.tsx
@@ -1,4 +1,11 @@
-import type { Annotation, SegueRecurrenceKind, Setlist, SetlistLight, TrackMusicianDelta } from "@bip/domain";
+import type {
+  Annotation,
+  SegueRecurrenceKind,
+  Setlist,
+  SetlistLight,
+  SongPagePerformance,
+  TrackMusicianDelta,
+} from "@bip/domain";
 import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import {
@@ -724,16 +731,17 @@ export function buildShowFootnotes(setlist: Setlist | SetlistLight): DerivedFoot
   const suppressDebuts = debutFootnoteSuppressed(setlist.show.date);
   const suppressGaps = gapFootnoteSuppressed(setlist.show.date);
   const footnoteSources = [
-    // DB annotations are numbered before synthesized performer footnotes on any
-    // given track, so the existing annotation indices stay stable.
-    ...annotationFootnoteSources(setlist.annotations),
-    // All of a track's structured flags + completion links read on one line,
-    // right after annotations so the setlist reads like its annotation era.
-    ...dataDrivenFootnoteSources(allTracks, { suppressRecurrences: suppressGaps }),
+    // Performer / guest footnotes lead the list everywhere — the table Notes
+    // column, the public setlist, and the edit page all surface "who played"
+    // first, before the song-level markers.
     ...synthesizePerformerFootnotes(setlist.trackMusicianDeltas, elevatedGuestIds(lineupNotes)),
     ...guestExclusionFootnotes(lineupNotes.guests, setlist.trackMusicianDeltas),
-    // Auto last-time-played / debut footnotes append after the above so the
-    // existing annotation and performer footnote numbers stay stable.
+    // Then the DB annotations, ahead of the structured markers on any shared
+    // track so the original annotation wording reads first.
+    ...annotationFootnoteSources(setlist.annotations),
+    // All of a track's structured flags + completion links read on one line.
+    ...dataDrivenFootnoteSources(allTracks, { suppressRecurrences: suppressGaps }),
+    // Auto last-time-played / debut footnotes append last.
     ...(!suppressGaps ? lastTimePlayedFootnoteSources(allTracks, LAST_TIME_PLAYED_GAP_THRESHOLD) : []),
     ...(!suppressDebuts ? debutFootnoteSources(allTracks) : []),
   ];
@@ -756,4 +764,42 @@ export function footnotesByTrack(derived: DerivedFootnotes): Map<string, ReactNo
     );
   }
   return byTrack;
+}
+
+/** Derive then slice a single isolated track's footnote contents (dedup + order
+ *  via the same engine the setlist uses), with no show-wide numbering context. */
+function perTrackFootnoteContents(trackId: string, sources: FootnoteSource[]): ReactNode[] {
+  return footnotesByTrack(deriveFootnotes([{ id: trackId }], sources)).get(trackId) ?? [];
+}
+
+/**
+ * The data-driven footnotes for ONE performance row in a cross-show table's
+ * Notes column. Mirrors the setlist's per-track wording (guests first, then
+ * flags / completions / recurrence clauses) by reusing the same source builders,
+ * but deliberately omits the debut and last-time-played footnotes — the table
+ * already carries those as its Gap and Last Played columns — and the
+ * guest-exclusion "without" notes, which only make sense beside a show-level
+ * "with X, except where noted" claim the table doesn't render. Whole-show guests
+ * are not suppressed here (there is no show-level note to defer them to).
+ */
+export function buildPerformanceFootnotes(performance: SongPagePerformance): ReactNode[] {
+  const track: FootnoteTrack = {
+    id: performance.trackId,
+    // Single-track derivation: songId only keys within-call recurrence sharing,
+    // so the song slug is a stable stand-in (the row carries no songId).
+    songId: performance.songSlug ?? performance.trackId,
+    gap: performance.gap ?? null,
+    previousPerformanceShow: performance.previousShow ?? null,
+    completes: performance.completes,
+    completedBy: performance.completedBy,
+    flags: performance.flags,
+    flagRecurrences: performance.flagRecurrences,
+    segueRecurrences: performance.segueRecurrences,
+    song: { slug: performance.songSlug ?? "", kind: performance.kind ?? null },
+  };
+  const sources = [
+    ...synthesizePerformerFootnotes(performance.trackMusicianDeltas ?? []),
+    ...dataDrivenFootnoteSources([track], { suppressRecurrences: gapFootnoteSuppressed(performance.show.date) }),
+  ];
+  return perTrackFootnoteContents(performance.trackId, sources);
 }

--- a/packages/core/src/page-composers/song-page-composer.test.ts
+++ b/packages/core/src/page-composers/song-page-composer.test.ts
@@ -1,9 +1,10 @@
-import type { SongPagePerformance } from "@bip/domain";
+import type { SongPagePerformance, Track, TrackMusicianDelta } from "@bip/domain";
 import { CacheKeys } from "@bip/domain";
 import { Prisma } from "@prisma/client";
 import { describe, expect, test, vi } from "vitest";
 import {
   assignFilteredGaps,
+  attachTrackFootnoteData,
   buildSetPositionKey,
   computeRarityStats,
   computeTagsForPerformance,
@@ -216,6 +217,46 @@ describe("computeTagsForPerformance", () => {
     expect(noFlagsTags.inverted).toBe(false);
     expect(noFlagsTags.dyslexic).toBe(false);
     expect(noFlagsTags.unfinished).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attachTrackFootnoteData — copy footnote inputs onto performance rows
+// ---------------------------------------------------------------------------
+
+describe("attachTrackFootnoteData", () => {
+  test("copies flags, recurrences, completions, and deltas onto matching performances", () => {
+    const performances = [makePerformance({ trackId: "track-1" }), makePerformance({ trackId: "track-2" })];
+    const track1 = {
+      flags: ["INVERTED"],
+      flagRecurrences: [
+        { flag: "DYSLEXIC", versionGap: 3, gap: 10, lastPlayed: { date: "2020-01-01", slug: "2020-01-01" } },
+      ],
+      segueRecurrences: [],
+      completes: [{ date: "2019-05-05", slug: "2019-05-05" }],
+      completedBy: [],
+    } as unknown as Track;
+    const deltas = [{} as TrackMusicianDelta];
+
+    attachTrackFootnoteData(performances, new Map([["track-1", track1]]), new Map([["track-1", deltas]]));
+
+    expect(performances[0].flags).toEqual(["INVERTED"]);
+    expect(performances[0].flagRecurrences).toHaveLength(1);
+    expect(performances[0].completes).toEqual([{ date: "2019-05-05", slug: "2019-05-05" }]);
+    expect(performances[0].trackMusicianDeltas).toBe(deltas);
+  });
+
+  test("defaults rows with no matching track to empty footnote fields", () => {
+    const performances = [makePerformance({ trackId: "unmapped" })];
+
+    attachTrackFootnoteData(performances, new Map(), new Map());
+
+    expect(performances[0].flags).toEqual([]);
+    expect(performances[0].flagRecurrences).toEqual([]);
+    expect(performances[0].segueRecurrences).toEqual([]);
+    expect(performances[0].completes).toEqual([]);
+    expect(performances[0].completedBy).toEqual([]);
+    expect(performances[0].trackMusicianDeltas).toEqual([]);
   });
 });
 
@@ -615,7 +656,7 @@ describe("buildSongPerformances", () => {
     const mockDb = {
       $queryRaw: vi.fn().mockResolvedValue(rows.map((r) => makeDto(r as Partial<PerformanceDto>))),
       annotation: { findMany: vi.fn().mockResolvedValue([]) },
-      trackFlagAssignment: { findMany: vi.fn().mockResolvedValue([]) },
+      track: { findMany: vi.fn().mockResolvedValue([]) },
     };
     return { composer: new SongPageComposer(mockDb as never, {} as never), mockDb };
   }
@@ -702,7 +743,7 @@ describe("CacheKeys.songs.jamCharts", () => {
   // Mirrors the cache-key shape of `allTimers`. Versioned suffix is
   // bumped together with the rest of the songs cache family.
   test("returns a stable, versioned key string", () => {
-    expect(CacheKeys.songs.jamCharts()).toBe("songs:jam-charts:v9");
+    expect(CacheKeys.songs.jamCharts()).toBe("songs:jam-charts:v10");
   });
 });
 
@@ -1075,7 +1116,7 @@ describe("CacheKeys", () => {
   // The on-this-day all-timers cache key must embed the monthDay so each
   // calendar day gets its own cache entry.
   test("allTimersOnThisDay includes the monthDay in the key", () => {
-    expect(CacheKeys.songs.allTimersOnThisDay("04-08")).toBe("songs:all-timers:on-this-day:04-08:v8");
+    expect(CacheKeys.songs.allTimersOnThisDay("04-08")).toBe("songs:all-timers:on-this-day:04-08:v9");
   });
 
   // The on-this-day counts cache key is used by the home page to cache

--- a/packages/core/src/page-composers/song-page-composer.ts
+++ b/packages/core/src/page-composers/song-page-composer.ts
@@ -8,12 +8,19 @@ import {
   type SongKind,
   type SongPagePerformance,
   type SongPageView,
-  type TrackFlag,
+  type Track,
+  type TrackMusicianDelta,
 } from "@bip/domain";
 import { Prisma } from "@prisma/client";
 import type { DbClient } from "../_shared/database/models";
 import { showOrderBySql, statsShowsSql } from "../_shared/show-ordering";
 import { computeTrackGaps, sortTracksForGapWalk, type TrackForGapWalk } from "../_shared/track-gap";
+import {
+  mapTrackMusicianToDelta,
+  mapTrackToDomainEntity,
+  TRACK_FOOTNOTE_INCLUDE,
+  TRACK_PERFORMER_INCLUDE,
+} from "../setlists/setlist-service";
 import type { SongService } from "../songs/song-service";
 import type { StatsService } from "../stats/stats-service";
 
@@ -682,22 +689,28 @@ export class SongPageComposer {
       trackAnnotations.push(annotation);
       annotationsByTrackId.set(annotation.trackId, trackAnnotations);
     }
-
-    const flagRows = await this.db.trackFlagAssignment.findMany({
-      where: { trackId: { in: trackIds } },
-      select: { trackId: true, flag: true },
-    });
-    const flagsByTrackId = new Map<string, TrackFlag[]>();
-    for (const row of flagRows) {
-      const trackFlags = flagsByTrackId.get(row.trackId) || [];
-      trackFlags.push(row.flag);
-      flagsByTrackId.set(row.trackId, trackFlags);
-    }
-
     for (const performance of performances) {
       performance.annotations = annotationsByTrackId.get(performance.trackId) || [];
-      performance.flags = flagsByTrackId.get(performance.trackId) || [];
     }
+
+    // Reuse the setlist's footnote include + mappers so the Notes column's
+    // data-driven footnotes derive from identical gating (flags, recurrence
+    // clauses, completion links, performer deltas) — the wording can't drift.
+    const footnoteTracks = await this.db.track.findMany({
+      where: { id: { in: trackIds } },
+      relationLoadStrategy: "join",
+      include: { ...TRACK_FOOTNOTE_INCLUDE, ...TRACK_PERFORMER_INCLUDE },
+    });
+    const tracksById = new Map<string, Track>();
+    const deltasByTrackId = new Map<string, TrackMusicianDelta[]>();
+    for (const track of footnoteTracks) {
+      tracksById.set(track.id, mapTrackToDomainEntity(track));
+      deltasByTrackId.set(
+        track.id,
+        (track.trackMusicians ?? []).map((tm) => mapTrackMusicianToDelta(tm, track.id)),
+      );
+    }
+    attachTrackFootnoteData(performances, tracksById, deltasByTrackId);
 
     await this.computePerformanceTags(performances);
   }
@@ -839,6 +852,28 @@ export function assignFilteredGaps(performances: SongPagePerformance[], matching
 
   for (const performance of performances) {
     performance.filteredGap = gapByTrackId.get(performance.trackId) ?? null;
+  }
+}
+
+/**
+ * Copy the footnote-bearing fields from each mapped domain Track onto its
+ * matching performance row, so the Notes column can render the same data-driven
+ * footnotes the setlist shows. Pure: no DB. Tracks absent from the maps (none in
+ * practice) default to empty, leaving the row footnote-free.
+ */
+export function attachTrackFootnoteData(
+  performances: SongPagePerformance[],
+  tracksById: Map<string, Track>,
+  deltasByTrackId: Map<string, TrackMusicianDelta[]>,
+): void {
+  for (const performance of performances) {
+    const track = tracksById.get(performance.trackId);
+    performance.flags = track?.flags ?? [];
+    performance.flagRecurrences = track?.flagRecurrences ?? [];
+    performance.segueRecurrences = track?.segueRecurrences ?? [];
+    performance.completes = track?.completes ?? [];
+    performance.completedBy = track?.completedBy ?? [];
+    performance.trackMusicianDeltas = deltasByTrackId.get(performance.trackId) ?? [];
   }
 }
 

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -83,13 +83,13 @@ export const CacheKeys = {
     /** Full songs index page data */
     index: () => "songs:index:full:v6",
     /** All-timers page data */
-    allTimers: () => "songs:all-timers:v8",
+    allTimers: () => "songs:all-timers:v9",
     /** Jam Charts page data (tracks that are all-timers OR carry a curated note) */
-    jamCharts: () => "songs:jam-charts:v9",
+    jamCharts: () => "songs:jam-charts:v10",
     /** Songs with history content */
     histories: () => "songs:histories:v6",
     /** All-timers for a specific calendar day (On This Day page) */
-    allTimersOnThisDay: (monthDay: string) => `songs:all-timers:on-this-day:${monthDay}:v8`,
+    allTimersOnThisDay: (monthDay: string) => `songs:all-timers:on-this-day:${monthDay}:v9`,
     /** Every On-This-Day all-timer cache across all calendar days (for pattern deletion). */
     allTimersOnThisDayAll: () => "songs:all-timers:on-this-day:*",
     /** Filtered song results by era/author/kind/musician/tags/attended */
@@ -97,9 +97,9 @@ export const CacheKeys = {
       const filterHash = hashFilters(filters);
       const attendedUserId = filters.attended;
       if (attendedUserId) {
-        return `songs:filtered:user:${attendedUserId}:${filterHash}:v11`;
+        return `songs:filtered:user:${attendedUserId}:${filterHash}:v12`;
       }
-      return `songs:filtered:${filterHash}:v11`;
+      return `songs:filtered:${filterHash}:v12`;
     },
     /** All filtered song caches (for pattern deletion) */
     allFiltered: () => "songs:filtered:*",
@@ -112,7 +112,7 @@ export const CacheKeys = {
    */
   musicians: {
     /** Full musician profile payload (appearances, songs played/written, performances). */
-    page: (slug: string) => `musician:${slug}:data:v3`,
+    page: (slug: string) => `musician:${slug}:data:v4`,
     /** Every musician profile cache (for pattern deletion on broad mutations). */
     allPages: () => "musician:*:data:*",
   },

--- a/packages/domain/src/views/song-page.ts
+++ b/packages/domain/src/views/song-page.ts
@@ -1,7 +1,8 @@
 import type { Annotation } from "../models/annotation";
+import type { TrackMusicianDelta } from "../models/musician";
 import type { ShowMinimal } from "../models/show";
 import type { Song, SongKind } from "../models/song";
-import type { TrackFlag, TrackMinimal } from "../models/track";
+import type { FlagRecurrence, SegueRecurrence, Track, TrackFlag, TrackMinimal } from "../models/track";
 import type { VenueMinimal } from "../models/venue";
 
 export type SongPageView = {
@@ -24,6 +25,15 @@ export type SongPagePerformance = {
   annotations?: Annotation[];
   // Structured performance markers backing the inverted/dyslexic/unfinished tags.
   flags?: TrackFlag[];
+  // Data-driven footnote inputs, mirroring the setlist's per-track footnotes so
+  // the Notes column can render them. Populated by the composer from the same
+  // gating the setlist uses; absent (defaulted empty) when not enriched.
+  flagRecurrences?: FlagRecurrence[];
+  segueRecurrences?: SegueRecurrence[];
+  completes?: Track["completes"];
+  completedBy?: Track["completedBy"];
+  // Per-track sit-in / sat-out performer deltas, for the "with X on Y" footnotes.
+  trackMusicianDeltas?: TrackMusicianDelta[];
   set?: string;
   position?: number;
   songTitle?: string;


### PR DESCRIPTION
The Notes column on the performance tables again shows the track annotations
that recently became structured data. On a song's Performances tab, plus
All-Timers, Jam Charts, On This Day, and musician pages, each row now lists its
guest sit-ins, flags (dyslexic / inverted / unfinished / section-only),
completions ("completes 12/30/21 version"), and flag/segue recurrence clauses,
matching what the show's setlist renders. Guests sort to the top.

Debut and last-time-played footnotes are deliberately omitted from the table:
the Gap and Last Played columns already show that information, so repeating it as
a footnote would be redundant.

The per-row footnotes reuse the setlist's own source builders, and the
cross-show composer enriches each row through the setlist's footnote include and
mappers, so the wording is derived from identical gating and stays in lockstep
with the setlist.

#### Notes for reviewers

- Performer/guest footnotes were moved to the front of `buildShowFootnotes`, so
  they now lead the numbered footnote list on every public setlist and the
  show-edit page too (this renumbers existing setlist footnotes).
- Cache keys for the affected payloads are bumped (`songs.allTimers`,
  `jamCharts`, `allTimersOnThisDay`, `filtered`, `musicians.page`).
- Whole-show guests recorded only in the show lineup (no per-track delta) are not
  synthesized per row; they remain visible on the linked show page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
