### PR TITLE
Add Split filter and group song-table filters into popovers

### DIFF
--- a/apps/web/app/components/performance/performance-columns.test.tsx
+++ b/apps/web/app/components/performance/performance-columns.test.tsx
@@ -556,6 +556,45 @@ describe("createPerformanceColumns", () => {
     expect(screen.getByText("5")).toBeInTheDocument();
   });
 
+  // Positions reset per set, so an encore reprise (E1 #2) can carry the same
+  // or a lower position number than its earlier second-set play (S2 #2).
+  // Set order must break the tie or the encore loses its ↺ and renders a
+  // duplicate gap number.
+  test("Gap column flags a cross-set repeat where the later set has an equal-or-lower position", async () => {
+    const columns = createPerformanceColumns(defaultOptions);
+    const sharedShow = {
+      id: "show-cross-set",
+      slug: "2025-07-02-xl-live-harrisburg-pa",
+      date: "2025-07-02",
+      venueId: "v",
+      countForStats: true,
+    };
+    const performances = [
+      makePerformance({
+        trackId: "t-s2",
+        show: sharedShow,
+        set: "S2",
+        position: 2,
+        gap: 5,
+        previousPerformanceShowId: "p",
+      }),
+      makePerformance({
+        trackId: "t-e1",
+        show: sharedShow,
+        set: "E1",
+        position: 2,
+        gap: 5,
+        previousPerformanceShowId: "p",
+      }),
+    ];
+    const { container } = await setupWithRouter(
+      <DataTable columns={columns} data={performances} hideSearch hidePagination />,
+    );
+
+    expect(container.querySelectorAll(".lucide-rotate-ccw").length).toBe(1);
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
   // The Last Played column shows the date of the song's prior performance
   // (sourced from the Track.previousPerformanceShowId join) and links to
   // that show. When sorted by Gap (or any non-date order), this column

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -4,7 +4,7 @@ import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon, Filter, RotateCcw, Star } from
 import type { ReactNode } from "react";
 import { GapIcon } from "~/components/gap-icon";
 import { buildPerformanceFootnotes } from "~/components/setlist/footnotes";
-import { formatSetLabel } from "~/components/setlist/set-label";
+import { compareBySetThenPosition, formatSetLabel } from "~/components/setlist/set-label";
 import { ShowDate } from "~/components/show-date";
 import { ShowDateLink } from "~/components/show-date-link";
 import { AllTimerCell, allTimerColumnMeta } from "~/components/track/all-timer-cell";
@@ -154,11 +154,20 @@ function renderGapCell({ value, isRepeat }: { value: number | null | undefined; 
  * Detects whether `row` is the second-or-later occurrence of its song
  * within the same show. The gap and filtered-gap values themselves are
  * shared across within-show repeats, so the icon — not the number —
- * distinguishes the repeat from its first occurrence.
+ * distinguishes the repeat from its first occurrence. "Earlier" is
+ * canonical set-then-position order, not raw `position`: positions reset per
+ * set, so an encore reprise (E1 #2) can carry the same or a lower position
+ * number than its earlier second-set play (S2 #2). Comparing on `position`
+ * alone would miss that and drop the ↺ marker.
  */
 function isWithinShowRepeat(row: SongPagePerformance, allRows: Array<{ original: SongPagePerformance }>): boolean {
   return allRows.some(
-    (other) => other.original.show.id === row.show.id && (other.original.position ?? 0) < (row.position ?? 0),
+    (other) =>
+      other.original.show.id === row.show.id &&
+      compareBySetThenPosition(
+        { set: other.original.set ?? "", position: other.original.position ?? 0 },
+        { set: row.set ?? "", position: row.position ?? 0 },
+      ) < 0,
   );
 }
 

--- a/apps/web/app/components/performance/performance-filter-controls.test.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.test.tsx
@@ -54,6 +54,24 @@ describe("PerformanceFilterControls", () => {
     expect(screen.queryByRole("button", { name: "Clear All" })).not.toBeInTheDocument();
   });
 
+  // The toggle filters render as a compact strip of group popover buttons
+  // (Quality / Position / Attributes) instead of a flat chip wall.
+  test("renders the toggle group popover buttons", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} />);
+
+    expect(screen.getByRole("button", { name: "Quality" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Position" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Attributes" })).toBeInTheDocument();
+  });
+
+  // Attended is a personal on/off, so it renders as a standalone chip rather
+  // than inside a group popover.
+  test("renders the Attended toggle as a standalone chip", async () => {
+    await setup(<PerformanceFilterControls {...defaultProps} />);
+
+    expect(screen.getByRole("button", { name: "Attended" })).toBeInTheDocument();
+  });
+
   // The Time Range dropdown renders with grouped options (Recent, Eras, Years).
   test("renders a single Time Range dropdown", async () => {
     await setup(<PerformanceFilterControls {...defaultProps} />);

--- a/apps/web/app/components/performance/performance-filter-controls.tsx
+++ b/apps/web/app/components/performance/performance-filter-controls.tsx
@@ -4,9 +4,10 @@ import { AuthorSearch } from "~/components/author/author-search";
 import { MusicianSearch } from "~/components/musician/musician-search";
 import { CollapsibleSection } from "~/components/ui/collapsible-section";
 import { SelectFilter } from "~/components/ui/filters";
+import { GroupedToggleFilters } from "~/components/ui/filters/grouped-toggle-filters";
 import { ToggleFilterGroup } from "~/components/ui/filters/toggle-filter-group";
 import { Input } from "~/components/ui/input";
-import { TIME_RANGE_GROUPS, TOGGLE_FILTER_DEFINITIONS } from "~/lib/song-filters";
+import { STANDALONE_TOGGLE_KEY, TIME_RANGE_GROUPS, TOGGLE_FILTER_DEFINITIONS } from "~/lib/song-filters";
 
 const ALL_TOGGLE_FILTERS = TOGGLE_FILTER_DEFINITIONS as unknown as Array<{ key: string; label: string }>;
 
@@ -70,6 +71,8 @@ export function PerformanceFilterControls({
     if (!showJamChartToggle && filter.key === "jamChart") return false;
     return true;
   });
+  const groupedToggleFilters = toggleFilters.filter((filter) => filter.key !== STANDALONE_TOGGLE_KEY);
+  const standaloneToggleFilters = toggleFilters.filter((filter) => filter.key === STANDALONE_TOGGLE_KEY);
   const showPlayedFilter =
     playedFilter !== undefined &&
     (hideTimeRange ||
@@ -208,14 +211,16 @@ export function PerformanceFilterControls({
           />
         )}
         {extraSelectFilters}
-      </div>
-      <div className="flex flex-wrap gap-2 items-center">
-        <ToggleFilterGroup filters={toggleFilters} activeFilters={activeToggleSet} onToggle={toggleFilter} />
+        {/* Toggle filters live in the same row as the selects: a compact strip
+            of group popovers (Quality / Position / Attributes) plus the
+            standalone Attended chip (a personal on/off, not a curation group). */}
+        <GroupedToggleFilters filters={groupedToggleFilters} activeFilters={activeToggleSet} onToggle={toggleFilter} />
+        <ToggleFilterGroup filters={standaloneToggleFilters} activeFilters={activeToggleSet} onToggle={toggleFilter} />
         {hasActiveFilters && (
           <button
             type="button"
             onClick={clearFilters}
-            className="px-3 py-1.5 text-sm rounded-md bg-transparent border border-glass-border text-content-text-tertiary hover:text-content-text-secondary transition-colors"
+            className="h-[34px] px-3 text-sm rounded-md bg-transparent border border-glass-border text-content-text-tertiary hover:text-content-text-secondary transition-colors"
           >
             Clear All
           </button>

--- a/apps/web/app/components/setlist/gap-cell.test.tsx
+++ b/apps/web/app/components/setlist/gap-cell.test.tsx
@@ -66,8 +66,8 @@ describe("isWithinShowRepeat", () => {
   // not a repeat.
   test("returns false when no earlier same-song row exists", () => {
     const rows = [
-      { id: "t1", songId: "tractorbeam", position: 1 },
-      { id: "t2", songId: "spaga", position: 2 },
+      { id: "t1", songId: "tractorbeam", set: "S1", position: 1 },
+      { id: "t2", songId: "spaga", set: "S1", position: 2 },
     ];
     expect(isWithinShowRepeat(rows, rows[0])).toBe(false);
     expect(isWithinShowRepeat(rows, rows[1])).toBe(false);
@@ -76,9 +76,9 @@ describe("isWithinShowRepeat", () => {
   // Same songId at an earlier position → repeat.
   test("returns true when the same song appears at an earlier position", () => {
     const rows = [
-      { id: "t1", songId: "tractorbeam", position: 1 },
-      { id: "t2", songId: "spaga", position: 2 },
-      { id: "t3", songId: "tractorbeam", position: 5 }, // reprise
+      { id: "t1", songId: "tractorbeam", set: "S1", position: 1 },
+      { id: "t2", songId: "spaga", set: "S1", position: 2 },
+      { id: "t3", songId: "tractorbeam", set: "S1", position: 5 }, // reprise
     ];
     expect(isWithinShowRepeat(rows, rows[2])).toBe(true);
   });
@@ -87,8 +87,21 @@ describe("isWithinShowRepeat", () => {
   // occurrence (not a repeat); the later one is.
   test("only the second-and-later occurrences are repeats", () => {
     const rows = [
-      { id: "t1", songId: "helicopters", position: 2 },
-      { id: "t2", songId: "helicopters", position: 7 },
+      { id: "t1", songId: "helicopters", set: "S1", position: 2 },
+      { id: "t2", songId: "helicopters", set: "S1", position: 7 },
+    ];
+    expect(isWithinShowRepeat(rows, rows[0])).toBe(false);
+    expect(isWithinShowRepeat(rows, rows[1])).toBe(true);
+  });
+
+  // Cross-set repeat where the later set carries a LOWER position number.
+  // Positions reset per set, so the encore's I-Man (E1 #2) follows the
+  // second-set I-Man (S2 #2) in the show even though the raw position is
+  // equal — set order must break the tie or the encore loses its ↺.
+  test("detects a repeat across sets when the later set has an equal-or-lower position", () => {
+    const rows = [
+      { id: "t1", songId: "i-man", set: "S2", position: 2 },
+      { id: "t2", songId: "i-man", set: "E1", position: 2 },
     ];
     expect(isWithinShowRepeat(rows, rows[0])).toBe(false);
     expect(isWithinShowRepeat(rows, rows[1])).toBe(true);

--- a/apps/web/app/components/setlist/gap-cell.tsx
+++ b/apps/web/app/components/setlist/gap-cell.tsx
@@ -1,6 +1,7 @@
 import { RotateCcw, Star } from "lucide-react";
 import { GapIcon } from "~/components/gap-icon";
 import { NumberCell } from "~/components/ui/number-cell";
+import { compareBySetThenPosition } from "./set-label";
 
 /**
  * Discriminated union for the three possible states of a Gap or Your-Gap
@@ -24,16 +25,19 @@ export function buildGapCellState(args: { isRepeat: boolean; gap: number | null 
 }
 
 /**
- * True when this row's `songId` already appears at an earlier `position`
- * in the supplied list — i.e., the row is a within-show repeat. Generic
- * over the row shape; both column factories and the personal pure helpers
- * use this to drive the ↺ marker.
+ * True when this row's `songId` already appears earlier in the show within
+ * the supplied list — i.e., the row is a within-show repeat. "Earlier" is
+ * canonical set-then-position order, not raw `position`: positions reset per
+ * set, so an encore reprise (E1 #2) can carry the same or a lower position
+ * number than its earlier second-set play (S2 #2). Comparing on `position`
+ * alone would miss that and drop the ↺ marker. Generic over the row shape;
+ * both column factories and the personal pure helpers use this.
  */
-export function isWithinShowRepeat<T extends { id: string; songId: string; position: number }>(
+export function isWithinShowRepeat<T extends { id: string; songId: string; set: string; position: number }>(
   rows: ReadonlyArray<T>,
   current: T,
 ): boolean {
-  return rows.some((r) => r.songId === current.songId && r.position < current.position);
+  return rows.some((r) => r.songId === current.songId && compareBySetThenPosition(r, current) < 0);
 }
 
 /**

--- a/apps/web/app/components/ui/filters/grouped-toggle-filters.test.tsx
+++ b/apps/web/app/components/ui/filters/grouped-toggle-filters.test.tsx
@@ -1,0 +1,68 @@
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { TOGGLE_FILTER_DEFINITIONS } from "~/lib/song-filters";
+import { GroupedToggleFilters } from "./grouped-toggle-filters";
+
+const ALL_FILTERS = TOGGLE_FILTER_DEFINITIONS.map((filter) => ({ key: filter.key, label: filter.label }));
+
+describe("GroupedToggleFilters", () => {
+  // The three groups each render as one popover trigger button; the chips
+  // themselves live inside the (closed) popover until it's opened.
+  test("renders a popover trigger per group", async () => {
+    await setup(<GroupedToggleFilters filters={ALL_FILTERS} activeFilters={new Set()} onToggle={() => {}} />);
+
+    for (const label of ["Quality", "Position", "Attributes"]) {
+      expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
+    }
+  });
+
+  // A group whose chips are all hidden by the caller is not rendered. Quality's
+  // chips (jamChart, allTimer, attended) hidden → no Quality button.
+  test("skips a group with no visible chips", async () => {
+    const hidden = new Set(["jamChart", "allTimer", "attended"]);
+    const withoutQuality = ALL_FILTERS.filter((filter) => !hidden.has(filter.key));
+    await setup(<GroupedToggleFilters filters={withoutQuality} activeFilters={new Set()} onToggle={() => {}} />);
+
+    expect(screen.queryByRole("button", { name: "Quality" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Position" })).toBeInTheDocument();
+  });
+
+  // Active filters inside a group surface as a count badge on its trigger, so
+  // the user sees there's an active filter without opening the popover.
+  test("shows an active-count badge for a group with active filters", async () => {
+    await setup(
+      <GroupedToggleFilters
+        filters={ALL_FILTERS}
+        activeFilters={new Set(["split", "standalone"])}
+        onToggle={() => {}}
+      />,
+    );
+
+    // Attributes holds both active filters; its trigger shows the count.
+    expect(screen.getByRole("button", { name: /Attributes/ }).textContent).toContain("2");
+  });
+
+  // Opening a group's popover reveals its chips.
+  test("opening a group reveals its chips", async () => {
+    const { user } = await setup(
+      <GroupedToggleFilters filters={ALL_FILTERS} activeFilters={new Set()} onToggle={() => {}} />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Split" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Attributes" }));
+    expect(await screen.findByRole("button", { name: "Split" })).toBeInTheDocument();
+  });
+
+  // The component is controlled: clicking a chip reports its key to the parent.
+  test("clicking a chip calls onToggle with its key", async () => {
+    const handleToggle = vi.fn();
+    const { user } = await setup(
+      <GroupedToggleFilters filters={ALL_FILTERS} activeFilters={new Set()} onToggle={handleToggle} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Attributes" }));
+    await user.click(await screen.findByRole("button", { name: "Standalone" }));
+    expect(handleToggle).toHaveBeenCalledWith("standalone");
+  });
+});

--- a/apps/web/app/components/ui/filters/grouped-toggle-filters.tsx
+++ b/apps/web/app/components/ui/filters/grouped-toggle-filters.tsx
@@ -1,0 +1,65 @@
+import { ChevronDown } from "lucide-react";
+import { ToggleFilterGroup } from "~/components/ui/filters/toggle-filter-group";
+import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
+import { TOGGLE_FILTER_GROUPS } from "~/lib/song-filters";
+
+interface GroupedToggleFiltersProps {
+  /** Visible toggle chips ({key, label}); already filtered by the caller so
+   *  preset-hidden chips (e.g. jamChart on /songs/jam-charts) are absent. */
+  filters: Array<{ key: string; label: string }>;
+  activeFilters: Set<string>;
+  onToggle: (key: string) => void;
+}
+
+const triggerBase =
+  "inline-flex items-center gap-2 h-[34px] px-3 rounded-md border text-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/20";
+
+/**
+ * Renders the toggle chips as a compact strip of group popovers (Quality,
+ * Position, Attributes) so the filter row stays one line of buttons instead of
+ * a sprawling chip wall. Each button shows an active-count badge and opens a
+ * popover of its chips; a group whose chips are all hidden by the caller is
+ * skipped.
+ */
+export function GroupedToggleFilters({ filters, activeFilters, onToggle }: GroupedToggleFiltersProps) {
+  return (
+    <>
+      {TOGGLE_FILTER_GROUPS.map((group) => {
+        const groupFilters = filters.filter((filter) => (group.keys as readonly string[]).includes(filter.key));
+        if (groupFilters.length === 0) return null;
+
+        const activeCount = groupFilters.reduce((count, filter) => count + (activeFilters.has(filter.key) ? 1 : 0), 0);
+        const active = activeCount > 0;
+
+        return (
+          <Popover key={group.label}>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className={`${triggerBase} ${
+                  active
+                    ? "bg-brand-primary/15 border-brand-primary text-white"
+                    : "bg-glass-bg border-glass-border text-content-text-secondary hover:bg-glass-bg/80"
+                }`}
+              >
+                {group.label}
+                {active && (
+                  <span className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-brand-primary text-white text-xs font-semibold">
+                    {activeCount}
+                  </span>
+                )}
+                <ChevronDown className="h-3.5 w-3.5 opacity-60" aria-hidden="true" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent
+              align="start"
+              className="w-auto max-w-xs p-3 bg-glass-bg border-glass-border backdrop-blur-md"
+            >
+              <ToggleFilterGroup filters={groupFilters} activeFilters={activeFilters} onToggle={onToggle} />
+            </PopoverContent>
+          </Popover>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/web/app/lib/performance-filter-params.test.ts
+++ b/apps/web/app/lib/performance-filter-params.test.ts
@@ -50,6 +50,16 @@ describe("parsePerformanceFilters — jamChart scope", () => {
 
     expect(filters.jamChart).toBe(true);
   });
+
+  // "Split" (song played 2+ times in one show) rides the `filters` param like
+  // the other toggle chips and parses into its boolean option.
+  test("parses ?filters=split into the split option", async () => {
+    const url = new URL("https://x.test/songs?filters=split");
+
+    const filters = await parsePerformanceFilters(url, emptyContext);
+
+    expect(filters.split).toBe(true);
+  });
 });
 
 describe("parsePerformanceFilters — excludeRange", () => {

--- a/apps/web/app/lib/performance-filter-params.ts
+++ b/apps/web/app/lib/performance-filter-params.ts
@@ -13,6 +13,7 @@ const VALID_FILTER_KEYS = new Set([
   "segueIn",
   "segueOut",
   "standalone",
+  "split",
   "inverted",
   "dyslexic",
   "jamChart",

--- a/apps/web/app/lib/song-filters.test.ts
+++ b/apps/web/app/lib/song-filters.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "vitest";
-import { getTimeRangeParam, SONG_FILTERS, TIME_RANGE_GROUPS } from "./song-filters";
+import {
+  getTimeRangeParam,
+  SONG_FILTERS,
+  TIME_RANGE_GROUPS,
+  TOGGLE_FILTER_DEFINITIONS,
+  TOGGLE_FILTER_GROUPS,
+} from "./song-filters";
 
 describe("TIME_RANGE_GROUPS", () => {
   // The groups should be ordered: Recent, Eras, Years — matching the
@@ -60,6 +66,32 @@ describe("SONG_FILTERS", () => {
   test("existing era keys still resolve to date ranges", () => {
     expect(SONG_FILTERS.sammy).toBeDefined();
     expect(SONG_FILTERS.sammy.endDate).toEqual(new Date("2005-08-27"));
+  });
+});
+
+describe("TOGGLE_FILTER_GROUPS", () => {
+  // The Split chip is a defined toggle (song played 2+ times in one show).
+  test("Split is a defined toggle filter", () => {
+    const split = TOGGLE_FILTER_DEFINITIONS.find((filter) => filter.key === "split");
+    expect(split).toEqual({ key: "split", label: "Split" });
+  });
+
+  // Every toggle chip except `attended` must belong to exactly one group, or it
+  // would be unreachable (no group) or rendered twice (two groups). `attended`
+  // is the personal toggle, rendered as a standalone chip outside the groups.
+  test("every toggle key except attended belongs to exactly one group", () => {
+    const grouped = TOGGLE_FILTER_GROUPS.flatMap((group) => group.keys);
+    const defined = TOGGLE_FILTER_DEFINITIONS.map((filter) => filter.key).filter((key) => key !== "attended");
+
+    expect([...grouped].sort()).toEqual([...defined].sort());
+    expect(grouped).toHaveLength(new Set(grouped).size);
+    expect(grouped).not.toContain("attended");
+  });
+
+  // Split lives in the Attributes group (how the song was played / connects).
+  test("Split is in the Attributes group", () => {
+    const attributes = TOGGLE_FILTER_GROUPS.find((group) => group.label === "Attributes");
+    expect(attributes?.keys).toContain("split");
   });
 });
 

--- a/apps/web/app/lib/song-filters.ts
+++ b/apps/web/app/lib/song-filters.ts
@@ -82,9 +82,27 @@ export const TOGGLE_FILTER_DEFINITIONS = [
   { key: "segueIn", label: "Segue In" },
   { key: "segueOut", label: "Segue Out" },
   { key: "standalone", label: "Standalone" },
+  { key: "split", label: "Split" },
   { key: "inverted", label: "Inverted" },
   { key: "dyslexic", label: "Dyslexic" },
   { key: "jamChart", label: "Jam Chart" },
   { key: "allTimer", label: "All-Timer" },
   { key: "attended", label: "Attended" },
 ] as const;
+
+/**
+ * Groups the toggle chips into labeled popovers so the filter row stays a
+ * single compact strip of buttons as filters accumulate. Each group renders as
+ * one popover button (with an active-count badge) holding its chips; labels
+ * come from TOGGLE_FILTER_DEFINITIONS (the canonical key→label source). Every
+ * toggle key except `attended` belongs to exactly one group — `attended` is a
+ * personal on/off, so it renders as a standalone chip rather than in a group.
+ */
+export const TOGGLE_FILTER_GROUPS = [
+  { label: "Quality", keys: ["jamChart", "allTimer"] },
+  { label: "Position", keys: ["setOpener", "setCloser", "encore"] },
+  { label: "Attributes", keys: ["split", "standalone", "segueIn", "segueOut", "inverted", "dyslexic"] },
+] as const;
+
+/** The personal toggle rendered on its own (not in a group popover). */
+export const STANDALONE_TOGGLE_KEY = "attended";

--- a/packages/core/src/page-composers/song-page-composer.test.ts
+++ b/packages/core/src/page-composers/song-page-composer.test.ts
@@ -443,6 +443,21 @@ describe("buildFilterQuery", () => {
     expect(sql).toMatch(/EXISTS.*OR.*EXISTS/s);
   });
 
+  // "Split" = the same song played 2+ times in one show (broken into pieces
+  // around other songs). Detected via a correlated COUNT over sibling tracks
+  // of the same song in the same show, with no extra JOIN.
+  test("split filters on songs played more than once in the same show", () => {
+    const { conditions, extraJoins } = SongPageComposer.buildFilterQuery([], { split: true });
+
+    expect(conditions).toHaveLength(1);
+    expect(extraJoins).toHaveLength(0);
+    const sql = conditions[0].strings.join("");
+    expect(sql).toContain("COUNT(*)");
+    expect(sql).toContain("t2.show_id = tracks.show_id");
+    expect(sql).toContain("t2.song_id = tracks.song_id");
+    expect(sql).toContain("> 1");
+  });
+
   // The attended filter is special: it produces a JOIN (on the attendances
   // table) rather than a WHERE condition. Important because JOINs and
   // conditions are injected at different points in the SQL template.
@@ -783,6 +798,7 @@ describe("isNarrowingFilter", () => {
     ["segueIn", { segueIn: true }],
     ["segueOut", { segueOut: true }],
     ["standalone", { standalone: true }],
+    ["split", { split: true }],
     ["inverted", { inverted: true }],
     ["dyslexic", { dyslexic: true }],
     ["unfinished", { unfinished: true }],

--- a/packages/core/src/page-composers/song-page-composer.ts
+++ b/packages/core/src/page-composers/song-page-composer.ts
@@ -59,6 +59,8 @@ export interface PerformanceFilterOptions {
   segueIn?: boolean;
   segueOut?: boolean;
   standalone?: boolean;
+  /** Narrow to performances where the song was played 2+ times in the same show. */
+  split?: boolean;
   inverted?: boolean;
   dyslexic?: boolean;
   unfinished?: boolean;
@@ -528,6 +530,15 @@ export class SongPageComposer {
             condition: Prisma.sql`(tracks.segue IS NULL OR tracks.segue = '') AND (prevTracks.segue IS NULL OR prevTracks.segue = '')`,
           }
         : null,
+    // "Split" = the same song appears 2+ times in one show. A correlated count
+    // over sibling tracks of the same song in the same show; > 1 means it was
+    // broken into multiple performances.
+    split: (o) =>
+      o.split
+        ? {
+            condition: Prisma.sql`(SELECT COUNT(*) FROM tracks t2 WHERE t2.show_id = tracks.show_id AND t2.song_id = tracks.song_id) > 1`,
+          }
+        : null,
     allTimer: (o) => (o.allTimer ? { condition: Prisma.sql`tracks.all_timer = true` } : null),
     // Scope to one song by slug via a subquery so callers pass the readable
     // slug (not a resolved id). An unknown slug yields no rows.
@@ -793,6 +804,7 @@ export function isNarrowingFilter(options: PerformanceFilterOptions | undefined)
       options.segueIn ||
       options.segueOut ||
       options.standalone ||
+      options.split ||
       options.inverted ||
       options.dyslexic ||
       options.unfinished ||


### PR DESCRIPTION
Adds a **Split** filter to the song tables (stats and performance views) for songs played more than once in the same show, and reorganizes the toggle filters into a compact strip of grouped popover buttons so the filter row stops sprawling as filters accumulate.

## What changed for users

- New **Split** toggle: narrows to songs broken into multiple performances within a single show (e.g. a Basis for a Day sandwiched around other songs). Works on `/songs`, the song-detail performance tabs, and anywhere the filter controls appear.
- The toggle chips are now three popover buttons in the same row as the dropdowns: **Quality** (Jam Chart, All-Timer), **Position** (Opener, Closer, Encore), **Attributes** (Split, Standalone, Segue In/Out, Inverted, Dyslexic). Each shows an active-count badge. **Attended** stays a standalone chip since it is a personal on/off, not a curation group.
- Fixes the within-show "played again" (↺) marker: a song's reprise in a later set or the encore now reliably shows the marker.

## Notes for the reviewer

- **Split detection** is a correlated count in the filter SQL: a track matches when its `(show_id, song_id)` appears in 2+ tracks. No denormalized column, and it slots into the existing `FILTER_BUILDERS` / `isNarrowingFilter` machinery like the other toggle filters. No cache-key bump is needed: the stored payload shape is unchanged and `split` already varies the existing `filters` cache hash.
- **The ↺ bug:** within-show-repeat detection compared rows on raw `position`, but positions reset per set, so an encore reprise (E1 #2) could carry the same or a lower position than its earlier second-set play (S2 #2) and be missed. Both `isWithinShowRepeat` helpers (gap-cell and performance-columns) now compare with `compareBySetThenPosition`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
