### PR TITLE
Add rating distribution histograms for shows and tracks

### DIFF
--- a/apps/web/app/components/rating/rating-distribution-chart.test.tsx
+++ b/apps/web/app/components/rating/rating-distribution-chart.test.tsx
@@ -1,0 +1,65 @@
+import type { RatingValueBucket } from "@bip/core";
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { RatingDistributionChart, RatingHistogramTooltip } from "./rating-distribution-chart";
+
+// Recharts ResponsiveContainer measures parent layout via ResizeObserver,
+// which jsdom doesn't implement. Stub it to a fixed-size div so the chart
+// mounts during tests (axis SVG ticks still don't render reliably under
+// jsdom, so assertions target the component's own DOM, not recharts output).
+vi.mock("recharts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("recharts")>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 600, height: 240 }}>{children}</div>
+    ),
+  };
+});
+
+const buckets: RatingValueBucket[] = [
+  { value: 5, count: 60 },
+  { value: 4.5, count: 40 },
+  { value: 4, count: 20 },
+  { value: 0.5, count: 8 },
+];
+
+describe("RatingDistributionChart", () => {
+  // A rateable with no ratings has no shape to draw — render nothing rather
+  // than an empty axis card.
+  test("renders nothing when there are no ratings", async () => {
+    const { container } = await setup(<RatingDistributionChart buckets={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  // Total summarizes the sample size so a 3-vote distribution doesn't read
+  // with the same authority as a 300-vote one.
+  test("shows the total rating count, pluralized", async () => {
+    await setup(<RatingDistributionChart buckets={buckets} />);
+    expect(screen.getByText("128 ratings")).toBeInTheDocument();
+  });
+
+  test("uses the singular when exactly one rating", async () => {
+    await setup(<RatingDistributionChart buckets={[{ value: 5, count: 1 }]} />);
+    expect(screen.getByText("1 rating")).toBeInTheDocument();
+  });
+});
+
+describe("RatingHistogramTooltip", () => {
+  // Tooltip shows both the raw count and its share of the total so the user
+  // reads volume and proportion at once.
+  test("renders the hovered bucket's count and percent", async () => {
+    const { container } = await setup(
+      <RatingHistogramTooltip active total={128} label="4½" payload={[{ value: 40, dataKey: "all" }]} />,
+    );
+    expect(container.textContent).toContain("4½ stars");
+    expect(container.textContent).toContain("40 ratings");
+    expect(container.textContent).toContain("31.3%");
+  });
+
+  test("renders nothing when inactive", async () => {
+    const { container } = await setup(<RatingHistogramTooltip total={128} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/web/app/components/rating/rating-distribution-chart.tsx
+++ b/apps/web/app/components/rating/rating-distribution-chart.tsx
@@ -1,0 +1,119 @@
+import type { RatingValueBucket } from "@bip/core";
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { ChartTooltipCard } from "~/components/ui/chart-tooltip";
+import { CHART_BAR_CURSOR, CHART_COLORS } from "~/lib/chart-colors";
+import { ALL_YEARS_SERIES, buildHistogramData, histogramYAxisConfig } from "~/lib/rating-charts";
+
+interface RatingDistributionChartProps {
+  buckets: RatingValueBucket[];
+  /**
+   * Tighter height + margins for the in-overlay variant (per-track hover
+   * panel) vs. the roomier right-rail card. Defaults to the rail size.
+   */
+  compact?: boolean;
+  /**
+   * Suppress the built-in "Rating distribution · N ratings" header. The
+   * right-rail card supplies its own collapsible header, so it hides this
+   * one to avoid a duplicate title; the per-track overlay keeps it.
+   */
+  hideHeader?: boolean;
+}
+
+/**
+ * Single rateable's rating distribution as a 10-bar histogram (0.5–5 in
+ * half steps). Drives the show-level right-rail card and the per-track
+ * overlay from the same `{ value, count }` buckets. Renders nothing when
+ * nothing has been rated — callers don't have to guard the empty case.
+ *
+ * Reuses the profile charts' `buildHistogramData` (with no year selection,
+ * so it collapses to a single all-time series) and `histogramYAxisConfig`
+ * so the axis scaling and zero-fill stay identical across every histogram.
+ */
+export function RatingDistributionChart({
+  buckets,
+  compact = false,
+  hideHeader = false,
+}: RatingDistributionChartProps) {
+  // buildHistogramData is year-aware; this chart has no year axis, so stamp
+  // every bucket with a single sentinel year and read back the combined
+  // all-years series it produces.
+  const yearless = buckets.map((bucket) => ({ year: 0, value: bucket.value, count: bucket.count }));
+  const { data, seriesTotals } = buildHistogramData(yearless, [], "count");
+  const total = seriesTotals[ALL_YEARS_SERIES] ?? 0;
+  if (total === 0) return null;
+
+  const max = data.reduce((highest, row) => Math.max(highest, row[ALL_YEARS_SERIES] as number), 0);
+  const yAxis = histogramYAxisConfig(false, max);
+  const height = compact ? "h-28" : "h-44";
+
+  return (
+    <div>
+      {!hideHeader && (
+        <div className="flex items-center justify-between mb-2 gap-2">
+          <h4 className="text-sm font-semibold text-content-text-primary">Rating distribution</h4>
+          <span className="text-xs text-content-text-tertiary">
+            {total} {total === 1 ? "rating" : "ratings"}
+          </span>
+        </div>
+      )}
+      <div className={height}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }} barCategoryGap="12%">
+            <CartesianGrid strokeDasharray="3 3" stroke={CHART_COLORS.grid} opacity={0.3} />
+            <XAxis dataKey="label" stroke={CHART_COLORS.axis} fontSize={compact ? 10 : 12} />
+            <YAxis
+              stroke={CHART_COLORS.axis}
+              fontSize={compact ? 10 : 12}
+              allowDecimals={false}
+              domain={yAxis.domain}
+              ticks={yAxis.ticks}
+              width={30}
+            />
+            <Tooltip
+              content={<RatingHistogramTooltip total={total} />}
+              cursor={CHART_BAR_CURSOR}
+              isAnimationActive={false}
+            />
+            {/* Skip the grow-in animation in the compact (popup) variant —
+                bars animating every time the hover panel opens reads as
+                jittery; the roomier rail card still animates on mount. */}
+            <Bar
+              dataKey={ALL_YEARS_SERIES}
+              fill={CHART_COLORS.accent}
+              radius={[2, 2, 0, 0]}
+              isAnimationActive={!compact}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+interface RatingHistogramTooltipProps {
+  active?: boolean;
+  payload?: Array<{ value?: number; dataKey?: string }>;
+  label?: number | string;
+  /** Sample size, so the tooltip can show each bar's share of the whole. */
+  total: number;
+}
+
+/**
+ * Histogram tooltip: the hovered star value plus its rating count and the
+ * share of all ratings that count represents, so volume and proportion read
+ * together regardless of the chart's units.
+ */
+export function RatingHistogramTooltip({ active, payload, label, total }: RatingHistogramTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  const count = payload[0]?.value ?? 0;
+  const fraction = total > 0 ? count / total : 0;
+  return (
+    <ChartTooltipCard>
+      <div className="font-medium">{label} stars</div>
+      <div>
+        {count} {count === 1 ? "rating" : "ratings"}
+        <span className="text-content-text-tertiary"> · {(fraction * 100).toFixed(1)}%</span>
+      </div>
+    </ChartTooltipCard>
+  );
+}

--- a/apps/web/app/components/setlist/setlist-columns.test.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.test.tsx
@@ -13,6 +13,14 @@ vi.mock("~/components/performance/track-rating-cell", () => ({
   TrackRatingCell: (props: object) => mockShallowComponent("TrackRatingCell", props),
 }));
 
+// The song-title cell wraps its link in TrackRatingOverlay (the per-track
+// rating + histogram hover panel), which calls useSession and needs a data
+// router. Stub it to render its children so these column-wiring tests stay
+// router-free, mirroring setlist-flow.test.tsx.
+vi.mock("./track-rating-overlay", () => ({
+  TrackRatingOverlay: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 const { createSetlistColumns } = await import("./setlist-columns");
 type SetlistTableRow = TrackLight & { priorPerformanceCount: number | null };
 

--- a/apps/web/app/components/setlist/setlist-common-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-common-columns.tsx
@@ -8,6 +8,7 @@ import { NumberCell } from "~/components/ui/number-cell";
 import { SortableHeader } from "~/components/ui/sortable-header";
 import { GapCell, type GapCellState } from "./gap-cell";
 import { compareBySetThenPosition, countDistinctEncores, formatSetLabel } from "./set-label";
+import { TrackRatingOverlay } from "./track-rating-overlay";
 
 /**
  * Wraps a value-compare with the canonical set/track tiebreaker so two
@@ -438,9 +439,11 @@ export function createSetlistCommonColumns<T extends TrackLight>(options?: {
         );
         // Preserve the flow view's segue marker so "Tractorbeam > Above
         // the Waves" still reads as a continuous run inside the table.
+        // Wrap the title in TrackRatingOverlay so the table view gets the
+        // same per-track rating + histogram hover panel the flow view has.
         return (
           <>
-            {titleNode}
+            <TrackRatingOverlay track={info.row.original}>{titleNode}</TrackRatingOverlay>
             {segue && <span className="text-content-text-secondary ml-1 font-medium">&gt;</span>}
           </>
         );

--- a/apps/web/app/components/setlist/track-rating-overlay.test.tsx
+++ b/apps/web/app/components/setlist/track-rating-overlay.test.tsx
@@ -1,11 +1,23 @@
 import { setup } from "@test/test-utils";
 import { screen } from "@testing-library/react";
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 // Stub the session hook so the overlay can render without a data router.
 vi.mock("~/hooks/use-session", () => ({
   useSession: () => ({ user: null, supabase: null }),
 }));
+
+// Recharts ResponsiveContainer needs ResizeObserver (absent in jsdom); stub
+// it so the histogram mounts when the overlay renders it.
+vi.mock("recharts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("recharts")>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 600, height: 240 }}>{children}</div>
+    ),
+  };
+});
 
 import { TrackRatingOverlay, type TrackRatingOverlayTrack } from "./track-rating-overlay";
 
@@ -57,6 +69,48 @@ describe('TrackRatingOverlay trigger="click"', () => {
     expect(await screen.findByText("Big jam.")).toBeInTheDocument();
     // …but the rating number does not.
     expect(screen.queryByText("4.75")).not.toBeInTheDocument();
+  });
+});
+
+describe("TrackRatingOverlay histogram", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // Opening the overlay fetches fresh track data; when that response carries
+  // a rating distribution, the mini histogram renders in the panel.
+  test("renders the histogram from the fetched distribution", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          track: {
+            id: "track-1",
+            songTitle: "Aceetobee",
+            averageRating: 4.5,
+            ratingsCount: 4,
+            likesCount: 0,
+            note: null,
+          },
+          userRating: null,
+          distribution: [
+            { value: 5, count: 3 },
+            { value: 4, count: 1 },
+          ],
+        }),
+      }),
+    );
+
+    const { user } = await setup(
+      <TrackRatingOverlay track={makeTrack({ ratingsCount: 4 })} trigger="click">
+        <button type="button">title</button>
+      </TrackRatingOverlay>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "title" }));
+    expect(await screen.findByText("Rating distribution")).toBeInTheDocument();
+    expect(screen.getByText("4 ratings")).toBeInTheDocument();
   });
 });
 

--- a/apps/web/app/components/setlist/track-rating-overlay.tsx
+++ b/apps/web/app/components/setlist/track-rating-overlay.tsx
@@ -1,5 +1,7 @@
+import type { RatingValueBucket } from "@bip/core";
 import { useEffect, useRef, useState } from "react";
 import { RatingComponent } from "~/components/rating";
+import { RatingDistributionChart } from "~/components/rating/rating-distribution-chart";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "~/components/ui/hover-card";
 import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
 import { Skeleton } from "~/components/ui/skeleton";
@@ -54,6 +56,7 @@ interface TrackDataResponse {
     note: string | null;
   };
   userRating: number | null;
+  distribution: RatingValueBucket[];
 }
 
 export function TrackRatingOverlay({ track, children, showRating = true, trigger = "hover" }: TrackRatingOverlayProps) {
@@ -125,6 +128,8 @@ export function TrackRatingOverlay({ track, children, showRating = true, trigger
           {(data?.track.likesCount ?? track.likesCount) === 1 ? "like" : "likes"}
         </div>
       )}
+
+      {showRating && data?.distribution && <RatingDistributionChart compact buckets={data.distribution} />}
 
       {(data?.track.note ?? track.note) && (
         <div className="text-xs text-content-text-secondary border-t border-glass-border pt-2 mt-2">

--- a/apps/web/app/components/show/debut-year-chart.tsx
+++ b/apps/web/app/components/show/debut-year-chart.tsx
@@ -134,9 +134,9 @@ export function DebutYearChart({ setlist }: DebutYearChartProps) {
       {view === "chart" ? (
         <div className="h-28">
           <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={distribution} margin={{ top: 4, right: 4, left: -16, bottom: 4 }} barCategoryGap="10%">
+            <BarChart data={distribution} margin={{ top: 4, right: 4, left: 0, bottom: 4 }} barCategoryGap="10%">
               <XAxis dataKey="year" stroke={CHART_COLORS.axis} fontSize={10} interval={labelInterval} />
-              <YAxis stroke={CHART_COLORS.axis} fontSize={10} allowDecimals={false} width={28} />
+              <YAxis stroke={CHART_COLORS.axis} fontSize={10} allowDecimals={false} width={30} />
               <Tooltip content={<DebutYearTooltip />} cursor={CHART_BAR_CURSOR} isAnimationActive={false} />
               <Bar dataKey="count" fill={CHART_COLORS.accent} />
             </BarChart>

--- a/apps/web/app/components/show/show-rating-histogram.test.tsx
+++ b/apps/web/app/components/show/show-rating-histogram.test.tsx
@@ -1,0 +1,40 @@
+import type { RatingValueBucket } from "@bip/core";
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { ShowRatingHistogram } from "./show-rating-histogram";
+
+// Recharts ResponsiveContainer needs ResizeObserver (absent in jsdom); stub
+// it so the card body mounts. Assertions target the card chrome, not the
+// recharts SVG.
+vi.mock("recharts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("recharts")>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 600, height: 240 }}>{children}</div>
+    ),
+  };
+});
+
+const buckets: RatingValueBucket[] = [
+  { value: 5, count: 30 },
+  { value: 4, count: 12 },
+];
+
+describe("ShowRatingHistogram", () => {
+  // The card titles itself and surfaces the sample size so the collapsed
+  // mobile header still says what it holds.
+  test("renders the heading and total when there are ratings", async () => {
+    await setup(<ShowRatingHistogram buckets={buckets} />);
+    expect(screen.getByRole("heading", { name: /rating distribution/i })).toBeInTheDocument();
+    expect(screen.getByText("42 ratings")).toBeInTheDocument();
+  });
+
+  // A show with no ratings gets no card — avoids an empty-axis panel in the
+  // right rail.
+  test("renders nothing when there are no ratings", async () => {
+    const { container } = await setup(<ShowRatingHistogram buckets={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/web/app/components/show/show-rating-histogram.tsx
+++ b/apps/web/app/components/show/show-rating-histogram.tsx
@@ -1,0 +1,37 @@
+import type { RatingValueBucket } from "@bip/core";
+import { RatingDistributionChart } from "~/components/rating/rating-distribution-chart";
+import { cardVariants } from "~/components/ui/card";
+import { CollapsibleSection } from "~/components/ui/collapsible-section";
+
+interface ShowRatingHistogramProps {
+  buckets: RatingValueBucket[];
+}
+
+/**
+ * Right-rail card showing the distribution of this show's ratings. Expanded
+ * on desktop, collapsed behind a tappable header on mobile (the rail stacks
+ * under the setlist there, so the chart shouldn't push reviews far down by
+ * default). Renders nothing when the show has no ratings.
+ */
+export function ShowRatingHistogram({ buckets }: ShowRatingHistogramProps) {
+  const total = buckets.reduce((sum, bucket) => sum + bucket.count, 0);
+  if (total === 0) return null;
+
+  return (
+    <div className={cardVariants({ variant: "elevated", className: "rounded-lg p-3" })}>
+      <CollapsibleSection
+        title={<span className="text-sm font-semibold text-content-text-primary">Rating distribution</span>}
+        titleAs="h3"
+        breakpoint="md"
+        headerExtra={
+          <span className="text-xs text-content-text-tertiary">
+            {total} {total === 1 ? "rating" : "ratings"}
+          </span>
+        }
+        contentClassName="pt-2"
+      >
+        <RatingDistributionChart buckets={buckets} hideHeader />
+      </CollapsibleSection>
+    </div>
+  );
+}

--- a/apps/web/app/routes/api/tracks/$trackId.tsx
+++ b/apps/web/app/routes/api/tracks/$trackId.tsx
@@ -33,6 +33,11 @@ export const loader = publicLoader(async ({ params, context }) => {
   const averageRating = track.averageRating || 0;
   const ratingsCount = track.ratingsCount || 0;
 
+  // Rating distribution for the per-track histogram in the hover overlay.
+  // Computed here (not denormalized) so it loads only when a user opens a
+  // track's overlay, which is the only caller of this loader.
+  const distribution = await services.ratings.getRatingDistribution(trackId, "Track");
+
   return new Response(
     JSON.stringify({
       track: {
@@ -44,6 +49,7 @@ export const loader = publicLoader(async ({ params, context }) => {
         note: track.note,
       },
       userRating: userRating?.value || null,
+      distribution,
     }),
     {
       status: 200,

--- a/apps/web/app/routes/shows/$slug.tsx
+++ b/apps/web/app/routes/shows/$slug.tsx
@@ -1,4 +1,4 @@
-import type { ShowNavItem } from "@bip/core";
+import type { RatingValueBucket, ShowNavItem } from "@bip/core";
 import { type ArchiveDotOrgRecording, CacheKeys, type ReviewMinimal, type Setlist, type ShowFile } from "@bip/domain";
 import { type DehydratedState, dehydrate } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight, Edit } from "lucide-react";
@@ -15,6 +15,7 @@ import { DebutYearChart } from "~/components/show/debut-year-chart";
 import { type ExternalLink, ExternalLinkCard } from "~/components/show/external-link-card";
 import { ShowLineupSection } from "~/components/show/show-lineup-section";
 import { ShowPhotos } from "~/components/show/show-photos";
+import { ShowRatingHistogram } from "~/components/show/show-rating-histogram";
 import { ShowDate } from "~/components/show-date";
 import { LinkButton } from "~/components/ui/link-button";
 import { PageHeader } from "~/components/ui/page-header";
@@ -45,6 +46,7 @@ interface ShowLoaderData {
   externalSources: ShowExternalSources;
   photos: ShowFile[];
   adjacentShows: { previous: ShowNavItem | null; next: ShowNavItem | null };
+  ratingDistribution: RatingValueBucket[];
   dehydratedState: DehydratedState;
 }
 
@@ -75,11 +77,14 @@ export const loader = publicLoader(async ({ params, context }): Promise<ShowLoad
     return setlist;
   });
 
-  // Load reviews, photos, and adjacent shows fresh (not cached - simple queries)
-  const [reviews, photos, adjacentShows] = await Promise.all([
+  // Load reviews, photos, adjacent shows, and the rating distribution fresh
+  // (not cached - simple indexed queries). The distribution feeds the
+  // right-rail histogram; one groupBy over the ratings index is cheap.
+  const [reviews, photos, adjacentShows, ratingDistribution] = await Promise.all([
     services.reviews.findByShowId(setlist.show.id),
     services.files.findByShowId(setlist.show.id),
     services.shows.findAdjacentShows(setlist.show.date, setlist.show.slug),
+    services.ratings.getRatingDistribution(setlist.show.id, "Show"),
   ]);
 
   logger.info(`Show data loaded for ${slug} - setlist cached, reviews fresh`);
@@ -122,6 +127,7 @@ export const loader = publicLoader(async ({ params, context }): Promise<ShowLoad
     externalSources: externalSourcesMap[setlist.show.id] ?? {},
     photos,
     adjacentShows,
+    ratingDistribution,
     dehydratedState: dehydrate(queryClient),
   };
 });
@@ -141,6 +147,7 @@ export default function Show() {
     externalSources,
     photos,
     adjacentShows,
+    ratingDistribution,
   } = useSerializedLoaderData<ShowLoaderData>();
   const { user } = useSession();
   const revalidator = useRevalidator();
@@ -343,6 +350,8 @@ export default function Show() {
             <SetlistHighlights setlist={setlist} />
 
             <DebutYearChart setlist={setlist} />
+
+            <ShowRatingHistogram buckets={ratingDistribution} />
           </div>
         </div>
 

--- a/packages/core/src/ratings/rating-service.ts
+++ b/packages/core/src/ratings/rating-service.ts
@@ -116,6 +116,17 @@ export interface RatingYearBucket {
   count: number;
 }
 
+/**
+ * One bar of a single rateable's rating distribution: how many ratings
+ * landed on a given star value. Drives the per-show and per-track
+ * histograms, which (unlike the profile charts) need no year axis since a
+ * show or track is a single date.
+ */
+export interface RatingValueBucket {
+  value: number;
+  count: number;
+}
+
 // Mapper functions
 function mapRatingToDomainEntity(dbRating: DbRating): Rating {
   return {
@@ -550,6 +561,21 @@ export class RatingService {
       GROUP BY LEFT(s.date, 4)::int, r.value
     `;
     return rows.map((row) => ({ year: row.year, value: row.value, count: Number(row.count) }));
+  }
+
+  /**
+   * Distribution of a single rateable's ratings by star value, for the
+   * per-show / per-track histograms. Groups by value over the
+   * (rateable_type, rateable_id) index and includes 0.5 ratings so the
+   * chart reflects every vote.
+   */
+  async getRatingDistribution(rateableId: string, rateableType: string): Promise<RatingValueBucket[]> {
+    const rows = await this.db.rating.groupBy({
+      by: ["value"],
+      where: { rateableId, rateableType, value: { gte: 0.5 } },
+      _count: { id: true },
+    });
+    return rows.map((row) => ({ value: row.value, count: row._count.id }));
   }
 
   async deleteByRateableId(rateableId: string, rateableType: string): Promise<void> {


### PR DESCRIPTION
See the shape of a show's or track's ratings, not just the average. A new
**Rating distribution** card in the show page's right rail charts how many
ratings landed on each star value (0.5 to 5). It's expanded on desktop and
collapsed behind a tap on mobile.

The same histogram now appears for each track inside its existing hover/tap
panel, in both the flow view and the gap-chart table view. It loads only when
you open a track, so the show page itself stays light for the common case
where nobody opens a track.

While in here, the y-axis labels on the "Songs by debut year" chart (and the
new histogram) were getting clipped by a negative plot margin; that's fixed.

## Notes for the reviewer

- The per-track histogram piggybacks on the overlay's existing
  `/api/tracks/:id` fetch, so opening a track makes no extra request.
- The chart reuses the profile rating-chart helpers (`buildHistogramData`,
  `histogramYAxisConfig`); since a show/track is a single date there's no year
  axis, so the buckets are stamped with a sentinel year and collapsed to one
  all-time series.
- The show-level distribution is computed in the loader (one indexed
  `groupBy` over `ratings`), not denormalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
