### PR TITLE
Add Unfinished track filter

### DIFF
--- a/apps/web/app/lib/performance-filter-params.ts
+++ b/apps/web/app/lib/performance-filter-params.ts
@@ -16,6 +16,7 @@ const VALID_FILTER_KEYS = new Set([
   "split",
   "inverted",
   "dyslexic",
+  "unfinished",
   "jamChart",
   "allTimer",
 ]);

--- a/apps/web/app/lib/song-filters.ts
+++ b/apps/web/app/lib/song-filters.ts
@@ -85,6 +85,7 @@ export const TOGGLE_FILTER_DEFINITIONS = [
   { key: "split", label: "Split" },
   { key: "inverted", label: "Inverted" },
   { key: "dyslexic", label: "Dyslexic" },
+  { key: "unfinished", label: "Unfinished" },
   { key: "jamChart", label: "Jam Chart" },
   { key: "allTimer", label: "All-Timer" },
   { key: "attended", label: "Attended" },
@@ -101,7 +102,7 @@ export const TOGGLE_FILTER_DEFINITIONS = [
 export const TOGGLE_FILTER_GROUPS = [
   { label: "Quality", keys: ["jamChart", "allTimer"] },
   { label: "Position", keys: ["setOpener", "setCloser", "encore"] },
-  { label: "Attributes", keys: ["split", "standalone", "segueIn", "segueOut", "inverted", "dyslexic"] },
+  { label: "Attributes", keys: ["split", "standalone", "segueIn", "segueOut", "inverted", "dyslexic", "unfinished"] },
 ] as const;
 
 /** The personal toggle rendered on its own (not in a group popover). */


### PR DESCRIPTION
Filter setlists/songs by unfinished performances. "Unfinished" now appears as the last chip in the Attributes filter popover, alongside Split, Inverted, and Dyslexic.

The backend (filter type, SQL against the `UNFINISHED` track_flag, narrowing check) was already in place; this wires up the frontend: adds the toggle definition, places it in the Attributes group, and accepts `unfinished` as a URL query param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)