### PR TITLE
Rename FilteredSongsTable to FilteredSongsStatsTable

### DIFF
--- a/apps/web/app/components/song/filtered-songs-stats-table.test.tsx
+++ b/apps/web/app/components/song/filtered-songs-stats-table.test.tsx
@@ -22,7 +22,7 @@ vi.mock("./songs-table", () => ({
   ),
 }));
 
-import { FilteredSongsTable } from "./filtered-songs-table";
+import { FilteredSongsStatsTable } from "./filtered-songs-stats-table";
 
 interface HookReturnOverrides {
   selectedTimeRange?: string;
@@ -69,12 +69,12 @@ function renderComponent(
 ) {
   return render(
     <MemoryRouter>
-      <FilteredSongsTable songs={[]} {...props} />
+      <FilteredSongsStatsTable songs={[]} {...props} />
     </MemoryRouter>,
   );
 }
 
-describe("FilteredSongsTable", () => {
+describe("FilteredSongsStatsTable", () => {
   // The component wires up usePerformancePageFilters, PerformanceFilterControls,
   // and SongsTable together — verify SongsTable renders.
   test("renders SongsTable", () => {
@@ -97,7 +97,7 @@ describe("FilteredSongsTable", () => {
 
   // /songs and its tabs fetch through the loader (via fetchFilteredSongs),
   // so the hook's client fetch would be a duplicate request. Unpinned
-  // FilteredSongsTable opts out of the hook's internal fetch path.
+  // FilteredSongsStatsTable opts out of the hook's internal fetch path.
   test("passes skipClientFetch: true to usePerformancePageFilters", () => {
     setHookReturn();
     renderComponent();

--- a/apps/web/app/components/song/filtered-songs-stats-table.tsx
+++ b/apps/web/app/components/song/filtered-songs-stats-table.tsx
@@ -6,7 +6,7 @@ import { hasNarrowingFilter } from "~/lib/played-filter";
 import { controlsHiddenByPreset } from "~/lib/preset-filters";
 import { SongsTable } from "./songs-table";
 
-interface FilteredSongsTableProps {
+interface FilteredSongsStatsTableProps {
   songs: Song[];
   extraParams?: Record<string, string>;
   hideTimeRange?: boolean;
@@ -32,14 +32,14 @@ interface FilteredSongsTableProps {
 
 const searchFilter = (song: Song, query: string) => song.title.toLowerCase().includes(query);
 
-export function FilteredSongsTable({
+export function FilteredSongsStatsTable({
   songs,
   extraParams,
   hideTimeRange,
   presetFilters,
   filteredAsPrimary,
   collapsibleOnDesktop,
-}: FilteredSongsTableProps) {
+}: FilteredSongsStatsTableProps) {
   const effectiveExtraParams = useMemo(
     () => (presetFilters ? { ...extraParams, ...presetFilters } : extraParams),
     [presetFilters, extraParams],

--- a/apps/web/app/routes/authors/$slug.tsx
+++ b/apps/web/app/routes/authors/$slug.tsx
@@ -2,7 +2,7 @@ import type { Song } from "@bip/domain";
 import { CacheKeys } from "@bip/domain/cache-keys";
 import { useMemo } from "react";
 import { redirect } from "react-router-dom";
-import { FilteredSongsTable } from "~/components/song/filtered-songs-table";
+import { FilteredSongsStatsTable } from "~/components/song/filtered-songs-stats-table";
 import { PageHeader } from "~/components/ui/page-header";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
@@ -57,7 +57,7 @@ export default function AuthorPage() {
       <div className="space-y-2 mb-6">
         <PageHeader title={author.name} backLink={{ to: "/songs", label: "All Songs" }} />
       </div>
-      <FilteredSongsTable songs={songs} presetFilters={presetFilters} />
+      <FilteredSongsStatsTable songs={songs} presetFilters={presetFilters} />
     </div>
   );
 }

--- a/apps/web/app/routes/musicians/$slug.test.tsx
+++ b/apps/web/app/routes/musicians/$slug.test.tsx
@@ -6,8 +6,8 @@ import type { MusicianTier } from "~/lib/musicians-constants";
 // The two shared tables client-fetch and pull in React Query; stub them to
 // markers that echo their presetFilters so the page's wiring is assertable
 // without the fetch machinery.
-vi.mock("~/components/song/filtered-songs-table", () => ({
-  FilteredSongsTable: ({ presetFilters }: { presetFilters?: Record<string, string> }) => (
+vi.mock("~/components/song/filtered-songs-stats-table", () => ({
+  FilteredSongsStatsTable: ({ presetFilters }: { presetFilters?: Record<string, string> }) => (
     <div data-testid="songs-table" data-preset={JSON.stringify(presetFilters ?? null)} />
   ),
 }));

--- a/apps/web/app/routes/musicians/$slug.tsx
+++ b/apps/web/app/routes/musicians/$slug.tsx
@@ -8,7 +8,7 @@ import { Link } from "react-router-dom";
 import { AdminOnly } from "~/components/admin/admin-only";
 import { DateVenueCell } from "~/components/performance/date-venue-cell";
 import { ShowDate } from "~/components/show-date";
-import { FilteredSongsTable } from "~/components/song/filtered-songs-table";
+import { FilteredSongsStatsTable } from "~/components/song/filtered-songs-stats-table";
 import { CollapsibleSection } from "~/components/ui/collapsible-section";
 import { DataTable } from "~/components/ui/data-table";
 import { LinkButton } from "~/components/ui/link-button";
@@ -286,7 +286,7 @@ export default function MusicianPage() {
             titleClassName={sectionTitleClass}
             contentClassName="pt-4"
           >
-            <FilteredSongsTable songs={songsWritten} presetFilters={songsWrittenPreset} collapsibleOnDesktop />
+            <FilteredSongsStatsTable songs={songsWritten} presetFilters={songsWrittenPreset} collapsibleOnDesktop />
           </CollapsibleSection>
         )}
 
@@ -310,7 +310,7 @@ export default function MusicianPage() {
                     <TabsTrigger value="all-performances">All Song Performances</TabsTrigger>
                   </TabsList>
                   <TabsContent value="by-song" className="mt-4">
-                    <FilteredSongsTable
+                    <FilteredSongsStatsTable
                       songs={songs}
                       presetFilters={musicianPreset}
                       filteredAsPrimary

--- a/apps/web/app/routes/songs/_index.test.tsx
+++ b/apps/web/app/routes/songs/_index.test.tsx
@@ -16,9 +16,9 @@ vi.mock("~/hooks/use-serialized-loader-data", () => ({
   useSerializedLoaderData: vi.fn(() => ({ songs: [] })),
 }));
 
-// Stub the shared FilteredSongsTable component
-vi.mock("~/components/song/filtered-songs-table", () => ({
-  FilteredSongsTable: (props: object) => mockShallowComponent("FilteredSongsTable", props),
+// Stub the shared FilteredSongsStatsTable component
+vi.mock("~/components/song/filtered-songs-stats-table", () => ({
+  FilteredSongsStatsTable: (props: object) => mockShallowComponent("FilteredSongsStatsTable", props),
 }));
 
 import Songs from "./_index";
@@ -53,11 +53,11 @@ describe("Songs index page", () => {
     expect(screen.queryByRole("link", { name: /create song/i })).not.toBeInTheDocument();
   });
 
-  // The FilteredSongsTable renders the songs table with filter controls.
-  test("renders the FilteredSongsTable", () => {
+  // The FilteredSongsStatsTable renders the songs table with filter controls.
+  test("renders the FilteredSongsStatsTable", () => {
     renderSongsIndex();
 
-    expect(screen.getByTestId("FilteredSongsTable")).toBeInTheDocument();
+    expect(screen.getByTestId("FilteredSongsStatsTable")).toBeInTheDocument();
   });
 
   // Trending data is accessible via the "Last 10 Shows" and "This Year" tabs,

--- a/apps/web/app/routes/songs/_index.tsx
+++ b/apps/web/app/routes/songs/_index.tsx
@@ -1,5 +1,5 @@
 import type { Song } from "@bip/domain";
-import { FilteredSongsTable } from "~/components/song/filtered-songs-table";
+import { FilteredSongsStatsTable } from "~/components/song/filtered-songs-stats-table";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
 import { getSongsMeta } from "~/lib/seo";
@@ -17,5 +17,5 @@ export function meta() {
 export default function Songs() {
   const { songs } = useSerializedLoaderData<{ songs: Song[] }>();
 
-  return <FilteredSongsTable songs={songs} />;
+  return <FilteredSongsStatsTable songs={songs} />;
 }

--- a/apps/web/app/routes/songs/recent.test.tsx
+++ b/apps/web/app/routes/songs/recent.test.tsx
@@ -15,9 +15,9 @@ vi.mock("~/hooks/use-serialized-loader-data", () => ({
   useSerializedLoaderData: vi.fn(() => ({ songs: [] })),
 }));
 
-// Stub the shared FilteredSongsTable to inspect props
-vi.mock("~/components/song/filtered-songs-table", () => ({
-  FilteredSongsTable: (props: object) => mockShallowComponent("FilteredSongsTable", props),
+// Stub the shared FilteredSongsStatsTable to inspect props
+vi.mock("~/components/song/filtered-songs-stats-table", () => ({
+  FilteredSongsStatsTable: (props: object) => mockShallowComponent("FilteredSongsStatsTable", props),
 }));
 
 import RecentPage from "./recent";
@@ -31,11 +31,11 @@ function renderRecent() {
 }
 
 describe("RecentPage", () => {
-  // The Recent tab renders a FilteredSongsTable with the last10shows time range.
-  test("renders FilteredSongsTable with last10shows extraParams and hideTimeRange", () => {
+  // The Recent tab renders a FilteredSongsStatsTable with the last10shows time range.
+  test("renders FilteredSongsStatsTable with last10shows extraParams and hideTimeRange", () => {
     renderRecent();
 
-    const table = screen.getByTestId("FilteredSongsTable");
+    const table = screen.getByTestId("FilteredSongsStatsTable");
     expect(table.textContent).toContain('"hideTimeRange":true');
   });
 });

--- a/apps/web/app/routes/songs/recent.tsx
+++ b/apps/web/app/routes/songs/recent.tsx
@@ -1,5 +1,5 @@
 import type { Song } from "@bip/domain";
-import { FilteredSongsTable } from "~/components/song/filtered-songs-table";
+import { FilteredSongsStatsTable } from "~/components/song/filtered-songs-stats-table";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
 import { fetchFilteredSongs } from "~/lib/song-utilities";
@@ -20,5 +20,5 @@ export function meta() {
 export default function RecentPage() {
   const { songs } = useSerializedLoaderData<{ songs: Song[] }>();
 
-  return <FilteredSongsTable songs={songs} extraParams={{ timeRange: "last10shows" }} hideTimeRange />;
+  return <FilteredSongsStatsTable songs={songs} extraParams={{ timeRange: "last10shows" }} hideTimeRange />;
 }

--- a/apps/web/app/routes/songs/this-year.test.tsx
+++ b/apps/web/app/routes/songs/this-year.test.tsx
@@ -15,9 +15,9 @@ vi.mock("~/hooks/use-serialized-loader-data", () => ({
   useSerializedLoaderData: vi.fn(() => ({ songs: [] })),
 }));
 
-// Stub the shared FilteredSongsTable to inspect props
-vi.mock("~/components/song/filtered-songs-table", () => ({
-  FilteredSongsTable: (props: object) => mockShallowComponent("FilteredSongsTable", props),
+// Stub the shared FilteredSongsStatsTable to inspect props
+vi.mock("~/components/song/filtered-songs-stats-table", () => ({
+  FilteredSongsStatsTable: (props: object) => mockShallowComponent("FilteredSongsStatsTable", props),
 }));
 
 import ThisYearPage from "./this-year";
@@ -31,11 +31,11 @@ function renderThisYear() {
 }
 
 describe("ThisYearPage", () => {
-  // The This Year tab renders a FilteredSongsTable with the thisYear time range.
-  test("renders FilteredSongsTable with thisYear extraParams and hideTimeRange", () => {
+  // The This Year tab renders a FilteredSongsStatsTable with the thisYear time range.
+  test("renders FilteredSongsStatsTable with thisYear extraParams and hideTimeRange", () => {
     renderThisYear();
 
-    const table = screen.getByTestId("FilteredSongsTable");
+    const table = screen.getByTestId("FilteredSongsStatsTable");
     expect(table.textContent).toContain('"hideTimeRange":true');
   });
 });

--- a/apps/web/app/routes/songs/this-year.tsx
+++ b/apps/web/app/routes/songs/this-year.tsx
@@ -1,5 +1,5 @@
 import type { Song } from "@bip/domain";
-import { FilteredSongsTable } from "~/components/song/filtered-songs-table";
+import { FilteredSongsStatsTable } from "~/components/song/filtered-songs-stats-table";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
 import { fetchFilteredSongs } from "~/lib/song-utilities";
@@ -23,5 +23,5 @@ export function meta() {
 export default function ThisYearPage() {
   const { songs } = useSerializedLoaderData<{ songs: Song[] }>();
 
-  return <FilteredSongsTable songs={songs} extraParams={{ timeRange: "thisYear" }} hideTimeRange />;
+  return <FilteredSongsStatsTable songs={songs} extraParams={{ timeRange: "thisYear" }} hideTimeRange />;
 }


### PR DESCRIPTION
Renames the song stats table component from `FilteredSongsTable` to `FilteredSongsStatsTable` so its name clearly distinguishes it from the performance table (`FilteredSongPerformanceTable` / `PerformanceTable`).

Pure rename, no behavior change: component, `FilteredSongsTableProps` interface, file (`filtered-songs-table.tsx` → `filtered-songs-stats-table.tsx`), test IDs, and all five route consumers (`/songs` index, recent, this-year, author page, musician page) plus their test mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)