### PR TITLE
Sync prod's public YouTube links, authors, reviews, and blog posts to local

### DIFF
--- a/MCP_README.md
+++ b/MCP_README.md
@@ -49,7 +49,7 @@ Add the same block to `.cursor/mcp.json`, or use **Settings → Features → MCP
 
 ## Available Tools
 
-The server exposes 23 tools: 17 for querying the database (below) and 6 internal Sync / Replication tools (documented at the end of this section) used to mirror prod into local dev environments.
+The server exposes 27 tools: 17 for querying the database (below) and 10 internal Sync / Replication tools (documented at the end of this section) used to mirror prod into local dev environments.
 
 ### 🔍 Search Tools
 
@@ -111,9 +111,10 @@ Get complete setlists for multiple shows at once, with the full structured paylo
 
 **Input:** `showSlugs` (required, array of show slugs)
 
-**Returns:** `setlists`, each with `showSlug`, `showDate`, `venue`, and `sets`. Per track: `id`, `position`, `songTitle`, `songSlug`, `segue`, `note`, `allTimer`, `duration`, `durationSource`, `annotations`, plus the structured performer data the local sync mirrors:
+**Returns:** `setlists`, each with `showSlug`, `showDate`, `venue`, and `sets`. Per track: `id`, `position`, `songTitle`, `songSlug`, `segue`, `note`, `allTimer`, `duration`, `durationSource`, `annotations`, plus the structured data the local sync mirrors:
 
 - `lineup` (per show): the whole-show performer lineup — each member `{ musicianSlug, musicianName, knownFrom, defaultInstrument, instruments }`, with musicians and instruments carried by slug (the stable cross-environment id) plus name.
+- `youtubes` (per show): the curated YouTube video links, each `{ videoId }`, in insertion order.
 - `trackMusicians` (per track): sit-in / sat-out deltas `{ musicianSlug, musicianName, present, defaultInstrument, instruments }` (`present: true` = sit-in, `false` = sat-out).
 - `flags` (per track): structured flag enum names (e.g. `DYSLEXIC`, `INVERTED`, `UNFINISHED`, `ENDING_ONLY`). Derived recurrence columns are excluded — the consumer recomputes them.
 - `completes` (per track): completion links where this is the later (completing) track, each pointing at the earlier track by natural key `{ showSlug, set, position }`.
@@ -134,7 +135,7 @@ Get detailed information for multiple songs at once.
 
 **Input:** `slugs` (required, array of song slugs)
 
-**Returns:** `songs`, each with `slug`, `title`, `author`, `lyrics`, `timesPlayed`, `dateFirstPlayed`, `dateLastPlayed`, plus the curated admin fields `kind` (original / cover / mashup / improvisation), `legacyAuthor`, `featuredLyric`, `tabs`, `notes`, `history`, and `guitarTabsUrl`. Unknown slugs come back in an `errors` array.
+**Returns:** `songs`, each with `slug`, `title`, `author` (the derived display string), `authors` (the structured songwriting credits the local sync mirrors into the `song_authors` join — each `{ slug, name, position }`, position-ordered), `lyrics`, `timesPlayed`, `dateFirstPlayed`, `dateLastPlayed`, plus the curated admin fields `kind` (original / cover / mashup / improvisation), `featuredLyric`, `tabs`, `notes`, `history`, and `guitarTabsUrl`. Unknown slugs come back in an `errors` array.
 
 #### `get_shows`
 
@@ -142,7 +143,7 @@ Get detailed information for multiple shows at once.
 
 **Input:** `slugs` (required, array of show slugs, e.g. ["1999-12-30", "2000-01-01"])
 
-**Returns:** `shows`, each with `id`, `slug`, `date`, `venueName`, `venueCity`, `averageRating`, `ratingsCount`, `notes`, `relistenUrl`, the admin-curated stat flags `countForStats` and `dayOrder`, and `rockOperaSlugs` (full-album performances tagged on the show). Unknown slugs come back in an `errors` array.
+**Returns:** `shows`, each with `id`, `slug`, `date`, `venueName`, `venueCity`, `averageRating`, `ratingsCount`, `notes`, `relistenUrl`, the admin-curated stat flags `countForStats` and `dayOrder`, `rockOperaSlugs` (full-album performances tagged on the show), and the denormalized display counts `showYoutubesCount`, `showPhotosCount`, and `likesCount` (drive the listing-page badges, the `hasYoutube` / `hasPhotos` filters, and the like count). Unknown slugs come back in an `errors` array.
 
 #### `get_venues`
 
@@ -204,19 +205,27 @@ List all shows from a specific year.
 
 ### 🔄 Sync / Replication Tools (internal)
 
-These tools mirror prod's user-activity tables into local dev databases (see `packages/core/scripts/sync-missing-shows.ts`); they are not meant for general LLM querying. They expose a PII-free projection only — the service-layer `select` allowlist enforces the shape.
+These tools mirror prod's user-activity and public-content tables (users, ratings, attendances, reviews, blog posts) into local dev databases (see `packages/core/scripts/sync-missing-shows.ts`); they are not meant for general LLM querying. They expose a PII-free projection only — the service-layer `select` allowlist enforces the shape.
 
-#### `list_users_since`, `list_ratings_since`, `list_attendances_since`
+#### `list_users_since`, `list_ratings_since`, `list_attendances_since`, `list_reviews_since`
 
 Cursor-paginated pulls of rows changed since a timestamp.
 
 **Input:** `since` (required, ISO-8601 timestamp), `cursor` (optional, opaque base64 of `updatedAt|id`), `limit` (default 2000, max 5000)
 
-**Returns:** A `users` / `ratings` / `attendances` array plus `nextCursor` (null when the page isn't full). Users carry no email or password — only the fields needed to attach activity (`id`, `username`, avatar references, timestamps). Ratings carry `id`, `userId`, `value`, `rateableType`, `rateableId`, timestamps; attendances carry `id`, `userId`, `showId`, timestamps.
+**Returns:** A `users` / `ratings` / `attendances` / `reviews` array plus `nextCursor` (null when the page isn't full). Users carry no email or password — only the fields needed to attach activity (`id`, `username`, avatar references, timestamps). Ratings carry `id`, `userId`, `value`, `rateableType`, `rateableId`, timestamps; attendances carry `id`, `userId`, `showId`, timestamps; reviews carry `id`, `userId`, `showId`, `content` (the public review prose), `status`, timestamps.
 
-#### `list_all_user_ids`, `list_all_rating_ids`, `list_all_attendance_ids`
+#### `list_blog_posts_since`
 
-Full id dumps used by the sync's `--full-users` / prune reconcile to delete local rows no longer present on prod.
+Cursor-paginated pull of **published** blog posts changed since a timestamp, with the cover image embedded so the sync can mirror the post's File + cover link in one call.
+
+**Input:** `since` (required, ISO-8601 timestamp), `cursor` (optional), `limit` (default 2000, max 5000)
+
+**Returns:** `blogPosts` plus `nextCursor`. Each post carries `id`, `slug`, `title`, `blurb`, `content`, `state`, `postType`, `publishedAt`, `userId`, timestamps, and `coverFile` (`{ cloudflareId, path, filename, size, type, variants, metadata }`, or `null`). Drafts are never returned.
+
+#### `list_all_user_ids`, `list_all_rating_ids`, `list_all_attendance_ids`, `list_all_review_ids`, `list_all_blog_post_ids`
+
+Full id dumps used by the sync's `--full-users` / prune reconcile to delete local rows no longer present on prod. (`list_all_blog_post_ids` returns published post ids only.)
 
 **Input:** None
 
@@ -321,7 +330,7 @@ No rate limits are currently enforced, but please use the server responsibly. If
 
 ## Privacy
 
-The query tools expose only publicly available show, song, and venue data. The Sync / Replication tools expose a deliberately PII-free user projection (id, username, avatar reference, timestamps) plus ratings and attendance rows — no emails, passwords, or other account details are ever returned.
+The query tools expose only publicly available show, song, and venue data. The Sync / Replication tools expose a deliberately PII-free user projection (id, username, avatar reference, timestamps) plus ratings, attendances, reviews, and published blog posts — all already public on the site. No emails, passwords, or other account details are ever returned.
 
 ## Support
 

--- a/apps/web/app/routes/mcp/index.tsx
+++ b/apps/web/app/routes/mcp/index.tsx
@@ -284,6 +284,20 @@ const tools = [
     },
   },
   {
+    name: "list_reviews_since",
+    description:
+      "Paginated listing of reviews (id, userId, showId, content, status, timestamps) updated after a given time. Public review prose, PII-free. Used by the local sync script.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        since: { type: "string", description: "ISO-8601 timestamp; rows with updatedAt > since are returned" },
+        cursor: { type: "string", description: "Opaque cursor from a prior page (base64 of updatedAt|id)" },
+        limit: { type: "number", description: "Max rows per page (default 2000, max 5000)" },
+      },
+      required: ["since"],
+    },
+  },
+  {
     name: "list_all_user_ids",
     description: "Every user id on prod. Used by the local sync script's --full-users reconciliation pass.",
     inputSchema: { type: "object", properties: {}, required: [] },
@@ -296,6 +310,31 @@ const tools = [
   {
     name: "list_all_attendance_ids",
     description: "Every attendance id on prod. Used by the local sync script's --full-users reconciliation pass.",
+    inputSchema: { type: "object", properties: {}, required: [] },
+  },
+  {
+    name: "list_all_review_ids",
+    description: "Every review id on prod. Used by the local sync script's --full-users reconciliation pass.",
+    inputSchema: { type: "object", properties: {}, required: [] },
+  },
+  {
+    name: "list_blog_posts_since",
+    description:
+      "Paginated listing of PUBLISHED blog posts (title, blurb, content, slug, state, postType, timestamps, embedded cover image) updated after a given time. PII-free. Used by the local sync script.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        since: { type: "string", description: "ISO-8601 timestamp; rows with updatedAt > since are returned" },
+        cursor: { type: "string", description: "Opaque cursor from a prior page (base64 of updatedAt|id)" },
+        limit: { type: "number", description: "Max rows per page (default 2000, max 5000)" },
+      },
+      required: ["since"],
+    },
+  },
+  {
+    name: "list_all_blog_post_ids",
+    description:
+      "Every published blog post id on prod. Used by the local sync script's --full-users reconciliation pass.",
     inputSchema: { type: "object", properties: {}, required: [] },
   },
 ];
@@ -616,10 +655,15 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
               list.push(mapDeltaToWire(delta));
               trackMusiciansByTrackId.set(delta.trackId, list);
             }
+            // Curated YouTube ids for the show, in insertion order. Sync's
+            // diffShowYoutubes replaces local-by-videoId and re-inserts in this
+            // order so the detail-page "first video" stays deterministic.
+            const youtubeEntries = await services.youtube.listEntriesForShow(setlist.show.id);
             setlists.push({
               showSlug: setlist.show.slug,
               showDate: setlist.show.date,
               venue: { name: setlist.venue.name, city: setlist.venue.city, state: setlist.venue.state },
+              youtubes: youtubeEntries.map((entry) => ({ videoId: entry.videoId })),
               // Whole-show performer lineup. Sync's diffShowMusicians mirrors it.
               lineup: setlist.lineup.map((member) => ({
                 musicianSlug: member.musician.slug,
@@ -710,6 +754,13 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
               // Admin-curated full-rock-opera tagging. Sync mirrors via
               // findManyRockOperaSlugsForShow in buildShowDriftUpdate.
               rockOperaSlugs: rockOperaAnnotations.map((annotation) => annotation.rockOpera.slug),
+              // Denormalized display counts. Sync mirrors them as columns so
+              // local's YouTube/photo badges, hasYoutube/hasPhotos filters, and
+              // like count match prod — likes and show_photos rows aren't synced,
+              // so the column is the authoritative source for those.
+              showYoutubesCount: show.showYoutubesCount,
+              showPhotosCount: show.showPhotosCount,
+              likesCount: show.likesCount,
             });
           } else {
             errors.push({ slug, error: "Not found" });
@@ -746,6 +797,16 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
               slug: song.slug,
               title: song.title,
               author: song.authorName,
+              // Structured authorship (the song_authors join). `authorName`
+              // above is the derived display string; this carries the rows sync
+              // mirrors so local's join populates. Position is the array index —
+              // song.authors is already position-ordered, and position is only
+              // used to order the authorName string, so the index is faithful.
+              authors: song.authors.map((author, index) => ({
+                slug: author.slug,
+                name: author.name,
+                position: index,
+              })),
               lyrics: song.lyrics,
               timesPlayed: song.timesPlayed,
               dateFirstPlayed: song.dateFirstPlayed,
@@ -862,6 +923,23 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
       };
     }
 
+    case "list_reviews_since": {
+      const since = new Date(args.since as string);
+      const cursor = decodeSyncCursor(args.cursor as string | undefined);
+      const limit = clampSyncLimit(args.limit);
+      const rows = await services.reviews.listForSync({
+        since,
+        cursorId: cursor?.id,
+        cursorUpdatedAt: cursor?.updatedAt,
+        limit,
+      });
+      const last = rows[rows.length - 1];
+      return {
+        reviews: rows,
+        nextCursor: rows.length === limit && last ? encodeSyncCursor(last.updatedAt, last.id) : null,
+      };
+    }
+
     case "list_all_user_ids": {
       return { ids: await services.users.listAllIdsForSync() };
     }
@@ -872,6 +950,31 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
 
     case "list_all_attendance_ids": {
       return { ids: await services.attendances.listAllIdsForSync() };
+    }
+
+    case "list_all_review_ids": {
+      return { ids: await services.reviews.listAllIdsForSync() };
+    }
+
+    case "list_blog_posts_since": {
+      const since = new Date(args.since as string);
+      const cursor = decodeSyncCursor(args.cursor as string | undefined);
+      const limit = clampSyncLimit(args.limit);
+      const rows = await services.blogPosts.listForSync({
+        since,
+        cursorId: cursor?.id,
+        cursorUpdatedAt: cursor?.updatedAt,
+        limit,
+      });
+      const last = rows[rows.length - 1];
+      return {
+        blogPosts: rows,
+        nextCursor: rows.length === limit && last ? encodeSyncCursor(last.updatedAt, last.id) : null,
+      };
+    }
+
+    case "list_all_blog_post_ids": {
+      return { ids: await services.blogPosts.listAllIdsForSync() };
     }
 
     default:

--- a/packages/core/scripts/sync-missing-shows.test.ts
+++ b/packages/core/scripts/sync-missing-shows.test.ts
@@ -13,6 +13,8 @@ import {
   collectVenueKeys,
   diffCompletions,
   diffShowMusicians,
+  diffShowYoutubes,
+  diffSongAuthors,
   diffTrackAnnotations,
   diffTrackFlags,
   diffTrackMusicians,
@@ -216,6 +218,9 @@ describe("buildShowCreateInput", () => {
       relistenUrl: "https://relisten.example/xyz",
       countForStats: true,
       dayOrder: null,
+      showYoutubesCount: 0,
+      showPhotosCount: 0,
+      likesCount: 0,
       venueId: null,
       bandId: null,
       createdAt: now,
@@ -313,6 +318,55 @@ describe("buildShowCreateInput", () => {
     );
     expect(input.countForStats).toBe(true);
     expect(input.dayOrder).toBeNull();
+  });
+
+  // Display counts (showYoutubesCount / showPhotosCount / likesCount) drive the
+  // listing-page badges, the hasYoutube/hasPhotos calendar filters, and the
+  // like count. They're mirrored as columns because the underlying rows (likes,
+  // show_photos) aren't synced, so the column is the only local source.
+  test("mirrors display counts from MCP into the insert", () => {
+    const now = new Date("2026-04-23T12:00:00Z");
+    const input = buildShowCreateInput(
+      {
+        slug: "2026-02-06-miami-beach-bandshell-miami-beach-fl",
+        date: "2026-02-06",
+        venueName: "Miami Beach Bandshell",
+        venueCity: "Miami Beach",
+        averageRating: null,
+        ratingsCount: 0,
+        notes: null,
+        relistenUrl: null,
+        showYoutubesCount: 3,
+        showPhotosCount: 5,
+        likesCount: 8,
+      },
+      now,
+    );
+    expect(input.showYoutubesCount).toBe(3);
+    expect(input.showPhotosCount).toBe(5);
+    expect(input.likesCount).toBe(8);
+  });
+
+  // Pre-deploy MCP omits the counts; the builder falls back to the schema
+  // default (0) so a sparse upstream never inserts undefined.
+  test("defaults display counts to 0 when MCP omits them", () => {
+    const now = new Date("2026-04-23T12:00:00Z");
+    const input = buildShowCreateInput(
+      {
+        slug: "2026-04-18-the-uc-theatre-berkeley-ca",
+        date: "2026-04-18",
+        venueName: "The UC Theatre",
+        venueCity: "Berkeley",
+        averageRating: null,
+        ratingsCount: 0,
+        notes: null,
+        relistenUrl: null,
+      },
+      now,
+    );
+    expect(input.showYoutubesCount).toBe(0);
+    expect(input.showPhotosCount).toBe(0);
+    expect(input.likesCount).toBe(0);
   });
 });
 
@@ -499,6 +553,45 @@ describe("showNeedsUpdate", () => {
           relistenUrl: "https://relisten.example/rr",
           countForStats: false,
           dayOrder: 3,
+        },
+        remote,
+      ),
+    ).toBe(false);
+  });
+
+  // A YouTube link added on prod bumps showYoutubesCount; local must mirror it
+  // so the hasYoutube filter and the per-row badge light up.
+  test("returns true when a display count drifts", () => {
+    const remoteWithCount: McpShow = { ...remote, showYoutubesCount: 2 };
+    expect(
+      showNeedsUpdate(
+        {
+          date: "2025-07-04",
+          averageRating: 4.2,
+          ratingsCount: 19,
+          notes: "Fourth of July run opener",
+          relistenUrl: "https://relisten.example/rr",
+          showYoutubesCount: 1,
+        },
+        remoteWithCount,
+      ),
+    ).toBe(true);
+  });
+
+  // Pre-deploy MCP omits the counts; a missing remote field must not claim
+  // drift against the local default of 0.
+  test("ignores display counts when remote omits them", () => {
+    expect(
+      showNeedsUpdate(
+        {
+          date: "2025-07-04",
+          averageRating: 4.2,
+          ratingsCount: 19,
+          notes: "Fourth of July run opener",
+          relistenUrl: "https://relisten.example/rr",
+          showYoutubesCount: 4,
+          showPhotosCount: 2,
+          likesCount: 9,
         },
         remote,
       ),
@@ -827,6 +920,21 @@ describe("buildShowDriftUpdate", () => {
       countForStats: false,
       dayOrder: 2,
     });
+  });
+
+  // Display-count drift in isolation: a YouTube link was added on prod. Patch
+  // carries only the changed count, doesn't churn the aggregate block.
+  test("emits a display count when it drifts", () => {
+    const remoteWithCount: McpShow = { ...remote, showYoutubesCount: 2 };
+    const localWithCount = { ...localInSync, showYoutubesCount: 1 };
+    const patch = buildShowDriftUpdate(localWithCount, remoteWithCount, "venue-brooklyn-steel-uuid");
+    expect(patch).toEqual({ showYoutubesCount: 2 });
+  });
+
+  // Pre-deploy MCP omits the counts; a local row whose counts default to 0 must
+  // not be patched (and re-runs stay idempotent) when remote is silent.
+  test("returns null when remote omits display counts and nothing else drifts", () => {
+    expect(buildShowDriftUpdate(localInSync, remote, "venue-brooklyn-steel-uuid")).toBeNull();
   });
 
   // Date drift in isolation: the row got dump-frozen with a date column that
@@ -2003,6 +2111,114 @@ describe("diffTrackFlags", () => {
   });
 });
 
+// diffShowYoutubes is the same replace-not-merge contract over a show's curated
+// video ids. The reconcile inserts toAdd in remote order so the detail-page
+// "first video" stays deterministic.
+describe("diffShowYoutubes", () => {
+  test("returns the add/remove delta to reach the remote video set", () => {
+    expect(diffShowYoutubes(["abc123"], ["abc123", "def456"])).toEqual({ toAdd: ["def456"], toRemove: [] });
+    expect(diffShowYoutubes(["abc123", "stale99"], ["abc123"])).toEqual({ toAdd: [], toRemove: ["stale99"] });
+  });
+
+  // Pre-deploy MCP omits `youtubes`; no-opinion must not wipe local rows.
+  test("returns empty deltas when remote is undefined (pre-deploy MCP)", () => {
+    expect(diffShowYoutubes(["abc123"], undefined)).toEqual({ toAdd: [], toRemove: [] });
+  });
+
+  // An explicit empty array means prod cleared the show's videos — remove all.
+  test("removes all videos when remote is explicitly empty", () => {
+    expect(diffShowYoutubes(["abc123", "def456"], [])).toEqual({ toAdd: [], toRemove: ["abc123", "def456"] });
+  });
+
+  // Idempotent re-run: identical sets produce no writes.
+  test("returns empty deltas when local already matches remote", () => {
+    expect(diffShowYoutubes(["abc123", "def456"], ["abc123", "def456"])).toEqual({ toAdd: [], toRemove: [] });
+  });
+
+  // Additions preserve remote order so the staggered-createdAt insert keeps the
+  // first-video badge deterministic.
+  test("preserves remote order in the additions", () => {
+    expect(diffShowYoutubes([], ["first0", "second1", "third2"])).toEqual({
+      toAdd: ["first0", "second1", "third2"],
+      toRemove: [],
+    });
+  });
+});
+
+// diffSongAuthors mirrors a song's song_authors join, keyed by authorId. A
+// reorder patches position in place; an added/removed author creates/deletes.
+describe("diffSongAuthors", () => {
+  test("creates authors present only on the remote side", () => {
+    expect(
+      diffSongAuthors(
+        [{ authorId: "marc", position: 0 }],
+        [
+          { authorId: "marc", position: 0 },
+          { authorId: "aron", position: 1 },
+        ],
+      ),
+    ).toEqual({ toCreate: [{ authorId: "aron", position: 1 }], toDeleteAuthorIds: [], toUpdatePositions: [] });
+  });
+
+  test("deletes authors present only on the local side", () => {
+    expect(
+      diffSongAuthors(
+        [
+          { authorId: "marc", position: 0 },
+          { authorId: "stale", position: 1 },
+        ],
+        [{ authorId: "marc", position: 0 }],
+      ),
+    ).toEqual({ toCreate: [], toDeleteAuthorIds: ["stale"], toUpdatePositions: [] });
+  });
+
+  // A reorder (same authors, different positions) patches position rather than
+  // churning a delete + re-insert.
+  test("updates position when an author is reordered", () => {
+    expect(
+      diffSongAuthors(
+        [
+          { authorId: "marc", position: 0 },
+          { authorId: "aron", position: 1 },
+        ],
+        [
+          { authorId: "marc", position: 1 },
+          { authorId: "aron", position: 0 },
+        ],
+      ),
+    ).toEqual({
+      toCreate: [],
+      toDeleteAuthorIds: [],
+      toUpdatePositions: [
+        { authorId: "marc", position: 1 },
+        { authorId: "aron", position: 0 },
+      ],
+    });
+  });
+
+  // Pre-deploy MCP omits `authors`; no-opinion must not wipe local rows.
+  test("returns empty deltas when remote is undefined (pre-deploy MCP)", () => {
+    expect(diffSongAuthors([{ authorId: "marc", position: 0 }], undefined)).toEqual({
+      toCreate: [],
+      toDeleteAuthorIds: [],
+      toUpdatePositions: [],
+    });
+  });
+
+  // Idempotent re-run: identical sets produce no writes.
+  test("returns empty deltas when local already matches remote", () => {
+    const same = [
+      { authorId: "marc", position: 0 },
+      { authorId: "aron", position: 1 },
+    ];
+    expect(diffSongAuthors(same, [...same])).toEqual({
+      toCreate: [],
+      toDeleteAuthorIds: [],
+      toUpdatePositions: [],
+    });
+  });
+});
+
 // Completions cross shows and reference tracks by natural key. resolveCompletionLinks
 // turns the (slug,set,position) endpoints into local track ids, dropping links
 // whose other end isn't in the synced scope; diffCompletions then computes the
@@ -2231,19 +2447,49 @@ type StubAttendanceRow = {
   createdAt: Date;
   updatedAt: Date;
 };
+type StubReviewRow = {
+  id: string;
+  userId: string;
+  showId: string | null;
+  content: string;
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+type StubBlogPostRow = {
+  id: string;
+  slug: string;
+  title: string;
+  state: string;
+  userId: string;
+  updatedAt: Date;
+  [key: string]: unknown;
+};
+type StubFileRow = { id: string; cloudflareId: string | null; variants?: unknown; [key: string]: unknown };
+type StubBlogPostToFileRow = { id: string; blogPostId: string; fileId: string; isCover: boolean };
 
 function makeStubDb(seed: {
   users?: StubUserRow[];
   ratings?: StubRatingRow[];
   attendances?: StubAttendanceRow[];
+  reviews?: StubReviewRow[];
+  blogPosts?: StubBlogPostRow[];
+  files?: StubFileRow[];
+  blogPostToFiles?: StubBlogPostToFileRow[];
   shows?: Array<{ id: string; slug: string }>;
   tracks?: Array<{ id: string; showId: string }>;
 }) {
   const users = seed.users ?? [];
   const ratings = seed.ratings ?? [];
   const attendances = seed.attendances ?? [];
+  const reviews = seed.reviews ?? [];
+  const blogPosts = seed.blogPosts ?? [];
+  const files = seed.files ?? [];
+  const blogPostToFiles = seed.blogPostToFiles ?? [];
   const shows = seed.shows ?? [];
   const tracks = seed.tracks ?? [];
+  let stubIdSeq = 0;
+  const nextStubId = (prefix: string) => `${prefix}-${++stubIdSeq}`;
 
   const findFirstByMaxUpdatedAt = <T extends { updatedAt: Date }>(rows: T[]) => {
     if (rows.length === 0) return null;
@@ -2252,7 +2498,13 @@ function makeStubDb(seed: {
 
   const db = {
     user: {
-      findFirst: vi.fn(async () => findFirstByMaxUpdatedAt(users)),
+      findFirst: vi.fn(async (args?: { where?: { id?: string } }) => {
+        if (args?.where?.id) {
+          const u = users.find((row) => row.id === args.where?.id);
+          return u ? { id: u.id } : null;
+        }
+        return findFirstByMaxUpdatedAt(users);
+      }),
       findMany: vi.fn(
         async (args?: {
           where?: { id?: { in?: string[] }; username?: { in?: string[] } };
@@ -2387,6 +2639,114 @@ function makeStubDb(seed: {
         return { count: ids.size };
       }),
     },
+    review: {
+      findFirst: vi.fn(async () => findFirstByMaxUpdatedAt(reviews)),
+      findMany: vi.fn(async () => reviews.map((r) => ({ id: r.id, userId: r.userId, showId: r.showId }))),
+      upsert: vi.fn(
+        async (args: {
+          where: { id?: string; showId_userId?: { showId: string; userId: string } };
+          create: StubReviewRow;
+          update: Partial<StubReviewRow>;
+        }) => {
+          const existing = args.where.id
+            ? reviews.find((r) => r.id === args.where.id)
+            : args.where.showId_userId
+              ? reviews.find(
+                  (r) => r.showId === args.where.showId_userId?.showId && r.userId === args.where.showId_userId.userId,
+                )
+              : undefined;
+          if (existing) {
+            Object.assign(existing, args.update);
+            return existing;
+          }
+          if (reviews.some((r) => r.id === args.create.id)) throw prismaUniqueIdError();
+          reviews.push(args.create);
+          return args.create;
+        },
+      ),
+      deleteMany: vi.fn(async (args: { where: { id: { in: string[] } } }) => {
+        const ids = new Set(args.where.id.in);
+        for (let i = reviews.length - 1; i >= 0; i--) {
+          if (ids.has(reviews[i].id)) reviews.splice(i, 1);
+        }
+        return { count: ids.size };
+      }),
+    },
+    blogPost: {
+      // Two call shapes: the cursor lookup (orderBy updatedAt, select updatedAt)
+      // and the slug existence lookup (where: { slug }, select: { id }).
+      findFirst: vi.fn(async (args?: { where?: { slug?: string } }) => {
+        if (args?.where?.slug) {
+          const p = blogPosts.find((row) => row.slug === args.where?.slug);
+          return p ? { id: p.id } : null;
+        }
+        return findFirstByMaxUpdatedAt(blogPosts);
+      }),
+      findMany: vi.fn(async () => blogPosts.filter((p) => p.state === "published").map((p) => ({ id: p.id }))),
+      create: vi.fn(async (args: { data: StubBlogPostRow }) => {
+        blogPosts.push(args.data);
+        return { id: args.data.id };
+      }),
+      update: vi.fn(async (args: { where: { id: string }; data: Partial<StubBlogPostRow> }) => {
+        const p = blogPosts.find((row) => row.id === args.where.id);
+        if (p) Object.assign(p, args.data);
+        return p ?? null;
+      }),
+      deleteMany: vi.fn(async (args: { where: { id: { in: string[] } } }) => {
+        const ids = new Set(args.where.id.in);
+        for (let i = blogPosts.length - 1; i >= 0; i--) {
+          if (ids.has(blogPosts[i].id)) blogPosts.splice(i, 1);
+        }
+        return { count: ids.size };
+      }),
+    },
+    file: {
+      findFirst: vi.fn(async (args: { where: { cloudflareId: string } }) => {
+        const f = files.find((row) => row.cloudflareId === args.where.cloudflareId);
+        return f ? { id: f.id } : null;
+      }),
+      create: vi.fn(async (args: { data: Record<string, unknown> }) => {
+        const row = { id: nextStubId("file"), ...args.data } as StubFileRow;
+        files.push(row);
+        return { id: row.id };
+      }),
+      update: vi.fn(async (args: { where: { id: string }; data: Record<string, unknown> }) => {
+        const f = files.find((row) => row.id === args.where.id);
+        if (f) Object.assign(f, args.data);
+        return f ?? null;
+      }),
+    },
+    blogPostToFile: {
+      findFirst: vi.fn(async (args: { where: { blogPostId: string; fileId: string } }) => {
+        const link = blogPostToFiles.find(
+          (row) => row.blogPostId === args.where.blogPostId && row.fileId === args.where.fileId,
+        );
+        return link ? { id: link.id } : null;
+      }),
+      create: vi.fn(async (args: { data: { blogPostId: string; fileId: string; isCover: boolean } }) => {
+        const row = { id: nextStubId("bptf"), ...args.data };
+        blogPostToFiles.push(row);
+        return row;
+      }),
+      deleteMany: vi.fn(async (args: { where: { blogPostId: string | { in: string[] }; isCover?: boolean } }) => {
+        const matchBlogPost = (id: string) =>
+          typeof args.where.blogPostId === "string"
+            ? id === args.where.blogPostId
+            : args.where.blogPostId.in.includes(id);
+        let count = 0;
+        for (let i = blogPostToFiles.length - 1; i >= 0; i--) {
+          const row = blogPostToFiles[i];
+          if (
+            matchBlogPost(row.blogPostId) &&
+            (args.where.isCover === undefined || row.isCover === args.where.isCover)
+          ) {
+            blogPostToFiles.splice(i, 1);
+            count++;
+          }
+        }
+        return { count };
+      }),
+    },
     show: {
       findUnique: vi.fn(async (args: { where: { id: string } }) => {
         const s = shows.find((row) => row.id === args.where.id);
@@ -2416,7 +2776,7 @@ function makeStubDb(seed: {
     },
   };
 
-  return { db, state: { users, ratings, attendances } };
+  return { db, state: { users, ratings, attendances, reviews, blogPosts, files, blogPostToFiles } };
 }
 
 /**
@@ -3433,5 +3793,247 @@ describe("syncUserActivity — pull-from-epoch (full reconcile)", () => {
 
     const ratingsCall = calls.find((c) => c.tool === "list_ratings_since");
     expect(ratingsCall?.args.since).toBe("1970-01-01T00:00:00.000Z");
+  });
+});
+
+describe("syncUserActivity — reviews", () => {
+  const emptyActivity = {
+    list_users_since: [{ users: [], nextCursor: null }],
+    list_ratings_since: [{ ratings: [], nextCursor: null }],
+    list_attendances_since: [{ attendances: [], nextCursor: null }],
+  };
+  const stubUser = (id: string): StubUserRow => ({
+    id,
+    email: `stub-${id}@local.invalid`,
+    passwordDigest: "STUB",
+    username: id,
+    avatarFileId: null,
+    avatarFileUrl: null,
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    updatedAt: new Date("2024-01-01T00:00:00Z"),
+  });
+  const reviewRow = (id: string, userId: string, showId: string) => ({
+    id,
+    userId,
+    showId,
+    content: "Tractorbeam into Munchkin, unreal.",
+    status: "published",
+    createdAt: "2024-08-12T00:00:00Z",
+    updatedAt: "2024-08-12T00:00:00Z",
+  });
+  const baseOpts = (mcp: ReturnType<typeof makeStubMcp>) => ({
+    isDryRun: false,
+    pullFromEpoch: false,
+    pruneOrphans: false,
+    ratingService: stubRatingService(),
+    cacheInvalidation: null,
+    changedSlugs: new Set<string>(),
+    now: new Date(),
+    mcp,
+  });
+
+  // Insert path: content + status mirror prod; userId/showId FK-resolve and the
+  // row is keyed by (showId, userId), preserving prod's id on create.
+  test("inserts a new review with content and status, preserving prod id", async () => {
+    const { db, state } = makeStubDb({
+      users: [stubUser("u-marc")],
+      shows: [{ id: "show-1", slug: "2024-08-12-cap-theatre" }],
+    });
+    const mcp = makeStubMcp({
+      ...emptyActivity,
+      list_reviews_since: [{ reviews: [reviewRow("rev-1", "u-marc", "show-1")], nextCursor: null }],
+    });
+    const result = await syncUserActivity(db as never, baseOpts(mcp));
+    expect(result.reviewsUpserted).toBe(1);
+    expect(state.reviews).toHaveLength(1);
+    expect(state.reviews[0]).toMatchObject({
+      id: "rev-1",
+      userId: "u-marc",
+      showId: "show-1",
+      content: "Tractorbeam into Munchkin, unreal.",
+      status: "published",
+    });
+  });
+
+  // FK-skip: a review whose show isn't local (narrow --years window) is skipped,
+  // not inserted with a dangling FK.
+  test("skips a review whose show is not local", async () => {
+    const { db, state } = makeStubDb({ users: [stubUser("u-marc")] });
+    const mcp = makeStubMcp({
+      ...emptyActivity,
+      list_reviews_since: [{ reviews: [reviewRow("rev-1", "u-marc", "show-missing")], nextCursor: null }],
+    });
+    const result = await syncUserActivity(db as never, baseOpts(mcp));
+    expect(result.reviewsFkSkipped).toBe(1);
+    expect(state.reviews).toHaveLength(0);
+  });
+
+  // Null-show reviews aren't rendered and have no (showId, userId) key — dropped
+  // before the FK check, so they aren't even counted as FK-skipped.
+  test("skips reviews with a null showId", async () => {
+    const { db, state } = makeStubDb({
+      users: [stubUser("u-marc")],
+      shows: [{ id: "show-1", slug: "2024-08-12-cap-theatre" }],
+    });
+    const mcp = makeStubMcp({
+      ...emptyActivity,
+      list_reviews_since: [
+        { reviews: [{ ...reviewRow("rev-1", "u-marc", "show-1"), showId: null }], nextCursor: null },
+      ],
+    });
+    const result = await syncUserActivity(db as never, baseOpts(mcp));
+    expect(result.reviewsUpserted).toBe(0);
+    expect(result.reviewsFkSkipped).toBe(0);
+    expect(state.reviews).toHaveLength(0);
+  });
+
+  // Compound-key absorption: a local review with the same (showId, userId) but a
+  // different id (older dump) absorbs the prod content in place — no duplicate,
+  // no primary-key collision.
+  test("absorbs a same-(showId,userId) local review with a different id", async () => {
+    const { db, state } = makeStubDb({
+      users: [stubUser("u-marc")],
+      shows: [{ id: "show-1", slug: "2024-08-12-cap-theatre" }],
+      reviews: [
+        {
+          id: "local-old-id",
+          userId: "u-marc",
+          showId: "show-1",
+          content: "old text",
+          status: "draft",
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-01-01T00:00:00Z"),
+        },
+      ],
+    });
+    const mcp = makeStubMcp({
+      ...emptyActivity,
+      list_reviews_since: [
+        {
+          reviews: [{ ...reviewRow("prod-id", "u-marc", "show-1"), content: "new text", status: "published" }],
+          nextCursor: null,
+        },
+      ],
+    });
+    const result = await syncUserActivity(db as never, baseOpts(mcp));
+    expect(result.reviewsUpserted).toBe(1);
+    expect(state.reviews).toHaveLength(1);
+    expect(state.reviews[0]).toMatchObject({ id: "local-old-id", content: "new text", status: "published" });
+  });
+});
+
+describe("syncUserActivity — blog posts", () => {
+  const emptyActivity = {
+    list_users_since: [{ users: [], nextCursor: null }],
+    list_ratings_since: [{ ratings: [], nextCursor: null }],
+    list_attendances_since: [{ attendances: [], nextCursor: null }],
+    list_reviews_since: [{ reviews: [], nextCursor: null }],
+  };
+  const stubUser = (id: string): StubUserRow => ({
+    id,
+    email: `stub-${id}@local.invalid`,
+    passwordDigest: "STUB",
+    username: id,
+    avatarFileId: null,
+    avatarFileUrl: null,
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    updatedAt: new Date("2024-01-01T00:00:00Z"),
+  });
+  const coverFile = (cloudflareId: string, variants: Record<string, string>) => ({
+    cloudflareId,
+    path: "/uploads/cover.jpg",
+    filename: "cover.jpg",
+    size: 4096,
+    type: "image/jpeg",
+    variants,
+    metadata: {},
+  });
+  const blogPost = (overrides: Record<string, unknown> = {}) => ({
+    id: "bp-1",
+    slug: "biscuits-announce-fall-tour",
+    title: "Biscuits Announce Fall Tour",
+    blurb: "Big news",
+    content: "Full content here.",
+    state: "published",
+    postType: "blog",
+    publishedAt: "2024-06-01T00:00:00Z",
+    userId: "u-marc",
+    createdAt: "2024-06-01T00:00:00Z",
+    updatedAt: "2024-06-01T00:00:00Z",
+    coverFile: null,
+    ...overrides,
+  });
+  const baseOpts = (mcp: ReturnType<typeof makeStubMcp>) => ({
+    isDryRun: false,
+    pullFromEpoch: false,
+    pruneOrphans: false,
+    ratingService: stubRatingService(),
+    cacheInvalidation: null,
+    changedSlugs: new Set<string>(),
+    now: new Date("2024-06-02T00:00:00Z"),
+    mcp,
+  });
+
+  // Insert path: post preserves prod id + slug; the cover image is mirrored as a
+  // File (keyed by cloudflareId) + an isCover BlogPostToFile link.
+  test("inserts a published post and mirrors its cover File + link", async () => {
+    const { db, state } = makeStubDb({ users: [stubUser("u-marc")] });
+    const mcp = makeStubMcp({
+      ...emptyActivity,
+      list_blog_posts_since: [
+        { blogPosts: [blogPost({ coverFile: coverFile("cf-1", { public: "https://cdn/x.jpg" }) })], nextCursor: null },
+      ],
+    });
+    const result = await syncUserActivity(db as never, baseOpts(mcp));
+    expect(result.blogPostsUpserted).toBe(1);
+    expect(state.blogPosts).toHaveLength(1);
+    expect(state.blogPosts[0]).toMatchObject({ id: "bp-1", slug: "biscuits-announce-fall-tour", state: "published" });
+    expect(state.files).toHaveLength(1);
+    expect(state.files[0]).toMatchObject({ cloudflareId: "cf-1" });
+    expect(state.blogPostToFiles).toHaveLength(1);
+    expect(state.blogPostToFiles[0]).toMatchObject({ blogPostId: "bp-1", isCover: true });
+  });
+
+  // FK-skip: a post whose author isn't local is skipped, not inserted with a
+  // dangling user FK.
+  test("skips a post whose author user is not local", async () => {
+    const { db, state } = makeStubDb({});
+    const mcp = makeStubMcp({
+      ...emptyActivity,
+      list_blog_posts_since: [{ blogPosts: [blogPost({})], nextCursor: null }],
+    });
+    const result = await syncUserActivity(db as never, baseOpts(mcp));
+    expect(result.blogPostsFkSkipped).toBe(1);
+    expect(state.blogPosts).toHaveLength(0);
+  });
+
+  // Cover drift + idempotency: re-running with the same cloudflareId but new
+  // variants updates the File in place (no duplicate) and reuses the link.
+  test("updates an existing cover File in place by cloudflareId without duplicating", async () => {
+    const { db, state } = makeStubDb({
+      users: [stubUser("u-marc")],
+      blogPosts: [
+        {
+          id: "bp-1",
+          slug: "biscuits-announce-fall-tour",
+          title: "old title",
+          state: "published",
+          userId: "u-marc",
+          updatedAt: new Date("2024-01-01T00:00:00Z"),
+        },
+      ],
+      files: [{ id: "file-existing", cloudflareId: "cf-1", variants: { public: "old.jpg" } }],
+      blogPostToFiles: [{ id: "bptf-existing", blogPostId: "bp-1", fileId: "file-existing", isCover: true }],
+    });
+    const mcp = makeStubMcp({
+      ...emptyActivity,
+      list_blog_posts_since: [
+        { blogPosts: [blogPost({ coverFile: coverFile("cf-1", { public: "new.jpg" }) })], nextCursor: null },
+      ],
+    });
+    await syncUserActivity(db as never, baseOpts(mcp));
+    expect(state.files).toHaveLength(1);
+    expect(state.files[0]).toMatchObject({ id: "file-existing", variants: { public: "new.jpg" } });
+    expect(state.blogPostToFiles).toHaveLength(1);
   });
 });

--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -29,6 +29,7 @@ import { recomputeShowDuration } from "../src/tracks/show-duration";
 
 const MCP_URL = process.env.MCP_URL ?? "https://discobiscuits.net/mcp";
 const DEFAULT_BAND_SLUG = "the-disco-biscuits";
+const DEFAULT_BAND_NAME = "The Disco Biscuits";
 
 // --- MCP response types (match apps/web/app/routes/mcp/index.tsx handlers).
 // No shared Zod schemas exist between server and client for these shapes, so
@@ -69,6 +70,15 @@ export interface McpShow {
   // `countForStats`: undefined = pre-deploy MCP, explicit array (including
   // empty) = authoritative. See buildRockOperaAssignmentDiff.
   rockOperaSlugs?: string[];
+  // Denormalized counts that drive listing UI (the per-row YouTube/photo badges
+  // and `hasYoutube`/`hasPhotos` filters via getShowDatesWithFlags) and the
+  // like count. Mirrored as columns rather than recomputed: likes and photos
+  // (show_photos) aren't synced as rows, so the column is the only source, and
+  // mirroring keeps local's filters/counts matching prod verbatim. Optional +
+  // "no opinion" drift semantics like countForStats.
+  showYoutubesCount?: number;
+  showPhotosCount?: number;
+  likesCount?: number;
 }
 
 export interface McpRockOpera {
@@ -170,6 +180,28 @@ export interface McpSetlist {
   // as the per-track fields: `undefined` = pre-deploy MCP (no opinion),
   // explicit empty = "prod has no lineup for this show". See diffShowMusicians.
   lineup?: McpLineupMember[];
+  // Curated YouTube video ids for the show (the `show_youtubes` table), in
+  // insertion order so the detail-page "first video" stays deterministic.
+  // Same optional + replace-not-merge semantics: `undefined` = no opinion,
+  // explicit empty = "prod cleared this show's videos". See diffShowYoutubes.
+  youtubes?: McpShowYoutube[];
+}
+
+export interface McpShowYoutube {
+  videoId: string;
+}
+
+// A Cloudflare-backed file on the wire. `cloudflareId` is the stable cross-env
+// key the sync upserts on; `variants` (the URL map) is what the UI renders, so
+// local images resolve against prod's public CDN. PII-free.
+export interface McpFile {
+  cloudflareId: string;
+  path: string;
+  filename: string;
+  size: number;
+  type: string;
+  variants: unknown;
+  metadata: unknown;
 }
 
 export interface McpSong {
@@ -191,6 +223,18 @@ export interface McpSong {
   notes?: string | null;
   history?: string | null;
   guitarTabsUrl?: string | null;
+  // Structured authorship (the song_authors join). `author` above is the
+  // derived display string; this carries the rows sync mirrors into SongAuthor.
+  // Each entry's name lets the sync seed a missing Author row (slug is the
+  // natural key). `undefined` = no opinion (pre-deploy MCP); explicit empty =
+  // "prod has no authors for this song". See diffSongAuthors.
+  authors?: McpSongAuthor[];
+}
+
+export interface McpSongAuthor {
+  slug: string;
+  name: string;
+  position: number;
 }
 
 export interface McpVenue {
@@ -247,6 +291,37 @@ export interface McpSyncAttendance {
   showId: string;
   createdAt: string;
   updatedAt: string;
+}
+
+// Public review prose. `showId` is nullable on the model; the sync skips
+// null-show reviews (they aren't rendered and can't match the (showId, userId)
+// upsert key). No PII — content/status are public, userId resolves to a stub.
+export interface McpSyncReview {
+  id: string;
+  userId: string;
+  showId: string | null;
+  content: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// Published blog post + its cover image. Keyed by slug; the cover File rides
+// inline (keyed by cloudflareId) so the sync mirrors File + BlogPostToFile
+// without a separate file endpoint. No PII — userId resolves to a stub.
+export interface McpBlogPost {
+  id: string;
+  slug: string;
+  title: string;
+  blurb: string | null;
+  content: string | null;
+  state: string;
+  postType: string;
+  publishedAt: string | null;
+  userId: string;
+  createdAt: string;
+  updatedAt: string;
+  coverFile: McpFile | null;
 }
 
 const SYNC_PAGE_LIMIT = 2000;
@@ -401,6 +476,11 @@ export function buildShowCreateInput(
     // ever shifts.
     countForStats: show.countForStats ?? true,
     dayOrder: show.dayOrder ?? null,
+    // Display counts — fall back to the schema default (0) when a pre-deploy
+    // MCP omits them, same `??` contract as countForStats.
+    showYoutubesCount: show.showYoutubesCount ?? 0,
+    showPhotosCount: show.showPhotosCount ?? 0,
+    likesCount: show.likesCount ?? 0,
     venueId: opts.venueId ?? null,
     bandId: opts.bandId ?? null,
     createdAt: now,
@@ -442,6 +522,9 @@ export interface LocalShowAggregates {
   relistenUrl: string | null;
   countForStats?: boolean;
   dayOrder?: number | null;
+  showYoutubesCount?: number;
+  showPhotosCount?: number;
+  likesCount?: number;
 }
 
 const AVERAGE_RATING_TOLERANCE = 1e-6;
@@ -457,6 +540,9 @@ export function showNeedsUpdate(local: LocalShowAggregates, remote: McpShow): bo
   // and clobbering admin-set values.
   if (remote.countForStats !== undefined && (local.countForStats ?? true) !== remote.countForStats) return true;
   if (remote.dayOrder !== undefined && (local.dayOrder ?? null) !== remote.dayOrder) return true;
+  if (displayCountDrift(local.showYoutubesCount, remote.showYoutubesCount)) return true;
+  if (displayCountDrift(local.showPhotosCount, remote.showPhotosCount)) return true;
+  if (displayCountDrift(local.likesCount, remote.likesCount)) return true;
   const la = local.averageRating;
   const ra = remote.averageRating;
   if (la === null || ra === null) return la !== ra;
@@ -483,6 +569,15 @@ export interface ShowDriftUpdate {
   venueId?: string | null;
   countForStats?: boolean;
   dayOrder?: number | null;
+  showYoutubesCount?: number;
+  showPhotosCount?: number;
+  likesCount?: number;
+}
+
+// Display-count drift: undefined remote = "no opinion" (pre-deploy MCP), so a
+// missing field never claims drift. Local defaults to 0 (the schema default).
+function displayCountDrift(local: number | undefined, remote: number | undefined): boolean {
+  return remote !== undefined && (local ?? 0) !== remote;
 }
 
 /**
@@ -510,8 +605,21 @@ export function buildShowDriftUpdate(
   const countForStatsDrift =
     remote.countForStats !== undefined && (local.countForStats ?? true) !== remote.countForStats;
   const dayOrderDrift = remote.dayOrder !== undefined && (local.dayOrder ?? null) !== remote.dayOrder;
+  const youtubesCountDrift = displayCountDrift(local.showYoutubesCount, remote.showYoutubesCount);
+  const photosCountDrift = displayCountDrift(local.showPhotosCount, remote.showPhotosCount);
+  const likesCountDrift = displayCountDrift(local.likesCount, remote.likesCount);
   const venueDrift = local.venueId === null && resolvedVenueId !== null;
-  if (!dateDrift && !aggregatesDrift && !countForStatsDrift && !dayOrderDrift && !venueDrift) return null;
+  if (
+    !dateDrift &&
+    !aggregatesDrift &&
+    !countForStatsDrift &&
+    !dayOrderDrift &&
+    !youtubesCountDrift &&
+    !photosCountDrift &&
+    !likesCountDrift &&
+    !venueDrift
+  )
+    return null;
   const update: ShowDriftUpdate = {};
   if (dateDrift) update.date = remote.date;
   if (aggregatesDrift) {
@@ -522,6 +630,9 @@ export function buildShowDriftUpdate(
   }
   if (countForStatsDrift) update.countForStats = remote.countForStats;
   if (dayOrderDrift) update.dayOrder = remote.dayOrder ?? null;
+  if (youtubesCountDrift) update.showYoutubesCount = remote.showYoutubesCount;
+  if (photosCountDrift) update.showPhotosCount = remote.showPhotosCount;
+  if (likesCountDrift) update.likesCount = remote.likesCount;
   if (venueDrift) update.venueId = resolvedVenueId;
   return update;
 }
@@ -1109,6 +1220,45 @@ export function diffTrackFlags(local: string[], remote: string[] | undefined): {
   return { toAdd: remote.filter((f) => !localSet.has(f)), toRemove: local.filter((f) => !remoteSet.has(f)) };
 }
 
+// Show YouTube links mirror diffTrackFlags exactly: identity by the video id,
+// replace-not-merge, `undefined` = no opinion (pre-deploy MCP). The caller
+// inserts the additions in remote order so the "first video" (oldest by
+// createdAt) stays deterministic across runs.
+export function diffShowYoutubes(
+  local: string[],
+  remote: string[] | undefined,
+): { toAdd: string[]; toRemove: string[] } {
+  if (remote === undefined) return { toAdd: [], toRemove: [] };
+  const localSet = new Set(local);
+  const remoteSet = new Set(remote);
+  return { toAdd: remote.filter((v) => !localSet.has(v)), toRemove: local.filter((v) => !remoteSet.has(v)) };
+}
+
+export interface SongAuthorEntry {
+  authorId: string;
+  position: number;
+}
+
+// SongAuthor rows keyed by authorId (resolved from slug upstream), replace-not-
+// merge. `undefined` remote = no opinion (pre-deploy MCP). An author present on
+// both sides with a changed position lands in toUpdatePositions, so a reorder
+// patches the row instead of churning a delete + re-insert.
+export function diffSongAuthors(
+  local: SongAuthorEntry[],
+  remote: SongAuthorEntry[] | undefined,
+): { toCreate: SongAuthorEntry[]; toDeleteAuthorIds: string[]; toUpdatePositions: SongAuthorEntry[] } {
+  if (remote === undefined) return { toCreate: [], toDeleteAuthorIds: [], toUpdatePositions: [] };
+  const localByAuthor = new Map(local.map((e) => [e.authorId, e.position]));
+  const remoteByAuthor = new Map(remote.map((e) => [e.authorId, e.position]));
+  return {
+    toCreate: remote.filter((e) => !localByAuthor.has(e.authorId)),
+    toDeleteAuthorIds: local.filter((e) => !remoteByAuthor.has(e.authorId)).map((e) => e.authorId),
+    toUpdatePositions: remote.filter(
+      (e) => localByAuthor.has(e.authorId) && localByAuthor.get(e.authorId) !== e.position,
+    ),
+  };
+}
+
 export interface CompletionKey {
   showSlug: string;
   set: string;
@@ -1306,6 +1456,52 @@ export function findSquatterIds(
   return stale;
 }
 
+// Upsert a File row by its stable cloudflareId, returning the local file id.
+// variants/metadata (the rendered URL maps) drift-patch on every run. Shared by
+// the blog-cover and show-photo sync so File handling stays DRY. Accepts either
+// the top-level client or a transaction client (both expose `.file`).
+async function upsertFileByCloudflareId(
+  client: Pick<Prisma.TransactionClient, "file">,
+  file: McpFile,
+  userId: string,
+  now: Date,
+): Promise<string> {
+  const variants = (file.variants ?? {}) as Prisma.InputJsonValue;
+  const metadata = (file.metadata ?? {}) as Prisma.InputJsonValue;
+  const existing = await client.file.findFirst({ where: { cloudflareId: file.cloudflareId }, select: { id: true } });
+  if (existing) {
+    await client.file.update({
+      where: { id: existing.id },
+      data: {
+        path: file.path,
+        filename: file.filename,
+        size: file.size,
+        type: file.type,
+        variants,
+        metadata,
+        updatedAt: now,
+      },
+    });
+    return existing.id;
+  }
+  const created = await client.file.create({
+    data: {
+      cloudflareId: file.cloudflareId,
+      path: file.path,
+      filename: file.filename,
+      size: file.size,
+      type: file.type,
+      userId,
+      variants,
+      metadata,
+      createdAt: now,
+      updatedAt: now,
+    },
+    select: { id: true },
+  });
+  return created.id;
+}
+
 interface UserActivityStats {
   usersCreated: number;
   usersUpdated: number;
@@ -1313,14 +1509,21 @@ interface UserActivityStats {
   ratingsFkSkipped: number;
   attendancesUpserted: number;
   attendancesFkSkipped: number;
+  reviewsUpserted: number;
+  reviewsFkSkipped: number;
+  blogPostsUpserted: number;
+  blogPostsFkSkipped: number;
   usersDeleted: number;
   ratingsDeleted: number;
   attendancesDeleted: number;
+  reviewsDeleted: number;
+  blogPostsDeleted: number;
   // Squatter rows deleted by the epoch id-binding reconcile (re-inserted under
   // their correct prod id during the same upsert pass). Separate from the
   // prune's *Deleted counters, which remove rows prod no longer has at all.
   ratingsReconciled: number;
   attendancesReconciled: number;
+  reviewsReconciled: number;
   aggregatesRebuilt: number;
 }
 
@@ -1379,7 +1582,7 @@ export async function syncUserActivity(
   db: typeof prisma,
   options: SyncUserActivityOptions,
 ): Promise<UserActivityStats> {
-  const { isDryRun, pullFromEpoch, pruneOrphans, ratingService, changedSlugs } = options;
+  const { isDryRun, pullFromEpoch, pruneOrphans, ratingService, changedSlugs, now } = options;
   const mcp = options.mcp ?? mcpCall;
   const prodShowIdToLocalId = options.prodShowIdToLocalId ?? new Map<string, string>();
   const prodTrackIdToLocalId = options.prodTrackIdToLocalId ?? new Map<string, string>();
@@ -1390,11 +1593,18 @@ export async function syncUserActivity(
     ratingsFkSkipped: 0,
     attendancesUpserted: 0,
     attendancesFkSkipped: 0,
+    reviewsUpserted: 0,
+    reviewsFkSkipped: 0,
+    blogPostsUpserted: 0,
+    blogPostsFkSkipped: 0,
     usersDeleted: 0,
     ratingsDeleted: 0,
     attendancesDeleted: 0,
+    reviewsDeleted: 0,
+    blogPostsDeleted: 0,
     ratingsReconciled: 0,
     attendancesReconciled: 0,
+    reviewsReconciled: 0,
     aggregatesRebuilt: 0,
   };
 
@@ -1404,13 +1614,17 @@ export async function syncUserActivity(
   // single-cursor approach can't pull rows whose updatedAt is below the
   // current local MAX, which happens whenever the dump that seeded the DB
   // didn't cover those rows.
-  async function localMaxUpdatedAt(table: "user" | "rating" | "attendance"): Promise<Date> {
+  async function localMaxUpdatedAt(table: "user" | "rating" | "attendance" | "review" | "blogPost"): Promise<Date> {
     if (pullFromEpoch) return new Date(0);
     let row: { updatedAt: Date } | null;
     if (table === "user")
       row = await db.user.findFirst({ orderBy: { updatedAt: "desc" }, select: { updatedAt: true } });
     else if (table === "rating")
       row = await db.rating.findFirst({ orderBy: { updatedAt: "desc" }, select: { updatedAt: true } });
+    else if (table === "review")
+      row = await db.review.findFirst({ orderBy: { updatedAt: "desc" }, select: { updatedAt: true } });
+    else if (table === "blogPost")
+      row = await db.blogPost.findFirst({ orderBy: { updatedAt: "desc" }, select: { updatedAt: true } });
     else row = await db.attendance.findFirst({ orderBy: { updatedAt: "desc" }, select: { updatedAt: true } });
     return row?.updatedAt ?? new Date(0);
   }
@@ -1814,6 +2028,197 @@ export async function syncUserActivity(
   }
   console.log(`🎫 Attendances: +${stats.attendancesUpserted} (skipped ${stats.attendancesFkSkipped} on missing FK)`);
 
+  // --- Reviews ---
+  // Public review prose, keyed by (showId, userId) like attendances. Wrapped in
+  // try/catch so a pre-deploy prod MCP (no list_reviews_since tool) is tolerated
+  // — reviews skip until the MCP change deploys. Same buffer → resolve →
+  // epoch-reconcile → chunked-apply shape as attendances.
+  try {
+    const reviewCursor = await localMaxUpdatedAt("review");
+    console.log(`📝 Reviews: ${pullFromEpoch ? "full epoch pull" : `incremental since ${reviewCursor.toISOString()}`}`);
+    const prodReviews: McpSyncReview[] = [];
+    pageCursor = null;
+    do {
+      const args: Record<string, unknown> = { since: reviewCursor.toISOString(), limit: SYNC_PAGE_LIMIT };
+      if (pageCursor) args.cursor = pageCursor;
+      const { reviews, nextCursor } = await mcp<{ reviews: McpSyncReview[]; nextCursor: string | null }>(
+        "list_reviews_since",
+        args,
+      );
+      prodReviews.push(...reviews);
+      pageCursor = nextCursor;
+    } while (pageCursor !== null);
+
+    // Skip null-show reviews (not rendered, and no (showId, userId) key) and
+    // remap userId + showId through the drift maps, same as attendances.
+    const resolvedReviews = prodReviews
+      .filter((r): r is McpSyncReview & { showId: string } => r.showId !== null)
+      .map((r) => ({
+        ...r,
+        localUserId: prodIdToLocalId.get(r.userId) ?? r.userId,
+        localShowId: prodShowIdToLocalId.get(r.showId) ?? r.showId,
+      }));
+
+    // Epoch id-binding reconcile — same rationale as attendances: clear local
+    // rows squatting an id prod now binds to a different (user, show) before the
+    // id-preserving create runs. The (userId, showId) tuple matches attendances,
+    // so attendanceBindingKey serves both.
+    if (pullFromEpoch && !isDryRun) {
+      const prodKeyById = new Map<string, string>();
+      for (const r of resolvedReviews) prodKeyById.set(r.id, attendanceBindingKey(r.localUserId, r.localShowId));
+      const localReviews = await db.review.findMany({ select: { id: true, userId: true, showId: true } });
+      const squatterIds = new Set(
+        findSquatterIds(
+          localReviews
+            .filter((r): r is { id: string; userId: string; showId: string } => r.showId !== null)
+            .map((r) => ({ id: r.id, key: attendanceBindingKey(r.userId, r.showId) })),
+          prodKeyById,
+        ),
+      );
+      if (squatterIds.size > 0) {
+        await db.review.deleteMany({ where: { id: { in: Array.from(squatterIds) } } });
+        stats.reviewsReconciled = squatterIds.size;
+        console.log(`🧩 Reviews: reconciled ${squatterIds.size} stale id binding(s)`);
+      }
+    }
+
+    for (let offset = 0; offset < resolvedReviews.length; offset += SYNC_PAGE_LIMIT) {
+      const chunk = resolvedReviews.slice(offset, offset + SYNC_PAGE_LIMIT);
+      const reviewUserIds = Array.from(new Set(chunk.map((r) => r.localUserId)));
+      const reviewShowIds = Array.from(new Set(chunk.map((r) => r.localShowId)));
+      const [existingReviewUsers, existingReviewShows] = await Promise.all([
+        reviewUserIds.length > 0
+          ? db.user.findMany({ where: { id: { in: reviewUserIds } }, select: { id: true } })
+          : Promise.resolve([]),
+        reviewShowIds.length > 0
+          ? db.show.findMany({ where: { id: { in: reviewShowIds } }, select: { id: true } })
+          : Promise.resolve([]),
+      ]);
+      const localReviewUserSet = new Set(existingReviewUsers.map((u) => u.id));
+      const localReviewShowSet = new Set(existingReviewShows.map((s) => s.id));
+
+      for (const r of chunk) {
+        if (!localReviewUserSet.has(r.localUserId)) {
+          stats.reviewsFkSkipped++;
+          console.warn(`  ⚠️  review ${r.id}: skipping — user ${r.localUserId} not local`);
+          continue;
+        }
+        if (!localReviewShowSet.has(r.localShowId)) {
+          stats.reviewsFkSkipped++;
+          console.warn(`  ⚠️  review ${r.id}: skipping — show ${r.localShowId} not local`);
+          continue;
+        }
+        if (isDryRun) {
+          stats.reviewsUpserted++;
+          continue;
+        }
+        try {
+          // Compound-key upsert by (showId, userId) — same id-drift absorption
+          // as attendances. content/status drift patches in place.
+          await db.review.upsert({
+            where: { showId_userId: { showId: r.localShowId, userId: r.localUserId } },
+            update: { content: r.content, status: r.status, updatedAt: new Date(r.updatedAt) },
+            create: {
+              id: r.id,
+              userId: r.localUserId,
+              showId: r.localShowId,
+              content: r.content,
+              status: r.status,
+              createdAt: new Date(r.createdAt),
+              updatedAt: new Date(r.updatedAt),
+            },
+          });
+          stats.reviewsUpserted++;
+        } catch (err) {
+          console.error(`  ❌ review ${r.id} upsert failed:`, err);
+        }
+      }
+    }
+    console.log(`📝 Reviews: +${stats.reviewsUpserted} (skipped ${stats.reviewsFkSkipped} on missing FK)`);
+  } catch (err) {
+    console.log(`📝 Reviews: skipped (${err instanceof Error ? err.message : "MCP tool unavailable"})`);
+  }
+
+  // --- Blog posts ---
+  // Published posts keyed by slug, with the cover image mirrored as File +
+  // BlogPostToFile so the /blog cards render. Runs after users so the author FK
+  // resolves through prodIdToLocalId. Wrapped in try/catch for pre-deploy MCP
+  // tolerance (list_blog_posts_since absent until the MCP change deploys).
+  try {
+    const blogCursor = await localMaxUpdatedAt("blogPost");
+    console.log(
+      `📰 Blog posts: ${pullFromEpoch ? "full epoch pull" : `incremental since ${blogCursor.toISOString()}`}`,
+    );
+    const prodPosts: McpBlogPost[] = [];
+    pageCursor = null;
+    do {
+      const args: Record<string, unknown> = { since: blogCursor.toISOString(), limit: SYNC_PAGE_LIMIT };
+      if (pageCursor) args.cursor = pageCursor;
+      const { blogPosts, nextCursor } = await mcp<{ blogPosts: McpBlogPost[]; nextCursor: string | null }>(
+        "list_blog_posts_since",
+        args,
+      );
+      prodPosts.push(...blogPosts);
+      pageCursor = nextCursor;
+    } while (pageCursor !== null);
+
+    for (const post of prodPosts) {
+      const localUserId = prodIdToLocalId.get(post.userId) ?? post.userId;
+      const userExists = await db.user.findFirst({ where: { id: localUserId }, select: { id: true } });
+      if (!userExists) {
+        stats.blogPostsFkSkipped++;
+        console.warn(`  ⚠️  blog post ${post.slug}: skipping — user ${localUserId} not local`);
+        continue;
+      }
+      if (isDryRun) {
+        stats.blogPostsUpserted++;
+        continue;
+      }
+      try {
+        const postData = {
+          title: post.title,
+          blurb: post.blurb,
+          content: post.content,
+          state: post.state,
+          postType: post.postType,
+          publishedAt: post.publishedAt ? new Date(post.publishedAt) : null,
+          userId: localUserId,
+          updatedAt: new Date(post.updatedAt),
+        };
+        // Upsert by slug (the unique natural key); a local row under prod's slug
+        // absorbs the patch in place. New posts preserve prod's id + createdAt.
+        const existing = await db.blogPost.findFirst({ where: { slug: post.slug }, select: { id: true } });
+        let blogPostId: string;
+        if (existing) {
+          await db.blogPost.update({ where: { id: existing.id }, data: postData });
+          blogPostId = existing.id;
+        } else {
+          const created = await db.blogPost.create({
+            data: { ...postData, id: post.id, slug: post.slug, createdAt: new Date(post.createdAt) },
+            select: { id: true },
+          });
+          blogPostId = created.id;
+        }
+        // Mirror the cover image: upsert the File by cloudflareId, then ensure a
+        // single isCover BlogPostToFile link points at it (replace any stale one).
+        if (post.coverFile) {
+          const fileId = await upsertFileByCloudflareId(db, post.coverFile, localUserId, now);
+          const link = await db.blogPostToFile.findFirst({ where: { blogPostId, fileId }, select: { id: true } });
+          if (!link) {
+            await db.blogPostToFile.deleteMany({ where: { blogPostId, isCover: true } });
+            await db.blogPostToFile.create({ data: { blogPostId, fileId, isCover: true, createdAt: now } });
+          }
+        }
+        stats.blogPostsUpserted++;
+      } catch (err) {
+        console.error(`  ❌ blog post ${post.slug} upsert failed:`, err);
+      }
+    }
+    console.log(`📰 Blog posts: +${stats.blogPostsUpserted} (skipped ${stats.blogPostsFkSkipped} on missing FK)`);
+  } catch (err) {
+    console.log(`📰 Blog posts: skipped (${err instanceof Error ? err.message : "MCP tool unavailable"})`);
+  }
+
   // --- Full-mode reconciliation: delete local rows not on prod ---
   if (pruneOrphans) {
     console.log("🧹 Pruning local rows missing from prod");
@@ -1868,6 +2273,44 @@ export async function syncUserActivity(
       stats.ratingsDeleted = ratingsToDelete.length;
     }
     console.log(`⭐ Ratings: -${stats.ratingsDeleted}`);
+
+    // Reviews — same pattern. Before users (the user prune counts review refs).
+    // Tolerated when prod lacks list_all_review_ids (pre-deploy MCP).
+    try {
+      const { ids: prodReviewIds } = await mcp<{ ids: string[] }>("list_all_review_ids", {});
+      const prodReviewSet = new Set(prodReviewIds);
+      const localReviews = await db.review.findMany({ select: { id: true } });
+      const reviewsToDelete = localReviews.filter((r) => !prodReviewSet.has(r.id)).map((r) => r.id);
+      if (reviewsToDelete.length > 0) {
+        if (!isDryRun) {
+          await db.review.deleteMany({ where: { id: { in: reviewsToDelete } } });
+        }
+        stats.reviewsDeleted = reviewsToDelete.length;
+      }
+      console.log(`📝 Reviews: -${stats.reviewsDeleted}`);
+    } catch (err) {
+      console.log(`📝 Reviews prune: skipped (${err instanceof Error ? err.message : "MCP tool unavailable"})`);
+    }
+
+    // Blog posts — delete local published posts prod no longer has. Drop their
+    // cover links first (FK); orphan File rows are harmless and left in place.
+    // Tolerated when prod lacks list_all_blog_post_ids (pre-deploy MCP).
+    try {
+      const { ids: prodBlogIds } = await mcp<{ ids: string[] }>("list_all_blog_post_ids", {});
+      const prodBlogSet = new Set(prodBlogIds);
+      const localPosts = await db.blogPost.findMany({ where: { state: "published" }, select: { id: true } });
+      const postsToDelete = localPosts.filter((p) => !prodBlogSet.has(p.id)).map((p) => p.id);
+      if (postsToDelete.length > 0) {
+        if (!isDryRun) {
+          await db.blogPostToFile.deleteMany({ where: { blogPostId: { in: postsToDelete } } });
+          await db.blogPost.deleteMany({ where: { id: { in: postsToDelete } } });
+        }
+        stats.blogPostsDeleted = postsToDelete.length;
+      }
+      console.log(`📰 Blog posts: -${stats.blogPostsDeleted}`);
+    } catch (err) {
+      console.log(`📰 Blog posts prune: skipped (${err instanceof Error ? err.message : "MCP tool unavailable"})`);
+    }
 
     // Users last. Two FKs (ratings, attendances) — we've already deleted any
     // we're going to delete above, so a delete here for a user whose data
@@ -1947,6 +2390,9 @@ interface SyncStats {
   songsCreated: number;
   songsOrphanedDeleted: number;
   songsOrphanedWithTracks: number;
+  authorsCreated: number;
+  songAuthorsUpserted: number;
+  songAuthorsDeleted: number;
   showsOrphanedDeleted: number;
   showsOrphanedWithUserData: number;
   venuesCreated: number;
@@ -1974,6 +2420,8 @@ interface SyncStats {
   trackMusiciansDeleted: number;
   trackFlagsAdded: number;
   trackFlagsRemoved: number;
+  showYoutubesAdded: number;
+  showYoutubesRemoved: number;
   completionsUpserted: number;
   completionsDeleted: number;
   completionsSkipped: number;
@@ -2145,6 +2593,9 @@ async function syncMissingShows(): Promise<void> {
     songsCreated: 0,
     songsOrphanedDeleted: 0,
     songsOrphanedWithTracks: 0,
+    authorsCreated: 0,
+    songAuthorsUpserted: 0,
+    songAuthorsDeleted: 0,
     showsOrphanedDeleted: 0,
     showsOrphanedWithUserData: 0,
     venuesCreated: 0,
@@ -2172,6 +2623,8 @@ async function syncMissingShows(): Promise<void> {
     trackMusiciansDeleted: 0,
     trackFlagsAdded: 0,
     trackFlagsRemoved: 0,
+    showYoutubesAdded: 0,
+    showYoutubesRemoved: 0,
     completionsUpserted: 0,
     completionsDeleted: 0,
     completionsSkipped: 0,
@@ -2238,6 +2691,9 @@ async function syncMissingShows(): Promise<void> {
       venueId: true,
       countForStats: true,
       dayOrder: true,
+      showYoutubesCount: true,
+      showPhotosCount: true,
+      likesCount: true,
     } as const;
     const existingLocal = await db.show.findMany({ where: { slug: { in: realSlugs } }, select: localShowSelect });
     // Local Show.slug is nullable in the schema, but every show this script
@@ -2307,10 +2763,22 @@ async function syncMissingShows(): Promise<void> {
     }
     const setlistBySlug = new Map(setlists.map((s) => [s.showSlug, s]));
 
-    // Step 4: default band lookup. Only one band in practice (Disco Biscuits);
-    // bandId is nullable, so a missing band just means shows land without band FK.
-    const band = await db.band.findFirst({ where: { slug: DEFAULT_BAND_SLUG } });
-    if (!band) console.warn(`⚠️  No band with slug "${DEFAULT_BAND_SLUG}" in local DB; bandId will be NULL`);
+    // Step 4: default band. Only one band in practice (Disco Biscuits). A fresh
+    // local DB (or one seeded without it) lacks the row that Show.bandId
+    // references, so create it on miss — the name is cosmetic (never displayed;
+    // the show form hardcodes the band id), only the FK matters.
+    let band = await db.band.findFirst({ where: { slug: DEFAULT_BAND_SLUG }, select: { id: true } });
+    if (!band) {
+      if (isDryRun) {
+        console.log(`🎸 Would create band "${DEFAULT_BAND_SLUG}" (dry run)`);
+      } else {
+        band = await db.band.create({
+          data: { name: DEFAULT_BAND_NAME, slug: DEFAULT_BAND_SLUG, createdAt: now, updatedAt: now },
+          select: { id: true },
+        });
+        console.log(`🎸 Created band "${DEFAULT_BAND_SLUG}"`);
+      }
+    }
 
     // Step 4b: rock opera lookup table. Independent of the per-show data —
     // mirror the small (3-row) lookup so the per-show assignment diff in step
@@ -2602,6 +3070,117 @@ async function syncMissingShows(): Promise<void> {
           stats.errors++;
         }
       }
+
+      // Step 6b: song authorship (the song_authors join). Authors are shared,
+      // seeded-or-resolved by slug — Author.slug is a non-unique index, so a
+      // duplicate slug resolves to the lex-min id (like matchVenue) and re-runs
+      // stay deterministic. Then each in-scope song's SongAuthor rows are
+      // mirrored by diffSongAuthors. `undefined` authors = no opinion (pre-deploy
+      // MCP), so the whole step is a no-op until the get_songs change deploys.
+      const authorNameBySlug = new Map<string, string>();
+      for (const song of remoteSongs) {
+        for (const a of song.authors ?? []) {
+          if (!authorNameBySlug.has(a.slug)) authorNameBySlug.set(a.slug, a.name);
+        }
+      }
+      const authorSlugToId = new Map<string, string>();
+      if (authorNameBySlug.size > 0) {
+        const existingAuthors = await db.author.findMany({
+          where: { slug: { in: Array.from(authorNameBySlug.keys()) } },
+          select: { id: true, slug: true, name: true },
+        });
+        const idsBySlug = new Map<string, string[]>();
+        const nameById = new Map<string, string | null>();
+        for (const row of existingAuthors) {
+          const list = idsBySlug.get(row.slug);
+          if (list) list.push(row.id);
+          else idsBySlug.set(row.slug, [row.id]);
+          nameById.set(row.id, row.name);
+        }
+        for (const [slug, ids] of idsBySlug) authorSlugToId.set(slug, [...ids].sort()[0]);
+        for (const [slug, name] of authorNameBySlug) {
+          const existingId = authorSlugToId.get(slug);
+          if (existingId) {
+            // Name drift on the canonical (lex-min) row → patch by slug.
+            if (!isDryRun && nameById.get(existingId) !== name) {
+              try {
+                await db.author.update({ where: { id: existingId }, data: { name, updatedAt: now } });
+                songsChanged = true;
+              } catch (err) {
+                console.error(`  ❌ failed to update author ${slug}:`, err);
+                stats.errors++;
+              }
+            }
+            continue;
+          }
+          if (isDryRun) {
+            authorSlugToId.set(slug, `dry-run-author-${slug}`);
+            stats.authorsCreated++;
+            continue;
+          }
+          try {
+            const created = await db.author.create({
+              data: { name, slug, createdAt: now, updatedAt: now },
+              select: { id: true },
+            });
+            authorSlugToId.set(slug, created.id);
+            stats.authorsCreated++;
+            songsChanged = true;
+          } catch (err) {
+            console.error(`  ❌ failed to create author ${slug}:`, err);
+            stats.errors++;
+          }
+        }
+      }
+
+      for (const song of remoteSongs) {
+        if (song.authors === undefined) continue;
+        const songId = songSlugToId.get(song.slug);
+        if (!songId || songId.startsWith("dry-run-song-")) continue;
+        const desired: SongAuthorEntry[] = [];
+        for (const a of song.authors) {
+          const authorId = authorSlugToId.get(a.slug);
+          if (authorId && !authorId.startsWith("dry-run-author-")) desired.push({ authorId, position: a.position });
+        }
+        const localSongAuthorRows = await db.songAuthor.findMany({
+          where: { songId },
+          select: { authorId: true, position: true },
+        });
+        const diff = diffSongAuthors(localSongAuthorRows, desired);
+        if (diff.toCreate.length === 0 && diff.toDeleteAuthorIds.length === 0 && diff.toUpdatePositions.length === 0) {
+          continue;
+        }
+        stats.songAuthorsUpserted += diff.toCreate.length + diff.toUpdatePositions.length;
+        stats.songAuthorsDeleted += diff.toDeleteAuthorIds.length;
+        songsChanged = true;
+        const summary = `authors +${diff.toCreate.length} -${diff.toDeleteAuthorIds.length} ~${diff.toUpdatePositions.length}`;
+        if (isDryRun) {
+          console.log(`  ✍️  song ${song.slug}: ${summary} (dry run)`);
+          continue;
+        }
+        try {
+          await db.$transaction(async (tx) => {
+            if (diff.toDeleteAuthorIds.length > 0) {
+              await tx.songAuthor.deleteMany({ where: { songId, authorId: { in: diff.toDeleteAuthorIds } } });
+            }
+            for (const e of diff.toCreate) {
+              await tx.songAuthor.create({
+                data: { songId, authorId: e.authorId, position: e.position, createdAt: now, updatedAt: now },
+              });
+            }
+            for (const e of diff.toUpdatePositions) {
+              await tx.songAuthor.updateMany({
+                where: { songId, authorId: e.authorId },
+                data: { position: e.position, updatedAt: now },
+              });
+            }
+          });
+          console.log(`  ✍️  song ${song.slug}: ${summary}`);
+        } catch (err) {
+          console.error(`  ❌ failed to mirror authors for ${song.slug}:`, err);
+          stats.errors++;
+        }
+      }
     }
 
     // Step 7: insert missing show rows (no tracks yet — those land in step 8).
@@ -2634,6 +3213,9 @@ async function syncMissingShows(): Promise<void> {
           venueId,
           countForStats: show.countForStats ?? true,
           dayOrder: show.dayOrder ?? null,
+          showYoutubesCount: show.showYoutubesCount ?? 0,
+          showPhotosCount: show.showPhotosCount ?? 0,
+          likesCount: show.likesCount ?? 0,
         });
         const showDate = String(show.date);
         if (earliestInsertedDate === null || showDate < earliestInsertedDate) {
@@ -2656,6 +3238,9 @@ async function syncMissingShows(): Promise<void> {
           venueId: createdShow.venueId,
           countForStats: createdShow.countForStats,
           dayOrder: createdShow.dayOrder,
+          showYoutubesCount: createdShow.showYoutubesCount,
+          showPhotosCount: createdShow.showPhotosCount,
+          likesCount: createdShow.likesCount,
         });
         changedSlugs.add(slug);
         const showDate = String(show.date);
@@ -3437,6 +4022,68 @@ async function syncMissingShows(): Promise<void> {
           );
         }
       }
+
+      // Step 8e: show YouTube links. Show-scoped, mirrored after the setlist
+      // reconcile so every show exists locally. diffShowYoutubes keys on the
+      // video id (replace-not-merge); `undefined` remote = no opinion, so this
+      // is a no-op until the get_setlists change deploys.
+      const youtubesServed = Array.from(setlistBySlug.values()).some((s) => s.youtubes !== undefined);
+      if (youtubesServed && performerShowIds.length > 0) {
+        const localYoutubeRows = await db.showYoutube.findMany({
+          where: { showId: { in: performerShowIds } },
+          select: { showId: true, videoId: true },
+          orderBy: { createdAt: "asc" },
+        });
+        const localVideoIdsByShowId = new Map<string, string[]>();
+        for (const row of localYoutubeRows) {
+          const list = localVideoIdsByShowId.get(row.showId);
+          if (list) list.push(row.videoId);
+          else localVideoIdsByShowId.set(row.showId, [row.videoId]);
+        }
+        for (const [slug, setlist] of setlistBySlug) {
+          if (setlist.youtubes === undefined) continue;
+          const local = existingBySlug.get(slug);
+          if (!local || String(local.id).startsWith("dry-run-show-")) continue;
+          const diff = diffShowYoutubes(
+            localVideoIdsByShowId.get(local.id) ?? [],
+            setlist.youtubes.map((y) => y.videoId),
+          );
+          if (diff.toAdd.length === 0 && diff.toRemove.length === 0) continue;
+          stats.showYoutubesAdded += diff.toAdd.length;
+          stats.showYoutubesRemoved += diff.toRemove.length;
+          changedSlugs.add(slug);
+          if (isDryRun) {
+            console.log(`  📺 ${slug}: youtube +${diff.toAdd.length} -${diff.toRemove.length} (dry run)`);
+            continue;
+          }
+          try {
+            await db.$transaction(async (tx) => {
+              if (diff.toRemove.length > 0) {
+                await tx.showYoutube.deleteMany({
+                  where: { showId: local.id, videoId: { in: diff.toRemove } },
+                });
+              }
+              if (diff.toAdd.length > 0) {
+                await tx.showYoutube.createMany({
+                  // Stagger createdAt by index so oldest-first ordering (the
+                  // detail-page "first video") stays deterministic when several
+                  // videos land in one insert.
+                  data: diff.toAdd.map((videoId, index) => ({
+                    showId: local.id,
+                    videoId,
+                    createdAt: new Date(now.getTime() + index),
+                    updatedAt: now,
+                  })),
+                });
+              }
+            });
+            console.log(`  📺 ${slug}: youtube +${diff.toAdd.length} -${diff.toRemove.length}`);
+          } catch (err) {
+            console.error(`  ❌ failed to mirror youtube for ${slug}:`, err);
+            stats.errors++;
+          }
+        }
+      }
     }
 
     // Step 8b: ghost-show detection. Local shows in the synced years whose
@@ -3730,6 +4377,8 @@ function printSummary(stats: SyncStats, isDryRun: boolean): void {
   console.log(`Shows renamed (slug realigned): ${stats.showsRenamed}`);
   console.log(`Songs fetched: ${stats.songsFetched}`);
   console.log(`Songs created: ${stats.songsCreated}`);
+  console.log(`Authors created: ${stats.authorsCreated}`);
+  console.log(`Song authors (upserted / deleted): ${stats.songAuthorsUpserted} / ${stats.songAuthorsDeleted}`);
   console.log(
     `Songs orphaned (deleted / with tracks): ${stats.songsOrphanedDeleted} / ${stats.songsOrphanedWithTracks}`,
   );
@@ -3758,6 +4407,7 @@ function printSummary(stats: SyncStats, isDryRun: boolean): void {
   console.log(`Show lineup (upserted / deleted): ${stats.showMusiciansUpserted} / ${stats.showMusiciansDeleted}`);
   console.log(`Track musicians (upserted / deleted): ${stats.trackMusiciansUpserted} / ${stats.trackMusiciansDeleted}`);
   console.log(`Track flags (added / removed): ${stats.trackFlagsAdded} / ${stats.trackFlagsRemoved}`);
+  console.log(`Show YouTube links (added / removed): ${stats.showYoutubesAdded} / ${stats.showYoutubesRemoved}`);
   console.log(
     `Completions (upserted / deleted / skipped): ${stats.completionsUpserted} / ${stats.completionsDeleted} / ${stats.completionsSkipped}`,
   );
@@ -3769,6 +4419,12 @@ function printSummary(stats: SyncStats, isDryRun: boolean): void {
     );
     console.log(
       `Attendances (upserted / deleted / reconciled / FK skipped): ${ua.attendancesUpserted} / ${ua.attendancesDeleted} / ${ua.attendancesReconciled} / ${ua.attendancesFkSkipped}`,
+    );
+    console.log(
+      `Reviews (upserted / deleted / reconciled / FK skipped): ${ua.reviewsUpserted} / ${ua.reviewsDeleted} / ${ua.reviewsReconciled} / ${ua.reviewsFkSkipped}`,
+    );
+    console.log(
+      `Blog posts (upserted / deleted / FK skipped): ${ua.blogPostsUpserted} / ${ua.blogPostsDeleted} / ${ua.blogPostsFkSkipped}`,
     );
     console.log(`Rating aggregates rebuilt: ${ua.aggregatesRebuilt}`);
   } else {

--- a/packages/core/src/blog-posts/blog-post-service.ts
+++ b/packages/core/src/blog-posts/blog-post-service.ts
@@ -236,4 +236,113 @@ export class BlogPostService {
     await this.redis.del(BLOG_POSTS_CACHE_KEY);
     return true;
   }
+
+  /**
+   * Sync export: page through PUBLISHED blog posts for the local sync script,
+   * with the cover image embedded so the sync can mirror the File +
+   * BlogPostToFile rows the `/blog` cards render. Only published posts travel
+   * (drafts aren't shown publicly). PII-free — `userId` resolves to a stub
+   * locally; the cover File carries only its Cloudflare variants/filename/type.
+   * Cursor + ordering match the rating/review sync: (updatedAt ASC, id ASC).
+   */
+  async listForSync(opts: {
+    since: Date;
+    cursorId?: string;
+    cursorUpdatedAt?: Date;
+    limit: number;
+  }): Promise<BlogPostForSync[]> {
+    const { since, cursorId, cursorUpdatedAt, limit } = opts;
+    const cursorWhere = cursorUpdatedAt
+      ? {
+          OR: [
+            { updatedAt: { gt: cursorUpdatedAt } },
+            { AND: [{ updatedAt: cursorUpdatedAt }, { id: { gt: cursorId ?? "" } }] },
+          ],
+        }
+      : { updatedAt: { gt: since } };
+    const rows = await this.db.blogPost.findMany({
+      where: { AND: [{ state: "published" }, cursorWhere] },
+      orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+      take: limit,
+      select: {
+        id: true,
+        slug: true,
+        title: true,
+        blurb: true,
+        content: true,
+        state: true,
+        postType: true,
+        publishedAt: true,
+        userId: true,
+        createdAt: true,
+        updatedAt: true,
+        files: {
+          where: { isCover: true },
+          select: {
+            file: {
+              select: {
+                cloudflareId: true,
+                path: true,
+                filename: true,
+                size: true,
+                type: true,
+                variants: true,
+                metadata: true,
+              },
+            },
+          },
+        },
+      },
+    });
+    return rows.map((row) => {
+      const { files, ...rest } = row;
+      // Only a cover with a Cloudflare id is mirrorable (cloudflareId is the
+      // stable cross-env file key); legacy files without one are dropped.
+      const cover = files.map((f) => f.file).find((f) => f.cloudflareId !== null) ?? null;
+      return {
+        ...rest,
+        coverFile: cover
+          ? {
+              cloudflareId: cover.cloudflareId as string,
+              path: cover.path,
+              filename: cover.filename,
+              size: cover.size,
+              type: cover.type,
+              variants: cover.variants,
+              metadata: cover.metadata,
+            }
+          : null,
+      };
+    });
+  }
+
+  async listAllIdsForSync(): Promise<string[]> {
+    const rows = await this.db.blogPost.findMany({ where: { state: "published" }, select: { id: true } });
+    return rows.map((r) => r.id);
+  }
+}
+
+export interface BlogPostForSyncFile {
+  cloudflareId: string;
+  path: string;
+  filename: string;
+  size: number;
+  type: string;
+  variants: unknown;
+  metadata: unknown;
+}
+
+export interface BlogPostForSync {
+  id: string;
+  slug: string;
+  title: string;
+  blurb: string | null;
+  content: string | null;
+  state: string;
+  postType: string;
+  publishedAt: Date | null;
+  userId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  coverFile: BlogPostForSyncFile | null;
 }

--- a/packages/core/src/reviews/review-service.ts
+++ b/packages/core/src/reviews/review-service.ts
@@ -191,4 +191,47 @@ export class ReviewService {
       return false;
     }
   }
+
+  /**
+   * Sync export: page through reviews for the local sync script. PII-free —
+   * `content` is the public review prose shown on the show page, `userId`
+   * resolves to a stub user locally; no email/name/secret is on the Review
+   * model. Cursor and ordering match RatingService.listForSync so the sync
+   * pages identically: (updatedAt ASC, id ASC), exclusive on the boundary tuple.
+   */
+  async listForSync(opts: {
+    since: Date;
+    cursorId?: string;
+    cursorUpdatedAt?: Date;
+    limit: number;
+  }): Promise<Array<Pick<Review, "id" | "userId" | "showId" | "content" | "status" | "createdAt" | "updatedAt">>> {
+    const { since, cursorId, cursorUpdatedAt, limit } = opts;
+    const where = cursorUpdatedAt
+      ? {
+          OR: [
+            { updatedAt: { gt: cursorUpdatedAt } },
+            { AND: [{ updatedAt: cursorUpdatedAt }, { id: { gt: cursorId ?? "" } }] },
+          ],
+        }
+      : { updatedAt: { gt: since } };
+    return this.db.review.findMany({
+      where,
+      orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+      take: limit,
+      select: {
+        id: true,
+        userId: true,
+        showId: true,
+        content: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  }
+
+  async listAllIdsForSync(): Promise<string[]> {
+    const rows = await this.db.review.findMany({ select: { id: true } });
+    return rows.map((r) => r.id);
+  }
 }


### PR DESCRIPTION
Running `make db-sync-missing-shows` against a local dev DB now brings over more
of prod's already-public data, so local testing matches prod more closely:

- **Show YouTube links** render on the show detail "Video" card and the listing badges.
- **Song authors** render on song pages (they were blank locally before, because
  `Song.authorName` is derived from the `song_authors` join and synced songs had
  no author rows).
- **Reviews** and **published blog posts** (with cover images) come over.
- The **`hasYoutube` / `hasPhotos` calendar filters** and the **like count** light
  up, because the denormalized count columns are now mirrored.

## Tools

- New: `list_reviews_since`, `list_blog_posts_since`, `list_all_review_ids`,
  `list_all_blog_post_ids`.
- Extended: `get_setlists` (per-show `youtubes`), `get_shows`
  (`showYoutubesCount` / `showPhotosCount` / `likesCount`), `get_songs`
  (structured `authors`).
- `MCP_README.md` documents all of the above.

This is a coordinated change: the new behavior only activates once the MCP server
(`apps/web`) deploys to prod. Until then the sync runs exactly as before. After
deploy, run `make db-sync-missing-shows` (add `--full-users` to backfill reviews
and blog posts).

## Notes for the reviewer

- **Pre-deploy tolerance.** Every new MCP pull is wrapped so that a prod server
  without the new tool (the window between deploying this and the next prod
  release) is treated as "no opinion" and skipped, never an error. Same
  `undefined` = no-opinion convention the existing diffs use.
- **PII stays stubbed.** New rows reference users by id only; the owning user
  remains a local stub. No emails, names, or secrets travel. Each `listForSync`
  has a `select` allowlist.
- **DurationSource was dropped from scope** after verifying it is already seeded
  by migration `20260530130000` with the exact values prod uses, and the same FK
  exists on prod, so it cannot drift.
- **Show photos are deferred.** The `show_files` / File rows need an uploader
  `userId` FK, but users only sync in the user-activity pass, which runs after the
  setlist step where show-scoped photo data arrives. Doing it correctly needs a
  separate post-user pass; rather than bolt on a fragile one, it is left as a
  follow-up. (`show_photos` rows themselves are unused dead data and intentionally
  not synced.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
