### PR TITLE
Show 0.5-star ratings in profile rating tables

### DIFF
--- a/apps/web/app/lib/rating-charts.ts
+++ b/apps/web/app/lib/rating-charts.ts
@@ -4,8 +4,7 @@ import { formatHalfStep } from "~/components/rating/rating";
 /**
  * The 0.5-step star values a rating can take, low to high. The histogram
  * always renders all ten so empty buckets read as genuine gaps rather than
- * a compressed axis. Includes 0.5, which the profile rating *tables* exclude
- * (their query filters value BETWEEN 1 AND 5) — the charts show every rating.
+ * a compressed axis.
  */
 export const RATING_BUCKETS = [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5] as const;
 

--- a/packages/core/src/ratings/rating-service.ts
+++ b/packages/core/src/ratings/rating-service.ts
@@ -429,7 +429,7 @@ export class RatingService {
       LEFT JOIN venues v ON v.id = s.venue_id
       WHERE r.user_id = ${userId}::uuid
         AND r.rateable_type = 'Show'
-        AND r.value BETWEEN 1 AND 5
+        AND r.value >= 0.5
       ORDER BY ${orderBy}
       LIMIT ${take} OFFSET ${skip}
     `;
@@ -500,7 +500,7 @@ export class RatingService {
       INNER JOIN songs sg ON sg.id = t.song_id
       WHERE r.user_id = ${userId}::uuid
         AND r.rateable_type = 'Track'
-        AND r.value BETWEEN 1 AND 5
+        AND r.value >= 0.5
       ORDER BY ${orderBy}
       LIMIT ${take} OFFSET ${skip}
     `;
@@ -526,9 +526,7 @@ export class RatingService {
 
   /**
    * Distribution of a user's show ratings by concert year and star value,
-   * for the profile charts. Unlike the table queries this includes 0.5
-   * ratings (value >= 0.5, not BETWEEN 1 AND 5) so the histogram reflects
-   * every rating, and it aggregates server-side: ~250 bucket rows instead
+   * for the profile charts. Aggregates server-side: ~250 bucket rows instead
    * of the user's full (often thousands) rating set.
    */
   async getShowRatingDistribution(userId: string): Promise<RatingYearBucket[]> {


### PR DESCRIPTION
User profile rating tables (the Show Ratings and Track Ratings tabs) now show 0.5-star ratings. Before, the table view dropped them while the distribution chart on the same tab showed them, so the two views of the same data disagreed: a user who rated shows 0.5 saw those ratings in the graph but not in the table.

The table queries filtered `r.value BETWEEN 1 AND 5`; the chart's distribution query used `r.value >= 0.5`. Both table queries now use `r.value >= 0.5` to match the chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
