### PR TITLE
Consolidate surfaces into named Card variants

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -38,6 +38,17 @@ Before writing markup, grep the className you're about to type. If it's already 
 - **DO extract a shared component for a repeated multi-element affordance.** A composite that's *more than a className* — e.g. a `Button asChild` + `Link` + icon nav button repeated across pages — belongs in one component so its styling AND verbiage stay consistent app-wide and change in one place. Use [LinkButton](app/components/ui/link-button.tsx) for prominent action/nav buttons ("Create X", "Back to X") and [BackLink](app/components/ui/back-link.tsx) for the subtle content-page back link ("All X"). The "no `<MyButton>`" rule above targets pure single-className hiding, not multi-element composites. Navigation should look identical across pages; settle on one pattern unless there's a real reason for two (e.g. prominent form/list actions vs. low-emphasis content-page nav). Verbiage convention: create buttons say **"Create X"** (not "New X").
 - **Don't bake project styling into shadcn defaults.** Auth/search/etc. use the upstream primitive. Project looks → constant or variant.
 
+## Surfaces: pick by intent, never by raw class
+
+A surface's background is chosen by a named role, not by pasting a CSS class. The whole menu is small on purpose; enforced by [app/lib/surface-system.test.ts](app/lib/surface-system.test.ts).
+
+- **Content blocks → `<Card variant>`** ([components/ui/card.tsx](app/components/ui/card.tsx)). `elevated` (default — gradient/border/shadow, the dominant content card and any prominent standalone card, including data/chart cards), `panel` (flat frosted, low-emphasis: small tiles in a grid like stat boxes, and inline secondary text such as notes/lyrics), `plain` (bare shadcn `bg-card`; also the escape hatch for a card with its own custom `bg-*`, e.g. the auth cards). A bare `<Card>` is `elevated`. For a block that must stay a `<div>`/`<a>` (grid item, `asChild`), use `cardVariants({ variant, className })` — never the raw `card-premium`/`glass-content` class. Rule of thumb: if it sits next to elevated cards, it's elevated.
+- **Form fields → `formInputClass`** ([lib/form-styles.ts](app/lib/form-styles.ts)) on every `Input`/`Textarea`/`SelectTrigger` in a content form (admin, contact, review, blog). Two deliberate exceptions: **auth** forms (login/register/password reset) use `authInputClass` (frosted `.auth-input`, matching the translucent auth card), and compact **filter-bar** controls use the glass-select tokens (`glassSelectTriggerClass`) because they sit on glass chrome.
+- **Chrome / overlays → `glass`** (dialogs, popovers, command palette, drawers, header). `glass-secondary` is the dashed "unrated / incomplete" affordance surface.
+- **Composable tokens** (`bg-glass-bg`, `border-glass-border`, `hover:bg-hover-glass`) are fine inline for borders/rows/hover states — they're tokens, not whole surfaces.
+
+Don't reintroduce `card-premium` or `glass-content` in markup (they only back the Card variants now), and don't add a new whole-surface class when a variant/constant covers the intent.
+
 ## Package-Specific Commands
 
 ```bash

--- a/apps/web/app/components/admin/admin-form-page.tsx
+++ b/apps/web/app/components/admin/admin-form-page.tsx
@@ -27,7 +27,7 @@ export function AdminFormPage({ title, backHref, backLabel, children, footer }: 
           <PageHeader title={title} backLink={{ to: backHref, label: backLabel }} />
         </div>
 
-        <Card className="card-premium">
+        <Card>
           <CardContent className="p-6 space-y-6">
             {children}
             {footer ? <div className="border-t border-glass-border pt-6">{footer}</div> : null}

--- a/apps/web/app/components/blog/blog-card.tsx
+++ b/apps/web/app/components/blog/blog-card.tsx
@@ -25,7 +25,7 @@ export function BlogCard({ blogPost, compact = false }: BlogCardProps) {
 
   return (
     <Link to={`/blog/${blogPost.slug}`} className="block h-full no-underline">
-      <Card className="h-full card-premium hover:border-brand-primary/60 transition-all duration-300 overflow-hidden">
+      <Card className="h-full hover:border-brand-primary/60 transition-all duration-300 overflow-hidden">
         <div className={`relative ${compact ? "h-[300px]" : "h-[400px]"} overflow-hidden`}>
           {coverImage ? (
             <img

--- a/apps/web/app/components/blog/blog-form.tsx
+++ b/apps/web/app/components/blog/blog-form.tsx
@@ -12,6 +12,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { Input } from "~/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
 import { Textarea } from "~/components/ui/textarea";
+import { formInputClass } from "~/lib/form-styles";
 import { cn } from "~/lib/utils";
 
 const BlogPostState = {
@@ -139,7 +140,7 @@ export function BlogPostForm({ defaultValues, submitLabel, cancelHref }: BlogPos
             <FormItem>
               <FormLabel className="text-content-text-primary">Title</FormLabel>
               <FormControl>
-                <Input placeholder="Enter title" {...field} className="glass-content text-content-text-primary" />
+                <Input placeholder="Enter title" {...field} className={formInputClass} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -158,7 +159,7 @@ export function BlogPostForm({ defaultValues, submitLabel, cancelHref }: BlogPos
                   {...field}
                   value={field.value || ""}
                   onChange={(e) => field.onChange(e.target.value || null)}
-                  className="glass-content text-content-text-primary min-h-[100px]"
+                  className={cn(formInputClass, "min-h-[100px]")}
                 />
               </FormControl>
               <FormMessage />
@@ -183,7 +184,7 @@ export function BlogPostForm({ defaultValues, submitLabel, cancelHref }: BlogPos
                     e.target.style.height = "auto";
                     e.target.style.height = `${e.target.scrollHeight}px`;
                   }}
-                  className="glass-content text-content-text-primary min-h-[300px] font-mono resize-none overflow-hidden"
+                  className={cn(formInputClass, "min-h-[300px] font-mono resize-none overflow-hidden")}
                 />
               </FormControl>
               <FormMessage />
@@ -199,11 +200,11 @@ export function BlogPostForm({ defaultValues, submitLabel, cancelHref }: BlogPos
               <FormLabel className="text-content-text-primary">State</FormLabel>
               <Select onValueChange={field.onChange} defaultValue={field.value}>
                 <FormControl>
-                  <SelectTrigger className="glass-content text-content-text-primary">
+                  <SelectTrigger className={formInputClass}>
                     <SelectValue placeholder="Select state" />
                   </SelectTrigger>
                 </FormControl>
-                <SelectContent className="glass-content">
+                <SelectContent className="glass">
                   <SelectItem value={BlogPostState.DRAFT} className="text-content-text-primary">
                     Draft
                   </SelectItem>

--- a/apps/web/app/components/contact/contact-dialog.tsx
+++ b/apps/web/app/components/contact/contact-dialog.tsx
@@ -17,6 +17,8 @@ import {
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "~/components/ui/form";
 import { Input } from "~/components/ui/input";
 import { Textarea } from "~/components/ui/textarea";
+import { formInputClass } from "~/lib/form-styles";
+import { cn } from "~/lib/utils";
 
 const contactFormSchema = z.object({
   name: z.string().min(1, "Name is required"),
@@ -95,7 +97,7 @@ export function ContactDialog({ children }: ContactDialogProps) {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="glass-content border-glass-border max-w-md">
+      <DialogContent className="glass border-glass-border max-w-md">
         <DialogHeader>
           <DialogTitle className="text-content-text-primary text-xl">Get in Touch</DialogTitle>
           <DialogDescription className="text-content-text-secondary">
@@ -124,7 +126,10 @@ export function ContactDialog({ children }: ContactDialogProps) {
                         <Input
                           placeholder="Your name"
                           {...field}
-                          className="glass-content pl-9 text-content-text-primary focus:ring-1 focus:ring-brand-primary/50 focus:border-brand-primary/50"
+                          className={cn(
+                            formInputClass,
+                            "pl-9 focus:ring-1 focus:ring-brand-primary/50 focus:border-brand-primary/50",
+                          )}
                         />
                       </FormControl>
                     </div>
@@ -146,7 +151,10 @@ export function ContactDialog({ children }: ContactDialogProps) {
                           type="email"
                           placeholder="your@email.com"
                           {...field}
-                          className="glass-content pl-9 text-content-text-primary focus:ring-1 focus:ring-brand-primary/50 focus:border-brand-primary/50"
+                          className={cn(
+                            formInputClass,
+                            "pl-9 focus:ring-1 focus:ring-brand-primary/50 focus:border-brand-primary/50",
+                          )}
                         />
                       </FormControl>
                     </div>
@@ -165,7 +173,10 @@ export function ContactDialog({ children }: ContactDialogProps) {
                       <Input
                         placeholder="What's this about?"
                         {...field}
-                        className="glass-content text-content-text-primary focus:ring-1 focus:ring-brand-primary/50 focus:border-brand-primary/50"
+                        className={cn(
+                          formInputClass,
+                          "focus:ring-1 focus:ring-brand-primary/50 focus:border-brand-primary/50",
+                        )}
                       />
                     </FormControl>
                     <FormMessage />
@@ -183,7 +194,10 @@ export function ContactDialog({ children }: ContactDialogProps) {
                       <Textarea
                         placeholder="Tell us more..."
                         {...field}
-                        className="glass-content text-content-text-primary min-h-[100px] focus:ring-1 focus:ring-brand-primary/50 focus:border-brand-primary/50"
+                        className={cn(
+                          formInputClass,
+                          "min-h-[100px] focus:ring-1 focus:ring-brand-primary/50 focus:border-brand-primary/50",
+                        )}
                       />
                     </FormControl>
                     <FormMessage />

--- a/apps/web/app/components/filter-nav.tsx
+++ b/apps/web/app/components/filter-nav.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { cardVariants } from "~/components/ui/card";
 import { CollapsibleSection } from "~/components/ui/collapsible-section";
 import { cn } from "~/lib/utils";
 
@@ -77,7 +78,7 @@ export function FilterNav({
   // `defaultExpanded={false}` makes it collapsible on desktop too.
   return (
     <CollapsibleSection
-      className="card-premium rounded-lg overflow-hidden"
+      className={cardVariants({ variant: "elevated", className: "rounded-lg overflow-hidden" })}
       title={title}
       titleClassName="text-sm font-semibold text-white"
       headerExtra={

--- a/apps/web/app/components/forgot-password-form.tsx
+++ b/apps/web/app/components/forgot-password-form.tsx
@@ -5,6 +5,7 @@ import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
+import { authInputClass } from "~/lib/form-styles";
 
 type ForgotPasswordFormProps = {
   className?: string;
@@ -15,7 +16,10 @@ type ForgotPasswordFormProps = {
 export function ForgotPasswordForm({ className, onSubmit, isLoading = false, ...props }: ForgotPasswordFormProps) {
   return (
     <div className={cn("flex flex-col gap-6", className)} {...props}>
-      <Card className="relative border border-brand/10 bg-content-bg/90 backdrop-blur-2xl transition-colors duration-300 hover:border-brand/30">
+      <Card
+        variant="plain"
+        className="relative border border-brand/10 bg-content-bg/90 backdrop-blur-2xl transition-colors duration-300 hover:border-brand/30"
+      >
         <div className="absolute inset-0 rounded-[inherit] bg-gradient-to-b from-brand/10 via-transparent to-transparent" />
         <div className="absolute inset-0 rounded-[inherit] shadow-2xl shadow-brand/5" />
         <div className="absolute -inset-0.5 rounded-lg bg-gradient-to-b from-brand/5 to-brand/0 opacity-50" />
@@ -40,7 +44,7 @@ export function ForgotPasswordForm({ className, onSubmit, isLoading = false, ...
                     type="email"
                     placeholder="m@example.com"
                     required
-                    className="glass-content pl-9 text-content-text-primary placeholder:text-content-text-tertiary"
+                    className={cn(authInputClass, "pl-9 placeholder:text-content-text-tertiary")}
                   />
                 </div>
               </div>

--- a/apps/web/app/components/forms/venue-form.tsx
+++ b/apps/web/app/components/forms/venue-form.tsx
@@ -11,7 +11,10 @@ type VenueFormProps = {
 
 export function VenueForm({ venue, onSubmit }: VenueFormProps) {
   return (
-    <Card className="relative border-none bg-content-bg/90 backdrop-blur-2xl before:pointer-events-none before:absolute before:-inset-1 before:rounded-[inherit] before:border before:border-brand-primary/20 before:opacity-0 before:transition before:duration-300 hover:before:opacity-100">
+    <Card
+      variant="plain"
+      className="relative border-none bg-content-bg/90 backdrop-blur-2xl before:pointer-events-none before:absolute before:-inset-1 before:rounded-[inherit] before:border before:border-brand-primary/20 before:opacity-0 before:transition before:duration-300 hover:before:opacity-100"
+    >
       <div className="absolute inset-0 rounded-[inherit] bg-gradient-to-b from-brand-primary/10 via-transparent to-transparent" />
       <div className="absolute inset-0 rounded-[inherit] shadow-2xl shadow-brand-primary/5" />
       <div className="absolute -inset-0.5 rounded-lg bg-gradient-to-b from-brand-primary/5 to-brand-primary/0 opacity-50" />

--- a/apps/web/app/components/login-form.tsx
+++ b/apps/web/app/components/login-form.tsx
@@ -5,6 +5,7 @@ import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
+import { authInputClass } from "~/lib/form-styles";
 
 type LoginFormProps = {
   className?: string;
@@ -15,7 +16,10 @@ type LoginFormProps = {
 export function LoginForm({ className, onSubmit, onGoogleClick, ...props }: LoginFormProps) {
   return (
     <div className={cn("flex flex-col gap-6", className)} {...props}>
-      <Card className="relative border border-brand/10 bg-content-bg/90 backdrop-blur-2xl transition-colors duration-300 hover:border-brand/30">
+      <Card
+        variant="plain"
+        className="relative border border-brand/10 bg-content-bg/90 backdrop-blur-2xl transition-colors duration-300 hover:border-brand/30"
+      >
         <div className="absolute inset-0 rounded-[inherit] bg-gradient-to-b from-brand/10 via-transparent to-transparent" />
         <div className="absolute inset-0 rounded-[inherit] shadow-2xl shadow-brand/5" />
         <div className="absolute -inset-0.5 rounded-lg bg-gradient-to-b from-brand/5 to-brand/0 opacity-50" />
@@ -77,7 +81,7 @@ export function LoginForm({ className, onSubmit, onGoogleClick, ...props }: Logi
                       type="email"
                       placeholder="m@example.com"
                       required
-                      className="glass-content pl-9 text-content-text-primary placeholder:text-content-text-tertiary"
+                      className={cn(authInputClass, "pl-9 placeholder:text-content-text-tertiary")}
                     />
                   </div>
                 </div>
@@ -97,7 +101,7 @@ export function LoginForm({ className, onSubmit, onGoogleClick, ...props }: Logi
                       name="password"
                       type="password"
                       required
-                      className="glass-content pl-9 text-content-text-primary"
+                      className={cn(authInputClass, "pl-9")}
                     />
                   </div>
                 </div>

--- a/apps/web/app/components/performance/performance-table.tsx
+++ b/apps/web/app/components/performance/performance-table.tsx
@@ -94,7 +94,7 @@ export function PerformanceTable({
   );
 
   return (
-    <Card className="card-premium py-4 px-1">
+    <Card className="py-4 px-1">
       <DataTable
         columns={columns}
         data={performances}

--- a/apps/web/app/components/rating/rating-charts.tsx
+++ b/apps/web/app/components/rating/rating-charts.tsx
@@ -12,6 +12,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { cardVariants } from "~/components/ui/card";
 import { ChartTooltipCard } from "~/components/ui/chart-tooltip";
 import { SegmentButton } from "~/components/ui/segment-button";
 import { CHART_BAR_CURSOR, CHART_COLORS, chartSeriesColor } from "~/lib/chart-colors";
@@ -66,7 +67,7 @@ export function RatingCharts({ buckets, kind }: RatingChartsProps) {
 
   return (
     <div className="space-y-4">
-      <div className="glass-content rounded-lg p-6">
+      <div className={cardVariants({ variant: "elevated", className: "rounded-lg p-6" })}>
         <div className="flex items-center justify-between mb-4 gap-3 flex-wrap">
           <h3 className="text-lg font-semibold text-content-text-primary">{noun} Rating Distribution</h3>
           <fieldset className="flex border-0 p-0 m-0">
@@ -121,7 +122,7 @@ export function RatingCharts({ buckets, kind }: RatingChartsProps) {
         </div>
       </div>
 
-      <div className="glass-content rounded-lg p-6">
+      <div className={cardVariants({ variant: "elevated", className: "rounded-lg p-6" })}>
         <h3 className="text-lg font-semibold text-content-text-primary mb-4">Average &amp; Median by Year</h3>
         <div className="h-80">
           <ResponsiveContainer width="100%" height="100%">

--- a/apps/web/app/components/register-form.tsx
+++ b/apps/web/app/components/register-form.tsx
@@ -5,6 +5,7 @@ import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
+import { authInputClass } from "~/lib/form-styles";
 
 type RegisterFormProps = {
   className?: string;
@@ -15,7 +16,10 @@ type RegisterFormProps = {
 export function RegisterForm({ className, onSubmit, onGoogleClick, ...props }: RegisterFormProps) {
   return (
     <div className={cn("flex flex-col gap-6", className)} {...props}>
-      <Card className="relative border border-brand/10 bg-content-bg/90 backdrop-blur-2xl transition-colors duration-300 hover:border-brand/30">
+      <Card
+        variant="plain"
+        className="relative border border-brand/10 bg-content-bg/90 backdrop-blur-2xl transition-colors duration-300 hover:border-brand/30"
+      >
         <div className="absolute inset-0 rounded-[inherit] bg-gradient-to-b from-brand/10 via-transparent to-transparent" />
         <div className="absolute inset-0 rounded-[inherit] shadow-2xl shadow-brand/5" />
         <div className="absolute -inset-0.5 rounded-lg bg-gradient-to-b from-brand/5 to-brand/0 opacity-50" />
@@ -79,7 +83,7 @@ export function RegisterForm({ className, onSubmit, onGoogleClick, ...props }: R
                       type="text"
                       placeholder="johndoe"
                       required
-                      className="border-content-bg-secondary bg-black/50 pl-9 text-content-text-secondary placeholder:text-content-text-tertiary focus:border-focus-ring focus:ring-focus-ring/20"
+                      className={cn(authInputClass, "pl-9 placeholder:text-content-text-tertiary")}
                     />
                   </div>
                 </div>
@@ -95,7 +99,7 @@ export function RegisterForm({ className, onSubmit, onGoogleClick, ...props }: R
                       type="email"
                       placeholder="m@example.com"
                       required
-                      className="border-content-bg-secondary bg-black/50 pl-9 text-content-text-secondary placeholder:text-content-text-tertiary focus:border-focus-ring focus:ring-focus-ring/20"
+                      className={cn(authInputClass, "pl-9 placeholder:text-content-text-tertiary")}
                     />
                   </div>
                 </div>
@@ -110,7 +114,7 @@ export function RegisterForm({ className, onSubmit, onGoogleClick, ...props }: R
                       name="password"
                       type="password"
                       required
-                      className="border-content-bg-secondary bg-black/50 pl-9 text-content-text-secondary focus:border-focus-ring focus:ring-focus-ring/20"
+                      className={cn(authInputClass, "pl-9")}
                     />
                   </div>
                 </div>

--- a/apps/web/app/components/reset-password-form.tsx
+++ b/apps/web/app/components/reset-password-form.tsx
@@ -5,6 +5,7 @@ import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
+import { authInputClass } from "~/lib/form-styles";
 
 type ResetPasswordFormProps = {
   className?: string;
@@ -15,7 +16,10 @@ type ResetPasswordFormProps = {
 export function ResetPasswordForm({ className, onSubmit, isLoading = false, ...props }: ResetPasswordFormProps) {
   return (
     <div className={cn("flex flex-col gap-6", className)} {...props}>
-      <Card className="relative border border-brand/20 bg-content-bg/90 backdrop-blur-2xl transition-colors duration-300 hover:border-brand/30">
+      <Card
+        variant="plain"
+        className="relative border border-brand/20 bg-content-bg/90 backdrop-blur-2xl transition-colors duration-300 hover:border-brand/30"
+      >
         <div className="absolute inset-0 rounded-[inherit] bg-gradient-to-b from-brand/10 via-transparent to-transparent" />
         <div className="absolute inset-0 rounded-[inherit] shadow-2xl shadow-brand/5" />
         <div className="absolute -inset-0.5 rounded-lg bg-gradient-to-b from-brand/5 to-brand/0 opacity-50" />
@@ -41,7 +45,7 @@ export function ResetPasswordForm({ className, onSubmit, isLoading = false, ...p
                     placeholder="Enter new password"
                     required
                     minLength={6}
-                    className="glass-content pl-9 text-content-text-primary placeholder:text-content-text-tertiary"
+                    className={cn(authInputClass, "pl-9 placeholder:text-content-text-tertiary")}
                   />
                 </div>
               </div>
@@ -59,7 +63,7 @@ export function ResetPasswordForm({ className, onSubmit, isLoading = false, ...p
                     placeholder="Confirm new password"
                     required
                     minLength={6}
-                    className="glass-content pl-9 text-content-text-primary placeholder:text-content-text-tertiary"
+                    className={cn(authInputClass, "pl-9 placeholder:text-content-text-tertiary")}
                   />
                 </div>
               </div>

--- a/apps/web/app/components/resources/resource-card.tsx
+++ b/apps/web/app/components/resources/resource-card.tsx
@@ -11,7 +11,7 @@ interface ResourceCardProps {
 export default function ResourceCard({ title, content, image, url }: ResourceCardProps) {
   return (
     <Link to={url} className="block h-full no-underline">
-      <Card className="h-full card-premium hover:border-brand-primary/60 transition-all duration-300 overflow-hidden">
+      <Card className="h-full hover:border-brand-primary/60 transition-all duration-300 overflow-hidden">
         <div className="relative h-[400px] overflow-hidden">
           <img
             className="w-full h-full object-cover transition-transform duration-500 hover:scale-110"

--- a/apps/web/app/components/review/review-card.tsx
+++ b/apps/web/app/components/review/review-card.tsx
@@ -7,7 +7,8 @@ import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader } from "~/components/ui/card";
 import { ConfirmDialog } from "~/components/ui/confirm-dialog";
 import { Textarea } from "~/components/ui/textarea";
-import { formatDateLong } from "~/lib/utils";
+import { formInputClass } from "~/lib/form-styles";
+import { cn, formatDateLong } from "~/lib/utils";
 
 interface ReviewCardProps {
   review: ReviewMinimal;
@@ -57,7 +58,7 @@ export function ReviewCard({ review, currentUserId, onDelete, onUpdate }: Review
 
   return (
     <>
-      <Card className="card-premium overflow-hidden transition-all duration-300 hover:border-brand-primary/60">
+      <Card className="overflow-hidden transition-all duration-300 hover:border-brand-primary/60">
         <CardHeader className="border-b border-glass-border/50 px-6 py-4">
           <div className="flex justify-between items-center">
             <div className="flex items-center gap-3">
@@ -99,7 +100,7 @@ export function ReviewCard({ review, currentUserId, onDelete, onUpdate }: Review
               <Textarea
                 value={editContent}
                 onChange={(e) => setEditContent(e.target.value)}
-                className="min-h-[100px] glass-content border-glass-border text-content-text-primary"
+                className={cn(formInputClass, "min-h-[100px]")}
               />
               <div className="flex justify-end gap-2">
                 <Button

--- a/apps/web/app/components/review/review-form.tsx
+++ b/apps/web/app/components/review/review-form.tsx
@@ -5,6 +5,8 @@ import { z } from "zod";
 import { Button } from "~/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "~/components/ui/form";
 import { Textarea } from "~/components/ui/textarea";
+import { formInputClass } from "~/lib/form-styles";
+import { cn } from "~/lib/utils";
 
 const reviewFormSchema = z.object({
   content: z.string().min(1, "Review content is required"),
@@ -37,7 +39,7 @@ export function ReviewForm({ onSubmit }: ReviewFormProps) {
                 <Textarea
                   placeholder="Share your thoughts about this show..."
                   {...field}
-                  className="glass-content border-glass-border text-content-text-primary min-h-[120px]"
+                  className={cn(formInputClass, "min-h-[120px]")}
                 />
               </FormControl>
               <FormMessage />

--- a/apps/web/app/components/search/search-feedback.tsx
+++ b/apps/web/app/components/search/search-feedback.tsx
@@ -2,6 +2,8 @@ import { ThumbsDown, ThumbsUp } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { Textarea } from "~/components/ui/textarea";
+import { formInputClass } from "~/lib/form-styles";
+import { cn } from "~/lib/utils";
 
 interface SearchFeedbackProps {
   searchId: string;
@@ -94,7 +96,10 @@ export function SearchFeedback({ searchId, onFeedback, className }: SearchFeedba
           value={feedback}
           onChange={(e) => setFeedback(e.target.value)}
           placeholder="What could be better about these search results?"
-          className="glass-content text-content-text-primary min-h-[80px] text-sm focus:ring-1 focus:ring-brand-primary/50 focus:border-brand-primary/50"
+          className={cn(
+            formInputClass,
+            "min-h-[80px] text-sm focus:ring-1 focus:ring-brand-primary/50 focus:border-brand-primary/50",
+          )}
         />
         <div className="flex gap-2">
           <Button

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -159,7 +159,7 @@ function SetlistCardComponent({
   };
 
   return (
-    <Card className="card-premium relative overflow-hidden">
+    <Card className="relative overflow-hidden">
       <CardHeader
         data-testid="setlist-card-header"
         onClick={

--- a/apps/web/app/components/setlist/setlist-highlights.tsx
+++ b/apps/web/app/components/setlist/setlist-highlights.tsx
@@ -1,6 +1,7 @@
 import type { Setlist, TrackLight } from "@bip/domain";
 import { Link } from "react-router-dom";
 import { TrackIcon } from "~/components/track/track-icon";
+import { cardVariants } from "~/components/ui/card";
 import { compareBySetThenPosition, countDistinctEncores, formatSetLabel } from "./set-label";
 
 interface SetlistHighlightsProps {
@@ -23,7 +24,7 @@ export function SetlistHighlights({ setlist }: SetlistHighlightsProps) {
   const ordered = [...highlights].sort(compareBySetThenPosition);
 
   return (
-    <div className="card-premium rounded-lg px-3 py-2 space-y-3">
+    <div className={cardVariants({ variant: "elevated", className: "rounded-lg px-3 py-2 space-y-3" })}>
       <h3 className="text-sm font-medium text-content-text-secondary">Show Highlights</h3>
       <ul className="space-y-2">
         {ordered.map((track, idx) => {

--- a/apps/web/app/components/show-filters-nav.tsx
+++ b/apps/web/app/components/show-filters-nav.tsx
@@ -1,5 +1,6 @@
 import { Camera } from "lucide-react";
 import { TriStateFilterButton } from "~/components/tri-state-filter-button";
+import { cardVariants } from "~/components/ui/card";
 import { EXTERNAL_SOURCE_DOMAINS, faviconSrc } from "~/lib/favicon";
 import { parseTriState, TRI_STATE_NEXT, writeTriState } from "~/lib/tri-state-filter";
 
@@ -41,7 +42,7 @@ interface ShowFiltersNavProps {
  */
 export function ShowFiltersNav({ basePath, currentURLParameters }: ShowFiltersNavProps) {
   return (
-    <div className="card-premium rounded-lg px-2 py-2">
+    <div className={cardVariants({ variant: "elevated", className: "rounded-lg px-2 py-2" })}>
       <h2 className="text-[10px] font-semibold text-content-text-tertiary uppercase tracking-wide mb-1.5 text-center">
         Filter by Media
       </h2>

--- a/apps/web/app/components/show/debut-year-chart.tsx
+++ b/apps/web/app/components/show/debut-year-chart.tsx
@@ -2,6 +2,7 @@ import { average, median } from "@bip/domain";
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { cardVariants } from "~/components/ui/card";
 import { ChartTooltipCard } from "~/components/ui/chart-tooltip";
 import { SegmentButton } from "~/components/ui/segment-button";
 import { CHART_BAR_CURSOR, CHART_COLORS } from "~/lib/chart-colors";
@@ -113,7 +114,7 @@ export function DebutYearChart({ setlist }: DebutYearChartProps) {
   const labelInterval = labelStride - 1;
 
   return (
-    <div className="glass-content rounded-lg p-3">
+    <div className={cardVariants({ variant: "elevated", className: "rounded-lg p-3" })}>
       <h3 className="text-sm font-semibold text-content-text-primary mb-2">Songs by debut year</h3>
       <div className="flex items-center justify-between gap-2 mb-2 text-xs">
         <div className="inline-flex items-center">

--- a/apps/web/app/components/show/external-source-card.tsx
+++ b/apps/web/app/components/show/external-source-card.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { cardVariants } from "~/components/ui/card";
 import { faviconSrc } from "~/lib/favicon";
 
 /**
@@ -21,7 +22,7 @@ interface ExternalSourceCardProps {
  */
 export function ExternalSourceCard({ faviconDomain, title, children }: ExternalSourceCardProps) {
   return (
-    <div className="card-premium rounded-lg px-3 py-2">
+    <div className={cardVariants({ variant: "elevated", className: "rounded-lg px-3 py-2" })}>
       <div className="flex items-center gap-2 mb-1.5">
         <img src={faviconSrc(faviconDomain)} alt="" className="h-4 w-4 shrink-0" />
         <h4 className="text-sm font-medium text-content-text-secondary">{title}</h4>

--- a/apps/web/app/components/show/show-day-order-manager.tsx
+++ b/apps/web/app/components/show/show-day-order-manager.tsx
@@ -112,7 +112,7 @@ export function ShowDayOrderManager({ currentShowId, date, initialShows }: ShowD
   };
 
   return (
-    <Card className="border-content-bg-secondary bg-content-bg/50">
+    <Card variant="plain" className="border-content-bg-secondary bg-content-bg/50">
       <CardHeader>
         <CardTitle className="text-content-text-primary">Same-date show order</CardTitle>
         <p className="text-sm text-content-text-secondary">

--- a/apps/web/app/components/show/show-lineup-manager.tsx
+++ b/apps/web/app/components/show/show-lineup-manager.tsx
@@ -110,7 +110,7 @@ export function ShowLineupManager({ showId, initialLineup }: ShowLineupManagerPr
 
   if (!editing) {
     return (
-      <Card className="card-premium">
+      <Card>
         <CardContent className="p-4">
           <div className="mb-2 flex items-center justify-between gap-2">
             <h3 className="text-base font-medium text-content-text-primary">Lineup</h3>
@@ -136,7 +136,7 @@ export function ShowLineupManager({ showId, initialLineup }: ShowLineupManagerPr
   }
 
   return (
-    <Card className="card-premium">
+    <Card>
       <CardHeader className="flex-row flex-wrap items-center justify-between gap-2 space-y-0 py-3">
         <CardTitle className="text-base text-content-text-primary">Edit lineup</CardTitle>
         <div className="flex items-center gap-2">

--- a/apps/web/app/components/show/show-lineup-section.tsx
+++ b/apps/web/app/components/show/show-lineup-section.tsx
@@ -74,7 +74,7 @@ export function ShowLineupSection({
   if (bare) return list;
 
   return (
-    <Card className="card-premium relative overflow-hidden mt-4">
+    <Card className="relative overflow-hidden mt-4">
       <CollapsibleSection
         title="Lineup"
         titleAs="h3"

--- a/apps/web/app/components/song/songs-table.tsx
+++ b/apps/web/app/components/song/songs-table.tsx
@@ -38,7 +38,7 @@ export function SongsTable({
   const initialSorting = useMemo(() => [{ id: sortColumnId, desc: true }], [sortColumnId]);
 
   return (
-    <Card className="card-premium py-4 px-1">
+    <Card className="py-4 px-1">
       <DataTable
         // Remount when the sort column changes so the default sort actually
         // flips. DataTable's `initialSorting` only runs once per mount, so a

--- a/apps/web/app/components/song/yearly-play-chart.tsx
+++ b/apps/web/app/components/song/yearly-play-chart.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { cardVariants } from "~/components/ui/card";
 import { ChartTooltipCard } from "~/components/ui/chart-tooltip";
 import { SegmentButton } from "~/components/ui/segment-button";
 import { CHART_COLORS } from "~/lib/chart-colors";
@@ -35,7 +36,7 @@ export function YearlyPlayChart({ yearlyPlayData, showsByYear }: YearlyPlayChart
   const isPercent = mode === "percent";
 
   return (
-    <div className="glass-content rounded-lg p-6">
+    <div className={cardVariants({ variant: "elevated", className: "rounded-lg p-6" })}>
       <div className="flex items-center justify-between mb-4 gap-3 flex-wrap">
         <h3 className="text-lg font-semibold text-content-text-primary">Played by Year</h3>
         <div className="flex items-center flex-wrap gap-y-2">

--- a/apps/web/app/components/track/track-manager.tsx
+++ b/apps/web/app/components/track/track-manager.tsx
@@ -352,7 +352,7 @@ export function TrackManager({ showId, initialTracks = [], footnoteSetlist }: Tr
   );
 
   return (
-    <Card className="card-premium">
+    <Card>
       <CardHeader>
         <div className="flex justify-between items-center">
           <CardTitle className="text-content-text-primary">Track List</CardTitle>

--- a/apps/web/app/components/ui/breadcrumb.tsx
+++ b/apps/web/app/components/ui/breadcrumb.tsx
@@ -17,7 +17,7 @@ const BreadcrumbList = React.forwardRef<HTMLOListElement, React.ComponentPropsWi
     <ol
       ref={ref}
       className={cn(
-        "flex flex-wrap items-center gap-2 break-words text-sm text-content-text-secondary sm:gap-3 glass-content px-4 py-2 rounded-full backdrop-blur-sm",
+        "flex flex-wrap items-center gap-2 break-words text-sm text-content-text-secondary sm:gap-3 glass px-4 py-2 rounded-full backdrop-blur-sm",
         className,
       )}
       {...props}

--- a/apps/web/app/components/ui/card.test.tsx
+++ b/apps/web/app/components/ui/card.test.tsx
@@ -1,0 +1,64 @@
+import { setup } from "@test/test-utils";
+import { describe, expect, test } from "vitest";
+
+import { Card } from "./card";
+
+describe("Card surface variants", () => {
+  // "elevated" is the dominant content-block surface (the old `card-premium`
+  // raw class): gradient bg, brand border, drop shadow. It's the no-arg
+  // default so a plain <Card> reads as the elevated content block.
+  test("variant='elevated' applies the elevated card surface", async () => {
+    const { container } = await setup(<Card variant="elevated">content</Card>);
+    const card = container.firstElementChild as HTMLElement;
+    expect(card.className).toContain("card-premium");
+  });
+
+  // A no-arg <Card> defaults to the elevated surface — the most common
+  // content block — so callers don't have to remember to pick it.
+  test("default (no variant) is the elevated surface", async () => {
+    const { container } = await setup(<Card>content</Card>);
+    const card = container.firstElementChild as HTMLElement;
+    expect(card.className).toContain("card-premium");
+  });
+
+  // "panel" is the flat frosted surface (the old `glass-content` tile look)
+  // for things nested inside an elevated card — stat tiles, chart containers.
+  test("variant='panel' applies the flat panel surface", async () => {
+    const { container } = await setup(<Card variant="panel">content</Card>);
+    const card = container.firstElementChild as HTMLElement;
+    expect(card.className).toContain("glass-content");
+  });
+
+  // "plain" is the opaque shadcn escape hatch: the bare bg-card defaults and
+  // no project surface class.
+  test("variant='plain' applies the bare shadcn card defaults", async () => {
+    const { container } = await setup(<Card variant="plain">content</Card>);
+    const card = container.firstElementChild as HTMLElement;
+    expect(card.className).toContain("bg-card");
+    expect(card.className).toContain("shadow-sm");
+    expect(card.className).not.toContain("card-premium");
+    expect(card.className).not.toContain("glass-content");
+  });
+
+  // The panel surface is flat by design — the shadcn `shadow-sm` default must
+  // not leak onto it (only `elevated` carries elevation).
+  test("variant='panel' is flat (no shadcn shadow-sm)", async () => {
+    const { container } = await setup(<Card variant="panel">content</Card>);
+    const card = container.firstElementChild as HTMLElement;
+    expect(card.className).not.toContain("shadow-sm");
+  });
+
+  // Caller-supplied className must stack on top of the variant so layout
+  // utilities (padding, overflow) compose with the surface.
+  test("caller className stacks with the variant classes", async () => {
+    const { container } = await setup(
+      <Card variant="elevated" className="p-4 overflow-hidden">
+        content
+      </Card>,
+    );
+    const card = container.firstElementChild as HTMLElement;
+    expect(card.className).toContain("card-premium");
+    expect(card.className).toContain("p-4");
+    expect(card.className).toContain("overflow-hidden");
+  });
+});

--- a/apps/web/app/components/ui/card.tsx
+++ b/apps/web/app/components/ui/card.tsx
@@ -1,9 +1,36 @@
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "~/lib/utils";
 
-const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)} {...props} />
+// The app's surface system. A card's background is picked by intent, not by
+// pasting a raw CSS class:
+//   elevated — the dominant content block (gradient, brand border, drop shadow).
+//   panel    — flat frosted surface for things nested inside an elevated card
+//              (stat tiles, chart containers, small info cards).
+//   plain    — opaque shadcn bg-card; the rare escape hatch.
+// `elevated` is the default so a bare <Card> is the common content block.
+// Exported for the handful of div/`asChild` sites that can't be a <Card>.
+const cardVariants = cva("rounded-lg text-card-foreground", {
+  variants: {
+    variant: {
+      // Gradient, brand border, drop shadow — all supplied by the class.
+      elevated: "card-premium",
+      // Flat frosted surface: its own bg/border, intentionally no shadow.
+      panel: "glass-content",
+      // The bare shadcn card defaults.
+      plain: "border bg-card shadow-sm",
+    },
+  },
+  defaultVariants: {
+    variant: "elevated",
+  },
+});
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof cardVariants> {}
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(({ className, variant, ...props }, ref) => (
+  <div ref={ref} className={cn(cardVariants({ variant, className }))} {...props} />
 ));
 Card.displayName = "Card";
 
@@ -40,4 +67,4 @@ const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
 );
 CardFooter.displayName = "CardFooter";
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent, cardVariants };

--- a/apps/web/app/components/ui/command.tsx
+++ b/apps/web/app/components/ui/command.tsx
@@ -27,7 +27,7 @@ interface CommandDialogProps extends DialogProps {
 const CommandDialog = ({ children, shouldFilter = true, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="glass-content max-w-3xl w-[90vw] h-[90vh] max-h-[90vh] overflow-hidden p-0 shadow-2xl">
+      <DialogContent className="glass max-w-3xl w-[90vw] h-[90vh] max-h-[90vh] overflow-hidden p-0 shadow-2xl">
         <DialogTitle className="sr-only">Search</DialogTitle>
         <Command
           shouldFilter={shouldFilter}

--- a/apps/web/app/components/ui/login-prompt-popover.tsx
+++ b/apps/web/app/components/ui/login-prompt-popover.tsx
@@ -13,7 +13,7 @@ export function LoginPromptPopover({ children, message = "Sign in to rate" }: Lo
   return (
     <Popover>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
-      <PopoverContent className="w-auto glass-content border-glass-border p-3" onClick={(e) => e.stopPropagation()}>
+      <PopoverContent className="w-auto glass border-glass-border p-3" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center gap-3">
           <p className="text-sm text-content-text-secondary">{message}</p>
           <Link

--- a/apps/web/app/components/ui/stat-box.tsx
+++ b/apps/web/app/components/ui/stat-box.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { cardVariants } from "~/components/ui/card";
 
 interface StatBoxProps {
   label: string;
@@ -17,7 +18,12 @@ interface StatBoxProps {
  */
 export function StatBox({ label, value, icon, sublabel, sublabel2 }: StatBoxProps) {
   return (
-    <div className="glass-content p-2 sm:p-3 short:!py-1 short:!px-2.5 rounded-lg h-full">
+    <div
+      className={cardVariants({
+        variant: "panel",
+        className: "p-2 sm:p-3 short:!py-1 short:!px-2.5 rounded-lg h-full",
+      })}
+    >
       <dt className="flex items-center gap-2 text-sm short:!text-[11px] short:!leading-tight font-medium text-content-text-secondary">
         {icon}
         {label}

--- a/apps/web/app/lib/form-styles.ts
+++ b/apps/web/app/lib/form-styles.ts
@@ -1,13 +1,23 @@
 /**
- * Dark-theme styling for form Input / Textarea controls used in admin
- * and edit forms across the app. Centralized here so a token change
- * (e.g. swapping `--content-bg-secondary` for a different surface)
- * propagates to every form at once instead of needing 17+ edits.
- *
- * Auth forms (login / register / forgot-password) and search inputs use
- * a different visual treatment and should NOT use this constant.
+ * The single dark-theme surface for form fields (`Input` / `Textarea` /
+ * `SelectTrigger`) everywhere a value is entered: admin/edit forms, auth,
+ * contact, review, and blog. One surface so a field looks the same in every
+ * form and a token change propagates in one edit, instead of the old
+ * three-way split (this constant vs. raw `glass-content` vs. the glass-select
+ * tokens). The only inputs that stay off it are the compact filter-bar
+ * controls (`glassSelectTriggerClass`), which sit on glass chrome rather than
+ * inside a content form.
  */
 export const formInputClass = "bg-content-bg-secondary border-content-bg-secondary text-content-text-primary";
+
+/**
+ * The auth form field surface — login, register, and password reset. Auth has
+ * its own visual identity (a translucent gradient card with brand borders), so
+ * its inputs use the matching frosted-glass `.auth-input` treatment rather than
+ * the opaque `formInputClass` used by admin/content forms. One constant so the
+ * four auth forms stay identical.
+ */
+export const authInputClass = "auth-input text-content-text-primary";
 
 /**
  * Block-level label style for native `<label>` elements in forms that

--- a/apps/web/app/lib/surface-system.test.ts
+++ b/apps/web/app/lib/surface-system.test.ts
@@ -1,0 +1,91 @@
+import { readFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import fg from "fast-glob";
+import ts from "typescript";
+import { describe, expect, test } from "vitest";
+
+/**
+ * Guardrail for the surface design system. A surface's background is chosen by
+ * `Card` variant (`elevated` / `panel` / `plain`) — see card.tsx — not by
+ * pasting the raw `card-premium` / `glass-content` CSS classes into a
+ * `<Card className>`. This test fails if a `<Card>` reintroduces a raw surface
+ * class, which is how the surfaces drifted in the first place.
+ */
+
+const WEB_ROOT = resolve(__dirname, "../..");
+const APP_ROOT = resolve(WEB_ROOT, "app");
+const STYLES_CSS = resolve(APP_ROOT, "styles.css");
+
+// Surface classes that were defined but never used — deleted so the menu of
+// surfaces stays small. A redefinition is the bloat this guard prevents.
+const DEAD_SURFACE_CLASSES = ["glass-heavy", "glass-accent", "card-premium-accent"];
+
+const FORBIDDEN_SURFACES = ["card-premium", "glass-content"];
+
+// Surfaces are chosen by Card variant; form controls get the dedicated input
+// surface (formInputClass). A raw surface class on any of these is the drift
+// this guard prevents.
+const GUARDED_TAGS = new Set(["Card", "Input", "Textarea", "SelectTrigger"]);
+
+function parse(filePath: string): ts.SourceFile {
+  return ts.createSourceFile(filePath, readFileSync(filePath, "utf8"), ts.ScriptTarget.Latest, true);
+}
+
+/** The literal string value of a className attribute, if it's a plain string literal. */
+function classNameLiteral(attr: ts.JsxAttribute): string | null {
+  if (!ts.isJsxAttribute(attr) || attr.name.getText() !== "className") return null;
+  const init = attr.initializer;
+  if (!init) return null;
+  if (ts.isStringLiteral(init)) return init.text;
+  if (ts.isJsxExpression(init) && init.expression && ts.isStringLiteral(init.expression)) {
+    return init.expression.text;
+  }
+  return null;
+}
+
+function surfaceViolations(sourceFile: ts.SourceFile, file: string): string[] {
+  const violations: string[] = [];
+  const visit = (node: ts.Node) => {
+    if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+      const tag = node.tagName.getText();
+      if (GUARDED_TAGS.has(tag)) {
+        for (const attr of node.attributes.properties) {
+          if (!ts.isJsxAttribute(attr)) continue;
+          const value = classNameLiteral(attr);
+          if (!value) continue;
+          for (const token of FORBIDDEN_SURFACES) {
+            if (new RegExp(`(^|\\s)${token}(\\s|$)`).test(value)) {
+              const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+              const fix = tag === "Card" ? "use a variant instead" : "use formInputClass instead";
+              violations.push(`${file}:${line + 1} <${tag} className> still uses "${token}" — ${fix}`);
+            }
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return violations;
+}
+
+describe("surface design system", () => {
+  // A raw card-premium / glass-content class must not reappear on a Card
+  // (use a variant) or on a form control (use formInputClass) — that's the
+  // drift this consolidation removes.
+  test("no Card or form control carries a raw card-premium / glass-content class", async () => {
+    const files = await fg("**/*.tsx", { cwd: APP_ROOT, absolute: true, ignore: ["**/*.test.tsx"] });
+    const violations: string[] = [];
+    for (const file of files) {
+      violations.push(...surfaceViolations(parse(file), relative(WEB_ROOT, file)));
+    }
+    expect(violations).toEqual([]);
+  });
+
+  // The unused surface classes must not be redefined in the stylesheet.
+  test("dead surface classes are not defined in styles.css", () => {
+    const css = readFileSync(STYLES_CSS, "utf8");
+    const redefined = DEAD_SURFACE_CLASSES.filter((name) => css.includes(`.${name}`));
+    expect(redefined).toEqual([]);
+  });
+});

--- a/apps/web/app/routes/_index.tsx
+++ b/apps/web/app/routes/_index.tsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 import { BlogCard } from "~/components/blog/blog-card";
 import { SetlistList } from "~/components/setlist/setlist-list";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
-import { Card } from "~/components/ui/card";
+import { Card, cardVariants } from "~/components/ui/card";
 import { DonationBanner } from "~/components/ui/donation-banner";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
@@ -201,7 +201,7 @@ export default function Index() {
         {/* Next Show Banner - Mobile only */}
         {nextTourDate && (
           <div className="mb-6">
-            <Card className="card-premium">
+            <Card>
               <div className="p-4 text-center">
                 <div className="flex items-center justify-center mb-1">
                   <Calendar className="h-4 w-4 mr-2 text-brand-primary" />
@@ -270,7 +270,7 @@ export default function Index() {
                   </Link>
                 </div>
 
-                <div className="card-premium rounded-lg overflow-hidden">
+                <div className={cardVariants({ variant: "elevated", className: "rounded-lg overflow-hidden" })}>
                   {latestEpisode.image && (
                     <div className="relative">
                       <img src={latestEpisode.image} alt={latestEpisode.title} className="w-full h-32 object-cover" />
@@ -324,7 +324,7 @@ export default function Index() {
               </div>
 
               {tourDates.length > 0 ? (
-                <Card className="card-premium">
+                <Card>
                   <div className="relative overflow-x-auto">
                     <table className="w-full">
                       <tbody>
@@ -358,7 +358,7 @@ export default function Index() {
             {/* Revolution in Motion */}
             <div>
               <Link to={rockOperaPath(ROCK_OPERA_SLUG.REVOLUTION_IN_MOTION)} className="block group">
-                <div className="card-premium rounded-lg overflow-hidden">
+                <div className={cardVariants({ variant: "elevated", className: "rounded-lg overflow-hidden" })}>
                   <div className="relative">
                     <img
                       src="https://pub-6aa5e67069a14fc286677addbdd10c65.r2.dev/public/revolution-in-motion.png"
@@ -423,7 +423,7 @@ export default function Index() {
               </Link>
             </div>
 
-            <div className="card-premium rounded-lg overflow-hidden">
+            <div className={cardVariants({ variant: "elevated", className: "rounded-lg overflow-hidden" })}>
               {latestEpisode.image && (
                 <div className="relative">
                   <img src={latestEpisode.image} alt={latestEpisode.title} className="w-full h-32 object-cover" />
@@ -512,7 +512,7 @@ export default function Index() {
           </div>
 
           {tourDates.length > 0 ? (
-            <Card className="card-premium">
+            <Card>
               <div className="relative overflow-x-auto">
                 <table className="w-full text-md">
                   <thead>

--- a/apps/web/app/routes/about.tsx
+++ b/apps/web/app/routes/about.tsx
@@ -21,7 +21,7 @@ export default function About() {
       </div>
 
       <div className="grid gap-6 md:gap-8">
-        <Card className="glass-content">
+        <Card variant="panel">
           <CardContent className="p-6">
             <h2 className="text-2xl font-semibold text-content-text-primary mb-4">The Biscuits Internet Project</h2>
             <div className="prose prose-invert max-w-none space-y-4">
@@ -39,7 +39,7 @@ export default function About() {
           </CardContent>
         </Card>
 
-        <Card className="glass-content">
+        <Card variant="panel">
           <CardContent className="p-6">
             <h2 className="text-2xl font-semibold text-content-text-primary mb-4">What We Offer</h2>
             <div className="grid md:grid-cols-2 gap-6">
@@ -73,7 +73,7 @@ export default function About() {
           </CardContent>
         </Card>
 
-        <Card className="glass-content">
+        <Card variant="panel">
           <CardContent className="p-6">
             <h2 className="text-2xl font-semibold text-content-text-primary mb-4">Community Driven</h2>
             <p className="text-content-text-secondary mb-4">
@@ -89,7 +89,7 @@ export default function About() {
           </CardContent>
         </Card>
 
-        <Card className="glass-content">
+        <Card variant="panel">
           <CardContent className="p-6">
             <h2 className="text-2xl font-semibold text-content-text-primary mb-4">Disclaimer</h2>
             <p className="text-content-text-secondary text-sm">

--- a/apps/web/app/routes/admin/index.tsx
+++ b/apps/web/app/routes/admin/index.tsx
@@ -24,7 +24,7 @@ interface AdminCardProps {
 function AdminCard({ title, description, href, icon }: AdminCardProps) {
   return (
     <Link to={href}>
-      <Card className="card-premium hover:border-brand-primary/50 transition-all duration-300 group h-full">
+      <Card className="hover:border-brand-primary/50 transition-all duration-300 group h-full">
         <CardHeader>
           <div className="flex items-center gap-3 mb-2">
             <div className="p-2 rounded-lg bg-brand-primary/20 text-brand-primary group-hover:bg-brand-primary/30 transition-colors">
@@ -99,7 +99,7 @@ export default function AdminIndex() {
           />
         </div>
 
-        <Card className="card-premium">
+        <Card>
           <CardHeader>
             <div className="flex items-center gap-3">
               <div className="p-2 rounded-lg bg-brand-primary/20 text-brand-primary">

--- a/apps/web/app/routes/blog/$slug.edit.tsx
+++ b/apps/web/app/routes/blog/$slug.edit.tsx
@@ -142,7 +142,7 @@ export default function EditBlogPost() {
       </div>
 
       <AdminOnly>
-        <Card className="card-premium">
+        <Card>
           <CardContent className="p-6">
             <BlogPostForm
               defaultValues={defaultValues}

--- a/apps/web/app/routes/blog/$slug.tsx
+++ b/apps/web/app/routes/blog/$slug.tsx
@@ -78,7 +78,7 @@ export default function BlogPostPage() {
         </div>
       </div>
 
-      <Card className="relative overflow-hidden border-content-bg-secondary">
+      <Card variant="plain" className="relative overflow-hidden border-content-bg-secondary">
         <div className="absolute inset-0 bg-gradient-to-br from-content-bg via-content-bg/95 to-brand/20 pointer-events-none" />
         <CardContent className="relative z-10 p-6">
           <div className="prose prose-invert max-w-none">

--- a/apps/web/app/routes/blog/new.tsx
+++ b/apps/web/app/routes/blog/new.tsx
@@ -70,7 +70,7 @@ export default function NewBlogPost() {
       </div>
 
       <AdminOnly>
-        <Card className="card-premium">
+        <Card>
           <CardContent className="p-6">
             <BlogPostForm submitLabel="Create Post" cancelHref="/blog" />
           </CardContent>

--- a/apps/web/app/routes/community.tsx
+++ b/apps/web/app/routes/community.tsx
@@ -103,7 +103,7 @@ function UserCard({ userStats }: { userStats: UserStats }) {
   const displayBadges = badges?.slice(0, 3) || [];
 
   return (
-    <Card className="glass-content hover:glass-content-hover transition-all duration-300">
+    <Card variant="panel" className="hover:glass-content-hover transition-all duration-300">
       <CardContent className="p-4">
         {/* Header with avatar, username, and score */}
         <div className="flex items-center gap-3 mb-3">
@@ -189,7 +189,7 @@ function LeaderboardSection({
   metric: keyof Pick<UserStats, "reviewCount" | "attendanceCount" | "ratingCount" | "blogPostCount">;
 }) {
   return (
-    <Card className="card-premium">
+    <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-xl">
           <Icon className="h-5 w-5 text-brand-primary" />
@@ -296,19 +296,19 @@ export default function Community() {
 
         {/* Community Stats */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
-          <Card className="glass-content">
+          <Card variant="panel">
             <CardContent className="p-4 text-center">
               <div className="text-3xl font-bold text-brand-primary">{communityTotals.totalUsers}</div>
               <div className="text-sm text-content-text-secondary">Community Members</div>
             </CardContent>
           </Card>
-          <Card className="glass-content">
+          <Card variant="panel">
             <CardContent className="p-4 text-center">
               <div className="text-3xl font-bold text-brand-secondary">{communityTotals.totalReviews}</div>
               <div className="text-sm text-content-text-secondary">Total Reviews</div>
             </CardContent>
           </Card>
-          <Card className="glass-content">
+          <Card variant="panel">
             <CardContent className="p-4 text-center">
               <div className="text-3xl font-bold text-brand-tertiary">{communityTotals.totalRatings}</div>
               <div className="text-sm text-content-text-secondary">Ratings Given</div>
@@ -319,7 +319,7 @@ export default function Community() {
 
       {/* Top Community Scores */}
       <div className="mb-8">
-        <Card className="card-premium">
+        <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-xl">
               <Trophy className="h-5 w-5 text-brand-primary" />

--- a/apps/web/app/routes/mcp-info.tsx
+++ b/apps/web/app/routes/mcp-info.tsx
@@ -74,7 +74,7 @@ export default function McpInfo() {
 
       {/* Features */}
       <div className="grid md:grid-cols-3 gap-5 mb-10">
-        <Card className="glass-content">
+        <Card variant="panel">
           <CardHeader className="pb-2">
             <Terminal className="h-6 w-6 text-brand-primary mb-2" />
             <CardTitle className="text-lg">Search Shows</CardTitle>
@@ -83,7 +83,7 @@ export default function McpInfo() {
             <CardDescription>Find shows by date, venue, city, or songs played.</CardDescription>
           </CardContent>
         </Card>
-        <Card className="glass-content">
+        <Card variant="panel">
           <CardHeader className="pb-2">
             <Code2 className="h-6 w-6 text-brand-primary mb-2" />
             <CardTitle className="text-lg">Get Setlists</CardTitle>
@@ -92,7 +92,7 @@ export default function McpInfo() {
             <CardDescription>Retrieve complete setlists with song transitions and notes.</CardDescription>
           </CardContent>
         </Card>
-        <Card className="glass-content">
+        <Card variant="panel">
           <CardHeader className="pb-2">
             <Zap className="h-6 w-6 text-brand-primary mb-2" />
             <CardTitle className="text-lg">Song History</CardTitle>
@@ -104,7 +104,7 @@ export default function McpInfo() {
       </div>
 
       {/* Server URL */}
-      <Card className="mb-8 glass-content">
+      <Card variant="panel" className="mb-8">
         <CardHeader className="space-y-1">
           <CardTitle>Server URL</CardTitle>
           <CardDescription>Use this URL to connect your MCP client</CardDescription>
@@ -118,7 +118,7 @@ export default function McpInfo() {
       </Card>
 
       {/* Setup Instructions */}
-      <Card className="glass-content">
+      <Card variant="panel">
         <CardHeader className="space-y-1">
           <CardTitle>Setup Instructions</CardTitle>
           <CardDescription>Choose your AI client to get started</CardDescription>
@@ -295,7 +295,7 @@ export default function McpInfo() {
       </Card>
 
       {/* Available Tools */}
-      <Card className="mt-8 glass-content">
+      <Card variant="panel" className="mt-8">
         <CardHeader className="space-y-1">
           <CardTitle>Available Tools</CardTitle>
           <CardDescription>16 tools exposed by the MCP server</CardDescription>
@@ -411,7 +411,7 @@ export default function McpInfo() {
       </Card>
 
       {/* Example Usage */}
-      <Card className="mt-8 mb-8 glass-content">
+      <Card variant="panel" className="mt-8 mb-8">
         <CardHeader className="space-y-1">
           <CardTitle>Example Queries</CardTitle>
           <CardDescription>Try asking your AI assistant these questions</CardDescription>

--- a/apps/web/app/routes/musicians/$slug.tsx
+++ b/apps/web/app/routes/musicians/$slug.tsx
@@ -9,6 +9,7 @@ import { AdminOnly } from "~/components/admin/admin-only";
 import { DateVenueCell } from "~/components/performance/date-venue-cell";
 import { ShowDate } from "~/components/show-date";
 import { FilteredSongsStatsTable } from "~/components/song/filtered-songs-stats-table";
+import { cardVariants } from "~/components/ui/card";
 import { CollapsibleSection } from "~/components/ui/collapsible-section";
 import { DataTable } from "~/components/ui/data-table";
 import { LinkButton } from "~/components/ui/link-button";
@@ -291,7 +292,7 @@ export default function MusicianPage() {
         )}
 
         {tier === "core" ? (
-          <div className="glass-content rounded-lg p-6 text-content-text-secondary">
+          <div className={cardVariants({ variant: "panel", className: "rounded-lg p-6 text-content-text-secondary" })}>
             Core member: appears on essentially every show. The full shows and songs tables are omitted.
           </div>
         ) : (

--- a/apps/web/app/routes/oauth/consent.tsx
+++ b/apps/web/app/routes/oauth/consent.tsx
@@ -76,7 +76,10 @@ export default function OAuthConsent() {
   return (
     <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
       <div className="w-full max-w-md">
-        <Card className="relative border border-brand/10 bg-content-bg/90 backdrop-blur-2xl transition-colors duration-300">
+        <Card
+          variant="plain"
+          className="relative border border-brand/10 bg-content-bg/90 backdrop-blur-2xl transition-colors duration-300"
+        >
           <div className="absolute inset-0 rounded-[inherit] bg-gradient-to-b from-brand/10 via-transparent to-transparent" />
           <div className="absolute inset-0 rounded-[inherit] shadow-2xl shadow-brand/5" />
           <div className="absolute -inset-0.5 rounded-lg bg-gradient-to-b from-brand/5 to-brand/0 opacity-50" />

--- a/apps/web/app/routes/privacy.tsx
+++ b/apps/web/app/routes/privacy.tsx
@@ -17,7 +17,7 @@ export default function Privacy() {
         <h1 className="page-heading">PRIVACY POLICY</h1>
       </div>
 
-      <Card className="glass-content">
+      <Card variant="panel">
         <CardContent className="p-6">
           <div className="prose prose-invert max-w-none space-y-6">
             <p className="text-content-text-secondary text-sm">Last updated: {new Date().toLocaleDateString()}</p>

--- a/apps/web/app/routes/profile/edit.tsx
+++ b/apps/web/app/routes/profile/edit.tsx
@@ -150,7 +150,7 @@ export default function ProfileEdit() {
       </div>
 
       {/* Profile Form */}
-      <Card className="card-premium">
+      <Card>
         <CardHeader>
           <CardTitle className="text-content-text-primary">Profile Information</CardTitle>
         </CardHeader>

--- a/apps/web/app/routes/resources/band-history.tsx
+++ b/apps/web/app/routes/resources/band-history.tsx
@@ -2,7 +2,7 @@ import { Twitter } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
-import { Card, CardContent, CardHeader } from "~/components/ui/card";
+import { Card, CardContent, CardHeader, cardVariants } from "~/components/ui/card";
 import { publicLoader } from "~/lib/base-loaders";
 import { ROCK_OPERA_SLUG, rockOperaPath } from "~/lib/rock-operas";
 
@@ -56,7 +56,7 @@ const BandHistory: React.FC = () => {
           <h1 className="page-heading">BAND HISTORY</h1>
         </div>
 
-        <div className="glass-content rounded-lg p-6">
+        <div className={cardVariants({ variant: "elevated", className: "rounded-lg p-6" })}>
           <div className="space-y-4">
             <h2 className="text-xl font-semibold text-content-text-primary">Current Members</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -79,7 +79,7 @@ const BandHistory: React.FC = () => {
           </div>
         </div>
 
-        <Card className="card-premium rounded-lg">
+        <Card className="rounded-lg">
           <CardHeader>
             <h3 className="text-2xl font-semibold">Early Years</h3>
           </CardHeader>
@@ -115,7 +115,7 @@ const BandHistory: React.FC = () => {
           </CardContent>
         </Card>
 
-        <Card className="card-premium rounded-lg">
+        <Card className="rounded-lg">
           <CardHeader>
             <h3 className="text-2xl font-semibold">1997 - 1999</h3>
           </CardHeader>
@@ -157,7 +157,7 @@ const BandHistory: React.FC = () => {
           </CardContent>
         </Card>
 
-        <Card className="card-premium rounded-lg">
+        <Card className="rounded-lg">
           <CardHeader>
             <h3 className="text-2xl font-semibold">2000 - The Disco Triscuits and The Maui Project</h3>
           </CardHeader>
@@ -189,7 +189,7 @@ const BandHistory: React.FC = () => {
           </CardContent>
         </Card>
 
-        <Card className="card-premium rounded-lg">
+        <Card className="rounded-lg">
           <CardHeader>
             <h3 className="text-2xl font-semibold">2000 - 2004</h3>
           </CardHeader>
@@ -208,7 +208,7 @@ const BandHistory: React.FC = () => {
           </CardContent>
         </Card>
 
-        <Card className="card-premium rounded-lg">
+        <Card className="rounded-lg">
           <CardHeader>
             <h3 className="text-2xl font-semibold">2005 - The Doctor is Out. Enter Batman.</h3>
           </CardHeader>
@@ -236,7 +236,7 @@ const BandHistory: React.FC = () => {
           </CardContent>
         </Card>
 
-        <Card className="card-premium rounded-lg">
+        <Card className="rounded-lg">
           <CardHeader>
             <h3 className="text-2xl font-semibold">2006</h3>
           </CardHeader>
@@ -325,7 +325,7 @@ const BandHistory: React.FC = () => {
           </CardContent>
         </Card>
 
-        <Card className="card-premium rounded-lg">
+        <Card className="rounded-lg">
           <CardHeader>
             <h3 className="text-2xl font-semibold">2007</h3>
           </CardHeader>
@@ -394,7 +394,7 @@ const BandHistory: React.FC = () => {
           </CardContent>
         </Card>
 
-        <Card className="card-premium rounded-lg">
+        <Card className="rounded-lg">
           <CardHeader>
             <h3 className="text-2xl font-semibold">2008</h3>
           </CardHeader>
@@ -462,7 +462,7 @@ const BandHistory: React.FC = () => {
           </CardContent>
         </Card>
 
-        <Card className="card-premium rounded-lg">
+        <Card className="rounded-lg">
           <CardHeader>
             <h3 className="text-2xl font-semibold">2009</h3>
           </CardHeader>
@@ -654,7 +654,7 @@ const BandHistory: React.FC = () => {
           </CardContent>
         </Card>
 
-        <Card className="card-premium rounded-lg">
+        <Card className="rounded-lg">
           <CardHeader>
             <h3 className="text-2xl font-semibold">2011 - 2019 - Setbreak</h3>
           </CardHeader>
@@ -666,7 +666,7 @@ const BandHistory: React.FC = () => {
           </CardContent>
         </Card>
 
-        <Card className="card-premium rounded-lg">
+        <Card className="rounded-lg">
           <CardHeader>
             <h3 className="text-2xl font-semibold">2019 - Present - Setbreak is Over</h3>
           </CardHeader>

--- a/apps/web/app/routes/resources/chemical-warfare-brigade.tsx
+++ b/apps/web/app/routes/resources/chemical-warfare-brigade.tsx
@@ -755,7 +755,7 @@ const ChemicalWarfareBrigade: React.FC = () => {
               >
                 {index + 1}
               </div>
-              <Card className="card-premium relative overflow-hidden flex-1 min-w-0">
+              <Card className="relative overflow-hidden flex-1 min-w-0">
                 <CardHeader className="relative z-10 px-3 md:px-6 py-1 md:py-1">
                   <div className="flex flex-col gap-1">
                     <div className="text-lg md:text-2xl font-medium text-content-text-primary">{perf.date}</div>

--- a/apps/web/app/routes/resources/media.tsx
+++ b/apps/web/app/routes/resources/media.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 import { useEffect, useState } from "react";
+import { cardVariants } from "~/components/ui/card";
 
 interface Media {
   date: Date;
@@ -33,7 +34,12 @@ export default function MediaResources(): ReactElement {
           <h1 className="page-heading">NEWS FROM NOWHERE</h1>
         </div>
 
-        <div className="overflow-x-auto rounded-lg border border-content-bg-secondary glass-content">
+        <div
+          className={cardVariants({
+            variant: "panel",
+            className: "overflow-x-auto rounded-lg border border-content-bg-secondary",
+          })}
+        >
           <table className="min-w-full divide-y divide-divider">
             <thead className="bg-table-header">
               <tr>

--- a/apps/web/app/routes/resources/mixes.tsx
+++ b/apps/web/app/routes/resources/mixes.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { cardVariants } from "~/components/ui/card";
 import { publicLoader } from "~/lib/base-loaders";
 
 // Define types for our data
@@ -107,7 +108,7 @@ const Mixes: React.FC = () => {
   ];
 
   const Card = ({ title, children }: { title: string; children: React.ReactNode }) => (
-    <div className="glass-content rounded-lg shadow-md overflow-hidden mb-8">
+    <div className={cardVariants({ variant: "panel", className: "rounded-lg shadow-md overflow-hidden mb-8" })}>
       <div className="p-6">
         <h2 className="text-2xl font-semibold text-brand-primary mb-4">{title}</h2>
         {children}

--- a/apps/web/app/routes/resources/movie-scores.tsx
+++ b/apps/web/app/routes/resources/movie-scores.tsx
@@ -23,7 +23,7 @@ export function meta() {
 
 const MovieScores: React.FC = () => {
   const MovieCard = ({ title, children }: { title: React.ReactNode; children: React.ReactNode }) => (
-    <Card className="card-premium mb-6">
+    <Card className="mb-6">
       <CardHeader>
         <h2 className="text-2xl font-semibold text-content-text-primary">{title}</h2>
       </CardHeader>

--- a/apps/web/app/routes/resources/music.tsx
+++ b/apps/web/app/routes/resources/music.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { cardVariants } from "~/components/ui/card";
 import { publicLoader } from "~/lib/base-loaders";
 
 // Add a loader function
@@ -27,7 +28,7 @@ export default function Music() {
           <h1 className="page-heading">MUSIC TERMINOLOGY</h1>
         </div>
 
-        <div className="glass-content rounded-lg shadow-md p-6 mb-8">
+        <div className={cardVariants({ variant: "panel", className: "rounded-lg shadow-md p-6 mb-8" })}>
           <h2 id="inverted" className="text-2xl font-semibold text-brand-secondary mb-4 scroll-mt-24">
             Inverted
           </h2>
@@ -75,7 +76,7 @@ export default function Music() {
           </ul>
         </div>
 
-        <div className="glass-content rounded-lg shadow-md p-6 mb-8">
+        <div className={cardVariants({ variant: "panel", className: "rounded-lg shadow-md p-6 mb-8" })}>
           <h2 id="dyslexic" className="text-2xl font-semibold text-brand-secondary mb-4 scroll-mt-24">
             Dyslexic
           </h2>
@@ -112,7 +113,7 @@ export default function Music() {
           </ul>
         </div>
 
-        <div className="glass-content rounded-lg shadow-md p-6 mb-8">
+        <div className={cardVariants({ variant: "panel", className: "rounded-lg shadow-md p-6 mb-8" })}>
           <h2 className="text-2xl font-semibold text-brand-secondary mb-4">Palindrome</h2>
           <p className="text-content-text-secondary mb-4">
             Palindrome versions are played with the sections in a mirror-like structure. For example, if a song normally
@@ -143,7 +144,7 @@ export default function Music() {
           </ul>
         </div>
 
-        <div className="glass-content rounded-lg shadow-md p-6 mb-8">
+        <div className={cardVariants({ variant: "panel", className: "rounded-lg shadow-md p-6 mb-8" })}>
           <h2 className="text-2xl font-semibold text-brand-secondary mb-4">Techno</h2>
           <p className="text-content-text-secondary mb-4">
             In 2003 and 2004, the band experimented with techno versions of their songs, particularly during shows where

--- a/apps/web/app/routes/resources/perfume.tsx
+++ b/apps/web/app/routes/resources/perfume.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { Link } from "react-router-dom";
+import { cardVariants } from "~/components/ui/card";
 import { publicLoader } from "~/lib/base-loaders";
 
 // Add a loader function
@@ -36,7 +37,7 @@ const Perfume: React.FC = () => {
     <div>
       <h1 className="page-heading">THE PERFUME</h1>
 
-      <div className="glass-content rounded-lg shadow-md overflow-hidden mb-8 p-6">
+      <div className={cardVariants({ variant: "panel", className: "rounded-lg shadow-md overflow-hidden mb-8 p-6" })}>
         <p className="mb-6 text-content-text-secondary leading-relaxed">
           The Disco Biscuits first performed under the moniker "The Perfume" on{" "}
           <ShowLink to="/shows/2001-04-16-wetlands-preserve-new-york-ny">April 16, 2001</ShowLink> at the Wetlands in

--- a/apps/web/app/routes/resources/side-projects.tsx
+++ b/apps/web/app/routes/resources/side-projects.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 import { useEffect, useState } from "react";
+import { cardVariants } from "~/components/ui/card";
 
 interface SideProject {
   notes?: string;
@@ -35,7 +36,7 @@ export default function SideProjects(): ReactElement {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {sideProjects.map((project) => (
             <div key={project.id || project.name} className="h-full">
-              <div className="card-premium rounded-lg p-6 h-full">
+              <div className={cardVariants({ variant: "elevated", className: "rounded-lg p-6 h-full" })}>
                 <h3 className="text-xl font-bold text-content-text-primary mb-2">{project.name}</h3>
                 <div className="text-content-text-tertiary mb-4">
                   {project.dates.split(",").map((item) => (

--- a/apps/web/app/routes/resources/think-tank.tsx
+++ b/apps/web/app/routes/resources/think-tank.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { cardVariants } from "~/components/ui/card";
 import { publicLoader } from "~/lib/base-loaders";
 
 export const loader = publicLoader<void>(async () => {});
@@ -79,7 +80,7 @@ export default function ThinkTank() {
     <div>
       <h1 className="page-heading">THINK TANK DUBS</h1>
 
-      <div className="glass-content rounded-lg shadow-md p-6 mb-8">
+      <div className={cardVariants({ variant: "panel", className: "rounded-lg shadow-md p-6 mb-8" })}>
         <h2 className="text-2xl font-semibold text-brand-secondary mb-4">The Basement Sessions</h2>
 
         <p className="text-content-text-secondary mb-6">

--- a/apps/web/app/routes/resources/touchdowns.tsx
+++ b/apps/web/app/routes/resources/touchdowns.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { BackLink } from "~/components/ui/back-link";
+import { cardVariants } from "~/components/ui/card";
 import { publicLoader } from "~/lib/base-loaders";
 import { formatDateLong } from "~/lib/utils";
 
@@ -64,7 +65,13 @@ export default function Touchdowns() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {episodes?.map((episode) => (
-            <div key={episode.id} className="card-premium rounded-lg overflow-hidden h-full flex flex-col">
+            <div
+              key={episode.id}
+              className={cardVariants({
+                variant: "elevated",
+                className: "rounded-lg overflow-hidden h-full flex flex-col",
+              })}
+            >
               {episode.image && (
                 <div className="relative">
                   <img src={episode.image} alt={episode.title} className="w-full h-48 object-cover" />

--- a/apps/web/app/routes/resources/tractorbeam.tsx
+++ b/apps/web/app/routes/resources/tractorbeam.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { cardVariants } from "~/components/ui/card";
 import { publicLoader } from "~/lib/base-loaders";
 
 export const loader = publicLoader<void>(async () => {});
@@ -23,7 +24,7 @@ export default function Tractorbeam() {
           <h1 className="page-heading">TRACTORBEAM</h1>
         </div>
 
-        <div className="card-premium rounded-lg p-6 mb-6">
+        <div className={cardVariants({ variant: "elevated", className: "rounded-lg p-6 mb-6" })}>
           <div className="space-y-4 text-content-text-secondary">
             <p className="leading-relaxed">
               Tractorbeam, like{" "}

--- a/apps/web/app/routes/shows/$slug.edit.tsx
+++ b/apps/web/app/routes/shows/$slug.edit.tsx
@@ -195,7 +195,7 @@ export default function EditShow() {
       </div>
 
       <div className="space-y-6">
-        <Card className="card-premium">
+        <Card>
           <CardContent className="p-6">
             <ShowForm
               defaultValues={defaultValues}

--- a/apps/web/app/routes/shows/new.tsx
+++ b/apps/web/app/routes/shows/new.tsx
@@ -49,7 +49,7 @@ export default function NewShow() {
         <PageHeader title="Create Show" backLink={{ to: "/shows", label: "Back to Shows" }} />
       </div>
 
-      <Card className="card-premium">
+      <Card>
         <CardContent className="p-6">
           <ShowForm onSubmit={handleSubmit} submitLabel="Create Show" cancelHref="/shows" requireVenue />
         </CardContent>

--- a/apps/web/app/routes/shows/tour-dates.tsx
+++ b/apps/web/app/routes/shows/tour-dates.tsx
@@ -40,7 +40,7 @@ export default function TourDates() {
           <h1 className="page-heading">TOUR DATES</h1>
         </div>
 
-        <Card className="card-premium">
+        <Card>
           <div className="relative overflow-x-auto">
             <table className="w-full text-md">
               <thead>

--- a/apps/web/app/routes/shows/year/$year.tsx
+++ b/apps/web/app/routes/shows/year/$year.tsx
@@ -9,6 +9,7 @@ import { SetlistList } from "~/components/setlist/setlist-list";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
 import { ShowFiltersNav } from "~/components/show-filters-nav";
 import { Button } from "~/components/ui/button";
+import { cardVariants } from "~/components/ui/card";
 import { CollapsibleSection } from "~/components/ui/collapsible-section";
 import { LinkButton } from "~/components/ui/link-button";
 import { YearFilterNav } from "~/components/year-filter-nav";
@@ -255,7 +256,7 @@ export default function ShowsByYear() {
               counts={showCountsByYear}
             />
             <CollapsibleSection
-              className="card-premium rounded-lg overflow-hidden"
+              className={cardVariants({ variant: "elevated", className: "rounded-lg overflow-hidden" })}
               title="Jump to Month"
               titleClassName="text-sm font-semibold text-white"
               headerExtra={

--- a/apps/web/app/routes/songs/$slug.edit.tsx
+++ b/apps/web/app/routes/songs/$slug.edit.tsx
@@ -88,7 +88,7 @@ export default function EditSong() {
       </div>
 
       <AdminOnly>
-        <Card className="card-premium">
+        <Card>
           <CardContent className="p-6">
             <SongForm defaultValues={defaultValues} submitLabel="Save Changes" cancelHref={`/songs/${song.slug}`} />
           </CardContent>

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -12,6 +12,7 @@ import { RatingComponent } from "~/components/rating";
 import { ShowDate } from "~/components/show-date";
 import { YearlyPlayChart } from "~/components/song/yearly-play-chart";
 import { isNoteworthy } from "~/components/track/noteworthy-marker";
+import { cardVariants } from "~/components/ui/card";
 import { LinkButton } from "~/components/ui/link-button";
 import { PageHeader } from "~/components/ui/page-header";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
@@ -330,7 +331,7 @@ export default function SongPage() {
       </dl>
 
       {song.notes && (
-        <div className="glass-content rounded-lg p-4">
+        <div className={cardVariants({ variant: "panel", className: "rounded-lg p-4" })}>
           <div
             className="text-md text-content-text-tertiary leading-relaxed"
             dangerouslySetInnerHTML={{ __html: song.notes }}
@@ -424,7 +425,10 @@ export default function SongPage() {
                       <a
                         href={`/shows/${p.show.slug}`}
                         key={p.trackId}
-                        className="glass-content block rounded-lg hover:border-brand-primary/60 transition-all duration-200 p-4"
+                        className={cardVariants({
+                          variant: "panel",
+                          className: "block rounded-lg hover:border-brand-primary/60 transition-all duration-200 p-4",
+                        })}
                       >
                         <div className="flex items-start justify-between gap-3 mb-2">
                           <div className="text-lg font-medium text-content-text-primary">{p.show.date}</div>
@@ -474,7 +478,7 @@ export default function SongPage() {
 
         {song.history && (
           <TabsContent value="history" className="mt-4">
-            <div className="glass-content rounded-lg p-6">
+            <div className={cardVariants({ variant: "panel", className: "rounded-lg p-6" })}>
               <div
                 className="text-base text-content-text-tertiary leading-relaxed [&>p]:mb-4 [&>p:last-child]:mb-0"
                 dangerouslySetInnerHTML={{
@@ -494,7 +498,7 @@ export default function SongPage() {
 
         {song.lyrics && (
           <TabsContent value="lyrics" className="mt-4">
-            <div className="glass-content rounded-lg p-4">
+            <div className={cardVariants({ variant: "panel", className: "rounded-lg p-4" })}>
               <div className="overflow-x-auto">
                 <div
                   className="text-md text-content-text-tertiary leading-relaxed"
@@ -507,7 +511,7 @@ export default function SongPage() {
 
         {(song.tabs || song.guitarTabsUrl) && (
           <TabsContent value="guitar-tabs" className="mt-4">
-            <div className="glass-content rounded-lg p-4">
+            <div className={cardVariants({ variant: "panel", className: "rounded-lg p-4" })}>
               <div className="overflow-x-auto">
                 <div className="text-md text-content-text-tertiary leading-relaxed">
                   {song.tabs ? (

--- a/apps/web/app/routes/songs/new.tsx
+++ b/apps/web/app/routes/songs/new.tsx
@@ -47,7 +47,7 @@ export default function NewSong() {
       </div>
 
       <AdminOnly>
-        <Card className="card-premium">
+        <Card>
           <CardContent className="p-6">
             <SongForm submitLabel="Create Song" cancelHref="/songs" />
           </CardContent>

--- a/apps/web/app/routes/terms.tsx
+++ b/apps/web/app/routes/terms.tsx
@@ -17,7 +17,7 @@ export default function Terms() {
         <h1 className="page-heading">TERMS OF SERVICE</h1>
       </div>
 
-      <Card className="glass-content">
+      <Card variant="panel">
         <CardContent className="p-6">
           <div className="prose prose-invert max-w-none space-y-6">
             <p className="text-content-text-secondary text-sm">Last updated: {new Date().toLocaleDateString()}</p>

--- a/apps/web/app/routes/users/$username.tsx
+++ b/apps/web/app/routes/users/$username.tsx
@@ -306,7 +306,7 @@ export default function UserProfile() {
   return (
     <div className="w-full space-y-6">
       {/* Profile Header */}
-      <Card className="card-premium">
+      <Card>
         <CardContent className="pt-6">
           {/* Top row: Avatar, Name/Score, Badges, Edit Button.
               Mobile stacks (avatar+info on top, badges+edit below); sm+ goes
@@ -470,7 +470,7 @@ export default function UserProfile() {
           {reviews.length > 0 ? (
             <div className="space-y-4">
               {reviews.map((review) => (
-                <Card key={review.id} className="card-premium">
+                <Card key={review.id}>
                   <CardHeader>
                     <div className="flex items-center justify-between">
                       <CardTitle className="text-lg">
@@ -506,7 +506,7 @@ export default function UserProfile() {
               ))}
             </div>
           ) : (
-            <Card className="card-premium">
+            <Card>
               <CardContent className="py-12 text-center">
                 <MessageSquare className="w-12 h-12 text-content-text-tertiary mx-auto mb-4" />
                 <h3 className="text-lg font-medium text-content-text-primary mb-2">No Reviews Yet</h3>
@@ -559,7 +559,7 @@ export default function UserProfile() {
               )}
             </>
           ) : (
-            <Card className="card-premium">
+            <Card>
               <CardContent className="py-12 text-center">
                 <Star className="w-12 h-12 text-content-text-tertiary mx-auto mb-4" />
                 <h3 className="text-lg font-medium text-content-text-primary mb-2">No Show Ratings Yet</h3>
@@ -612,7 +612,7 @@ export default function UserProfile() {
               )}
             </>
           ) : (
-            <Card className="card-premium">
+            <Card>
               <CardContent className="py-12 text-center">
                 <Star className="w-12 h-12 text-content-text-tertiary mx-auto mb-4" />
                 <h3 className="text-lg font-medium text-content-text-primary mb-2">No Song Version Ratings Yet</h3>
@@ -631,7 +631,7 @@ export default function UserProfile() {
           {blogPosts.length > 0 ? (
             <div className="space-y-4">
               {blogPosts.map((post) => (
-                <Card key={post.id} className="card-premium">
+                <Card key={post.id}>
                   <CardHeader>
                     <div className="flex items-center justify-between">
                       <CardTitle className="text-xl">
@@ -664,7 +664,7 @@ export default function UserProfile() {
               ))}
             </div>
           ) : (
-            <Card className="card-premium">
+            <Card>
               <CardContent className="py-12 text-center">
                 <Edit className="w-12 h-12 text-content-text-tertiary mx-auto mb-4" />
                 <h3 className="text-lg font-medium text-content-text-primary mb-2">No Blog Posts Yet</h3>
@@ -694,7 +694,7 @@ export default function UserProfile() {
             externalSources={attendedExternalSources}
             collapsible
             empty={
-              <Card className="card-premium">
+              <Card>
                 <CardContent className="py-12 text-center">
                   <CalendarDays className="w-12 h-12 text-content-text-tertiary mx-auto mb-4" />
                   <h3 className="text-lg font-medium text-content-text-primary mb-2">No Shows Attended</h3>

--- a/apps/web/app/routes/venues/$slug.edit.tsx
+++ b/apps/web/app/routes/venues/$slug.edit.tsx
@@ -98,7 +98,7 @@ export default function EditVenue() {
         <PageHeader title="Edit Venue" backLink={{ to: `/venues/${venue.slug}`, label: "Back to Venue" }} />
       </div>
 
-      <Card className="card-premium">
+      <Card>
         <CardContent className="p-6">
           <VenueForm
             defaultValues={defaultValues}

--- a/apps/web/app/routes/venues/$slug.tsx
+++ b/apps/web/app/routes/venues/$slug.tsx
@@ -5,6 +5,7 @@ import { AdminOnly } from "~/components/admin/admin-only";
 import { SetlistList } from "~/components/setlist/setlist-list";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
 import { ShowDate } from "~/components/show-date";
+import { cardVariants } from "~/components/ui/card";
 import { LinkButton } from "~/components/ui/link-button";
 import { PageHeader } from "~/components/ui/page-header";
 import { StatBox } from "~/components/ui/stat-box";
@@ -137,7 +138,12 @@ export default function VenuePage() {
             setlists={setlists}
             externalSources={externalSources}
             empty={
-              <div className="glass-content rounded-lg p-6 text-center text-content-text-secondary">
+              <div
+                className={cardVariants({
+                  variant: "panel",
+                  className: "rounded-lg p-6 text-center text-content-text-secondary",
+                })}
+              >
                 No shows found for this venue.
               </div>
             }

--- a/apps/web/app/routes/venues/new.tsx
+++ b/apps/web/app/routes/venues/new.tsx
@@ -46,7 +46,7 @@ export default function NewVenue() {
         <PageHeader title="Create Venue" backLink={{ to: "/venues", label: "Back to Venues" }} />
       </div>
 
-      <Card className="card-premium">
+      <Card>
         <CardContent className="p-6">
           <VenueForm onSubmit={handleSubmit} submitLabel="Create Venue" cancelHref="/venues" />
         </CardContent>

--- a/apps/web/app/styles.css
+++ b/apps/web/app/styles.css
@@ -483,21 +483,19 @@ html body[data-scroll-locked] {
     -webkit-backdrop-filter: var(--backdrop-blur) !important;
   }
 
-  .glass-heavy {
-    background-color: var(--glass-bg) !important;
-    border: 1px solid var(--glass-border) !important;
-    backdrop-filter: var(--backdrop-blur-heavy) !important;
-    -webkit-backdrop-filter: var(--backdrop-blur-heavy) !important;
-  }
-
-  .glass-accent {
-    background-color: var(--glass-bg) !important;
-    border: 1px solid var(--glass-border-accent) !important;
+  .glass-content {
+    background-color: var(--content-glass) !important;
+    border: 1px solid var(--content-glass-border) !important;
     backdrop-filter: var(--backdrop-blur) !important;
     -webkit-backdrop-filter: var(--backdrop-blur) !important;
   }
 
-  .glass-content {
+  /* The auth form field surface (login / register / password reset). A frosted
+     purple glass that matches the translucent auth card — kept separate from
+     the card/panel `glass-content` token so restyling content surfaces never
+     touches auth inputs. `!important` overrides the shadcn Input base
+     (`bg-background` / `border-input`). */
+  .auth-input {
     background-color: var(--content-glass) !important;
     border: 1px solid var(--content-glass-border) !important;
     backdrop-filter: var(--backdrop-blur) !important;
@@ -535,18 +533,6 @@ html body[data-scroll-locked] {
       0 20px 25px -5px rgb(0 0 0 / 0.05),
       0 8px 10px -6px rgb(0 0 0 / 0.05),
       0 8px 32px hsla(263, 50%, 60%, 0.1);
-  }
-
-  .card-premium-accent {
-    background-color: var(--glass-bg) !important;
-    border: 1px solid var(--glass-border-accent) !important;
-    backdrop-filter: var(--backdrop-blur) !important;
-    -webkit-backdrop-filter: var(--backdrop-blur) !important;
-    border-radius: 0.75rem;
-    box-shadow:
-      0 20px 25px -5px rgb(0 0 0 / 0.1),
-      0 8px 10px -6px rgb(0 0 0 / 0.1),
-      0 8px 32px var(--glass-shadow);
   }
 
   /* Gradient Utilities */


### PR DESCRIPTION
Surfaces are now chosen by a named role instead of hand-picking one of
~7 overlapping CSS classes. The menu collapses to three Card variants,
one form-input surface, one auth-input surface, one chrome surface, and
the existing composable tokens. This also fixes the drift that had two
data tables rendering as flat input panels instead of elevated cards.

## What changed

- **`<Card variant="elevated | panel | plain">`** (default `elevated`) is
  the single way to set a card surface. `cardVariants()` covers `<div>` /
  `<a>` blocks that can't be a `<Card>`.
- **Form fields** use `formInputClass`; **auth** forms (login / register /
  password reset) use a new `authInputClass` so they keep their frosted
  look and stay decoupled from the card surfaces; **filter-bar** controls
  keep the glass-select tokens.
- **Overlays** (dialogs, popovers, command palette, breadcrumb) use the
  `glass` chrome surface.
- Removed the dead `glass-heavy`, `glass-accent`, `card-premium-accent`
  classes and documented the system in `apps/web/CLAUDE.md`.

## Notes for the reviewer

- The migration preserves each surface's original look. Deliberate visual
  changes are limited to: a few standalone data/section cards that were
  wrongly flat are now elevated (debut-year chart, rating charts,
  yearly-play chart, band-history "Current Members"); panel cards lost a
  stray shadow so `panel` is truly flat; and register's inputs now match
  the other auth forms.
- Making `elevated` the default would let `card-premium`'s `!important`
  background clobber cards that carry a custom `bg-*`. Every such card
  (auth, oauth consent, venue form, blog detail) is pinned to
  `variant="plain"`.
- `surface-system.test.ts` fails if `card-premium` / `glass-content`
  reappears on a Card or form control, or if a dead class is redefined.

`make tc` clean; full suite green (562 core + 1324 web). Verified light +
dark on home, songs, song detail, show detail, and the auth pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
