### PR TITLE
Add opt-in Calibrated Show Rating

### DIFF
--- a/.github/workflows/cron-jobs.yml
+++ b/.github/workflows/cron-jobs.yml
@@ -11,6 +11,7 @@ on:
         type: choice
         options:
           - community-refresh
+          - recompute-ratings
       timeout:
         description: 'Timeout in minutes'
         required: false
@@ -61,6 +62,32 @@ jobs:
             echo "$body" | jq '.' || echo "$body"
           else
             echo "❌ Cron job failed with status $http_code"
+            echo "$body" | jq '.' || echo "$body"
+            exit 1
+          fi
+
+      # The hourly schedule also drives the rating recompute (dirty-gated server-side,
+      # so it's a cheap no-op when no ratings changed). Manual runs select it via the
+      # job input instead, which the step above handles.
+      - name: Run ratings recompute (scheduled)
+        if: github.event_name == 'schedule'
+        run: |
+          response=$(curl -s -w "\n%{http_code}" -X POST \
+            "${{ env.PRODUCTION_URL }}/api/cron/recompute-ratings" \
+            -H "Content-Type: application/json" \
+            --max-time 600)
+
+          http_code=$(echo "$response" | tail -n1)
+          body=$(echo "$response" | head -n -1)
+
+          echo "HTTP Status: $http_code"
+          echo "Response: $body"
+
+          if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+            echo "✅ Ratings recompute completed successfully"
+            echo "$body" | jq '.' || echo "$body"
+          else
+            echo "❌ Ratings recompute failed with status $http_code"
             echo "$body" | jq '.' || echo "$body"
             exit 1
           fi

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,18 @@ lint:
 test:
 	bun run test
 
+# Run a package's tests filtered to certain files (vitest path/name substrings).
+# Defaults to the core package. Examples:
+#   make test-file FILES="quonfig"
+#   make test-file PKG=web FILES="setlist-card"
+#   make test-file PKG=core FILES="rater-weight rater-weighting"
+test-file:
+	@if [ -z "$(FILES)" ]; then \
+		echo "Usage: make test-file [PKG=core|web|domain] FILES=\"<path-or-name substrings>\""; \
+		exit 1; \
+	fi
+	bun run -F @bip/$(or $(PKG),core) test $(FILES)
+
 format:
 	@if [ -z "$(FILES)" ]; then \
 		echo "Usage: make format FILES=\"file1.ts file2.tsx\""; \
@@ -79,6 +91,12 @@ db-restore:
 
 recompute-pending:
 	cd packages/core && doppler run -- bun run scripts/recompute-pending.ts
+
+recompute-ratings:
+	cd packages/core && QUONFIG_DATADIR=$(CURDIR)/quonfig doppler run -- bun run scripts/recompute-ratings.ts
+
+rating-validity-eval:
+	cd packages/core && doppler run -- bun run scripts/rating-validity-eval.ts
 
 db-sync-missing-shows:
 	cd packages/core && doppler run -- bun run scripts/sync-missing-shows.ts $(if $(HELP),--help) $(if $(YEARS),--years=$(YEARS)) $(if $(DRY_RUN),--dry-run) $(if $(PRUNE_GHOST_SHOWS),--prune-ghost-shows) $(if $(NO_USERS),--no-users) $(if $(FULL_USERS),--full-users) $(if $(PRUNE_USERS),--prune-users)

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -43,6 +43,10 @@ COPY --from=builder /app/packages/core/src ./packages/core/src
 # Copy deploy-time scripts run from docker-entrypoint.sh.
 COPY --from=builder /app/packages/core/scripts ./packages/core/scripts
 
+# Copy the quonfig feature-flag workspace; @quonfig/node reads it from disk at
+# runtime (local/offline datadir mode). QUONFIG_DATADIR below points here.
+COPY --from=builder /app/quonfig ./quonfig
+
 # The dev @bip/domain package.json points main/exports at ./src/index.ts, but the
 # runner only ships packages/domain/dist (not src). When the deploy-time script
 # runs core's raw TS, its `import "@bip/domain"` must resolve to the built dist —
@@ -67,6 +71,9 @@ RUN chmod +x /app/docker-entrypoint.sh
 
 ENV NODE_ENV=production
 ENV PORT=8080
+# quonfig local/offline datadir (absolute so it resolves regardless of cwd).
+ENV QUONFIG_DATADIR=/app/quonfig
+ENV QUONFIG_ENVIRONMENT=production
 
 EXPOSE 8080
 

--- a/apps/web/app/components/layout/footer.tsx
+++ b/apps/web/app/components/layout/footer.tsx
@@ -1,9 +1,13 @@
 import { Heart, Mail, Sparkles } from "lucide-react";
 import { Link } from "react-router-dom";
 import { ContactDialog } from "~/components/contact/contact-dialog";
+import { useFeatureFlags } from "~/hooks/use-feature-flags";
 
 export function Footer() {
   const currentYear = new Date().getFullYear();
+  // The rating-algorithm explainer is always reachable by URL; this footer link
+  // is gated by the `ratings.explainer-nav-link` feature flag.
+  const { explainerNavLink } = useFeatureFlags();
 
   return (
     <footer className="bg-content-bg/50 border-t border-content-bg-secondary mt-auto">
@@ -33,6 +37,14 @@ export function Footer() {
           >
             About
           </Link>
+          {explainerNavLink && (
+            <Link
+              to="/show-rating-algorithm"
+              className="text-content-text-secondary hover:text-content-text-primary transition-colors duration-200"
+            >
+              Ratings
+            </Link>
+          )}
           <Link
             to="/terms"
             className="text-content-text-secondary hover:text-content-text-primary transition-colors duration-200"

--- a/apps/web/app/components/performance/performance-table.test.tsx
+++ b/apps/web/app/components/performance/performance-table.test.tsx
@@ -12,6 +12,8 @@ vi.mock("~/hooks/use-show-user-data", () => ({
     attendanceMap: new Map(),
     userRatingMap: new Map(),
     averageRatingMap: new Map(),
+    displayedRatingMap: new Map(),
+    rankComparisonMap: new Map(),
     isLoading: false,
     error: null,
   })),
@@ -144,6 +146,8 @@ describe("PerformanceTable", () => {
       attendanceMap: new Map([["s-soundcheck", { id: "att-1" } as never]]),
       userRatingMap: new Map(),
       averageRatingMap: new Map(),
+      displayedRatingMap: new Map(),
+      rankComparisonMap: new Map(),
       isLoading: false,
       error: null,
     });
@@ -169,6 +173,8 @@ describe("PerformanceTable", () => {
       attendanceMap: new Map([["s-attended", { id: "att-1" } as never]]),
       userRatingMap: new Map(),
       averageRatingMap: new Map(),
+      displayedRatingMap: new Map(),
+      rankComparisonMap: new Map(),
       isLoading: false,
       error: null,
     });

--- a/apps/web/app/components/rating/calibrated-summary.test.tsx
+++ b/apps/web/app/components/rating/calibrated-summary.test.tsx
@@ -1,0 +1,37 @@
+import type { ShowRankComparison } from "@bip/core";
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { CalibratedSummary } from "./calibrated-summary";
+
+// The overlay shows the calibrated score plus rank movement over two fields. The
+// behavior worth pinning: a qualified show renders both an "all" and a "top" row;
+// a thin show (top === null) renders "not ranked" instead of a top-list rank.
+const qualified: ShowRankComparison = {
+  calibrated: 4.51,
+  all: { canonicalRank: 72, calibratedRank: 101, total: 300 },
+  top: { canonicalRank: 60, calibratedRank: 98, total: 100 },
+};
+
+describe("CalibratedSummary", () => {
+  test("renders both the all-field and top-list rank rows for a qualified show", async () => {
+    await setup(<CalibratedSummary canonical={4.64} rank={qualified} />);
+    expect(screen.getByText("all")).toBeInTheDocument();
+    expect(screen.getByText("top")).toBeInTheDocument();
+    // Calibrated ranks (the "now" column) for each field.
+    expect(screen.getByText("#101")).toBeInTheDocument();
+    expect(screen.getByText("#98")).toBeInTheDocument();
+  });
+
+  test("shows 'not ranked' on the top row when the show is below the rating floor", async () => {
+    const thin: ShowRankComparison = {
+      calibrated: 4.2,
+      all: { canonicalRank: 1, calibratedRank: 784, total: 800 },
+      top: null,
+    };
+    await setup(<CalibratedSummary canonical={5.0} rank={thin} />);
+    expect(screen.getByText(/not ranked/)).toBeInTheDocument();
+    // The all-field still shows its movement (raw #1 → calibrated #784).
+    expect(screen.getByText("#784")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/rating/calibrated-summary.tsx
+++ b/apps/web/app/components/rating/calibrated-summary.tsx
@@ -1,0 +1,80 @@
+import type { RankInField, ShowRankComparison } from "@bip/core";
+
+/**
+ * The debug rating comparison overlay: a show's simple→calibrated score plus how its
+ * rank moves under the calibration, shown over two fields: every rated show
+ * (`all`, where thin shows inflate the raw average) and the real top list (`top`,
+ * ≥10 ratings; a thin show reads "not ranked"). Laid out as a table so the
+ * was/now/change columns line up across the score and both rank rows. Rendered
+ * behind the `ratings.compare-visible` flag + the user's `showRatingComparisonDebug` pref.
+ */
+
+function formatScore(value: number | undefined): string {
+  return value != null && value > 0 ? value.toFixed(2) : "—";
+}
+
+const labelCell = "px-2 py-0.5 text-left font-normal text-content-text-secondary";
+const numCell = "px-2 py-0.5 text-right tabular-nums";
+
+function RankRow({ label, rank }: { label: string; rank: RankInField }) {
+  const improved = rank.calibratedRank < rank.canonicalRank;
+  const moved = rank.calibratedRank !== rank.canonicalRank;
+  const places = Math.abs(rank.canonicalRank - rank.calibratedRank);
+  return (
+    <tr>
+      <td className={labelCell}>{label}</td>
+      <td className={`${numCell} text-content-text-tertiary`}>#{rank.canonicalRank}</td>
+      <td className={`${numCell} font-semibold text-content-text-primary`}>#{rank.calibratedRank}</td>
+      <td className={numCell}>
+        {moved ? (
+          <span className={improved ? "text-green-500" : "text-red-500"}>
+            {improved ? "▲" : "▼"}
+            {places}
+          </span>
+        ) : (
+          <span className="text-content-text-tertiary">—</span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+export function CalibratedSummary({
+  canonical,
+  rank,
+  compact = false,
+}: {
+  canonical: number | null;
+  rank: ShowRankComparison;
+  compact?: boolean;
+}) {
+  const scoreDiff = canonical != null ? rank.calibrated - canonical : 0;
+  const scoreMoved = Math.abs(scoreDiff) >= 0.005;
+  return (
+    <table className={`border-collapse ${compact ? "text-[10px] leading-tight sm:text-xs" : "text-sm"}`}>
+      <tbody>
+        <tr>
+          <td className={labelCell}>Score</td>
+          <td className={`${numCell} text-content-text-tertiary`}>{formatScore(canonical ?? undefined)}</td>
+          <td className={`${numCell} font-semibold text-content-text-primary`}>{rank.calibrated.toFixed(2)}</td>
+          <td
+            className={`${numCell} ${scoreDiff > 0 ? "text-green-500" : scoreDiff < 0 ? "text-red-500" : "text-content-text-tertiary"}`}
+          >
+            {scoreMoved ? `${scoreDiff > 0 ? "+" : "−"}${Math.abs(scoreDiff).toFixed(2)}` : "—"}
+          </td>
+        </tr>
+        <RankRow label="all" rank={rank.all} />
+        {rank.top ? (
+          <RankRow label="top" rank={rank.top} />
+        ) : (
+          <tr>
+            <td className={labelCell}>top</td>
+            <td className={`${numCell} text-content-text-tertiary`} colSpan={3}>
+              not ranked (&lt;10)
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/web/app/components/rating/rating-display-settings.test.tsx
+++ b/apps/web/app/components/rating/rating-display-settings.test.tsx
@@ -1,0 +1,79 @@
+import { setup, setupWithRouter } from "@test/test-utils";
+import { screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { RatingDisplaySettings } from "./rating-display-settings";
+
+vi.mock("~/hooks/use-feature-flags", () => ({ useFeatureFlags: vi.fn() }));
+
+import { useFeatureFlags } from "~/hooks/use-feature-flags";
+
+// The card's whole point is conditional visibility plus auto-save: each toggle
+// appears only when its feature flag is on, the card hides when neither is, and
+// flipping a toggle persists immediately (no save button). v1 launches with only
+// the author flagged in, so a typical user must see nothing here.
+const base = { showCalibratedRatings: null, showRatingComparisonDebug: null };
+
+function mockFlags(overrides: Partial<ReturnType<typeof useFeatureFlags>>) {
+  vi.mocked(useFeatureFlags).mockReturnValue({
+    calibratedEnabled: true,
+    toggleVisible: false,
+    compareVisible: false,
+    defaultCalibrated: false,
+    explainerNavLink: false,
+    recomputeEnabled: false,
+    ...overrides,
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("RatingDisplaySettings", () => {
+  test("renders nothing when neither flag is enabled", async () => {
+    mockFlags({});
+    const { container } = await setup(<RatingDisplaySettings {...base} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("shows only the opt-in toggle when just toggle-visible is on", async () => {
+    mockFlags({ toggleVisible: true });
+    await setupWithRouter(<RatingDisplaySettings {...base} />);
+    expect(screen.getByText("Calibrated show rating")).toBeInTheDocument();
+    expect(screen.queryByText("Show Rating Comparison Overlay (debug)")).not.toBeInTheDocument();
+  });
+
+  test("shows the comparison overlay toggle when compare-visible is on", async () => {
+    mockFlags({ toggleVisible: true, compareVisible: true });
+    await setupWithRouter(<RatingDisplaySettings {...base} />);
+    expect(screen.getByText("Calibrated show rating")).toBeInTheDocument();
+    expect(screen.getByText("Show Rating Comparison Overlay (debug)")).toBeInTheDocument();
+  });
+
+  test("auto-saves the opt-in to /api/users immediately on toggle (no save button)", async () => {
+    mockFlags({ toggleVisible: true });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { user } = await setupWithRouter(<RatingDisplaySettings {...base} />);
+    await user.click(screen.getByLabelText("Use the calibrated show rating"));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/users");
+    expect(init.method).toBe("POST");
+    expect((init.body as FormData).get("showCalibratedRatings")).toBe("true");
+  });
+
+  test("reverts the toggle when the save fails", async () => {
+    mockFlags({ toggleVisible: true });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+
+    const { user } = await setupWithRouter(<RatingDisplaySettings {...base} />);
+    const toggle = screen.getByLabelText("Use the calibrated show rating");
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+    await user.click(toggle);
+    // Optimistic flip reverts once the failed response resolves (async, so wait).
+    await waitFor(() => expect(toggle).toHaveAttribute("aria-checked", "false"));
+  });
+});

--- a/apps/web/app/components/rating/rating-display-settings.tsx
+++ b/apps/web/app/components/rating/rating-display-settings.tsx
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { toast } from "sonner";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Switch } from "~/components/ui/switch";
+import { useFeatureFlags } from "~/hooks/use-feature-flags";
+
+/**
+ * Rating-display preferences for the viewer's own profile. The calibrated-rating
+ * opt-in renders only when `ratings.toggle-visible` makes it available to this
+ * user; the author comparison overlay only when `ratings.compare-visible` does;
+ * the whole card hides when neither is on. Each toggle auto-saves on change
+ * (optimistic, reverting on failure) to /api/users, which re-checks the flags
+ * before persisting, with no separate save step.
+ *
+ * Takes only the viewer's saved preferences as props; the gating feature flags are
+ * read from `useFeatureFlags()` so it's clear at this use site that flags drive
+ * what renders.
+ */
+export function RatingDisplaySettings({
+  showCalibratedRatings,
+  showRatingComparisonDebug,
+}: {
+  showCalibratedRatings: boolean | null;
+  showRatingComparisonDebug: boolean | null;
+}) {
+  const { toggleVisible, compareVisible, defaultCalibrated } = useFeatureFlags();
+  // Each switch reflects the user's explicit choice, falling back to the app
+  // default when they've never set one (a null pref resolves to the default).
+  const [calibrated, setCalibrated] = useState(showCalibratedRatings ?? defaultCalibrated);
+  const [compare, setCompare] = useState(showRatingComparisonDebug ?? false);
+  const [savingField, setSavingField] = useState<string | null>(null);
+
+  if (!toggleVisible && !compareVisible) return null;
+
+  async function save(
+    field: "showCalibratedRatings" | "showRatingComparisonDebug",
+    value: boolean,
+    apply: (v: boolean) => void,
+  ) {
+    apply(value); // optimistic
+    setSavingField(field);
+    try {
+      const body = new FormData();
+      body.set(field, String(value));
+      const response = await fetch("/api/users", { method: "POST", body });
+      if (!response.ok) throw new Error("save failed");
+      toast.success("Rating settings saved");
+    } catch {
+      apply(!value); // revert
+      toast.error("Couldn't save rating settings");
+    } finally {
+      setSavingField(null);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-content-text-primary">Rating display</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {toggleVisible && (
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <div className="text-content-text-primary font-medium">Calibrated show rating</div>
+              <p className="text-sm text-content-text-tertiary">
+                Weights raters by how much of the 0.5 to 5 star scale they use, corrects for generous and harsh graders,
+                and counts each person once.{" "}
+                <Link to="/show-rating-algorithm" className="text-brand-primary hover:underline">
+                  How it works →
+                </Link>
+              </p>
+            </div>
+            <Switch
+              checked={calibrated}
+              disabled={savingField === "showCalibratedRatings"}
+              onCheckedChange={(v) => save("showCalibratedRatings", v, setCalibrated)}
+              aria-label="Use the calibrated show rating"
+            />
+          </div>
+        )}
+
+        {compareVisible && (
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <div className="text-content-text-primary font-medium">Show Rating Comparison Overlay (debug)</div>
+              <p className="text-sm text-content-text-tertiary">
+                Show the community→calibrated score and rank delta on show cards and pages.
+              </p>
+            </div>
+            <Switch
+              checked={compare}
+              disabled={savingField === "showRatingComparisonDebug"}
+              onCheckedChange={(v) => save("showRatingComparisonDebug", v, setCompare)}
+              aria-label="Show rating comparison overlay"
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -423,6 +423,32 @@ describe("SetlistCard", () => {
     expect(onViewChange).not.toHaveBeenCalled();
   });
 
+  // Calibrated mode passes the post-exclusion count via showRatingCount, which must
+  // override the embedded deduped ratingsCount on the rating badge — so a calibrated
+  // viewer sees "· 33", not the deduped "· 10". (makeSetlist embeds ratingsCount=10.)
+  test("showRatingCount overrides the embedded ratingsCount on the rating badge", async () => {
+    await setupWithRouter(
+      <SetlistCard
+        setlist={makeSetlist()}
+        userAttendance={null}
+        userRating={null}
+        showRating={4.81}
+        showRatingCount={33}
+      />,
+    );
+    expect(screen.getAllByText("33").length).toBeGreaterThan(0);
+    expect(screen.queryByText("10")).not.toBeInTheDocument();
+  });
+
+  // Simple mode (no showRatingCount): the badge falls back to the embedded deduped
+  // ratingsCount (10).
+  test("rating badge falls back to the embedded ratingsCount when showRatingCount is absent", async () => {
+    await setupWithRouter(
+      <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={4.0} />,
+    );
+    expect(screen.getAllByText("10").length).toBeGreaterThan(0);
+  });
+
   // averageSongGap=null happens for all-debut/all-repeat shows. The summary
   // line should be omitted entirely (not "Average song gap: —") so the
   // toggle row stays clean on shows where the number isn't meaningful.

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -1,7 +1,9 @@
+import type { ShowRankComparison } from "@bip/core";
 import type { Attendance, Rating, Setlist, SetlistLight } from "@bip/domain";
 import { Check } from "lucide-react";
 import { memo, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
+import { CalibratedSummary } from "~/components/rating/calibrated-summary";
 import { RatingBadgeButton } from "~/components/rating/rating-badge-button";
 import { ShowLineupNote } from "~/components/show/show-lineup-note";
 import { ShowDate } from "~/components/show-date";
@@ -27,7 +29,18 @@ interface SetlistCardProps {
   userAttendance: Attendance | null;
   userRating: Rating | number | null;
   showRating: number | null;
+  /**
+   * Count shown beside the ★ score. In calibrated mode this is the calibrated
+   * (post-exclusion) contributing count; absent ⇒ the canonical deduped count.
+   */
+  showRatingCount?: number | null;
   externalSources?: ShowExternalSources;
+  /**
+   * Simple→calibrated score + rank summary for this show. Rendered next to the ★
+   * score when present. Optional — only set for viewers with the comparison
+   * overlay enabled.
+   */
+  rankComparison?: ShowRankComparison | null;
   /**
    * When true, the card starts with its body hidden and opens on header click.
    * Clicks originating from interactive descendants (links, buttons) are
@@ -53,7 +66,9 @@ function SetlistCardComponent({
   userAttendance,
   userRating,
   showRating,
+  showRatingCount,
   externalSources,
+  rankComparison,
   collapsible = false,
   defaultView = "setlist",
   onViewChange,
@@ -125,7 +140,16 @@ function SetlistCardComponent({
   // (a Rating object or a bare number) into a single value for the badge.
   const resolvedUserRating = typeof userRating === "number" ? userRating : (userRating?.value ?? null);
   const displayedRating = showRating ?? setlist.show.averageRating ?? null;
-  const displayedCount = setlist.show.ratingsCount ?? null;
+  // In calibrated mode the count is the post-exclusion contributing count (passed
+  // alongside the calibrated score); otherwise the canonical deduped count.
+  const displayedCount = showRatingCount ?? setlist.show.ratingsCount ?? null;
+
+  // Compact calibrated-score + rank summary, rendered to the right of the ★ score.
+  const summaryEl = rankComparison ? (
+    <div className="text-[10px] leading-tight sm:text-xs">
+      <CalibratedSummary canonical={setlist.show.averageRating ?? null} rank={rankComparison} compact />
+    </div>
+  ) : null;
 
   // Toggle attendance using mutation
   const toggleAttendance = () => {
@@ -248,18 +272,22 @@ function SetlistCardComponent({
                   userRating={resolvedUserRating}
                   isAuthenticated
                 />
+                {summaryEl}
               </div>
             )}
             {!user && (
-              <RatingBadgeButton
-                rateableId={setlist.show.id}
-                rateableType="Show"
-                showSlug={setlist.show.slug}
-                initialRating={displayedRating}
-                ratingsCount={displayedCount}
-                userRating={null}
-                isAuthenticated={false}
-              />
+              <div className="flex items-center gap-2">
+                <RatingBadgeButton
+                  rateableId={setlist.show.id}
+                  rateableType="Show"
+                  showSlug={setlist.show.slug}
+                  initialRating={displayedRating}
+                  ratingsCount={displayedCount}
+                  userRating={null}
+                  isAuthenticated={false}
+                />
+                {summaryEl}
+              </div>
             )}
             <div className="pr-2 sm:pr-3">
               <ShowExternalBadges

--- a/apps/web/app/components/setlist/setlist-list.test.tsx
+++ b/apps/web/app/components/setlist/setlist-list.test.tsx
@@ -110,6 +110,9 @@ function setMockReturn(
     attendanceMap: overrides.attendanceMap ?? new Map(),
     userRatingMap: overrides.userRatingMap ?? new Map(),
     averageRatingMap: overrides.averageRatingMap ?? new Map(),
+    weightedRatingMap: new Map(),
+    displayedRatingMap: new Map(),
+    rankComparisonMap: new Map(),
     isLoading: false,
     error: null,
   });

--- a/apps/web/app/components/setlist/setlist-list.tsx
+++ b/apps/web/app/components/setlist/setlist-list.tsx
@@ -43,7 +43,8 @@ export function SetlistList({
   collapsible,
 }: SetlistListProps) {
   const showIds = useMemo(() => setlists.map((s) => s.show.id), [setlists]);
-  const { attendanceMap, userRatingMap, averageRatingMap } = useShowUserData(showIds);
+  const { attendanceMap, userRatingMap, averageRatingMap, displayedRatingMap, rankComparisonMap } =
+    useShowUserData(showIds);
 
   if (setlists.length === 0) {
     return <>{empty ?? null}</>;
@@ -52,13 +53,18 @@ export function SetlistList({
   const renderCard = (setlist: Setlist | SetlistLight, index: number) => {
     const showId = setlist.show.id;
     const liveAverage = averageRatingMap.get(showId)?.average;
+    // The displayed ★ is the viewer's calibrated score when their mode resolves to
+    // calibrated (server only sends it then), else the live/canonical average.
+    const displayed = displayedRatingMap.get(showId);
     const card = (
       <SetlistCard
         setlist={setlist}
         userAttendance={attendanceMap.get(showId) ?? null}
         userRating={userRatingMap.get(showId) ?? null}
-        showRating={liveAverage ?? setlist.show.averageRating ?? null}
+        showRating={displayed?.rating ?? liveAverage ?? setlist.show.averageRating ?? null}
+        showRatingCount={displayed?.count ?? null}
         externalSources={externalSources[showId]}
+        rankComparison={rankComparisonMap.get(showId)}
         collapsible={collapsible}
       />
     );

--- a/apps/web/app/hooks/use-attendance-row-highlight.test.ts
+++ b/apps/web/app/hooks/use-attendance-row-highlight.test.ts
@@ -10,6 +10,8 @@ vi.mock("~/hooks/use-show-user-data", () => ({
     attendanceMap: new Map(),
     userRatingMap: new Map(),
     averageRatingMap: new Map(),
+    displayedRatingMap: new Map(),
+    rankComparisonMap: new Map(),
     isLoading: false,
     error: null,
   })),
@@ -34,6 +36,8 @@ describe("useAttendanceRowHighlight", () => {
       attendanceMap: new Map(),
       userRatingMap: new Map(),
       averageRatingMap: new Map(),
+      displayedRatingMap: new Map(),
+      rankComparisonMap: new Map(),
       isLoading: false,
       error: null,
     });
@@ -47,6 +51,8 @@ describe("useAttendanceRowHighlight", () => {
       attendanceMap: new Map([["show-attended", { id: "att-1" } as never]]),
       userRatingMap: new Map(),
       averageRatingMap: new Map(),
+      displayedRatingMap: new Map(),
+      rankComparisonMap: new Map(),
       isLoading: false,
       error: null,
     });
@@ -84,6 +90,8 @@ describe("useAttendanceRowHighlight", () => {
       attendanceMap: new Map([["show-yes", { id: "att-1" } as never]]),
       userRatingMap: new Map(),
       averageRatingMap: new Map(),
+      displayedRatingMap: new Map(),
+      rankComparisonMap: new Map(),
       isLoading: false,
       error: null,
     });
@@ -126,6 +134,8 @@ describe("useAttendanceRowHighlight", () => {
       attendanceMap: new Map(),
       userRatingMap: mockUserRatingMap,
       averageRatingMap: mockAverageRatingMap,
+      displayedRatingMap: new Map(),
+      rankComparisonMap: new Map(),
       isLoading: false,
       error: null,
     });

--- a/apps/web/app/hooks/use-feature-flags.ts
+++ b/apps/web/app/hooks/use-feature-flags.ts
@@ -1,0 +1,27 @@
+import type { FeatureFlags } from "@bip/core";
+import { useRouteLoaderData } from "react-router";
+import type { RootData } from "~/root";
+
+// Used when the root loader data isn't available (e.g. inside the error
+// boundary, or a component rendered outside the route tree in tests): every
+// flag reads off, so the app degrades to its pre-feature behavior.
+const FLAGS_OFF: FeatureFlags = {
+  calibratedEnabled: false,
+  toggleVisible: false,
+  defaultCalibrated: false,
+  compareVisible: false,
+  explainerNavLink: false,
+  recomputeEnabled: false,
+};
+
+/**
+ * Reads the feature flags resolved server-side in the root loader. Lets a
+ * client component check a flag at the point of use (`useFeatureFlags().toggleVisible`)
+ * so it's obvious a flag is gating the behavior, instead of receiving an opaque
+ * boolean prop resolved somewhere up the tree. SSR-seeded, so the first paint
+ * already has the right values.
+ */
+export function useFeatureFlags(): FeatureFlags {
+  const rootData = useRouteLoaderData("root") as RootData | undefined;
+  return rootData?.featureFlags ?? FLAGS_OFF;
+}

--- a/apps/web/app/hooks/use-show-user-data.ts
+++ b/apps/web/app/hooks/use-show-user-data.ts
@@ -1,3 +1,4 @@
+import type { ShowRankComparison } from "@bip/core";
 import type { Attendance } from "@bip/domain";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
@@ -9,6 +10,8 @@ interface UseShowUserDataResult {
   attendanceMap: Map<string, Attendance | null>;
   userRatingMap: Map<string, number | null>;
   averageRatingMap: Map<string, { average: number; count: number } | null>;
+  displayedRatingMap: Map<string, { rating: number; count: number }>;
+  rankComparisonMap: Map<string, ShowRankComparison>;
   isLoading: boolean;
   error: Error | null;
 }
@@ -18,12 +21,16 @@ function mergeShowUserData(results: ShowUserDataResponse[]): ShowUserDataRespons
     attendances: {},
     userRatings: {},
     averageRatings: {},
+    displayedRatings: {},
+    rankComparisons: {},
   };
 
   for (const result of results) {
     Object.assign(merged.attendances, result.attendances);
     Object.assign(merged.userRatings, result.userRatings);
     Object.assign(merged.averageRatings, result.averageRatings);
+    Object.assign(merged.displayedRatings, result.displayedRatings);
+    Object.assign(merged.rankComparisons, result.rankComparisons);
   }
 
   return merged;
@@ -71,10 +78,32 @@ export function useShowUserData(showIds: string[]): UseShowUserDataResult {
     return map;
   }, [data?.averageRatings]);
 
+  const displayedRatingMap = useMemo(() => {
+    const map = new Map<string, { rating: number; count: number }>();
+    if (data?.displayedRatings) {
+      for (const [showId, value] of Object.entries(data.displayedRatings)) {
+        map.set(showId, value);
+      }
+    }
+    return map;
+  }, [data?.displayedRatings]);
+
+  const rankComparisonMap = useMemo(() => {
+    const map = new Map<string, ShowRankComparison>();
+    if (data?.rankComparisons) {
+      for (const [showId, value] of Object.entries(data.rankComparisons)) {
+        map.set(showId, value);
+      }
+    }
+    return map;
+  }, [data?.rankComparisons]);
+
   return {
     attendanceMap,
     userRatingMap,
     averageRatingMap,
+    displayedRatingMap,
+    rankComparisonMap,
     isLoading,
     error: error as Error | null,
   };

--- a/apps/web/app/lib/musicians-constants.ts
+++ b/apps/web/app/lib/musicians-constants.ts
@@ -3,7 +3,7 @@
 // reference these values without the server-import-leak guardrail dragging
 // core into the client bundle.
 
-import type { ShowLineupMember } from "@bip/domain";
+import { DRUMMER_ERA_INFO, eraDateWindow, type ShowLineupMember } from "@bip/domain";
 
 // Mirrors MARLON_LINEUP_SLUGS in @bip/core/musicians/musician-constants. Kept
 // as a literal here rather than imported so this module stays free of any
@@ -14,13 +14,12 @@ const MARLON_LINEUP_SLUGS = ["jon-gutwillig", "marc-brownstein", "aron-magner", 
  * Drummer-era windows keyed by the drummer's musician slug. A drummer's
  * everyday appearances fall inside their window; the notable signal on a
  * drummer's profile is an appearance OUTSIDE it (a sit-in before or after their
- * tenure). Date ranges mirror the era filters in song-filters.ts.
+ * tenure). Derived from DRUMMER_ERA_INFO (@bip/domain) so the boundary dates
+ * live in one place.
  */
-export const DRUMMER_ERAS: Record<string, { startDate?: Date; endDate?: Date }> = {
-  "sam-altman": { endDate: new Date("2005-08-27") },
-  "allen-aucoin": { startDate: new Date("2005-12-28"), endDate: new Date("2025-09-07") },
-  "marlon-lewis": { startDate: new Date("2025-10-31") },
-};
+export const DRUMMER_ERAS: Record<string, { startDate?: Date; endDate?: Date }> = Object.fromEntries(
+  DRUMMER_ERA_INFO.map((info) => [info.musicianSlug, eraDateWindow(info)]),
+);
 
 /**
  * True when a date sits outside the given era window (before its start or after
@@ -47,11 +46,9 @@ export const EXPECTED_CORE_MEMBERS: ExpectedMember[] = [
 ];
 
 /** Drummer names keyed by slug, paired with their era window in DRUMMER_ERAS. */
-const DRUMMER_NAMES: Record<string, string> = {
-  "sam-altman": "Sam Altman",
-  "allen-aucoin": "Allen Aucoin",
-  "marlon-lewis": "Marlon Lewis",
-};
+const DRUMMER_NAMES: Record<string, string> = Object.fromEntries(
+  DRUMMER_ERA_INFO.map((info) => [info.musicianSlug, info.drummerName]),
+);
 
 /**
  * The members expected in the lineup for a show on the given date: the three

--- a/apps/web/app/lib/song-filters.ts
+++ b/apps/web/app/lib/song-filters.ts
@@ -1,3 +1,5 @@
+import { DRUMMER_ERA_INFO, eraDateWindow } from "@bip/domain";
+
 export interface SongFilterConfig {
   label: string;
   startDate?: Date;
@@ -20,10 +22,14 @@ const yearFilters: Record<string, SongFilterConfig> = Object.fromEntries(
   }),
 );
 
+// Drummer-era options derived from DRUMMER_ERA_INFO so the boundary dates live in
+// one place; `triscuits` is a special short window, not a drummer era.
+const drummerEraFilters: Record<string, SongFilterConfig> = Object.fromEntries(
+  DRUMMER_ERA_INFO.map((info) => [info.filterKey, { label: info.filterLabel, ...eraDateWindow(info) }]),
+);
+
 const eraFilters: Record<string, SongFilterConfig> = {
-  sammy: { label: "Sammy Era", endDate: new Date("2005-08-27") },
-  allen: { label: "Allen Era", startDate: new Date("2005-12-28"), endDate: new Date("2025-09-07") },
-  marlon: { label: "Marlon Era", startDate: new Date("2025-10-31") },
+  ...drummerEraFilters,
   triscuits: { label: "Triscuits", startDate: new Date("2000-03-11"), endDate: new Date("2000-07-12") },
 };
 

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -1,4 +1,5 @@
 import type { Route } from ".react-router/types/app/+types/root";
+import { type FeatureFlags, getFeatureFlags } from "@bip/core";
 import { type DehydratedState, HydrationBoundary } from "@tanstack/react-query";
 import { useMemo } from "react";
 import {
@@ -30,6 +31,12 @@ import stylesheet from "./styles.css?url";
 export type RootData = {
   env: ClientSideEnv;
   sessionUser: SessionUser | null;
+  /**
+   * Feature flags resolved once for the whole app so client components
+   * can read them at the point of use via `useFeatureFlags()` instead of having
+   * individual flag values threaded down as props.
+   */
+  featureFlags: FeatureFlags;
 };
 
 export type ClientSideEnv = {
@@ -52,10 +59,19 @@ export async function loader({ request }: Route.LoaderArgs): Promise<RootData> {
   // Seed useSession's initial state so user-specific UI paints on the
   // first frame instead of after supabase.auth.getSession() resolves.
   const user = await getRequestUser(request);
+  const sessionUser = user ? toSessionUser(user) : null;
+
+  // Resolve feature flags once here for the whole app; client components read them
+  // via useFeatureFlags(). Segment-targeted flags match on username, which the
+  // session user carries, so no extra DB lookup is needed.
+  const featureFlags = await getFeatureFlags(
+    sessionUser?.username ? { user: { username: sessionUser.username } } : undefined,
+  );
 
   return {
     env: clientEnv,
-    sessionUser: user ? toSessionUser(user) : null,
+    sessionUser,
+    featureFlags,
   };
 }
 

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -10,6 +10,7 @@ export default [
 
   // Legal and info pages
   route("about", "routes/about.tsx"),
+  route("show-rating-algorithm", "routes/show-rating-algorithm.tsx"),
   route("terms", "routes/terms.tsx"),
   route("privacy", "routes/privacy.tsx"),
   route("community", "routes/community.tsx"),

--- a/apps/web/app/routes/api/cron/$action.tsx
+++ b/apps/web/app/routes/api/cron/$action.tsx
@@ -1,3 +1,4 @@
+import { getFeatureFlags, runRatingsRecompute } from "@bip/core";
 import type { ActionFunctionArgs } from "react-router";
 import { logger } from "~/lib/logger";
 import { services } from "~/server/services";
@@ -74,9 +75,53 @@ async function refreshCommunityCache(): Promise<CronJobResult> {
   }
 }
 
+/**
+ * Hourly full rating recompute (and deploy-time backfill via the same routine).
+ * Gated by the `ratings.recompute-enabled` flag, then dirty-gated internally so it
+ * no-ops cheaply when no ratings changed since the last run.
+ */
+async function recomputeRatings(): Promise<CronJobResult> {
+  const startTime = Date.now();
+
+  try {
+    const flags = await getFeatureFlags();
+    if (!flags.recomputeEnabled) {
+      return {
+        success: true,
+        message: "Ratings recompute disabled by flag",
+        duration: Date.now() - startTime,
+        timestamp: new Date().toISOString(),
+      };
+    }
+
+    const result = await runRatingsRecompute({
+      raterWeights: services.raterWeights,
+      ratings: services.ratings,
+      logger,
+    });
+    const duration = Date.now() - startTime;
+    const message = result.ran
+      ? `Recomputed ratings: ${result.users} raters, ${result.shows} shows, ${result.rateables} canonical averages, anchor ${result.anchor?.toFixed(3)}`
+      : "Ratings unchanged since last recompute; skipped";
+    logger.info(message);
+
+    return { success: true, message, duration, timestamp: new Date().toISOString() };
+  } catch (error) {
+    const duration = Date.now() - startTime;
+    logger.error("Failed to recompute ratings", { error });
+    return {
+      success: false,
+      message: `Failed to recompute ratings: ${error instanceof Error ? error.message : "Unknown error"}`,
+      duration,
+      timestamp: new Date().toISOString(),
+    };
+  }
+}
+
 // Map of available cron jobs
 const cronJobs: Record<string, () => Promise<CronJobResult>> = {
   "community-refresh": refreshCommunityCache,
+  "recompute-ratings": recomputeRatings,
 };
 
 export async function action({ params, request }: ActionFunctionArgs) {

--- a/apps/web/app/routes/api/users.tsx
+++ b/apps/web/app/routes/api/users.tsx
@@ -1,3 +1,4 @@
+import { getFeatureFlags } from "@bip/core";
 import type { ActionFunctionArgs } from "react-router-dom";
 import { z } from "zod";
 import honeybadger from "~/lib/honeybadger";
@@ -7,6 +8,9 @@ import { getServerClient } from "~/server/supabase";
 
 const updateUserSchema = z.object({
   username: z.string().min(3).max(50).optional(),
+  // Toggles arrive as "true"/"false" strings; persistence is flag-gated below.
+  showCalibratedRatings: z.enum(["true", "false"]).optional(),
+  showRatingComparisonDebug: z.enum(["true", "false"]).optional(),
 });
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -63,7 +67,20 @@ export async function action({ request }: ActionFunctionArgs) {
       }
     }
 
-    const updatedUser = await services.users.update(localUser.id, validatedData);
+    // Build the update explicitly: persist a rating pref only if the matching flag
+    // makes that toggle visible for this user (so an ineligible user can't set it via
+    // a crafted POST), and coerce the "true"/"false" strings to booleans.
+    const update: { username?: string; showCalibratedRatings?: boolean; showRatingComparisonDebug?: boolean } = {};
+    if (validatedData.username) update.username = validatedData.username;
+    const flags = await getFeatureFlags({ user: { id: localUser.id, username: localUser.username } });
+    if (flags.toggleVisible && validatedData.showCalibratedRatings !== undefined) {
+      update.showCalibratedRatings = validatedData.showCalibratedRatings === "true";
+    }
+    if (flags.compareVisible && validatedData.showRatingComparisonDebug !== undefined) {
+      update.showRatingComparisonDebug = validatedData.showRatingComparisonDebug === "true";
+    }
+
+    const updatedUser = await services.users.update(localUser.id, update);
 
     if (!updatedUser) {
       return new Response(JSON.stringify({ error: "Failed to update user" }), {

--- a/apps/web/app/routes/mcp/index.tsx
+++ b/apps/web/app/routes/mcp/index.tsx
@@ -571,12 +571,17 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
         pagination: { page: 1, limit },
       });
 
+      const calibratedByShowId = await services.raterWeights.getDisplayedForShows(shows.map((s) => s.id));
+
       return {
         venue: { slug: venue.slug, name: venue.name, city: venue.city, state: venue.state },
         shows: shows.map((show) => ({
           slug: show.slug,
           date: show.date,
           averageRating: show.averageRating,
+          // Calibrated Show Rating (entropy-weighted, bias-centered, count-shrunk);
+          // null until the rating recompute has populated it.
+          calibratedRating: calibratedByShowId[show.id]?.rating ?? null,
           ratingsCount: show.ratingsCount,
         })),
       };
@@ -598,6 +603,8 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
         includes: ["venue"],
       });
 
+      const calibratedByShowId = await services.raterWeights.getDisplayedForShows(shows.map((s) => s.id));
+
       return {
         year,
         shows: shows.map((show) => ({
@@ -606,6 +613,9 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
           venueName: show.venue?.name || "",
           venueCity: show.venue?.city || "",
           averageRating: show.averageRating,
+          // Calibrated Show Rating (entropy-weighted, bias-centered, count-shrunk);
+          // null until the rating recompute has populated it.
+          calibratedRating: calibratedByShowId[show.id]?.rating ?? null,
         })),
       };
     }
@@ -729,9 +739,10 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
         try {
           const show = await services.shows.findBySlug(slug);
           if (show) {
-            const [venue, rockOperaAnnotations] = await Promise.all([
+            const [venue, rockOperaAnnotations, calibratedByShowId] = await Promise.all([
               show.venueId ? services.venues.findById(show.venueId) : Promise.resolve(null),
               services.rockOperas.findPerformancesForShow(show.id),
+              services.raterWeights.getDisplayedForShows([show.id]),
             ]);
             shows.push({
               // Preserved so sync-missing-shows can insert local rows with
@@ -743,6 +754,10 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
               venueName: venue?.name,
               venueCity: venue?.city,
               averageRating: show.averageRating,
+              // Calibrated Show Rating (entropy-weighted, bias-centered, count-shrunk);
+              // null until the rating recompute has populated it. Not consumed by
+              // sync-missing-shows, which recomputes the calibrated score locally.
+              calibratedRating: calibratedByShowId[show.id]?.rating ?? null,
               ratingsCount: show.ratingsCount,
               notes: show.notes,
               relistenUrl: show.relistenUrl,

--- a/apps/web/app/routes/show-rating-algorithm.tsx
+++ b/apps/web/app/routes/show-rating-algorithm.tsx
@@ -1,0 +1,260 @@
+import { Card, CardContent } from "~/components/ui/card";
+
+export function meta() {
+  return [
+    { title: "How show ratings work | Biscuits Internet Project" },
+    {
+      name: "description",
+      content:
+        "How the Calibrated Show Rating works: entropy weighting, bias-centering, bad-faith exclusion, duplicate-account de-duplication, and count-shrinkage, and how it draws on (and differs from) the phish.net ratings research.",
+    },
+  ];
+}
+
+const POSTS = {
+  part1: "https://phish.net/blog/1724255149/phishnet-show-ratings-part-1-an-introduction-to-the-ratings-database",
+  part2: "https://phish.net/blog/1724255474/phishnet-show-ratings-part-2-fluffers-bombers-and-other-anomalous-raters",
+  part3:
+    "https://phish.net/blog/1724255820/phishnet-show-ratings-part-3-variance-and-bias-in-ratings-whats-the-problem",
+  part4:
+    "https://phish.net/blog/1724255981/phishnet-show-ratings-part-4-can-rater-weights-improve-the-accuracy-of-show-ratings.html",
+};
+
+function PostLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" className="text-brand-primary hover:underline">
+      {children}
+    </a>
+  );
+}
+
+/**
+ * Public explainer for the Calibrated Show Rating. Always reachable by direct URL
+ * (the `ratings.explainer-nav-link` flag gates only the nav link, not this page).
+ * Written to be accurate enough to share with the phish.net ratings author whose
+ * series it builds on. Static content, no loader.
+ */
+export default function ShowRatingAlgorithm() {
+  return (
+    <div className="space-y-6 md:space-y-8">
+      <div>
+        <h1 className="page-heading">HOW SHOW RATINGS WORK</h1>
+      </div>
+
+      <div className="grid gap-6 md:gap-8">
+        <Card variant="panel">
+          <CardContent className="p-6">
+            <div className="prose prose-invert max-w-none space-y-4">
+              <p className="text-content-text-secondary">
+                Every show has a <strong className="text-content-text-primary">community average</strong>, the plain
+                mean of fans' star ratings. It is simple and transparent, but a raw average is easy to skew: a handful
+                of people who rate everything 5 (or everything 0.5), or one person voting from several accounts, can
+                move a show more than they should.
+              </p>
+              <p className="text-content-text-secondary">
+                The <strong className="text-content-text-primary">Calibrated Show Rating</strong> is an opt-in
+                alternative that tries to measure the same thing, how good the show was, while being much harder to
+                skew. Everyone sees the community average by default; you can switch on the Calibrated Show Rating in
+                your profile settings.
+              </p>
+              <p className="text-content-text-secondary">
+                This work is directly inspired by Paul Jakus's four-part series on rating shows for phish.net:{" "}
+                <PostLink href={POSTS.part1}>Part 1 (the ratings database)</PostLink>,{" "}
+                <PostLink href={POSTS.part2}>Part 2 (fluffers, bombers, and anomalous raters)</PostLink>,{" "}
+                <PostLink href={POSTS.part3}>Part 3 (variance and bias)</PostLink>, and{" "}
+                <PostLink href={POSTS.part4}>Part 4 (can rater weights improve accuracy?)</PostLink>. We use his core
+                tools but combine them differently; the section "How this differs from the proposed phish.net method"
+                below explains why.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card variant="panel">
+          <CardContent className="p-6">
+            <h2 className="text-2xl font-semibold text-content-text-primary mb-4">What the calibration does</h2>
+            <div className="space-y-5">
+              <div>
+                <h3 className="text-lg font-medium text-content-text-primary mb-1">Weights raters by how they rate</h3>
+                <p className="text-content-text-secondary text-sm">
+                  A rater who uses the whole 0.5 to 5 star scale carries more weight than a one-note rater who gives
+                  nearly everything the same score. The measure is statistical{" "}
+                  <em className="text-content-text-primary">entropy</em>: the more a person's ratings spread across the
+                  scale, the more information each one carries. A considered contrarian who uses the full scale keeps
+                  full weight; disagreement is never penalized.
+                </p>
+              </div>
+              <div>
+                <h3 className="text-lg font-medium text-content-text-primary mb-1">Removes each rater's bias</h3>
+                <p className="text-content-text-secondary text-sm">
+                  Some people run hot, some run cold. Each rating is{" "}
+                  <em className="text-content-text-primary">centered</em>: shifted by the gap between that rater's own
+                  average and the population average, so what counts is whether they liked a show more or less than they
+                  usually do, not whether they are a generous grader.
+                </p>
+              </div>
+              <div>
+                <h3 className="text-lg font-medium text-content-text-primary mb-1">Drops clear bad-faith raters</h3>
+                <p className="text-content-text-secondary text-sm">
+                  Accounts that hand out essentially one extreme value (all near 0.5, the "bombers", or all near 5, the
+                  "fluffers") are dropped from the calibrated score. Everyone else, including good-faith dissent, still
+                  counts.
+                </p>
+              </div>
+              <div>
+                <h3 className="text-lg font-medium text-content-text-primary mb-1">Counts each person once</h3>
+                <p className="text-content-text-secondary text-sm">
+                  One human who rated under several usernames is collapsed to a single most-recent vote, so
+                  re-registered or duplicate accounts cannot double-count. This de-duplication applies to the community
+                  average too.
+                </p>
+              </div>
+              <div>
+                <h3 className="text-lg font-medium text-content-text-primary mb-1">Does not over-reward thin shows</h3>
+                <p className="text-content-text-secondary text-sm">
+                  A show with only a few ratings is pulled toward the global average until enough people weigh in, so a
+                  lone 5-star vote cannot vault an obscure show to the top.
+                </p>
+              </div>
+              <div>
+                <h3 className="text-lg font-medium text-content-text-primary mb-1">Treats new raters fairly</h3>
+                <p className="text-content-text-secondary text-sm">
+                  A brand-new or low-volume rater would otherwise carry almost no weight. Their score is blended toward
+                  the typical rater until they have rated enough shows, so a newcomer's vote still moves the number.
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card variant="panel">
+          <CardContent className="p-6">
+            <h2 className="text-2xl font-semibold text-content-text-primary mb-4">
+              How this differs from the proposed phish.net method
+            </h2>
+            <div className="prose prose-invert max-w-none space-y-4">
+              <p className="text-content-text-secondary">
+                Jakus's series established the foundation we build on: two metrics, a rater's{" "}
+                <em className="text-content-text-primary">average deviation</em> and{" "}
+                <em className="text-content-text-primary">entropy</em>, can identify anomalous raters (
+                <PostLink href={POSTS.part2}>Part 2</PostLink>); those anomalous raters add bias to a show's average (
+                <PostLink href={POSTS.part3}>Part 3</PostLink>); and a RateYourMusic-style{" "}
+                <em className="text-content-text-primary">rater weighting</em> can correct for them (
+                <PostLink href={POSTS.part4}>Part 4</PostLink>). In his scheme each rater earns a single trust weight
+                (roughly 0, 0.25, 0.5, or 1) from those metrics, and the show's rating becomes a weighted average of raw
+                scores. On phish.net's large database, every weighted variant correlated more closely with setlist
+                quality than the simple average.
+              </p>
+              <p className="text-content-text-secondary">
+                We started in exactly that place, with the same two metrics and the same validity test (below). Two
+                things led us to a different estimator:
+              </p>
+              <ul className="text-content-text-secondary text-sm space-y-2 list-disc pl-5">
+                <li>
+                  <strong className="text-content-text-primary">Scale.</strong> The Disco Biscuits ratings database is
+                  far smaller than phish.net's. When we ran the discrete trust-weighting on it, it barely moved the
+                  rankings; the large gains the method showed on phish.net did not reproduce at our size.
+                </li>
+                <li>
+                  <strong className="text-content-text-primary">We did not want to discard raters.</strong> A trust
+                  weight of 0 throws a person out entirely, and the cutoff and weight values are admittedly hand-chosen
+                  (a point the series itself flags as unfinished).
+                </li>
+              </ul>
+              <p className="text-content-text-secondary">
+                So rather than assign a discrete trust weight, the Calibrated Show Rating keeps everyone and corrects
+                them continuously. It <strong className="text-content-text-primary">centers out</strong> each rater's
+                bias (Jakus's Part 3 problem) instead of down-weighting them, weights by entropy on a smooth 0-to-1
+                scale, and only fully drops the unambiguous one-note bombers and fluffers. It also adds two steps his
+                posts did not need: <strong className="text-content-text-primary">collapsing duplicate accounts</strong>{" "}
+                (a site rewrite here left many stub and re-registered logins) and{" "}
+                <strong className="text-content-text-primary">shrinking thin shows</strong> toward the overall average.
+                The spirit is "calibrate every rater" rather than "weight or discard raters." His series works through
+                the same problems, grader bias, thin samples, and gaming, for a sibling jam-band dataset.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card variant="panel">
+          <CardContent className="p-6">
+            <h2 className="text-2xl font-semibold text-content-text-primary mb-4">Does it work?</h2>
+            <p className="text-content-text-secondary text-sm mb-4">
+              We test it the way the phish.net research does, with a{" "}
+              <em className="text-content-text-primary">convergent validity</em> check: a better rating should line up
+              more closely with independent signs that a show was notable, here, its tracks on the community jam-chart /
+              all-timer list. We measure that agreement with a{" "}
+              <em className="text-content-text-primary">rank correlation</em> that runs from 0 (no relationship) to 1
+              (perfect agreement). Across the roughly 1,150 shows with at least 10 ratings (as of June 2026), the
+              calibrated rating tracks both how many all-timers a show has and their total length more closely than the
+              raw community average:
+            </p>
+            <div className="overflow-x-auto">
+              <table className="text-sm tabular-nums">
+                <thead>
+                  <tr className="text-content-text-tertiary text-left">
+                    <th className="px-3 py-1.5 font-normal">Rating</th>
+                    <th className="px-3 py-1.5 font-normal"># of all-timers</th>
+                    <th className="px-3 py-1.5 font-normal">Length of all-timers</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-glass-border/30 border-t">
+                    <td className="px-3 py-1.5 text-content-text-secondary">Community average</td>
+                    <td className="px-3 py-1.5 text-content-text-primary">0.54</td>
+                    <td className="px-3 py-1.5 text-content-text-primary">0.53</td>
+                  </tr>
+                  <tr className="border-glass-border/30 border-t">
+                    <td className="px-3 py-1.5 text-content-text-secondary">Calibrated Show Rating</td>
+                    <td className="px-3 py-1.5 text-content-text-primary font-semibold">0.58</td>
+                    <td className="px-3 py-1.5 text-content-text-primary font-semibold">0.56</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p className="text-content-text-tertiary text-xs mt-3">
+              Higher is better (0 to 1). The calibrated rating agrees more closely with the editorial jam-chart signals
+              than the raw average on both measures, and it held or improved at every cleaning step, with de-duplication
+              helping most.
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card variant="panel">
+          <CardContent className="p-6">
+            <h2 className="text-2xl font-semibold text-content-text-primary mb-4">Other approaches we tried</h2>
+            <p className="text-content-text-secondary text-sm mb-3">
+              We measured several alternatives against the same validity yardstick. These did worse and were dropped:
+            </p>
+            <ul className="text-content-text-secondary text-sm space-y-2 list-disc pl-5">
+              <li>
+                <strong className="text-content-text-primary">Scoping each rater to a slice of band history.</strong>{" "}
+                Measuring a rater's habits only within one stretch of the band's history actually correlated worse than
+                the plain average.
+              </li>
+              <li>
+                <strong className="text-content-text-primary">Discrete trust-weighting.</strong> The phish.net-style
+                weighted average barely moved our smaller dataset.
+              </li>
+              <li>
+                <strong className="text-content-text-primary">Z-score normalization.</strong> Rescaling each rater's
+                spread (not just removing their bias) did not beat plain bias-centering.
+              </li>
+              <li>
+                <strong className="text-content-text-primary">Anchoring on the scale midpoint.</strong> Centering on the
+                middle of the star scale instead of the crowd average did not help.
+              </li>
+              <li>
+                <strong className="text-content-text-primary">Gating the entropy weight.</strong> Turning the weight on
+                or off at a threshold added complexity without improving accuracy.
+              </li>
+            </ul>
+            <p className="text-content-text-secondary text-sm mt-3">
+              Plain global entropy-weighted bias-centering won, which is what the Calibrated Show Rating uses.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/routes/shows/$slug.tsx
+++ b/apps/web/app/routes/shows/$slug.tsx
@@ -152,8 +152,15 @@ export default function Show() {
   const { user } = useSession();
   const revalidator = useRevalidator();
   const [setlistView, setSetlistView] = useSetlistView();
-  const { userRatingMap, attendanceMap } = useShowUserData([setlist.show.id]);
+  const { userRatingMap, attendanceMap, displayedRatingMap, rankComparisonMap } = useShowUserData([setlist.show.id]);
   const userRating = userRatingMap.get(setlist.show.id) ?? null;
+  // Displayed ★ is the viewer's calibrated score when their mode resolves to calibrated
+  // (server sends it only then), else the canonical average. In calibrated mode the
+  // count beside it is the post-exclusion contributing count, not the deduped count.
+  const displayed = displayedRatingMap.get(setlist.show.id);
+  const displayedShowRating = displayed?.rating ?? setlist.show.averageRating;
+  // Comparison overlay data, present only for viewers with the overlay enabled.
+  const rankComparison = rankComparisonMap.get(setlist.show.id) ?? null;
   const userAttendance = attendanceMap.get(setlist.show.id) ?? null;
 
   const internalUserId = user?.internalUserId ?? undefined;
@@ -313,7 +320,9 @@ export default function Show() {
             setlist={setlist}
             userAttendance={userAttendance}
             userRating={userRating}
-            showRating={setlist.show.averageRating}
+            showRating={displayedShowRating}
+            showRatingCount={displayed?.count ?? null}
+            rankComparison={rankComparison}
             externalSources={externalSources}
             defaultView={setlistView}
             onViewChange={setSetlistView}

--- a/apps/web/app/routes/shows/top-rated-shows.ts
+++ b/apps/web/app/routes/shows/top-rated-shows.ts
@@ -1,5 +1,5 @@
-import type { FilterCondition } from "@bip/core/_shared/database/types";
-import type { Setlist, Show } from "@bip/domain";
+import type { RatingMode } from "@bip/core";
+import type { Setlist } from "@bip/domain";
 import { type DehydratedState, dehydrate } from "@tanstack/react-query";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
 import type { PublicContext } from "~/lib/base-loaders";
@@ -8,6 +8,7 @@ import { createPrefetchClient } from "~/lib/query-prefetch";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
 import { computeShowUserData } from "~/server/show-user-data";
+import { resolveViewerRatingMode } from "~/server/viewer-rating";
 
 const MIN_SHOW_RATINGS = 10;
 const TOP_RATED_LIMIT = 100;
@@ -15,6 +16,7 @@ const TOP_RATED_LIMIT = 100;
 export interface TopRatedShowsLoaderData {
   setlists: Setlist[];
   year: number | null;
+  mode: RatingMode;
   minShowRatings: number;
   countsByYear: Record<number, number>;
   allCount: number;
@@ -26,44 +28,21 @@ export async function getTopRatedShows(
   year: number | null,
   context: Pick<PublicContext, "currentUser">,
 ): Promise<TopRatedShowsLoaderData> {
-  const yearFilters: FilterCondition<Show>[] = year
-    ? [
-        {
-          field: "date",
-          operator: "gte",
-          value: `${year}-01-01`,
-        },
-        {
-          field: "date",
-          operator: "lte",
-          value: `${year}-12-31`,
-        },
-      ]
-    : [];
-  const shows = await services.shows.search("", {
-    pagination: { page: 1, limit: TOP_RATED_LIMIT },
-    sort: [
-      { field: "averageRating", direction: "desc" },
-      { field: "ratingsCount", direction: "desc" },
-      { field: "date", direction: "desc" },
-    ],
-    filters: [
-      {
-        field: "averageRating",
-        operator: "gt",
-        value: 0,
-      },
-      {
-        field: "ratingsCount",
-        operator: "gt",
-        value: MIN_SHOW_RATINGS,
-      },
-      ...yearFilters,
-    ],
-    includes: ["venue"],
-  });
+  // Reorder per viewer: calibrated-mode viewers see the shrunk weighted ranking,
+  // everyone else the canonical-average ranking.
+  const { mode } = await resolveViewerRatingMode(context);
+  // The calibrated score already shrinks thin shows toward the global average, so
+  // it needs no ratings floor; the simple average has no such guard, so it keeps one
+  // (else a single 5.0 vote tops the list).
+  const minRatings = mode === "calibrated" ? 0 : MIN_SHOW_RATINGS;
 
-  const showIds = shows.map((show) => show.id);
+  // One eligible+ranked set feeds both the list and the year-picker counts, so the
+  // counts can't disagree with what the list shows.
+  const ranked = await services.raterWeights.rankedShows(mode, minRatings);
+  const showYear = (date: string) => Number(date.slice(0, 4));
+
+  const inScope = year ? ranked.filter((show) => showYear(show.date) === year) : ranked;
+  const showIds = inScope.slice(0, TOP_RATED_LIMIT).map((show) => show.id);
   const rawSetlists = await services.setlists.findManyByShowIds(showIds);
   // findManyByShowIds defaults to `date DESC` ordering, which wipes out the
   // rank order from the shows query. Reindex back into rank order here.
@@ -78,27 +57,24 @@ export async function getTopRatedShows(
     queryFn: () => computeShowUserData(context, showIds),
   });
 
-  // Per-year counts for the year picker, capped by the page's row limit so
-  // the number matches what actually appears when the user clicks that year.
-  // Each year route returns at most TOP_RATED_LIMIT rows.
-  const ratedShows = await services.shows.findMany({
-    filters: [{ field: "ratingsCount", operator: "gt", value: MIN_SHOW_RATINGS }],
-  });
+  // Per-year counts for the year picker, grouped off the same ranked set, capped
+  // by the page's row limit so each number matches what the list shows when that
+  // year is opened.
   const countsByYear: Record<number, number> = {};
-  for (const show of ratedShows) {
-    const showYear = Number(String(show.date).slice(0, 4));
-    countsByYear[showYear] = (countsByYear[showYear] ?? 0) + 1;
+  for (const show of ranked) {
+    const yr = showYear(show.date);
+    countsByYear[yr] = (countsByYear[yr] ?? 0) + 1;
   }
-  for (const yearKey of Object.keys(countsByYear)) {
-    const n = Number(yearKey);
-    countsByYear[n] = Math.min(countsByYear[n], TOP_RATED_LIMIT);
+  for (const yr of Object.keys(countsByYear)) {
+    countsByYear[Number(yr)] = Math.min(countsByYear[Number(yr)], TOP_RATED_LIMIT);
   }
-  const allCount = Math.min(ratedShows.length, TOP_RATED_LIMIT);
+  const allCount = Math.min(ranked.length, TOP_RATED_LIMIT);
 
   return {
     setlists,
     year,
-    minShowRatings: MIN_SHOW_RATINGS,
+    mode,
+    minShowRatings: minRatings,
     countsByYear,
     allCount,
     externalSources,

--- a/apps/web/app/routes/shows/top-rated.test.tsx
+++ b/apps/web/app/routes/shows/top-rated.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+// Mock the loader module so importing the route component never pulls
+// @bip/core / Prisma into the test bundle (the component only needs the type).
+vi.mock("~/routes/shows/top-rated-shows", () => ({ getTopRatedShows: vi.fn() }));
+vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
+vi.mock("~/components/setlist/setlist-list", () => ({
+  SetlistList: () => <div data-testid="SetlistList" />,
+}));
+// Surface YearFilterNav's qualifier so we can assert the mode-aware copy.
+vi.mock("~/components/year-filter-nav", () => ({
+  YearFilterNav: ({ additionalText }: { additionalText: string }) => (
+    <div data-testid="qualifier">{additionalText}</div>
+  ),
+}));
+vi.mock("~/hooks/use-serialized-loader-data", () => ({ useSerializedLoaderData: vi.fn() }));
+
+import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
+import TopRated from "./top-rated";
+
+const base = {
+  setlists: [],
+  year: null,
+  countsByYear: {},
+  allCount: 0,
+  externalSources: {},
+  dehydratedState: { mutations: [], queries: [] },
+};
+
+// The top-rated list qualifier reflects the viewer's mode: the simple average
+// keeps a ratings floor (its only guard against a single-vote show topping the
+// list), while the calibrated score shrinks thin shows and needs no floor.
+describe("TopRated qualifier copy", () => {
+  test("simple mode shows the ratings floor", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValue({ ...base, mode: "simple", minShowRatings: 10 });
+    render(<TopRated />);
+    expect(screen.getByTestId("qualifier")).toHaveTextContent("min 10 ratings");
+  });
+
+  test("calibrated mode drops the floor", () => {
+    vi.mocked(useSerializedLoaderData).mockReturnValue({ ...base, mode: "calibrated", minShowRatings: 0 });
+    render(<TopRated />);
+    expect(screen.getByTestId("qualifier")).toHaveTextContent("all rated shows");
+  });
+});

--- a/apps/web/app/routes/shows/top-rated.tsx
+++ b/apps/web/app/routes/shows/top-rated.tsx
@@ -23,7 +23,7 @@ export function meta({ params }: { params: { year?: string } }) {
 }
 
 export default function TopRated() {
-  const { setlists, year, minShowRatings, countsByYear, allCount, externalSources } =
+  const { setlists, year, mode, minShowRatings, countsByYear, allCount, externalSources } =
     useSerializedLoaderData<TopRatedShowsLoaderData>();
 
   return (
@@ -36,7 +36,7 @@ export default function TopRated() {
           currentYear={year}
           basePath="/shows/top-rated/"
           showAllButton={true}
-          additionalText={`min ${minShowRatings} ratings`}
+          additionalText={mode === "calibrated" ? "all rated shows" : `min ${minShowRatings} ratings`}
           counts={countsByYear}
           allCount={allCount}
         />

--- a/apps/web/app/routes/users/$username.test.tsx
+++ b/apps/web/app/routes/users/$username.test.tsx
@@ -9,6 +9,17 @@ vi.mock("~/server/services", () => ({ services: {} }));
 vi.mock("~/server/show-external-sources", () => ({ computeShowExternalSources: vi.fn() }));
 vi.mock("~/server/show-user-data", () => ({ computeShowUserData: vi.fn() }));
 vi.mock("~/lib/base-loaders", () => ({ publicLoader: vi.fn() }));
+// The rating-display card reads flags via this hook; off by default in these tests.
+vi.mock("~/hooks/use-feature-flags", () => ({
+  useFeatureFlags: () => ({
+    calibratedEnabled: false,
+    toggleVisible: false,
+    compareVisible: false,
+    defaultCalibrated: false,
+    explainerNavLink: false,
+    recomputeEnabled: false,
+  }),
+}));
 
 // Default loader payload — most attendance has a Disco Biscuits setlist
 // (per project test convention).

--- a/apps/web/app/routes/users/$username.tsx
+++ b/apps/web/app/routes/users/$username.tsx
@@ -7,6 +7,7 @@ import type { LoaderFunctionArgs, MetaFunction } from "react-router-dom";
 import { Link, useNavigate } from "react-router-dom";
 import { formatHalfStep } from "~/components/rating/rating";
 import { RatingCharts } from "~/components/rating/rating-charts";
+import { RatingDisplaySettings } from "~/components/rating/rating-display-settings";
 import { formatSetLabel } from "~/components/setlist/set-label";
 import { SetlistList } from "~/components/setlist/setlist-list";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
@@ -409,6 +410,15 @@ export default function UserProfile() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Rating-display preferences — only on your own profile, and only when a
+          feature flag makes a toggle available (the component self-hides otherwise). */}
+      {isOwnProfile && (
+        <RatingDisplaySettings
+          showCalibratedRatings={user.showCalibratedRatings}
+          showRatingComparisonDebug={user.showRatingComparisonDebug}
+        />
+      )}
 
       {/* Content Tabs — mobile shows a <select> dropdown (sm:hidden), sm+
           renders the horizontal tab strip. Mirrors the song-detail page so

--- a/apps/web/app/server/show-user-data.test.ts
+++ b/apps/web/app/server/show-user-data.test.ts
@@ -5,6 +5,9 @@ const getAveragesForRateables = vi.fn();
 const findManyByUserIdAndShowIds = vi.fn();
 const findManyByUserIdAndRateableIds = vi.fn();
 const findByEmail = vi.fn();
+const getDisplayedForShows = vi.fn().mockResolvedValue({});
+const getShowRankComparisons = vi.fn().mockResolvedValue({});
+const getFeatureFlags = vi.fn();
 
 vi.mock("~/server/services", () => ({
   services: {
@@ -18,7 +21,30 @@ vi.mock("~/server/services", () => ({
     users: {
       findByEmail: (...args: unknown[]) => findByEmail(...args),
     },
+    raterWeights: {
+      getDisplayedForShows: (...args: unknown[]) => getDisplayedForShows(...args),
+      getShowRankComparisons: (...args: unknown[]) => getShowRankComparisons(...args),
+    },
   },
+}));
+
+// Mock @bip/core so the web test stays light: getFeatureFlags is controllable per
+// test; resolveRatingMode uses the real precedence logic (gate, pref, default).
+vi.mock("@bip/core", () => ({
+  getFeatureFlags: (...args: unknown[]) => getFeatureFlags(...args),
+  resolveRatingMode: (
+    pref: boolean | null | undefined,
+    flags: { calibratedEnabled: boolean; defaultCalibrated: boolean },
+  ) =>
+    !flags.calibratedEnabled
+      ? "simple"
+      : pref != null
+        ? pref
+          ? "calibrated"
+          : "simple"
+        : flags.defaultCalibrated
+          ? "calibrated"
+          : "simple",
 }));
 
 vi.mock("~/lib/logger", () => ({
@@ -27,9 +53,19 @@ vi.mock("~/lib/logger", () => ({
 
 import { computeShowUserData } from "./show-user-data";
 
+const FLAGS = {
+  calibratedEnabled: true,
+  toggleVisible: false,
+  defaultCalibrated: false,
+  compareVisible: false,
+  explainerNavLink: false,
+  recomputeEnabled: true,
+};
+
 describe("computeShowUserData", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getFeatureFlags.mockResolvedValue({ ...FLAGS });
   });
 
   // An empty input short-circuits before hitting any service. Callers pass
@@ -38,7 +74,13 @@ describe("computeShowUserData", () => {
   test("returns empty skeleton and makes no service calls when showIds is empty", async () => {
     const result = await computeShowUserData({ currentUser: undefined }, []);
 
-    expect(result).toEqual({ attendances: {}, userRatings: {}, averageRatings: {} });
+    expect(result).toEqual({
+      attendances: {},
+      userRatings: {},
+      averageRatings: {},
+      displayedRatings: {},
+      rankComparisons: {},
+    });
     expect(getAveragesForRateables).not.toHaveBeenCalled();
     expect(findManyByUserIdAndShowIds).not.toHaveBeenCalled();
     expect(findManyByUserIdAndRateableIds).not.toHaveBeenCalled();
@@ -106,5 +148,51 @@ describe("computeShowUserData", () => {
     expect(result.userRatings["show-2"]).toBe(5);
     expect(result.averageRatings["show-1"]).toEqual({ average: 4.0, count: 5 });
     expect(result.averageRatings["show-2"]).toEqual({ average: 3.0, count: 2 });
+  });
+
+  // Simple mode (the default for a user with no explicit pref) must NOT run the
+  // calibrated-score or rank-comparison queries — those are the expensive parts.
+  test("skips calibrated + rank queries in simple mode", async () => {
+    getAveragesForRateables.mockResolvedValue({});
+    findByEmail.mockResolvedValue({ id: "user-1", email: "evan@foo.net", showCalibratedRatings: null });
+    findManyByUserIdAndShowIds.mockResolvedValue([]);
+    findManyByUserIdAndRateableIds.mockResolvedValue([]);
+
+    const result = await computeShowUserData({ currentUser: { id: "a", email: "evan@foo.net", isAdmin: false } }, [
+      "show-1",
+    ]);
+
+    expect(getDisplayedForShows).not.toHaveBeenCalled();
+    expect(getShowRankComparisons).not.toHaveBeenCalled();
+    expect(result.displayedRatings).toEqual({});
+  });
+
+  // An opted-in user (showCalibratedRatings=true) gets the calibrated score; the
+  // comparison overlay also loads when they enable it AND the flag allows.
+  test("loads calibrated scores for an opted-in user, plus the overlay when compare is enabled", async () => {
+    getAveragesForRateables.mockResolvedValue({});
+    findByEmail.mockResolvedValue({
+      id: "user-1",
+      email: "evan@foo.net",
+      showCalibratedRatings: true,
+      showRatingComparisonDebug: true,
+    });
+    findManyByUserIdAndShowIds.mockResolvedValue([]);
+    findManyByUserIdAndRateableIds.mockResolvedValue([]);
+    getDisplayedForShows.mockResolvedValue({ "show-1": { rating: 4.2, count: 18 } });
+    getFeatureFlags.mockResolvedValue({ ...FLAGS, compareVisible: true });
+    const rank = {
+      calibrated: 4.2,
+      all: { canonicalRank: 12, calibratedRank: 6, total: 300 },
+      top: { canonicalRank: 10, calibratedRank: 5, total: 100 },
+    };
+    getShowRankComparisons.mockResolvedValue({ "show-1": rank });
+
+    const result = await computeShowUserData({ currentUser: { id: "a", email: "evan@foo.net", isAdmin: false } }, [
+      "show-1",
+    ]);
+
+    expect(result.displayedRatings["show-1"]).toEqual({ rating: 4.2, count: 18 });
+    expect(result.rankComparisons["show-1"]).toEqual(rank);
   });
 });

--- a/apps/web/app/server/show-user-data.ts
+++ b/apps/web/app/server/show-user-data.ts
@@ -1,20 +1,37 @@
+import type { ShowRankComparison } from "@bip/core";
 import type { Attendance } from "@bip/domain";
 import type { PublicContext } from "~/lib/base-loaders";
 import { logger } from "~/lib/logger";
 import { services } from "~/server/services";
+import { resolveViewerRatingMode } from "~/server/viewer-rating";
 
 export interface ShowUserDataResponse {
   attendances: Record<string, Attendance | null>;
   userRatings: Record<string, number | null>;
   averageRatings: Record<string, { average: number; count: number } | null>;
+  /**
+   * The calibrated (shrunk) score + its contributing count per show, populated only
+   * when the viewer's resolved mode is "calibrated"; absent means the headline falls
+   * back to the canonical average + count. The count is post-exclusion (bombers
+   * dropped), so it can be smaller than the canonical deduped count.
+   */
+  displayedRatings: Record<string, { rating: number; count: number }>;
+  /**
+   * Community vs calibrated score + rank summary per show, populated only when
+   * the viewer has the author comparison overlay enabled; absent means no overlay.
+   */
+  rankComparisons: Record<string, ShowRankComparison>;
 }
 
 /**
- * Fetches per-show data for a batch of shows: average ratings (public), plus
- * the current user's attendance and ratings (when authenticated). Shared by
- * the `/api/shows/user-data` action and any loader that wants to seed React
- * Query's cache with server-side data so SetlistCards render attendance /
- * rating badges on first paint (no hydration flicker).
+ * Fetches per-show data for a batch of shows: average ratings (public), the
+ * viewer's resolved calibrated score and/or comparison overlay, plus the current
+ * user's attendance and ratings (when authenticated). Shared by the
+ * `/api/shows/user-data` action and any loader that wants to seed React Query's
+ * cache with server-side data so SetlistCards render on first paint. The display
+ * mode (simple vs calibrated) and the comparison overlay are resolved server-side
+ * from the viewer's prefs + the feature flags, so the heavy calibrated/rank queries
+ * only run for viewers who actually see them.
  */
 export async function computeShowUserData(
   context: Pick<PublicContext, "currentUser">,
@@ -24,6 +41,8 @@ export async function computeShowUserData(
     attendances: {},
     userRatings: {},
     averageRatings: {},
+    displayedRatings: {},
+    rankComparisons: {},
   };
 
   for (const showId of showIds) {
@@ -35,23 +54,30 @@ export async function computeShowUserData(
   if (showIds.length === 0) return response;
 
   try {
+    const { user, flags, mode } = await resolveViewerRatingMode(context);
+    const compareOn = flags.compareVisible && user?.showRatingComparisonDebug === true;
+
     const averages = await services.ratings.getAveragesForRateables(showIds, "Show");
     for (const [showId, data] of Object.entries(averages)) {
       response.averageRatings[showId] = data;
     }
 
-    if (context.currentUser) {
-      const user = await services.users.findByEmail(context.currentUser.email);
-      if (user) {
-        const attendances = await services.attendances.findManyByUserIdAndShowIds(user.id, showIds);
-        for (const attendance of attendances) {
-          response.attendances[attendance.showId] = attendance;
-        }
+    if (mode === "calibrated") {
+      response.displayedRatings = await services.raterWeights.getDisplayedForShows(showIds);
+    }
+    if (compareOn) {
+      response.rankComparisons = await services.raterWeights.getShowRankComparisons(showIds);
+    }
 
-        const ratings = await services.ratings.findManyByUserIdAndRateableIds(user.id, showIds, "Show");
-        for (const rating of ratings) {
-          response.userRatings[rating.rateableId] = rating.value;
-        }
+    if (user) {
+      const attendances = await services.attendances.findManyByUserIdAndShowIds(user.id, showIds);
+      for (const attendance of attendances) {
+        response.attendances[attendance.showId] = attendance;
+      }
+
+      const ratings = await services.ratings.findManyByUserIdAndRateableIds(user.id, showIds, "Show");
+      for (const rating of ratings) {
+        response.userRatings[rating.rateableId] = rating.value;
       }
     }
   } catch (error) {

--- a/apps/web/app/server/viewer-rating.ts
+++ b/apps/web/app/server/viewer-rating.ts
@@ -1,0 +1,22 @@
+import { type FeatureFlags, getFeatureFlags, type RatingMode, resolveRatingMode } from "@bip/core";
+import type { PublicContext } from "~/lib/base-loaders";
+import { services } from "~/server/services";
+
+type Viewer = Awaited<ReturnType<typeof services.users.findByEmail>>;
+
+/**
+ * Resolve a viewer's rating display mode in one place: look up their local user
+ * (needed for the saved calibrated pref and to target segment-gated flags by
+ * username), read the feature flags for them, then decide simple vs calibrated.
+ * Returns the user and flags too, since callers also need them (attendance/
+ * ratings, the compare-overlay gate). Shared by show-user-data and Top Rated so
+ * the segment-context and pref wiring can't drift between them.
+ */
+export async function resolveViewerRatingMode(
+  context: Pick<PublicContext, "currentUser">,
+): Promise<{ user: Viewer; flags: FeatureFlags; mode: RatingMode }> {
+  const user = context.currentUser ? await services.users.findByEmail(context.currentUser.email) : null;
+  const flags = await getFeatureFlags(user ? { user: { id: user.id, username: user.username } } : undefined);
+  const mode = resolveRatingMode(user?.showCalibratedRatings, flags);
+  return { user, flags, mode };
+}

--- a/apps/web/docker-entrypoint.sh
+++ b/apps/web/docker-entrypoint.sh
@@ -26,5 +26,8 @@ bun prisma migrate deploy \
 echo "Recomputing pending stats..."
 bun run scripts/recompute-pending.ts
 
+echo "Recomputing ratings (deploy-time backfill; no-op when unchanged)..."
+bun run scripts/recompute-ratings.ts
+
 cd /app/apps/web
 exec "$@"

--- a/bun.lock
+++ b/bun.lock
@@ -106,6 +106,7 @@
         "@bip/domain": "workspace:*",
         "@prisma/adapter-pg": "^7.2.0",
         "@prisma/client": "^7.2.0",
+        "@quonfig/node": "^1.0.0",
         "@supabase/supabase-js": "^2.89.0",
         "dotenv": "^17.2.3",
         "postgres": "^3.4.7",
@@ -475,6 +476,8 @@
     "@prisma/query-plan-executor": ["@prisma/query-plan-executor@6.18.0", "", {}, "sha512-jZ8cfzFgL0jReE1R10gT8JLHtQxjWYLiQ//wHmVYZ2rVkFHoh0DT8IXsxcKcFlfKN7ak7k6j0XMNn2xVNyr5cA=="],
 
     "@prisma/studio-core": ["@prisma/studio-core@0.9.0", "", { "peerDependencies": { "@types/react": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-xA2zoR/ADu/NCSQuriBKTh6Ps4XjU0bErkEcgMfnSGh346K1VI7iWKnoq1l2DoxUqiddPHIEWwtxJ6xCHG6W7g=="],
+
+    "@quonfig/node": ["@quonfig/node@1.0.0", "", { "dependencies": { "eventsource": "^4.1.0", "murmurhash": "^2.0.1" }, "peerDependencies": { "pino": ">=7.0.0", "winston": ">=3.0.0" }, "optionalPeers": ["pino", "winston"] }, "sha512-i20cb4XvzqERTYVNYSBo8vnqiLUkGFs6CvylJDx/1SBAEFJX+lrGhMG9J70HQAYhaaJ9BWiVZ8Ng5T0GPbj+3A=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -1158,7 +1161,7 @@
 
     "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
-    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+    "eventsource": ["eventsource@4.1.0", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.3", "", {}, "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA=="],
 
@@ -1591,6 +1594,8 @@
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "msw": ["msw@2.10.4", "", { "dependencies": { "@bundled-es-modules/cookie": "^2.0.1", "@bundled-es-modules/statuses": "^1.0.1", "@bundled-es-modules/tough-cookie": "^0.1.6", "@inquirer/confirm": "^5.0.0", "@mswjs/interceptors": "^0.39.1", "@open-draft/deferred-promise": "^2.2.0", "@open-draft/until": "^2.1.0", "@types/cookie": "^0.6.0", "@types/statuses": "^2.0.4", "graphql": "^16.8.1", "headers-polyfill": "^4.0.2", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "strict-event-emitter": "^0.5.1", "type-fest": "^4.26.1", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-6R1or/qyele7q3RyPwNuvc0IxO8L8/Aim6Sz5ncXEgcWUNxSKE+udriTOWHtpMwmfkLYlacA2y7TIx4cL5lgHA=="],
+
+    "murmurhash": ["murmurhash@2.0.1", "", {}, "sha512-5vQEh3y+DG/lMPM0mCGPDnyV8chYg/g7rl6v3Gd8WMF9S429ox3Xk8qrk174kWhG767KQMqqxLD1WnGd77hiew=="],
 
     "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 
@@ -2235,6 +2240,8 @@
     "@jridgewell/gen-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
     "@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+
+    "@modelcontextprotocol/sdk/eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "@modelcontextprotocol/sdk/express": ["express@5.1.0", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.0", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA=="],
 

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -13,6 +13,25 @@
 - Database queries are centralized in repository classes
 - Use the dependency injection container for service instantiation
 
+## Rating aggregates MUST dedupe (one human, one vote)
+
+Some users rated under several accounts (case/space username variants, re-registrations after the
+rewrite). Any *shared* aggregate over the `ratings` table — average, count, distribution histogram,
+calibrated score — MUST collapse those duplicate accounts to a single most-recent vote per person,
+or the number silently disagrees with everything else on the page (e.g. a histogram summing to 20
+next to a "18 ratings" label).
+
+- **Never** compute a shared rating aggregate with a raw `db.rating.groupBy` / `_avg` / `_count` /
+  `AVG(...)`. Those count alias accounts twice.
+- Per-rateable aggregates source their rows from `RatingService.dedupedRatingsFor(...)` (the single
+  deduped fetch). Bulk paths run the same `dedupeRatings` rule (in `rating-service.ts`) over their
+  multi-rateable fetch. The rule itself lives in exactly one function — don't reinline it.
+- **Dedup is universal** (simple *and* calibrated views). It is NOT the same as bad-faith **bomber
+  exclusion**, which shapes ONLY the calibrated score — never the displayed average/count or the
+  histogram.
+- Scope: aggregate-only. A user's own ratings *history* (their profile) is never deduped — it lists
+  that account's literal votes.
+
 ## Prisma 7 Configuration
 
 Prisma 7 removed `url` from the `datasource` block in schema files. Use `prisma.config.ts` instead.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,7 @@
     "@bip/domain": "workspace:*",
     "@prisma/adapter-pg": "^7.2.0",
     "@prisma/client": "^7.2.0",
+    "@quonfig/node": "^1.0.0",
     "@supabase/supabase-js": "^2.89.0",
     "dotenv": "^17.2.3",
     "postgres": "^3.4.7",

--- a/packages/core/scripts/rating-validity-eval.ts
+++ b/packages/core/scripts/rating-validity-eval.ts
@@ -1,0 +1,101 @@
+import { shrinkToward } from "@bip/domain";
+import prisma from "../src/_shared/prisma/client";
+import { POPULATION_SHOW_MEAN, SHRINK_K } from "../src/ratings/rater-weighting";
+
+/**
+ * Validity eval for the calibrated show rating. Correlates each show's score against
+ * objective, rating-independent quality signals and reports whether the calibrated
+ * score tracks them at least as well as the raw community average. The guard for any
+ * change to the rating algorithm (rater weighting, dedup, exclusion, cold-start): a
+ * change that drops these correlations is regressing validity.
+ *
+ * Signals (community-curated jam-chart / all-timer data, not derived from the star votes):
+ *  - all-timer count — how many of a show's tracks are on the curated "best jams" list.
+ *  - all-timer length — total duration of those all-timer tracks (a show of long, notable jams).
+ *
+ * Method: Spearman rank correlation (tie-aware) over shows with >= MIN_RATINGS votes,
+ * for both the calibrated (count-shrunk weighted) score and the simple deduped average.
+ *
+ * Run: `make rating-validity-eval` (optionally `MIN_RATINGS=5 make rating-validity-eval`).
+ */
+
+/** Average (tie-aware, 1-based) ranks of the values, for Spearman. */
+function ranks(values: number[]): number[] {
+  const order = values.map((value, index) => ({ value, index })).sort((a, b) => a.value - b.value);
+  const out = new Array<number>(values.length);
+  let i = 0;
+  while (i < order.length) {
+    let j = i;
+    while (j + 1 < order.length && order[j + 1].value === order[i].value) j += 1;
+    const tiedRank = (i + j) / 2 + 1;
+    for (let k = i; k <= j; k += 1) out[order[k].index] = tiedRank;
+    i = j + 1;
+  }
+  return out;
+}
+
+function pearson(xs: number[], ys: number[]): number {
+  const n = xs.length;
+  const meanX = xs.reduce((a, b) => a + b, 0) / n;
+  const meanY = ys.reduce((a, b) => a + b, 0) / n;
+  let cov = 0;
+  let varX = 0;
+  let varY = 0;
+  for (let i = 0; i < n; i += 1) {
+    const dx = xs[i] - meanX;
+    const dy = ys[i] - meanY;
+    cov += dx * dy;
+    varX += dx * dx;
+    varY += dy * dy;
+  }
+  return varX === 0 || varY === 0 ? 0 : cov / Math.sqrt(varX * varY);
+}
+
+const spearman = (xs: number[], ys: number[]): number => pearson(ranks(xs), ranks(ys));
+
+async function main(): Promise<void> {
+  const minRatings = Number(process.env.MIN_RATINGS ?? 10);
+  const settings = await prisma.ratingSettings.findFirst({ select: { showShrinkAnchor: true } });
+  const anchor = settings?.showShrinkAnchor ?? POPULATION_SHOW_MEAN;
+
+  const rows = await prisma.$queryRaw<
+    Array<{ weighted: number; average: number; count: number; alltimer: bigint; alltimer_duration: number }>
+  >`
+    SELECT s.weighted_rating AS weighted,
+           s.average_rating AS average,
+           s.ratings_count AS count,
+           COUNT(*) FILTER (WHERE t.all_timer) AS alltimer,
+           COALESCE(SUM(t.duration) FILTER (WHERE t.all_timer), 0) AS alltimer_duration
+    FROM shows s
+    LEFT JOIN tracks t ON t.show_id = s.id
+    WHERE s.weighted_rating IS NOT NULL AND s.average_rating IS NOT NULL AND s.ratings_count >= ${minRatings}
+    GROUP BY s.id
+  `;
+
+  const calibrated = rows.map((r) => shrinkToward(Number(r.weighted), anchor, Number(r.count), SHRINK_K));
+  const simple = rows.map((r) => Number(r.average));
+  const allTimerCount = rows.map((r) => Number(r.alltimer));
+  const allTimerLength = rows.map((r) => Number(r.alltimer_duration));
+
+  console.log(`Shows: ${rows.length} (ratings_count >= ${minRatings}) · anchor ${anchor.toFixed(4)} · k=${SHRINK_K}`);
+  console.log("Spearman rank correlation (higher = better tracks objective quality):\n");
+  const report = (label: string, truth: number[]) => {
+    const c = spearman(calibrated, truth);
+    const s = spearman(simple, truth);
+    const delta = c - s;
+    // ±0.01 is within rank-correlation noise on this sample, so call it a tie.
+    const verdict = delta > 0.01 ? "✓ better" : delta < -0.01 ? "✗ worse" : "≈ tied";
+    console.log(
+      `  ${label.padEnd(22)} calibrated ${c.toFixed(4)} | simple ${s.toFixed(4)} | Δ ${delta >= 0 ? "+" : ""}${delta.toFixed(4)}  ${verdict}`,
+    );
+  };
+  report("vs all-timer count", allTimerCount);
+  report("vs all-timer length", allTimerLength);
+
+  await prisma.$disconnect();
+}
+
+main().catch((error) => {
+  console.error("rating-validity-eval failed:", error);
+  process.exit(1);
+});

--- a/packages/core/scripts/recompute-ratings.ts
+++ b/packages/core/scripts/recompute-ratings.ts
@@ -1,0 +1,47 @@
+import { CacheInvalidationService, CacheService } from "../src/_shared/cache";
+import prisma from "../src/_shared/prisma/client";
+import { getFeatureFlags } from "../src/_shared/quonfig";
+import { RedisService } from "../src/_shared/redis";
+import { createTestLogger } from "../src/_shared/test-logger";
+import { RaterWeightService } from "../src/ratings/rater-weight-service";
+import { RatingService } from "../src/ratings/rating-service";
+import { runRatingsRecompute } from "../src/ratings/recompute-ratings";
+
+/**
+ * Deploy-time rating recompute. Wired into apps/web/docker-entrypoint.sh after
+ * `prisma migrate deploy`, and runnable locally via `make recompute-ratings`. Uses
+ * the same dirty-gated routine as the hourly cron, so on a deploy with no rating
+ * change it costs one settings read; the first deploy of the feature (ratings_dirty
+ * seeded true) does the full backfill. Respects the `ratings.recompute-enabled` flag.
+ */
+async function main(): Promise<void> {
+  const logger = createTestLogger();
+
+  const flags = await getFeatureFlags();
+  if (!flags.recomputeEnabled) {
+    logger.info("Ratings recompute disabled by flag; skipping");
+    await prisma.$disconnect();
+    return;
+  }
+
+  const redisUrl = process.env.REDIS_URL;
+  const redis = redisUrl ? new RedisService(redisUrl, logger) : null;
+  if (redis) await redis.connect();
+  const cache = redis ? new CacheService(redis, logger) : null;
+  const cacheInvalidation = cache ? new CacheInvalidationService(cache, logger) : undefined;
+
+  const raterWeights = new RaterWeightService(prisma);
+  const ratings = new RatingService(prisma, cacheInvalidation as never, raterWeights);
+
+  try {
+    await runRatingsRecompute({ raterWeights, ratings, logger });
+  } finally {
+    await redis?.disconnect();
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error("recompute-ratings failed:", error);
+  process.exit(1);
+});

--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -22,7 +22,9 @@ import prisma from "../src/_shared/prisma/client";
 import { RedisService } from "../src/_shared/redis";
 import { createTestLogger } from "../src/_shared/test-logger";
 import { InstrumentService, MusicianService } from "../src/musicians/musician-service";
+import { RaterWeightService } from "../src/ratings/rater-weight-service";
 import { RatingService } from "../src/ratings/rating-service";
+import { runRatingsRecompute } from "../src/ratings/recompute-ratings";
 import { SegueRunGeneratorService } from "../src/segue-run/segue-run-generator-service";
 import { StatsService } from "../src/stats/stats-service";
 import { recomputeShowDuration } from "../src/tracks/show-duration";
@@ -271,6 +273,9 @@ export interface McpSyncUser {
   username: string | null;
   avatarFileId: string | null;
   avatarFileUrl: string | null;
+  // Rating-display opt-in prefs, mirrored from prod so adoption can be inspected locally.
+  showCalibratedRatings: boolean | null;
+  showRatingComparisonDebug: boolean | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -1702,6 +1707,8 @@ export async function syncUserActivity(
               username: u.username,
               avatarFileId: null,
               avatarFileUrl: u.avatarFileUrl,
+              showCalibratedRatings: u.showCalibratedRatings,
+              showRatingComparisonDebug: u.showRatingComparisonDebug,
               updatedAt: new Date(u.updatedAt),
             },
           });
@@ -1716,6 +1723,8 @@ export async function syncUserActivity(
             data: {
               avatarFileId: null,
               avatarFileUrl: u.avatarFileUrl,
+              showCalibratedRatings: u.showCalibratedRatings,
+              showRatingComparisonDebug: u.showRatingComparisonDebug,
               updatedAt: new Date(u.updatedAt),
             },
           });
@@ -1729,6 +1738,8 @@ export async function syncUserActivity(
               username: u.username,
               avatarFileId: null,
               avatarFileUrl: u.avatarFileUrl,
+              showCalibratedRatings: u.showCalibratedRatings,
+              showRatingComparisonDebug: u.showRatingComparisonDebug,
               createdAt: new Date(u.createdAt),
               updatedAt: new Date(u.updatedAt),
             },
@@ -2553,6 +2564,10 @@ async function syncMissingShows(): Promise<void> {
     prisma,
     cacheInvalidation ?? (createNoopCacheInvalidation() as unknown as CacheInvalidationService),
   );
+  // Synced ratings change rater stats and every show's calibrated weighted_rating,
+  // but they bypass the live write path that flags the recompute dirty, so the
+  // sync runs the calibrated recompute itself at the end (see below).
+  const raterWeights = new RaterWeightService(prisma);
   // SegueRun rows reference Track ids in a non-FK String[] array. When the
   // setlist reconcile inserts or deletes a track, those arrays go stale; we
   // call generateSegueRunsForShow per structurally-changed show to rebuild.
@@ -4349,6 +4364,26 @@ async function syncMissingShows(): Promise<void> {
         await statsService.rebuildGapsAndSongStatsSince(earliestInsertedDate);
       } catch (err) {
         console.error("  ❌ stats rebuild failed:", err);
+        stats.errors++;
+      }
+    }
+
+    // Calibrated ratings derive from the synced ratings but aren't refreshed by
+    // this script's per-row work, so recompute them when ratings actually changed.
+    // Mark dirty (the sync touched ratings) and run the same routine the cron and
+    // deploy use, so weighted_rating + the shrink anchor aren't left stale.
+    const ratingsChanged =
+      (stats.userActivity?.ratingsUpserted ?? 0) > 0 || (stats.userActivity?.ratingsDeleted ?? 0) > 0;
+    if (!isDryRun && ratingsChanged) {
+      console.log("📊 Recomputing calibrated ratings");
+      try {
+        await db.ratingSettings.updateMany({ data: { ratingsDirty: true } });
+        const result = await runRatingsRecompute({ raterWeights, ratings: ratingService, logger });
+        if (result.ran) {
+          console.log(`  ✔ ${result.users} raters, ${result.shows} shows, anchor ${result.anchor?.toFixed(3)}`);
+        }
+      } catch (err) {
+        console.error("  ❌ calibrated recompute failed:", err);
         stats.errors++;
       }
     }

--- a/packages/core/src/_shared/prisma/migrations/20260621000000_adjusted_ratings_production/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260621000000_adjusted_ratings_production/migration.sql
@@ -1,0 +1,56 @@
+-- Adjusted-rating production schema: the single shipped scheme denormalized onto
+-- `shows`, the trimmed `rater_stats`, per-user display prefs, and the
+-- `rating_settings` singleton. Forward-only create — prod never had the throwaway
+-- experiment tables, so there is nothing to drop here. Idempotent (guarded /
+-- IF NOT EXISTS) so a fresh local prod-restore applies it cleanly too.
+--
+-- (One-time note: an already-dirty local DB that had run the deleted experiment
+-- migrations was converged out-of-band; that cleanup is intentionally NOT part of
+-- this migration since it never applies to prod or to a fresh restore.)
+
+-- Enums for rater_stats (guarded — CREATE TYPE has no IF NOT EXISTS).
+DO $$ BEGIN
+  CREATE TYPE "rater_era" AS ENUM ('GLOBAL', 'ALTMAN', 'AUCOIN', 'MARLON');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  CREATE TYPE "rateable_kind" AS ENUM ('SHOW', 'TRACK');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- Per-user rating behavior (derived; maintained by RaterWeightService).
+CREATE TABLE IF NOT EXISTS "rater_stats" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "user_id" UUID NOT NULL,
+  "era" "rater_era" NOT NULL,
+  "kind" "rateable_kind" NOT NULL,
+  "ratings_count" INTEGER NOT NULL DEFAULT 0,
+  "entropy" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  "mean" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  "is_excluded" BOOLEAN NOT NULL DEFAULT false,
+  "computed_at" TIMESTAMP(6) NOT NULL DEFAULT now(),
+  CONSTRAINT "rater_stats_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "rater_stats_user_id_era_kind_unique" ON "rater_stats" ("user_id", "era", "kind");
+CREATE INDEX IF NOT EXISTS "rater_stats_era_idx" ON "rater_stats" ("era");
+DO $$ BEGIN
+  ALTER TABLE "rater_stats" ADD CONSTRAINT "fk_rater_stats_users_user_id"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- Denormalized adjusted score on shows.
+ALTER TABLE "shows" ADD COLUMN IF NOT EXISTS "weighted_rating" DOUBLE PRECISION;
+ALTER TABLE "shows" ADD COLUMN IF NOT EXISTS "weighted_ratings_count" INTEGER NOT NULL DEFAULT 0;
+
+-- Per-user display preferences (nullable tri-state: null = no explicit choice).
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "show_adjusted_rating" BOOLEAN;
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "show_rating_compare" BOOLEAN;
+
+-- Operational/derived settings singleton.
+CREATE TABLE IF NOT EXISTS "rating_settings" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "show_shrink_anchor" DOUBLE PRECISION NOT NULL DEFAULT 4.07,
+  "ratings_dirty" BOOLEAN NOT NULL DEFAULT true,
+  "last_recompute_at" TIMESTAMP(6),
+  CONSTRAINT "rating_settings_pkey" PRIMARY KEY ("id")
+);
+INSERT INTO "rating_settings" ("id")
+  SELECT gen_random_uuid() WHERE NOT EXISTS (SELECT 1 FROM "rating_settings");

--- a/packages/core/src/_shared/prisma/schema.prisma
+++ b/packages/core/src/_shared/prisma/schema.prisma
@@ -340,6 +340,8 @@ model Show {
   relistenUrl       String?                  @map("relisten_url") @db.VarChar
   averageRating     Float?                   @default(0) @map("average_rating")
   ratingsCount      Int                      @default(0) @map("ratings_count")
+  weightedRating       Float?                @map("weighted_rating")
+  weightedRatingsCount Int                   @default(0) @map("weighted_ratings_count")
   showPhotosCount   Int                      @default(0) @map("show_photos_count")
   showYoutubesCount Int                      @default(0) @map("show_youtubes_count")
   reviewsCount      Int                      @default(0) @map("reviews_count")
@@ -761,6 +763,8 @@ model User {
   username            String?      @unique(map: "users_username_unique") @db.VarChar
   avatarFileId        String?      @map("avatar_file_id") @db.Uuid
   avatarFileUrl       String?      @map("avatar_file_url") @db.VarChar
+  showCalibratedRatings     Boolean? @map("show_adjusted_rating")
+  showRatingComparisonDebug Boolean? @map("show_rating_compare")
   avatarFile          File?        @relation("UserAvatar", fields: [avatarFileId], references: [id], onDelete: SetNull, onUpdate: NoAction)
   attendances         Attendance[]
   blogPosts           BlogPost[]
@@ -768,6 +772,7 @@ model User {
   favorites           Favorite[]
   likes               Like[]
   ratings             Rating[]
+  raterStats          RaterStats[]
   reviews             Review[]
   showPhotos          ShowPhoto[]
   files               File[]
@@ -929,4 +934,63 @@ model MemoryMetric {
   @@index([requestUrl])
   @@index([memoryDelta])
   @@map("memory_metrics")
+}
+
+/// Per-user rating behavior, computed (not entered) for the calibrated-rating
+/// system. One row per scope: a `GLOBAL` row over all of a user's ratings plus
+/// one row per drummer era. Only the fields the entropy-centered + bad-faith
+/// exclusion algorithm reads: `mean` (centering baseline), `entropy` (weight),
+/// `ratingsCount` (cold-start shrink + the ≥5 exclusion threshold), `isExcluded`
+/// (per-era bomber/fluffer flag). Derived aggregate (like Show.average_rating),
+/// maintained by RaterWeightService; never feeds the canonical displayed average.
+model RaterStats {
+  id               String       @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId           String       @map("user_id") @db.Uuid
+  era              RaterEra
+  kind             RateableKind
+  ratingsCount     Int          @default(0) @map("ratings_count")
+  entropy          Float        @default(0)
+  mean             Float        @default(0)
+  isExcluded       Boolean      @default(false) @map("is_excluded")
+  computedAt       DateTime     @default(now()) @map("computed_at") @db.Timestamp(6)
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_rater_stats_users_user_id")
+
+  @@unique([userId, era, kind], map: "rater_stats_user_id_era_kind_unique")
+  @@index([era])
+  @@map("rater_stats")
+}
+
+/// Singleton row of operational/derived values for the calibrated-rating system.
+/// `showShrinkAnchor` is the cron-derived shrink target (cleaned global mean);
+/// `ratingsDirty` is set by rating writes and cleared by the cron; `lastRecomputeAt`
+/// stamps each recompute and serves as the rating-cache version key.
+model RatingSettings {
+  id               String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  showShrinkAnchor Float     @default(4.07) @map("show_shrink_anchor")
+  ratingsDirty     Boolean   @default(true) @map("ratings_dirty")
+  lastRecomputeAt  DateTime? @map("last_recompute_at") @db.Timestamp(6)
+
+  @@map("rating_settings")
+}
+
+/// Scope a RaterStats row is computed at: GLOBAL spans all of a user's ratings;
+/// the others are the Disco Biscuits drummer eras. Mirrors RaterEra in @bip/domain.
+enum RaterEra {
+  GLOBAL
+  ALTMAN
+  AUCOIN
+  MARLON
+
+  @@map("rater_era")
+}
+
+/// Whether a RaterStats row aggregates a user's show ratings or track ratings.
+/// Tracks have a far lower baseline (most are "nothing special"), so the two
+/// must be normalized separately. Mirrors RateableKind in @bip/domain.
+enum RateableKind {
+  SHOW
+  TRACK
+
+  @@map("rateable_kind")
 }

--- a/packages/core/src/_shared/quonfig/index.ts
+++ b/packages/core/src/_shared/quonfig/index.ts
@@ -1,0 +1,142 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { type Contexts, Quonfig } from "@quonfig/node";
+
+/**
+ * Fully-local quonfig client (datadir mode, no network/account). Reads the
+ * committed `quonfig/` workspace from disk and evaluates flags/configs in memory.
+ * The datadir + environment are env-overridable so scripts, the web server, and
+ * the docker image can point at the right copy. See the `quonfig/` workspace for
+ * the flag/config definitions.
+ */
+
+/**
+ * Resolve the `quonfig/` workspace. `QUONFIG_DATADIR` wins (set in the docker
+ * image); otherwise walk up from cwd to find the committed workspace, so it
+ * resolves no matter which package dir a process is launched from (the web dev
+ * server runs from `apps/web`, scripts from `packages/core`, etc.).
+ */
+function datadir(): string {
+  if (process.env.QUONFIG_DATADIR) return process.env.QUONFIG_DATADIR;
+  let dir = process.cwd();
+  while (true) {
+    const candidate = join(dir, "quonfig");
+    if (existsSync(join(candidate, "quonfig.json"))) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return join(process.cwd(), "quonfig");
+}
+function environment(): string {
+  return process.env.QUONFIG_ENVIRONMENT ?? "development";
+}
+
+// Surface a workspace-load failure once in server logs. We degrade to fallbacks
+// rather than throwing (a flag read must never 500 the page), but the failure
+// must be visible — a silent fallback hides a real misconfig (wrong datadir,
+// missing quonfig/ in the image), which reads as "my flags aren't working."
+let warnedQuonfigFailure = false;
+function warnQuonfigUnavailable(error: unknown): void {
+  if (warnedQuonfigFailure) return;
+  warnedQuonfigFailure = true;
+  // biome-ignore lint/suspicious/noConsole: server-side config-load failure must reach the logs.
+  console.error("[quonfig] failed to load the rating workspace; using fallback defaults.", error);
+}
+
+let initPromise: Promise<Quonfig> | undefined;
+
+/** Lazily-initialized singleton; awaits the one-time datadir load. */
+export async function getQuonfig(): Promise<Quonfig> {
+  if (!initPromise) {
+    const client = new Quonfig({
+      datadir: datadir(),
+      environment: environment(),
+      enableSSE: false,
+      fallbackPollEnabled: false,
+    });
+    // Don't cache a failed init — clear it so a later call can retry instead of
+    // permanently re-throwing the cached rejection.
+    initPromise = client
+      .init()
+      .then(() => client)
+      .catch((error) => {
+        initPromise = undefined;
+        throw error;
+      });
+  }
+  return initPromise;
+}
+
+/** The viewer context flag rules target on (segments / per-user). Username, not
+ * email — segment files are committed to a public repo, and usernames are public. */
+export interface RatingContext {
+  user?: { id?: string | null; username?: string | null };
+}
+
+function toContexts(context?: RatingContext): Contexts | undefined {
+  if (!context?.user) return undefined;
+  const user: Record<string, unknown> = {};
+  if (context.user.id != null) user.id = context.user.id;
+  if (context.user.username != null) user.username = context.user.username;
+  return { user };
+}
+
+export interface FeatureFlags {
+  calibratedEnabled: boolean;
+  toggleVisible: boolean;
+  defaultCalibrated: boolean;
+  compareVisible: boolean;
+  explainerNavLink: boolean;
+  recomputeEnabled: boolean;
+}
+
+// Degraded defaults if the datadir can't be read (misconfig). Matches the launch
+// JSON: the feature runs and the cron computes, but no segment-gated toggle shows
+// (segments can't evaluate without the workspace), so everyone falls to the simple
+// average. A broken flag read must never take down a page.
+const FALLBACK_FLAGS: FeatureFlags = {
+  calibratedEnabled: true,
+  toggleVisible: false,
+  defaultCalibrated: false,
+  compareVisible: false,
+  explainerNavLink: false,
+  recomputeEnabled: true,
+};
+
+/**
+ * Both opt-in controls (the calibrated toggle, the compare overlay) sit behind the
+ * master kill switch: when `calibrated-enabled` is off the whole feature is dead, so
+ * neither may render regardless of its own segment flag. Centralizing the AND here
+ * means consumers just read the resolved flag and never have to re-check the gate.
+ */
+export function controlVisibleUnderGate(calibratedEnabled: boolean, ownFlag: boolean): boolean {
+  return calibratedEnabled && ownFlag;
+}
+
+/** All feature flags resolved for a viewer (segment/per-user aware). */
+export async function getFeatureFlags(context?: RatingContext): Promise<FeatureFlags> {
+  let quonfig: Quonfig;
+  try {
+    quonfig = await getQuonfig();
+  } catch (error) {
+    warnQuonfigUnavailable(error);
+    return FALLBACK_FLAGS;
+  }
+  const ctx = toContexts(context);
+  const calibratedEnabled = quonfig.getBool("ratings.calibrated-enabled", ctx) ?? false;
+  return {
+    calibratedEnabled,
+    // resolveRatingMode already forces simple when the gate is off; gating the control
+    // visibility here too means the opt-in + compare toggles disappear entirely (the
+    // kill switch's documented behavior), not just go inert.
+    toggleVisible: controlVisibleUnderGate(calibratedEnabled, quonfig.getBool("ratings.toggle-visible", ctx) ?? false),
+    defaultCalibrated: quonfig.getBool("ratings.default-calibrated", ctx) ?? false,
+    compareVisible: controlVisibleUnderGate(
+      calibratedEnabled,
+      quonfig.getBool("ratings.compare-visible", ctx) ?? false,
+    ),
+    explainerNavLink: quonfig.getBool("ratings.explainer-nav-link") ?? false,
+    recomputeEnabled: quonfig.getBool("ratings.recompute-enabled") ?? false,
+  };
+}

--- a/packages/core/src/_shared/quonfig/quonfig.test.ts
+++ b/packages/core/src/_shared/quonfig/quonfig.test.ts
@@ -1,0 +1,47 @@
+import { join } from "node:path";
+import { beforeAll, describe, expect, test } from "vitest";
+import { controlVisibleUnderGate, getFeatureFlags } from "./index";
+
+/**
+ * Validates the committed `quonfig/` workspace parses and resolves to the
+ * intended launch flag posture, guarding against a malformed flag/segment file.
+ */
+beforeAll(() => {
+  // Point the singleton at the repo-root workspace (tests run with cwd=packages/core).
+  process.env.QUONFIG_DATADIR = join(import.meta.dirname, "..", "..", "..", "..", "..", "quonfig");
+  process.env.QUONFIG_ENVIRONMENT = "development";
+});
+
+describe("committed quonfig workspace", () => {
+  test("launch flag posture: feature on, default simple, beta gated to the author", async () => {
+    const anon = await getFeatureFlags();
+    expect(anon.calibratedEnabled).toBe(true); // feature runs in prod
+    expect(anon.recomputeEnabled).toBe(true); // cron runs from day one
+    expect(anon.defaultCalibrated).toBe(false); // default stays simple (opt-in)
+    expect(anon.toggleVisible).toBe(false); // not the author → no toggle
+    expect(anon.compareVisible).toBe(false);
+    expect(anon.explainerNavLink).toBe(false); // page reachable by URL; nav link off
+  });
+
+  test("the rating-beta segment opens the toggles to the author only", async () => {
+    const author = await getFeatureFlags({ user: { username: "evan" } });
+    expect(author.toggleVisible).toBe(true);
+    expect(author.compareVisible).toBe(true);
+
+    const other = await getFeatureFlags({ user: { username: "someone-else" } });
+    expect(other.toggleVisible).toBe(false);
+  });
+});
+
+describe("controlVisibleUnderGate (master kill switch)", () => {
+  // The kill switch must HIDE the controls, not leave them inert: even an
+  // author whose segment flag is on sees no toggle/overlay when calibrated is off.
+  test("master gate off hides a control whose own flag is on", () => {
+    expect(controlVisibleUnderGate(false, true)).toBe(false);
+  });
+
+  test("master gate on passes the control's own flag through", () => {
+    expect(controlVisibleUnderGate(true, true)).toBe(true);
+    expect(controlVisibleUnderGate(true, false)).toBe(false);
+  });
+});

--- a/packages/core/src/_shared/services.ts
+++ b/packages/core/src/_shared/services.ts
@@ -6,6 +6,7 @@ import { BlogPostService } from "../blog-posts/blog-post-service";
 import { FileService } from "../files/file-service";
 import { InstrumentService, MusicianService } from "../musicians/musician-service";
 import { SongPageComposer } from "../page-composers/song-page-composer";
+import { RaterWeightService } from "../ratings/rater-weight-service";
 import { RatingService } from "../ratings/rating-service";
 import { ReviewService } from "../reviews/review-service";
 import { RockOperaService } from "../rock-operas/rock-opera-service";
@@ -48,6 +49,7 @@ export interface Services {
   reviews: ReviewService;
   rockOperas: RockOperaService;
   ratings: RatingService;
+  raterWeights: RaterWeightService;
   attendances: AttendanceService;
   songPageComposer: SongPageComposer;
   tourDatesService: TourDatesService;
@@ -85,6 +87,10 @@ export function createServices(container: ServiceContainer): Services {
   const nugsService = new NugsService(container.redis, container.logger);
   const archiveDotOrgService = new ArchiveDotOrgService(container.redis, container.logger);
 
+  // RaterWeightService is constructed before RatingService so rating mutations
+  // can flag the calibrated-rating tables dirty + recompute the touched show.
+  const raterWeightService = new RaterWeightService(container.db);
+
   return {
     annotations: new AnnotationService(container.db, container.logger, container.cacheInvalidation),
     authors: new AuthorService(container.db, container.logger),
@@ -108,7 +114,8 @@ export function createServices(container: ServiceContainer): Services {
     personalSongHistory: new PersonalSongHistoryService(container.db, container.cache),
     reviews: new ReviewService(container.db, container.logger),
     rockOperas: rockOperaService,
-    ratings: new RatingService(container.db, container.cacheInvalidation),
+    ratings: new RatingService(container.db, container.cacheInvalidation, raterWeightService),
+    raterWeights: raterWeightService,
     attendances: new AttendanceService(container.db, container.logger),
     songPageComposer: new SongPageComposer(container.db, songService, statsService),
     tourDatesService: new TourDatesService(container.redis),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@
 export * from "./_shared/container";
 export * from "./_shared/database/models";
 // Shared exports
+export * from "./_shared/quonfig";
 export * from "./_shared/redis";
 export * from "./_shared/services";
 export * from "./annotations/annotation-service";
@@ -10,7 +11,11 @@ export * from "./attendances/attendance-service";
 export * from "./blog-posts/blog-post-service";
 // Views
 export * from "./page-composers/song-page-composer";
+export * from "./ratings/rater-weight-service";
+export * from "./ratings/rater-weighting";
+export * from "./ratings/rating-mode";
 export * from "./ratings/rating-service";
+export * from "./ratings/recompute-ratings";
 export * from "./reviews/review-service";
 export * from "./rock-operas/rock-opera-service";
 export * from "./search/postgres-search-service";

--- a/packages/core/src/ratings/rater-aliases.test.ts
+++ b/packages/core/src/ratings/rater-aliases.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+import { aliasKey, mostRecentPerKey, normalize } from "./rater-aliases";
+
+// normalize folds the cosmetic differences one login produces (case, spaces,
+// underscores) so "RyKnow" and "ryknow " resolve to the same identity.
+describe("normalize", () => {
+  test("lowercases and strips spaces and underscores", () => {
+    expect(normalize("RyKnow ")).toBe("ryknow");
+    expect(normalize("Digital_Buddha")).toBe("digitalbuddha");
+    expect(normalize("Digital Buddha")).toBe("digitalbuddha");
+  });
+});
+
+describe("aliasKey", () => {
+  test("login variants of one name share a key", () => {
+    expect(aliasKey("RyKnow")).toBe(aliasKey("ryknow "));
+  });
+
+  test("curated spelling variants merge to one representative", () => {
+    // "Invisble" (misspelled) and "Invisible" are the same person.
+    expect(aliasKey("InvisbleBuddha")).toBe(aliasKey("Invisible Buddha"));
+  });
+
+  test("a deny-listed name stays solo, keyed by its own account id", () => {
+    // digitalbuddha is held out of auto-merge: each account keeps a distinct key.
+    expect(aliasKey("DigitalBuddha", "user-1")).toBe("solo:user-1");
+    expect(aliasKey("DigitalBuddha", "user-1")).not.toBe(aliasKey("DigitalBuddha", "user-2"));
+  });
+});
+
+// mostRecentPerKey is the "one human, one vote" reducer: within each key group it
+// keeps only the latest-dated rating.
+describe("mostRecentPerKey", () => {
+  test("keeps the most recent rating within a key group", () => {
+    const ratings = [
+      { key: "a", value: 3, createdAt: new Date("2024-01-01") },
+      { key: "a", value: 5, createdAt: new Date("2024-06-01") },
+      { key: "a", value: 1, createdAt: new Date("2024-03-01") },
+    ];
+    const result = mostRecentPerKey(ratings, (rating) => rating.key);
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe(5);
+  });
+
+  test("keeps one entry per distinct key", () => {
+    const ratings = [
+      { key: "a", value: 3, createdAt: new Date("2024-01-01") },
+      { key: "b", value: 4, createdAt: new Date("2024-01-01") },
+    ];
+    const result = mostRecentPerKey(ratings, (rating) => rating.key);
+    expect(result.map((rating) => rating.value).sort()).toEqual([3, 4]);
+  });
+});

--- a/packages/core/src/ratings/rater-aliases.ts
+++ b/packages/core/src/ratings/rater-aliases.ts
@@ -1,0 +1,79 @@
+/**
+ * Duplicate-rater-account handling. One human sometimes rates under several
+ * usernames — case/space/underscore variants (the same login typed differently)
+ * or re-registrations after losing an old account. Left alone, that person's
+ * opinion is counted two or three times on every show they rated under multiple
+ * names, inflating the score. We collapse those to one identity at scoring time.
+ *
+ * Two layers:
+ *  - `normalize` folds case/space/underscore, which provably catches login
+ *    variants (e.g. "RyKnow" / "RyKnow ", "Digital Buddha" / "DigitalBuddha").
+ *  - `ALIAS_MERGE_GROUPS` curates spelling variants that normalization misses
+ *    (e.g. "Invisble" vs "Invisible"). Only confirmed-same-person groups go here;
+ *    fuzzy matches that might be distinct people are deliberately excluded.
+ */
+
+/** Fold a username to its login-variant key: lowercase, no spaces or underscores. */
+export function normalize(username: string): string {
+  return username.toLowerCase().replace(/[\s_]/g, "");
+}
+
+/**
+ * Confirmed same-person groups whose normalized keys still differ (spelling
+ * variants). Each inner array lists the normalized forms that should merge.
+ */
+const ALIAS_MERGE_GROUPS: string[][] = [
+  // "InvisbleBuddha" (misspelled) + "Invisiblebuddha" (correct) + "invisblebuddha".
+  ["invisblebuddha", "invisiblebuddha"],
+];
+
+/** normalized form → the group's chosen representative key. */
+const MERGE_REMAP = new Map<string, string>();
+for (const group of ALIAS_MERGE_GROUPS) {
+  const representative = group[0];
+  for (const member of group) MERGE_REMAP.set(member, representative);
+}
+
+/**
+ * Normalized keys held OUT of auto-merge pending human review. Email mismatch
+ * alone does NOT disqualify a merge — email is unique per account, so a user
+ * locked out of an old account must re-register with a different email, making a
+ * mismatch the expected signature of a re-registration. The real disambiguator
+ * is activity: a clean handoff (old account quiet, new one picks up) points to
+ * one person; overlapping activity points to two. Only `digitalbuddha` remains
+ * genuinely unclear AND affects scoring (both accounts rated, no email/name link,
+ * only a weak handoff). The other same-name pairs are either corroborated
+ * (handoff + username-as-email for axemoney) or have an empty side (moot).
+ */
+export const NO_AUTO_MERGE = new Set(["digitalbuddha"]);
+
+/**
+ * The identity key a username belongs to — same key ⇒ treated as same person.
+ * `denySoloKey` (the account's own id) is returned for deny-listed names so each
+ * stays its own identity despite sharing a normalized form.
+ */
+export function aliasKey(username: string, denySoloKey?: string): string {
+  const norm = normalize(username);
+  if (denySoloKey && NO_AUTO_MERGE.has(norm)) return `solo:${denySoloKey}`;
+  return MERGE_REMAP.get(norm) ?? norm;
+}
+
+/**
+ * Collapse ratings to one per identity: the most-recent vote within each key
+ * group. `keyOf` maps a rating to its identity key (the {@link aliasKey} of its
+ * username, or a prebuilt canonical-user id), so callers choose how accounts are
+ * grouped. The single home for the "one human, one vote" reduction, shared by the
+ * canonical average and the calibrated score.
+ */
+export function mostRecentPerKey<T extends { createdAt: Date }>(
+  ratings: ReadonlyArray<T>,
+  keyOf: (rating: T) => string,
+): T[] {
+  const best = new Map<string, T>();
+  for (const rating of ratings) {
+    const key = keyOf(rating);
+    const current = best.get(key);
+    if (!current || rating.createdAt > current.createdAt) best.set(key, rating);
+  }
+  return [...best.values()];
+}

--- a/packages/core/src/ratings/rater-weight-service.test.ts
+++ b/packages/core/src/ratings/rater-weight-service.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, test, vi } from "vitest";
+import { RaterWeightService, rankShowComparisons } from "./rater-weight-service";
+
+describe("rankShowComparisons", () => {
+  // The 2001-09-01 overlay scenario: two single-vote 5.0 shows top the raw-average
+  // field, but the genuine #1 (highest average among well-rated shows) must own the
+  // TOP-LIST rank — thin shows only inflate the `all` field, never the top list.
+  test("thin shows inflate the all-field but never the top list", () => {
+    const shows = [
+      { id: "thin-a", canonical: 5.0, weighted: 5.0, ratingsCount: 1 },
+      { id: "thin-b", canonical: 5.0, weighted: 5.0, ratingsCount: 2 },
+      { id: "wetlands", canonical: 4.868, weighted: 4.8, ratingsCount: 34 },
+      { id: "haymaker", canonical: 4.839, weighted: 4.7, ratingsCount: 31 },
+    ];
+    const wetlands = rankShowComparisons(shows, ["wetlands"], 3.93, 3).get("wetlands");
+    // Over all shows the two thin 5.0s sit above it; on the real top list it's #1.
+    expect(wetlands?.all).toMatchObject({ canonicalRank: 3, total: 4 });
+    expect(wetlands?.top).toMatchObject({ canonicalRank: 1, total: 2 });
+  });
+
+  // A thin show keeps a real `all` rank (so its movement is visible) but is not in
+  // the top list. Its raw average can top the all-field while its shrunk score sinks.
+  test("a thin show is ranked in the all-field but absent from the top list", () => {
+    const shows = [
+      { id: "big1", canonical: 4.8, weighted: 4.8, ratingsCount: 100 },
+      { id: "big2", canonical: 4.6, weighted: 4.6, ratingsCount: 100 },
+      { id: "thin", canonical: 5.0, weighted: 5.0, ratingsCount: 1 },
+    ];
+    const thin = rankShowComparisons(shows, ["thin"], 4.0, 3).get("thin");
+    expect(thin?.top).toBeNull();
+    // Raw 5.0 tops the all-field (#1 of 3); shrunk to ~4.25 it falls below both bigs (#3).
+    expect(thin?.all).toMatchObject({ canonicalRank: 1, calibratedRank: 3, total: 3 });
+  });
+
+  // Canonical and calibrated are ranked independently within the top list:
+  // count-shrinkage pulls a thinner high-average show below a heavily-rated one.
+  test("ranks the calibrated (shrunk) score independently of canonical", () => {
+    const shows = [
+      { id: "a", canonical: 4.9, weighted: 4.9, ratingsCount: 10 },
+      { id: "b", canonical: 4.7, weighted: 4.7, ratingsCount: 500 },
+    ];
+    const ranks = rankShowComparisons(shows, ["a", "b"], 4.0, 3);
+    // a canonical 4.9 > b 4.7, but shrink(4.9,4.0,10,3)=4.692 < shrink(4.7,4.0,500,3)=4.696.
+    expect(ranks.get("a")?.top).toMatchObject({ canonicalRank: 1, calibratedRank: 2 });
+    expect(ranks.get("b")?.top).toMatchObject({ canonicalRank: 2, calibratedRank: 1 });
+  });
+});
+
+// recomputeUser persists via createMany; find the row in any createMany call's data array.
+function createdRow(createMany: ReturnType<typeof vi.fn>, match: (data: Record<string, unknown>) => boolean) {
+  for (const call of createMany.mock.calls) {
+    const data = (call[0] as { data: Record<string, unknown>[] }).data;
+    const row = data?.find(match);
+    if (row) return row;
+  }
+  return undefined;
+}
+
+describe("RaterWeightService.recomputeUser", () => {
+  // A user who rates two Aucoin-era shows across the scale but bombs every
+  // Marlon-era show at 0.5 — the barfly07/Stepnotonpets pattern.
+  function makeDb() {
+    const ratingFindMany = vi.fn().mockResolvedValue([
+      { rateableId: "s1", rateableType: "Show", value: 5, createdAt: new Date("2010-01-02") },
+      { rateableId: "s2", rateableType: "Show", value: 4, createdAt: new Date("2011-01-02") },
+      { rateableId: "s3", rateableType: "Show", value: 0.5, createdAt: new Date("2026-01-02") },
+      { rateableId: "s4", rateableType: "Show", value: 0.5, createdAt: new Date("2026-02-02") },
+    ]);
+    const showFindMany = vi.fn().mockResolvedValue([
+      { id: "s1", date: "2010-01-01", averageRating: 4.5 },
+      { id: "s2", date: "2011-01-01", averageRating: 4.2 },
+      { id: "s3", date: "2026-01-01", averageRating: 4.0 },
+      { id: "s4", date: "2026-02-01", averageRating: 3.8 },
+    ]);
+    const raterStatsFindMany = vi.fn().mockResolvedValue([]); // empty population → nobody flagged high-deviation
+    const raterStatsDeleteMany = vi.fn().mockResolvedValue({ count: 0 });
+    const raterStatsCreateMany = vi.fn().mockResolvedValue({ count: 0 });
+    const db = {
+      user: { findMany: vi.fn().mockResolvedValue([]) }, // no alias dedup in this fixture
+      rating: { findMany: ratingFindMany, groupBy: vi.fn().mockResolvedValue([]) },
+      show: { findMany: showFindMany },
+      track: { findMany: vi.fn() },
+      raterStats: { findMany: raterStatsFindMany, deleteMany: raterStatsDeleteMany, createMany: raterStatsCreateMany },
+    } as never;
+    return { db, raterStatsCreateMany, raterStatsDeleteMany };
+  }
+
+  test("writes a GLOBAL scope row spanning all of the user's ratings", async () => {
+    const { db, raterStatsCreateMany } = makeDb();
+    await new RaterWeightService(db).recomputeUser("u1");
+    const global = createdRow(raterStatsCreateMany, (d) => d.era === "GLOBAL");
+    expect(global?.ratingsCount).toBe(4);
+  });
+
+  test("splits ratings into per-era scope rows", async () => {
+    const { db, raterStatsCreateMany } = makeDb();
+    await new RaterWeightService(db).recomputeUser("u1");
+    expect(createdRow(raterStatsCreateMany, (d) => d.era === "AUCOIN")?.ratingsCount).toBe(2);
+    expect(createdRow(raterStatsCreateMany, (d) => d.era === "MARLON")?.ratingsCount).toBe(2);
+  });
+
+  test("records zero entropy for the era the user bombs (→ zero weight at scoring)", async () => {
+    const { db, raterStatsCreateMany } = makeDb();
+    await new RaterWeightService(db).recomputeUser("u1");
+    const marlon = createdRow(raterStatsCreateMany, (d) => d.era === "MARLON");
+    expect(marlon?.entropy).toBe(0);
+  });
+
+  test("deletes the user's existing scope rows before recomputing", async () => {
+    const { db, raterStatsDeleteMany } = makeDb();
+    await new RaterWeightService(db).recomputeUser("u1");
+    expect(raterStatsDeleteMany).toHaveBeenCalledWith({ where: { userId: { in: ["u1"] } } });
+  });
+
+  test("a user with no ratings has their scope rows deleted", async () => {
+    const raterStatsDeleteMany = vi.fn().mockResolvedValue({ count: 4 });
+    const db = {
+      user: { findMany: vi.fn().mockResolvedValue([]) },
+      rating: { findMany: vi.fn().mockResolvedValue([]), groupBy: vi.fn().mockResolvedValue([]) },
+      raterStats: { deleteMany: raterStatsDeleteMany, createMany: vi.fn() },
+    } as never;
+    await new RaterWeightService(db).recomputeUser("u1");
+    expect(raterStatsDeleteMany).toHaveBeenCalledWith({ where: { userId: { in: ["u1"] } } });
+  });
+});
+
+describe("RaterWeightService recompute settings", () => {
+  // No settings row yet ⇒ treat as dirty so the very first recompute runs (the
+  // migration seeds one with dirty=true, but absence must not silently skip).
+  test("isDirty defaults to true when there is no settings row", async () => {
+    const db = { ratingSettings: { findFirst: vi.fn().mockResolvedValue(null) } } as never;
+    expect(await new RaterWeightService(db).isDirty()).toBe(true);
+  });
+
+  test("isDirty reflects the stored flag", async () => {
+    const db = { ratingSettings: { findFirst: vi.fn().mockResolvedValue({ ratingsDirty: false }) } } as never;
+    expect(await new RaterWeightService(db).isDirty()).toBe(false);
+  });
+
+  test("markRecomputed updates the existing singleton (anchor + clears dirty + stamps time)", async () => {
+    const update = vi.fn().mockResolvedValue(undefined);
+    const create = vi.fn();
+    const db = {
+      ratingSettings: { findFirst: vi.fn().mockResolvedValue({ id: "settings-1" }), update, create },
+    } as never;
+    await new RaterWeightService(db).markRecomputed(4.2);
+    expect(create).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "settings-1" },
+        data: expect.objectContaining({ showShrinkAnchor: 4.2, ratingsDirty: false }),
+      }),
+    );
+  });
+
+  test("markRecomputed creates the singleton when none exists", async () => {
+    const update = vi.fn();
+    const create = vi.fn().mockResolvedValue(undefined);
+    const db = { ratingSettings: { findFirst: vi.fn().mockResolvedValue(null), update, create } } as never;
+    await new RaterWeightService(db).markRecomputed(4.2);
+    expect(update).not.toHaveBeenCalled();
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ showShrinkAnchor: 4.2, ratingsDirty: false }) }),
+    );
+  });
+});
+
+describe("RaterWeightService.recomputeRateable", () => {
+  // A Marlon-era show rated 5 by a full-range credible rater (entropy 2 → full
+  // weight) and 0.5 by a zero-entropy bomber.
+  function makeDb() {
+    const ratingFindMany = vi.fn().mockResolvedValue([
+      { userId: "credible", value: 5 },
+      { userId: "bomber", value: 0.5 },
+    ]);
+    const showFindMany = vi.fn().mockResolvedValue([{ id: "s1", date: "2026-01-01", averageRating: 2.75 }]);
+    const raterStatsFindMany = vi.fn().mockResolvedValue([
+      { userId: "credible", era: "GLOBAL", mean: 4, entropy: 2, ratingsCount: 20, isExcluded: false },
+      { userId: "bomber", era: "GLOBAL", mean: 0.5, entropy: 0, ratingsCount: 30, isExcluded: false },
+      // The bomber is flagged bad-faith in this show's era (MARLON) → dropped before scoring.
+      { userId: "bomber", era: "MARLON", mean: 0.5, entropy: 0, ratingsCount: 28, isExcluded: true },
+    ]);
+    const showUpdate = vi.fn().mockResolvedValue(undefined);
+    const db = {
+      user: { findMany: vi.fn().mockResolvedValue([]) },
+      rating: { findMany: ratingFindMany, groupBy: vi.fn().mockResolvedValue([]) },
+      show: { findMany: showFindMany, update: showUpdate },
+      track: { findMany: vi.fn() },
+      raterStats: { findMany: raterStatsFindMany },
+      ratingSettings: { findFirst: vi.fn().mockResolvedValue(null) },
+      $queryRaw: vi.fn().mockResolvedValue([{ mean: 2.75, stddev: 1 }]), // populationStats
+    } as never;
+    return { db, showUpdate };
+  }
+
+  test("writes the calibrated score to shows.weighted_rating, dropping the bad-faith bomber", async () => {
+    const { db, showUpdate } = makeDb();
+    await new RaterWeightService(db).recomputeRateable("Show", "s1");
+    const data = (showUpdate.mock.calls[0][0] as { data: { weightedRating: number; weightedRatingsCount: number } })
+      .data;
+    // Bomber excluded in MARLON → dropped. credible (count 20): cold-start mean
+    // shrink(4, pop 2.75, 20, k=5) = 3.75; center(5, 3.75, 2.75) = 4.0, full weight.
+    expect(data.weightedRating).toBeCloseTo(4.0, 10);
+    expect(data.weightedRatingsCount).toBe(1);
+  });
+
+  test("ignores non-show rateables (no denormalized calibrated column for tracks)", async () => {
+    const { db, showUpdate } = makeDb();
+    await new RaterWeightService(db).recomputeRateable("Track", "t1");
+    expect(showUpdate).not.toHaveBeenCalled();
+  });
+
+  // Cold-start: a brand-new rater (no rater_stats row yet) must still move the
+  // score — count 0 → pop-centered + full entropy weight, so a lone 5 reads as 5.
+  test("a brand-new rater with no stats row still moves the score", async () => {
+    const showUpdate = vi.fn().mockResolvedValue(undefined);
+    const db = {
+      user: { findMany: vi.fn().mockResolvedValue([]) },
+      rating: {
+        findMany: vi.fn().mockResolvedValue([{ userId: "newbie", value: 5 }]),
+        groupBy: vi.fn().mockResolvedValue([]),
+      },
+      show: {
+        findMany: vi.fn().mockResolvedValue([{ id: "s1", date: "2026-01-01", averageRating: 5 }]),
+        update: showUpdate,
+      },
+      track: { findMany: vi.fn() },
+      raterStats: { findMany: vi.fn().mockResolvedValue([]) }, // newbie has no stats
+      ratingSettings: { findFirst: vi.fn().mockResolvedValue(null) },
+      $queryRaw: vi.fn().mockResolvedValue([{ mean: 4.07, stddev: 1 }]),
+    } as never;
+    await new RaterWeightService(db).recomputeRateable("Show", "s1");
+    const data = (showUpdate.mock.calls[0][0] as { data: { weightedRating: number; weightedRatingsCount: number } })
+      .data;
+    expect(data.weightedRating).toBeCloseTo(5, 10);
+    expect(data.weightedRatingsCount).toBe(1);
+  });
+
+  // Regression: a multi-account rater whose latest vote on a show came from their
+  // SECONDARY account must still be scored with their real stats. The fix remaps each
+  // vote to the canonical account before dedup, so rater_stats (stored under the
+  // canonical id) are looked up by the canonical id — not the secondary id, which would
+  // miss them and wrongly treat a known rater as a brand-new statless one.
+  test("looks up a duplicate-account rater's stats by their canonical id", async () => {
+    const raterStatsFindMany = vi
+      .fn()
+      .mockResolvedValue([
+        { userId: "u-primary", era: "GLOBAL", mean: 4, entropy: 2, ratingsCount: 20, isExcluded: false },
+      ]);
+    const db = {
+      user: {
+        findMany: vi.fn().mockResolvedValue([
+          { id: "u-primary", username: "Tractorbeam" },
+          { id: "u-dup", username: "tractorbeam" }, // same person, case variant → canonical = u-primary (more ratings)
+        ]),
+      },
+      rating: {
+        findMany: vi.fn().mockResolvedValue([{ userId: "u-dup", value: 5, createdAt: new Date(2026, 0, 1) }]),
+        groupBy: vi.fn().mockResolvedValue([
+          { userId: "u-primary", _count: { id: 20 } },
+          { userId: "u-dup", _count: { id: 1 } },
+        ]),
+      },
+      show: {
+        findMany: vi.fn().mockResolvedValue([{ id: "s1", date: "2026-01-01", averageRating: 5 }]),
+        update: vi.fn().mockResolvedValue(undefined),
+      },
+      track: { findMany: vi.fn() },
+      raterStats: { findMany: raterStatsFindMany },
+      ratingSettings: { findFirst: vi.fn().mockResolvedValue(null) },
+      $queryRaw: vi.fn().mockResolvedValue([{ mean: 4.07 }]),
+    } as never;
+
+    await new RaterWeightService(db).recomputeRateable("Show", "s1");
+
+    const where = (raterStatsFindMany.mock.calls[0][0] as { where: { userId: { in: string[] } } }).where;
+    expect(where.userId.in).toContain("u-primary"); // canonical id
+    expect(where.userId.in).not.toContain("u-dup"); // not the secondary account
+  });
+});
+
+describe("RaterWeightService.getDisplayedForShows", () => {
+  // The displayed count must be the calibrated, post-exclusion count
+  // (weighted_ratings_count), NOT the canonical deduped count — so the number shown
+  // beside a calibrated score reflects the cleaned population it was built from. The
+  // shrink itself still smooths by the deduped count.
+  test("returns the calibrated count (weighted_ratings_count), shrinking by the deduped count", async () => {
+    const db = {
+      show: {
+        findMany: vi
+          .fn()
+          .mockResolvedValue([{ id: "s1", weightedRating: 5, ratingsCount: 9, weightedRatingsCount: 3 }]),
+      },
+      ratingSettings: { findFirst: vi.fn().mockResolvedValue({ showShrinkAnchor: 3 }) },
+    } as never;
+
+    const byId = await new RaterWeightService(db).getDisplayedForShows(["s1"]);
+
+    // count = weighted_ratings_count (3), the bomber-excluded contributing count.
+    expect(byId.s1.count).toBe(3);
+    // rating = shrinkToward(5, anchor 3, deduped count 9, k=3) = (5*9 + 3*3)/(9+3) = 4.5
+    // (shrinking by the deduped 9, not the weighted 3 — which would give 4.0).
+    expect(byId.s1.rating).toBeCloseTo(4.5, 10);
+  });
+
+  test("omits shows with no calibrated score", async () => {
+    const db = {
+      show: { findMany: vi.fn().mockResolvedValue([]) },
+      ratingSettings: { findFirst: vi.fn().mockResolvedValue({ showShrinkAnchor: 3.93 }) },
+    } as never;
+
+    expect(await new RaterWeightService(db).getDisplayedForShows(["s1"])).toEqual({});
+  });
+});

--- a/packages/core/src/ratings/rater-weight-service.ts
+++ b/packages/core/src/ratings/rater-weight-service.ts
@@ -1,0 +1,634 @@
+import { drummerEraForDate, shrinkToward } from "@bip/domain";
+import { Prisma } from "@prisma/client";
+import type { DbClient } from "../_shared/database/models";
+import { aliasKey, mostRecentPerKey } from "./rater-aliases";
+import {
+  COLD_START_ENTROPY_K,
+  COLD_START_RATER_K,
+  computeCleanedScopeStats,
+  ENTROPY_FULL_WEIGHT,
+  entropyWeightedCenteredAverage,
+  meanOf,
+  POPULATION_SHOW_MEAN,
+  type PopulationStats,
+  RATEABLE_KINDS,
+  type RateableKind,
+  type RaterEra,
+  rateableKindFromType,
+  type ScopedRating,
+  SHRINK_K,
+} from "./rater-weighting";
+
+interface RateableRef {
+  rateableType: string;
+  rateableId: string;
+}
+
+interface RateableMeta {
+  /** YYYY-MM-DD of the rateable's show; "" when unknown (then era can't be derived). */
+  date: string;
+}
+
+/** A built rater_stats row ready to persist (only the columns the algorithm reads). */
+interface RaterStatRecord {
+  userId: string;
+  era: RaterEra;
+  kind: RateableKind;
+  ratingsCount: number;
+  entropy: number;
+  mean: number;
+  isExcluded: boolean;
+  computedAt: Date;
+}
+
+function rateableKey(rateableType: string, rateableId: string): string {
+  return `${rateableType}:${rateableId}`;
+}
+
+/**
+ * Minimum ratings for a show to count toward the "real" top list (Top Rated + the
+ * top-list rank). Thin shows are excluded there so a lone 5-star vote can't top the
+ * list; they're still ranked over the full field so their movement stays visible.
+ */
+export const RANKED_SHOW_MIN_RATINGS = 10;
+
+interface RankableShow {
+  id: string;
+  /** The canonical community average. */
+  canonical: number;
+  /** The raw (un-shrunk) weighted rating. */
+  weighted: number;
+  ratingsCount: number;
+}
+
+/** A show's position by canonical average vs calibrated score within one field. */
+export interface RankInField {
+  canonicalRank: number;
+  calibratedRank: number;
+  total: number;
+}
+
+export interface ShowRankComparison {
+  /** The calibrated (count-shrunk) score. */
+  calibrated: number;
+  /** Rank over every rated show — raw average inflates thin shows here. */
+  all: RankInField;
+  /** Rank over the real top list (>= {@link RANKED_SHOW_MIN_RATINGS}); null when this show isn't in it. */
+  top: RankInField | null;
+}
+
+/**
+ * Rank the requested shows over two fields: `all` rated shows (where a thin show's
+ * raw average can top the list) and the `top` list (>= {@link RANKED_SHOW_MIN_RATINGS}
+ * ratings, matching Top Rated). A show below the rating floor gets a real `all`
+ * rank but a null `top`. Pure (takes the full candidate set) so it stays testable.
+ */
+export function rankShowComparisons(
+  shows: ReadonlyArray<RankableShow>,
+  targetIds: ReadonlyArray<string>,
+  anchor: number,
+  k: number,
+): Map<string, ShowRankComparison> {
+  const scored = shows.map((show) => ({
+    id: show.id,
+    canonical: show.canonical,
+    calibrated: shrinkToward(show.weighted, anchor, show.ratingsCount, k),
+    qualified: show.ratingsCount >= RANKED_SHOW_MIN_RATINGS,
+  }));
+  const topField = scored.filter((show) => show.qualified);
+
+  // Competition rank within a field: 1 + the number strictly better (ties share a rank).
+  const rankIn = (field: typeof scored, target: (typeof scored)[number]): RankInField => ({
+    canonicalRank: 1 + field.filter((show) => show.canonical > target.canonical).length,
+    calibratedRank: 1 + field.filter((show) => show.calibrated > target.calibrated).length,
+    total: field.length,
+  });
+
+  const result = new Map<string, ShowRankComparison>();
+  for (const id of targetIds) {
+    const target = scored.find((show) => show.id === id);
+    if (!target) continue;
+    result.set(id, {
+      calibrated: target.calibrated,
+      all: rankIn(scored, target),
+      top: target.qualified ? rankIn(topField, target) : null,
+    });
+  }
+  return result;
+}
+
+/** One rater's GLOBAL-scope centering stats + their per-era bad-faith flag. */
+interface RaterScopeStat {
+  mean: number;
+  entropy: number;
+  count: number;
+  isExcluded: boolean;
+}
+
+/** Look up a rater's stats for a given scope era (`"GLOBAL"` for centering, the show's
+ * drummer era for exclusion); undefined for a statless (brand-new) rater. */
+type StatByUserEra = (userId: string, era: RaterEra) => RaterScopeStat | undefined;
+
+/**
+ * Pure: a show's calibrated score from its deduped ratings, the raters' GLOBAL-scope
+ * stats, and per-era bad-faith exclusion. The single source of the scoring rule, shared
+ * by the incremental ({@link RaterWeightService.recomputeRateable}) and batch
+ * ({@link RaterWeightService.recomputeAll}) paths so they can never diverge.
+ *
+ * Bad-faith raters flagged in THIS show's era are dropped (falling back to all ratings
+ * if that empties the show, so a score always exists). Each remaining rater's centering
+ * mean + entropy are cold-start-shrunk by their rating count so a new/low-volume rater
+ * still moves the score (a statless rater = pop-centered + full weight).
+ */
+function computeShowWeighted(
+  ratings: ReadonlyArray<{ userId: string; value: number }>,
+  showEra: RaterEra | null,
+  statByUserEra: StatByUserEra,
+  pop: PopulationStats,
+): { weightedRating: number | null; weightedRatingsCount: number } {
+  const excludedHere = new Set<string>();
+  if (showEra) {
+    for (const rating of ratings) {
+      if (statByUserEra(rating.userId, showEra)?.isExcluded) excludedHere.add(rating.userId);
+    }
+  }
+  const activeRatings = ratings.filter((rating) => !excludedHere.has(rating.userId));
+  const used = activeRatings.length > 0 ? activeRatings : ratings;
+
+  const result = entropyWeightedCenteredAverage(
+    used.map((rating) => {
+      const stats = statByUserEra(rating.userId, "GLOBAL") ?? { mean: pop.mean, entropy: 0, count: 0 };
+      return {
+        value: rating.value,
+        userMean: shrinkToward(stats.mean, pop.mean, stats.count, COLD_START_RATER_K),
+        entropy: shrinkToward(stats.entropy, ENTROPY_FULL_WEIGHT, stats.count, COLD_START_ENTROPY_K),
+      };
+    }),
+    pop,
+    ENTROPY_FULL_WEIGHT,
+  );
+  return {
+    weightedRating: result.contributingCount > 0 ? result.weightedAverage : null,
+    weightedRatingsCount: result.contributingCount,
+  };
+}
+
+/**
+ * Maintains the calibrated-rating tables: per-(user, kind, era) `rater_stats` and
+ * the denormalized `shows.weighted_rating`. Reads ratings + the canonical
+ * denormalized means; never writes the canonical average. One scheme:
+ * entropy-weighted, mean-centered, GLOBAL scope, with bad-faith raters excluded
+ * and duplicate accounts collapsed. Only shows get a denormalized calibrated score;
+ * track `rater_stats` are computed as a byproduct but not displayed.
+ *
+ * `recomputeUser`/`recomputeRateable` are the incremental paths; `recomputeAll`
+ * is the batch the cron/script runs.
+ */
+export class RaterWeightService {
+  constructor(protected readonly db: DbClient) {}
+
+  /** The shrink anchor: the cron-derived cleaned global mean (falls back to the seed). */
+  private async shrinkAnchor(): Promise<number> {
+    const settings = await this.db.ratingSettings.findFirst({ select: { showShrinkAnchor: true } });
+    return settings?.showShrinkAnchor ?? POPULATION_SHOW_MEAN;
+  }
+
+  /**
+   * Whether ratings have changed since the last recompute (set by rating writes,
+   * cleared by {@link markRecomputed}). Absent settings row ⇒ treat as dirty so the
+   * first run computes. Lets the cron/deploy recompute no-op when nothing changed.
+   */
+  async isDirty(): Promise<boolean> {
+    const settings = await this.db.ratingSettings.findFirst({ select: { ratingsDirty: true } });
+    return settings?.ratingsDirty ?? true;
+  }
+
+  /** Every distinct rated (rateableId, rateableType) — the set the canonical-average rebuild covers. */
+  async allRatedPairs(): Promise<Array<{ rateableId: string; rateableType: string }>> {
+    const groups = await this.db.rating.groupBy({ by: ["rateableId", "rateableType"] });
+    return groups.map((g) => ({ rateableId: g.rateableId, rateableType: g.rateableType }));
+  }
+
+  /**
+   * The recomputed shrink anchor: the mean of the cleaned (post-exclusion + dedup)
+   * calibrated show-score distribution. Tracking the cleaned mean keeps shrinkage from
+   * re-leaking bomber influence into thin shows. Falls back to the seed when empty.
+   */
+  async computeShrinkAnchor(): Promise<number> {
+    const { _avg } = await this.db.show.aggregate({
+      _avg: { weightedRating: true },
+      where: { weightedRating: { not: null } },
+    });
+    return _avg.weightedRating ?? POPULATION_SHOW_MEAN;
+  }
+
+  /**
+   * Stamp a completed recompute on the singleton settings row: store the new anchor,
+   * bump `lastRecomputeAt` (the rating-cache version key), and clear `ratingsDirty`.
+   */
+  async markRecomputed(anchor: number): Promise<void> {
+    const existing = await this.db.ratingSettings.findFirst({ select: { id: true } });
+    const data = { showShrinkAnchor: anchor, ratingsDirty: false, lastRecomputeAt: new Date() };
+    if (existing) await this.db.ratingSettings.update({ where: { id: existing.id }, data });
+    else await this.db.ratingSettings.create({ data });
+  }
+
+  /**
+   * Batch rank comparison for a set of shows. Ranks each over every rated show
+   * (`all`) and over the real top list (`top`, >= {@link RANKED_SHOW_MIN_RATINGS}),
+   * so thin shows stay visible in the full field without displacing the top list.
+   */
+  async getShowRankComparisons(showIds: string[]): Promise<Record<string, ShowRankComparison>> {
+    if (showIds.length === 0) return {};
+    const [shows, anchor] = await Promise.all([
+      this.db.show.findMany({
+        where: { weightedRating: { not: null } },
+        select: { id: true, averageRating: true, weightedRating: true, ratingsCount: true },
+      }),
+      this.shrinkAnchor(),
+    ]);
+    const rankable = shows.flatMap((show) =>
+      show.weightedRating != null && show.averageRating != null
+        ? [
+            {
+              id: show.id,
+              canonical: show.averageRating,
+              weighted: show.weightedRating,
+              ratingsCount: show.ratingsCount,
+            },
+          ]
+        : [],
+    );
+    const ranks = rankShowComparisons(rankable, showIds, anchor, SHRINK_K);
+    const byId: Record<string, ShowRankComparison> = {};
+    for (const [id, rank] of ranks) byId[id] = rank;
+    return byId;
+  }
+
+  /**
+   * The displayed calibrated score + count per show, keyed by show id. The score is
+   * `shows.weighted_rating` count-shrunk toward the global anchor; the count is
+   * `weighted_ratings_count` — the contributing raters after dedup AND bad-faith
+   * exclusion, so the number shown beside a calibrated score reflects the cleaned
+   * population it was built from (smaller than the canonical deduped count when a
+   * show has excluded bombers). Absent ⇒ caller falls back to the canonical average
+   * + count.
+   */
+  async getDisplayedForShows(showIds: string[]): Promise<Record<string, { rating: number; count: number }>> {
+    if (showIds.length === 0) return {};
+    const [shows, anchor] = await Promise.all([
+      this.db.show.findMany({
+        where: { id: { in: showIds }, weightedRating: { not: null } },
+        select: { id: true, weightedRating: true, ratingsCount: true, weightedRatingsCount: true },
+      }),
+      this.shrinkAnchor(),
+    ]);
+    const byId: Record<string, { rating: number; count: number }> = {};
+    for (const show of shows) {
+      if (show.weightedRating == null) continue;
+      byId[show.id] = {
+        rating: shrinkToward(show.weightedRating, anchor, show.ratingsCount, SHRINK_K),
+        count: show.weightedRatingsCount,
+      };
+    }
+    return byId;
+  }
+
+  /**
+   * Every show eligible for the top-rated list in the viewer's mode, best-first,
+   * each with its date: `calibrated` ranks by the count-shrunk weighted score over
+   * all rated shows, `simple` by the (deduped) canonical average over shows past
+   * the ratings floor. The loader slices this to a year and the row limit AND
+   * derives the year-picker counts from it, so the counts always match the list.
+   */
+  async rankedShows(mode: "simple" | "calibrated", minRatings: number): Promise<Array<{ id: string; date: string }>> {
+    if (mode === "simple") {
+      return this.db.$queryRaw<Array<{ id: string; date: string }>>`
+        SELECT s.id, s.date
+        FROM shows s
+        WHERE s.average_rating IS NOT NULL AND s.ratings_count >= ${minRatings}
+        ORDER BY s.average_rating DESC
+      `;
+    }
+
+    const anchor = await this.shrinkAnchor();
+    const rows = await this.db.$queryRaw<Array<{ id: string; date: string; raw: number; ratings: number }>>`
+      SELECT s.id, s.date, s.weighted_rating AS raw, s.ratings_count AS ratings
+      FROM shows s
+      WHERE s.weighted_rating IS NOT NULL AND s.ratings_count >= ${minRatings}
+    `;
+    return rows
+      .map((r) => ({ id: r.id, date: r.date, score: shrinkToward(r.raw, anchor, r.ratings, SHRINK_K) }))
+      .sort((a, b) => b.score - a.score)
+      .map(({ id, date }) => ({ id, date }));
+  }
+
+  /** Resolve each rateable's show date, for deriving the drummer era. */
+  private async loadRateableMeta(refs: ReadonlyArray<RateableRef>): Promise<Map<string, RateableMeta>> {
+    const showIds = new Set<string>();
+    const trackIds = new Set<string>();
+    for (const { rateableType, rateableId } of refs) {
+      if (rateableType === "Show") showIds.add(rateableId);
+      else if (rateableType === "Track") trackIds.add(rateableId);
+    }
+
+    const meta = new Map<string, RateableMeta>();
+    if (showIds.size > 0) {
+      const shows = await this.db.show.findMany({
+        where: { id: { in: Array.from(showIds) } },
+        select: { id: true, date: true },
+      });
+      for (const show of shows) {
+        meta.set(rateableKey("Show", show.id), { date: show.date });
+      }
+    }
+    if (trackIds.size > 0) {
+      const tracks = await this.db.track.findMany({
+        where: { id: { in: Array.from(trackIds) } },
+        select: { id: true, show: { select: { date: true } } },
+      });
+      for (const track of tracks) {
+        meta.set(rateableKey("Track", track.id), { date: track.show?.date ?? "" });
+      }
+    }
+    return meta;
+  }
+
+  /**
+   * Population rating mean for one kind — the centering reference. Deliberately
+   * computed over the RAW ratings table, not deduped: deduping shifts it ~0.017
+   * with no effect on rankings (jam-chart Spearman was flat in the validity eval),
+   * so it stays a single cheap aggregate. If this is ever deduped (e.g.
+   * SUM(average_rating * ratings_count) / SUM(ratings_count) over the deduped
+   * columns), re-run the validity eval — it moves every calibrated score slightly.
+   */
+  private async populationStats(kind: RateableKind): Promise<PopulationStats> {
+    const rateableType = kind === "TRACK" ? "Track" : "Show";
+    const [row] = await this.db.$queryRaw<Array<{ mean: number | null }>>`
+      SELECT AVG("value") AS mean
+      FROM "ratings" WHERE "rateable_type" = ${rateableType}
+    `;
+    return { mean: row?.mean ?? 0 };
+  }
+
+  /** Tag a user's ratings with each rateable's mean, drummer era, and kind. */
+  private async scopedRatingsForUser(
+    ratings: ReadonlyArray<{ rateableId: string; rateableType: string; value: number }>,
+  ): Promise<ScopedRating[]> {
+    const meta = await this.loadRateableMeta(ratings);
+    const scoped: ScopedRating[] = [];
+    for (const rating of ratings) {
+      const found = meta.get(rateableKey(rating.rateableType, rating.rateableId));
+      if (!found || !found.date) continue;
+      scoped.push({
+        value: rating.value,
+        era: drummerEraForDate(found.date),
+        kind: rateableKindFromType(rating.rateableType),
+      });
+    }
+    return scoped;
+  }
+
+  /** Build a person's rater_stats rows — one per (kind, era), with the per-era bad-faith flag. */
+  private buildUserStatRecords(userId: string, scoped: ScopedRating[]): RaterStatRecord[] {
+    const now = new Date();
+    const records: RaterStatRecord[] = [];
+    for (const kind of RATEABLE_KINDS) {
+      const subset = scoped.filter((rating) => rating.kind === kind);
+      if (subset.length === 0) continue;
+      for (const [era, stats] of computeCleanedScopeStats(subset)) {
+        records.push({
+          userId,
+          era,
+          kind,
+          ratingsCount: stats.ratingsCount,
+          entropy: stats.entropy,
+          mean: stats.mean,
+          isExcluded: stats.isExcluded,
+          computedAt: now,
+        });
+      }
+    }
+    return records;
+  }
+
+  /**
+   * Recompute one person's rater_stats (per kind × era). Operates on the canonical
+   * identity: all of the person's duplicate accounts are pulled in, collapsed to
+   * one (most-recent) vote per rateable, and stored under the canonical user id.
+   */
+  async recomputeUser(userId: string): Promise<void> {
+    const canonicalUsers = await this.buildCanonicalUserMap();
+    const canonicalId = canonicalUsers.get(userId) ?? userId;
+    const memberIds = [...canonicalUsers.entries()].filter(([, c]) => c === canonicalId).map(([id]) => id);
+    const ids = memberIds.length > 0 ? memberIds : [userId];
+
+    const rawRatings = await this.db.rating.findMany({
+      where: { userId: { in: ids } },
+      select: { rateableId: true, rateableType: true, value: true, createdAt: true },
+    });
+    await this.db.raterStats.deleteMany({ where: { userId: { in: ids } } });
+    if (rawRatings.length === 0) return;
+
+    // One (most recent) vote per rateable across the person's accounts.
+    const best = new Map<string, (typeof rawRatings)[number]>();
+    for (const rating of rawRatings) {
+      const key = `${rating.rateableType}:${rating.rateableId}`;
+      const current = best.get(key);
+      if (!current || rating.createdAt > current.createdAt) best.set(key, rating);
+    }
+
+    const scoped = await this.scopedRatingsForUser([...best.values()]);
+    const records = this.buildUserStatRecords(canonicalId, scoped);
+    if (records.length > 0) await this.db.raterStats.createMany({ data: records });
+  }
+
+  /**
+   * Recompute one show's calibrated score (`shows.weighted_rating`) from current
+   * rater_stats. Show-only — tracks have no denormalized calibrated column. The
+   * batch passes `population` + the prebuilt canonical map to skip per-call work.
+   */
+  async recomputeRateable(
+    rateableType: string,
+    rateableId: string,
+    population?: PopulationStats,
+    canonicalUsers?: Map<string, string>,
+  ): Promise<void> {
+    if (rateableType !== "Show") return;
+
+    const rawRatings = await this.db.rating.findMany({
+      where: { rateableType, rateableId },
+      select: { userId: true, value: true, createdAt: true },
+    });
+    if (rawRatings.length === 0) {
+      await this.db.show.update({
+        where: { id: rateableId },
+        data: { weightedRating: null, weightedRatingsCount: 0 },
+      });
+      return;
+    }
+
+    // Collapse duplicate accounts to one (most recent) vote per person, remapping each
+    // vote to its canonical account FIRST so the rater's stats (stored under the
+    // canonical id) are found — a multi-account rater is one person, scored once with
+    // their real stats regardless of which account cast the latest vote.
+    const canonical = canonicalUsers ?? (await this.buildCanonicalUserMap());
+    const ratings = mostRecentPerKey(
+      rawRatings.map((rating) => ({ ...rating, userId: canonical.get(rating.userId) ?? rating.userId })),
+      (rating) => rating.userId,
+    );
+
+    const kind = rateableKindFromType(rateableType);
+    const meta = await this.loadRateableMeta([{ rateableType, rateableId }]);
+    const date = meta.get(rateableKey(rateableType, rateableId))?.date;
+    const era = date ? drummerEraForDate(date) : null;
+    const pop = population ?? (await this.populationStats(kind));
+
+    const statRows = await this.db.raterStats.findMany({
+      where: { userId: { in: ratings.map((rating) => rating.userId) }, kind },
+      select: { userId: true, era: true, mean: true, entropy: true, ratingsCount: true, isExcluded: true },
+    });
+    const byUserEra = new Map<string, RaterScopeStat>();
+    for (const row of statRows) {
+      byUserEra.set(`${row.userId}:${row.era}`, {
+        mean: row.mean,
+        entropy: row.entropy,
+        count: row.ratingsCount,
+        isExcluded: row.isExcluded,
+      });
+    }
+    const statByUserEra: StatByUserEra = (userId, scopeEra) => byUserEra.get(`${userId}:${scopeEra}`);
+
+    const { weightedRating, weightedRatingsCount } = computeShowWeighted(ratings, era, statByUserEra, pop);
+    await this.db.show.update({
+      where: { id: rateableId },
+      data: { weightedRating, weightedRatingsCount },
+    });
+  }
+
+  /**
+   * userId → canonical userId, collapsing duplicate accounts (one human rating
+   * under several usernames) so a person counts once. Canonical = the account
+   * with the most ratings in the alias group. See {@link aliasKey}.
+   */
+  private async buildCanonicalUserMap(): Promise<Map<string, string>> {
+    const users = await this.db.user.findMany({
+      where: { username: { not: null } },
+      select: { id: true, username: true },
+    });
+    const counts = await this.db.rating.groupBy({ by: ["userId"], _count: { id: true } });
+    const ratingCount = new Map(counts.map((c) => [c.userId, c._count.id]));
+    const groups = new Map<string, Array<{ id: string; n: number }>>();
+    for (const user of users) {
+      if (!user.username) continue;
+      const key = aliasKey(user.username, user.id);
+      const group = groups.get(key) ?? [];
+      group.push({ id: user.id, n: ratingCount.get(user.id) ?? 0 });
+      groups.set(key, group);
+    }
+    const canonical = new Map<string, string>();
+    for (const group of groups.values()) {
+      const primary = group.reduce((best, member) => (member.n > best.n ? member : best)).id;
+      for (const member of group) canonical.set(member.id, primary);
+    }
+    return canonical;
+  }
+
+  /**
+   * Full rebuild: every person's per-kind scope stats (deduped) then every rated
+   * show's calibrated score. Run by the cron/script. Returns coverage counts.
+   */
+  async recomputeAll(): Promise<{ users: number; rateables: number }> {
+    const rawRatings = await this.db.rating.findMany({
+      select: { userId: true, rateableId: true, rateableType: true, value: true, createdAt: true },
+    });
+    // Collapse duplicate accounts: remap to canonical user, keep one (most recent)
+    // vote per (person, rateable) so a multi-account rater isn't double-counted.
+    const canonicalUsers = await this.buildCanonicalUserMap();
+    const dedupedByKey = new Map<string, (typeof rawRatings)[number]>();
+    for (const rating of rawRatings) {
+      const userId = canonicalUsers.get(rating.userId) ?? rating.userId;
+      const key = `${userId}:${rating.rateableType}:${rating.rateableId}`;
+      const current = dedupedByKey.get(key);
+      if (!current || rating.createdAt > current.createdAt) dedupedByKey.set(key, { ...rating, userId });
+    }
+    const ratings = [...dedupedByKey.values()];
+    const meta = await this.loadRateableMeta(ratings);
+
+    const scopedByUser = new Map<string, ScopedRating[]>();
+    for (const rating of ratings) {
+      const found = meta.get(rateableKey(rating.rateableType, rating.rateableId));
+      if (!found || !found.date) continue;
+      const scoped = scopedByUser.get(rating.userId) ?? [];
+      scoped.push({
+        value: rating.value,
+        era: drummerEraForDate(found.date),
+        kind: rateableKindFromType(rating.rateableType),
+      });
+      scopedByUser.set(rating.userId, scoped);
+    }
+
+    const allRecords: RaterStatRecord[] = [];
+    for (const [userId, scoped] of scopedByUser) {
+      allRecords.push(...this.buildUserStatRecords(userId, scoped));
+    }
+    await this.db.raterStats.deleteMany({});
+    if (allRecords.length > 0) await this.db.raterStats.createMany({ data: allRecords });
+
+    const populationByKind: Record<RateableKind, PopulationStats> = {
+      SHOW: { mean: meanOf(ratings.filter((r) => r.rateableType === "Show").map((r) => r.value)) },
+      TRACK: { mean: meanOf(ratings.filter((r) => r.rateableType === "Track").map((r) => r.value)) },
+    };
+    // Index the just-built SHOW-kind stats in memory so each show scores without
+    // re-fetching its raters' stats (the per-show DB read the old loop hit).
+    const showStatByUserEra = new Map<string, RaterScopeStat>();
+    for (const record of allRecords) {
+      if (record.kind !== "SHOW") continue;
+      showStatByUserEra.set(`${record.userId}:${record.era}`, {
+        mean: record.mean,
+        entropy: record.entropy,
+        count: record.ratingsCount,
+        isExcluded: record.isExcluded,
+      });
+    }
+    const statByUserEra: StatByUserEra = (userId, scopeEra) => showStatByUserEra.get(`${userId}:${scopeEra}`);
+
+    // Group the already-deduped show ratings by show — no per-show ratings refetch.
+    const ratingsByShow = new Map<string, Array<{ userId: string; value: number }>>();
+    for (const rating of ratings) {
+      if (rating.rateableType !== "Show") continue;
+      const bucket = ratingsByShow.get(rating.rateableId) ?? [];
+      bucket.push({ userId: rating.userId, value: rating.value });
+      ratingsByShow.set(rating.rateableId, bucket);
+    }
+
+    // Score every show in memory (shared rule with recomputeRateable), then bulk-write.
+    // This replaces the old N+1 loop that re-fetched each show's ratings/meta/stats.
+    const updates: Array<{ id: string; weightedRating: number | null; weightedRatingsCount: number }> = [];
+    for (const [showId, showRatings] of ratingsByShow) {
+      const date = meta.get(rateableKey("Show", showId))?.date;
+      const era = date ? drummerEraForDate(date) : null;
+      updates.push({ id: showId, ...computeShowWeighted(showRatings, era, statByUserEra, populationByKind.SHOW) });
+    }
+
+    // One bulk UPDATE instead of ~1800 per-row round-trips: join the computed values
+    // in as a VALUES table. Chunked only to stay well under the parameter limit.
+    const WRITE_CHUNK = 1000;
+    for (let i = 0; i < updates.length; i += WRITE_CHUNK) {
+      const rows = updates
+        .slice(i, i + WRITE_CHUNK)
+        .map(
+          (update) =>
+            Prisma.sql`(${update.id}::uuid, ${update.weightedRating}::double precision, ${update.weightedRatingsCount}::int)`,
+        );
+      await this.db.$executeRaw`
+        UPDATE shows AS s
+        SET weighted_rating = v.weighted_rating, weighted_ratings_count = v.weighted_ratings_count
+        FROM (VALUES ${Prisma.join(rows)}) AS v(id, weighted_rating, weighted_ratings_count)
+        WHERE s.id = v.id
+      `;
+    }
+
+    return { users: scopedByUser.size, rateables: updates.length };
+  }
+}

--- a/packages/core/src/ratings/rater-weighting.test.ts
+++ b/packages/core/src/ratings/rater-weighting.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "vitest";
+import {
+  center,
+  computeCleanedScopeStats,
+  entropyWeight,
+  entropyWeightedCenteredAverage,
+  isExcludedBucket,
+  meanOf,
+  RATER_ERAS,
+  ratingEntropy,
+  type ScopedRating,
+} from "./rater-weighting";
+
+// ratingEntropy — Shannon information entropy over a rater's value distribution.
+// 0 means perfectly predictable (a pure fluffer/bomber); higher means the rater
+// uses more of the scale, carrying more information about show quality.
+describe("ratingEntropy", () => {
+  test("a single-value rater (fluffer/bomber) has zero entropy", () => {
+    expect(ratingEntropy([5, 5, 5, 5])).toBe(0);
+    expect(ratingEntropy([0.5, 0.5, 0.5])).toBe(0);
+  });
+
+  test("an empty rater has zero entropy", () => {
+    expect(ratingEntropy([])).toBe(0);
+  });
+
+  test("an even two-value split is exactly one bit", () => {
+    expect(ratingEntropy([1, 5, 1, 5])).toBeCloseTo(1, 10);
+  });
+
+  test("a uniform five-value rater approaches log2(5)", () => {
+    expect(ratingEntropy([1, 2, 3, 4, 5])).toBeCloseTo(Math.log2(5), 10);
+  });
+
+  test("a full-scale rater carries more entropy than a near-fluffer", () => {
+    const fullScale = ratingEntropy([1, 2, 3, 4, 5, 4, 3, 2]);
+    const nearFluffer = ratingEntropy([5, 5, 5, 5, 5, 5, 5, 4]);
+    expect(fullScale).toBeGreaterThan(nearFluffer);
+  });
+});
+
+// The rater-stats scope axis: GLOBAL plus one bucket per drummer era.
+describe("RATER_ERAS", () => {
+  test("prepends GLOBAL to the drummer eras", () => {
+    expect(RATER_ERAS).toEqual(["GLOBAL", "ALTMAN", "AUCOIN", "MARLON"]);
+  });
+});
+
+// meanOf treats an empty set as 0 (not average's null), since a rater with no
+// ratings in a scope contributes a 0 baseline.
+describe("meanOf", () => {
+  test("averages values and returns 0 for an empty set", () => {
+    expect(meanOf([2, 4])).toBe(3);
+    expect(meanOf([])).toBe(0);
+  });
+});
+
+// center shifts a rating by the gap between the rater's own mean and the
+// population mean, so a harsh grader's "high for them" rating counts as high.
+describe("center", () => {
+  test("recenters a harsh rater's rating up toward what it means for them", () => {
+    // Harsh rater (own mean 2) gives a 3; population mean 4 → counts as a 5.
+    expect(center(3, 2, { mean: 4 })).toBe(5);
+  });
+
+  test("recenters a generous rater's rating down", () => {
+    // Generous rater (own mean 4.5) gives a 4; population mean 4 → counts as 3.5.
+    expect(center(4, 4.5, { mean: 4 })).toBe(3.5);
+  });
+
+  test("a rating equal to the rater's own mean lands on the population mean", () => {
+    expect(center(3, 3, { mean: 4 })).toBe(4);
+  });
+});
+
+// entropyWeight maps a rater's entropy to a [0,1] confidence: one-noters are
+// weightless, ramping to full at `fullAt` bits.
+describe("entropyWeight", () => {
+  test("a one-note (zero or negative entropy) rater is weightless", () => {
+    expect(entropyWeight(0, 2)).toBe(0);
+    expect(entropyWeight(-1, 2)).toBe(0);
+  });
+
+  test("ramps linearly to full weight at fullAt", () => {
+    expect(entropyWeight(1, 2)).toBe(0.5);
+    expect(entropyWeight(2, 2)).toBe(1);
+  });
+
+  test("clamps above fullAt to 1", () => {
+    expect(entropyWeight(3, 2)).toBe(1);
+  });
+});
+
+// The core score: center each rating, weight by entropy, average, clamp once.
+describe("entropyWeightedCenteredAverage", () => {
+  test("drops zero-entropy raters and keeps the entropy-weighted ones", () => {
+    const result = entropyWeightedCenteredAverage(
+      [
+        { value: 5, userMean: 4, entropy: 2 }, // full weight, center → 5
+        { value: 0.5, userMean: 4, entropy: 0 }, // weightless, dropped
+      ],
+      { mean: 4 },
+      2,
+    );
+    expect(result.contributingCount).toBe(1);
+    expect(result.weightedAverage).toBe(5);
+  });
+
+  test("clamps the result into the 0.5 to 5 star range", () => {
+    // center(5, 2, 4) = 7, clamped down to 5.
+    const result = entropyWeightedCenteredAverage([{ value: 5, userMean: 2, entropy: 2 }], { mean: 4 }, 2);
+    expect(result.weightedAverage).toBe(5);
+  });
+
+  test("returns an empty result when every rater is weightless", () => {
+    const result = entropyWeightedCenteredAverage([{ value: 5, userMean: 4, entropy: 0 }], { mean: 4 }, 2);
+    expect(result.contributingCount).toBe(0);
+    expect(result.weightedAverage).toBe(0);
+  });
+});
+
+// isExcludedBucket flags bad-faith buckets: one-note AND stuck at an extreme AND
+// numerous enough to be deliberate.
+describe("isExcludedBucket", () => {
+  test("flags a numerous one-note floor-bomber", () => {
+    expect(isExcludedBucket({ entropy: 0.2, mean: 0.6, ratingsCount: 10 })).toBe(true);
+  });
+
+  test("flags a numerous one-note ceiling-fluffer", () => {
+    expect(isExcludedBucket({ entropy: 0.3, mean: 4.9, ratingsCount: 8 })).toBe(true);
+  });
+
+  test("spares a wide-range rater even at an extreme mean (the entropy gate)", () => {
+    expect(isExcludedBucket({ entropy: 1.5, mean: 0.8, ratingsCount: 10 })).toBe(false);
+  });
+
+  test("spares a one-noter whose mean isn't extreme", () => {
+    expect(isExcludedBucket({ entropy: 0, mean: 3, ratingsCount: 10 })).toBe(false);
+  });
+
+  test("spares too small a sample to judge", () => {
+    expect(isExcludedBucket({ entropy: 0, mean: 0.5, ratingsCount: 3 })).toBe(false);
+  });
+});
+
+// computeCleanedScopeStats scores each era, drops the bad-faith ones, and rebuilds
+// GLOBAL from the survivors so a bimodal rater's bombing doesn't poison their mean.
+describe("computeCleanedScopeStats", () => {
+  const kind = "SHOW" as const;
+
+  test("excludes a bad-faith era and rebuilds GLOBAL from the surviving eras", () => {
+    const ratings: ScopedRating[] = [
+      // AUCOIN: a one-note floor-bombing bucket (excluded).
+      ...Array.from({ length: 5 }, () => ({ value: 0.5, era: "AUCOIN" as const, kind })),
+      // MARLON: genuine, varied ratings (kept).
+      { value: 3, era: "MARLON", kind },
+      { value: 4, era: "MARLON", kind },
+      { value: 5, era: "MARLON", kind },
+      { value: 2, era: "MARLON", kind },
+      { value: 4, era: "MARLON", kind },
+    ];
+    const scopes = computeCleanedScopeStats(ratings);
+    expect(scopes.get("AUCOIN")?.isExcluded).toBe(true);
+    expect(scopes.get("MARLON")?.isExcluded).toBe(false);
+    // GLOBAL is rebuilt from MARLON only, so the 0.5 bombs don't drag it down.
+    expect(scopes.get("GLOBAL")?.mean).toBeCloseTo(3.6, 10);
+  });
+
+  test("falls back to all ratings for GLOBAL when every era is excluded", () => {
+    const ratings: ScopedRating[] = [
+      ...Array.from({ length: 5 }, () => ({ value: 0.5, era: "AUCOIN" as const, kind })),
+      ...Array.from({ length: 5 }, () => ({ value: 0.5, era: "MARLON" as const, kind })),
+    ];
+    const scopes = computeCleanedScopeStats(ratings);
+    expect(scopes.get("GLOBAL")?.mean).toBe(0.5);
+    expect(scopes.get("GLOBAL")?.isExcluded).toBe(false);
+  });
+});

--- a/packages/core/src/ratings/rater-weighting.ts
+++ b/packages/core/src/ratings/rater-weighting.ts
@@ -1,0 +1,272 @@
+/**
+ * The Calibrated Show Rating's pure scoring math, plus its tuning constants and
+ * rater-stats scope vocabulary. Inspired by the Phish.net show-ratings series
+ * (Paul Jakus, 2024, https://phish.net/blog/1724255981/phishnet-show-ratings-part-4-can-rater-weights-improve-the-accuracy-of-show-ratings.html),
+ * which weights raters to discount anomalous ones. We diverge: each rating is
+ * weighted by the rater's Shannon entropy (how much of the 0.5 to 5 star ratings scale
+ * they use) and mean-centered to remove harsh/generous bias, and only clear bad-faith
+ * bombers/fluffers are dropped outright, rather than the original
+ * average-deviation "MRYM" weighting.
+ *
+ * Deliberately free of Prisma/DB so the methodology is unit-tested in isolation;
+ * `rater-weight-service.ts` feeds these functions rows and persists the results.
+ */
+
+import { average, DRUMMER_ERAS, type DrummerEra } from "@bip/domain";
+
+// Tuning constants: the chosen hyperparameters of the rating algorithm. The pure
+// functions below take them as parameters; rater-weight-service passes these in.
+// Edit a value here to retune.
+
+/**
+ * Count-shrinkage strength for the displayed show score. A show with only a
+ * handful of ratings can post an extreme average on an unreliable sample (one
+ * 5-star vote is a perfect 5.0); shrinkage pulls a thin show toward the global
+ * average until enough people have rated it, then its own ratings take over.
+ * `displayed = n/(n+k) * weighted + k/(n+k) * anchor`, where `n` is the
+ * contributing count; a higher k holds thin shows near the anchor longer. Kept
+ * small since even top shows are low-volume: at k=2 an 11-rating show can still
+ * crack the top 10, k=3 prevents that. Applied at read time, so a change takes
+ * effect without a recompute.
+ */
+export const SHRINK_K = 3;
+
+/**
+ * The global average show rating, used as the shrinkage anchor a thin show
+ * regresses toward. Anchoring on this (the overall prior) rather than the show's
+ * own canonical average is the correct empirical-Bayes move and, critically,
+ * stops a bomber-poisoned canonical from leaking back into the shrunk score.
+ */
+export const POPULATION_SHOW_MEAN = 4.07;
+
+/**
+ * Entropy (bits) at which a rater earns full confidence weight in the
+ * entropy-weighted scheme, ~4 values used evenly. Below it, weight ramps down to
+ * 0 for one-note raters; distance from the crowd is never penalized.
+ */
+export const ENTROPY_FULL_WEIGHT = 2.0;
+
+/**
+ * Cold-start (per-rater empirical-Bayes) tuning. The calibrated score weighs a
+ * rater by how far they deviate from their own average and how spread-out their
+ * ratings are; a brand-new rater has neither yet, so their vote would count for
+ * almost nothing (deviation 0 + entropy 0), a bad welcome and a slow ramp before
+ * anyone new can move a show. So a low-volume rater is blended toward the typical
+ * rater by their rating count, fading out as the count grows: `RATER_K` blends
+ * their centering mean toward the population mean, `ENTROPY_K` blends their
+ * entropy toward `ENTROPY_FULL_WEIGHT`. Both are needed: without the entropy half
+ * a new rater's weight stays 0 no matter what (spike-verified). Higher values
+ * treat newcomers as typical for longer.
+ */
+export const COLD_START_RATER_K = 5;
+export const COLD_START_ENTROPY_K = 3;
+
+/**
+ * Whether a stat aggregates show ratings or track ratings. They have very
+ * different baselines (most tracks are unrated / "nothing special", so a rated
+ * track is already a signal), so they must be normalized separately.
+ */
+export const RATEABLE_KINDS = ["SHOW", "TRACK"] as const;
+export type RateableKind = (typeof RATEABLE_KINDS)[number];
+
+/** Map the polymorphic `rateableType` ("Show"/"Track") to a RateableKind. */
+export function rateableKindFromType(rateableType: string): RateableKind {
+  return rateableType === "Track" ? "TRACK" : "SHOW";
+}
+
+/**
+ * Scopes a per-user rater-stats row can be computed at: one row per drummer era
+ * plus a `GLOBAL` row spanning all of a user's ratings. Era-defined, but a
+ * rating concept (the scope axis of `rater_stats`), so it lives with the rating
+ * code rather than the era vocabulary. The Prisma `RaterEra` enum uses these
+ * exact string values, so the DB enum and this TS union agree by construction.
+ */
+export const RATER_ERAS = ["GLOBAL", ...DRUMMER_ERAS] as const;
+export type RaterEra = (typeof RATER_ERAS)[number];
+
+/** A rater's summary statistics within some scope (global, or one drummer era). */
+export interface RaterStats {
+  ratingsCount: number;
+  entropy: number;
+  /** The rater's own mean rating in this scope — the centering baseline. */
+  mean: number;
+}
+
+/** A rating-population reference (the mean that centered scores recenter onto). */
+export interface PopulationStats {
+  mean: number;
+}
+
+/** One of a user's ratings, tagged with its rateable's drummer era and kind. */
+export interface ScopedRating {
+  value: number;
+  era: DrummerEra;
+  kind: RateableKind;
+}
+
+/**
+ * Shannon entropy (`−Σ pᵢ·log₂ pᵢ`) over the distribution of values a rater
+ * used, in bits. Zero for a rater who only ever gives one value.
+ */
+export function ratingEntropy(values: number[]): number {
+  if (values.length === 0) return 0;
+  const counts = new Map<number, number>();
+  for (const value of values) {
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  const total = values.length;
+  let entropy = 0;
+  for (const count of counts.values()) {
+    const probability = count / total;
+    entropy -= probability * Math.log2(probability);
+  }
+  return entropy;
+}
+
+/**
+ * Arithmetic mean, treating an empty set as 0 rather than `average`'s null (a
+ * rater with no ratings in a scope contributes a 0 baseline). Thin wrapper over
+ * `average` so the arithmetic lives in one place.
+ */
+export function meanOf(values: number[]): number {
+  return average(values) ?? 0;
+}
+
+const STAR_MIN = 0.5;
+const STAR_MAX = 5;
+
+function clampStar(value: number): number {
+  return Math.min(STAR_MAX, Math.max(STAR_MIN, value));
+}
+
+/**
+ * Mean-centering of one rating: shift by the gap between the rater's mean and
+ * the population mean, preserving the rater's own spread (unlike z-score, which
+ * also rescales spread). Corrects harsh/generous bias only. Not clamped.
+ */
+export function center(value: number, userMean: number, population: PopulationStats): number {
+  return value - userMean + population.mean;
+}
+
+/**
+ * A confidence weight in [0,1] from a rater's entropy: a one-note rater (0) is
+ * weightless, and weight ramps to full at `fullAt` bits (a rater using ~4 values
+ * evenly). Deliberately ignores distance from the crowd, so a considered
+ * contrarian who uses the whole scale is fully credited rather than penalized.
+ */
+export function entropyWeight(entropy: number, fullAt: number): number {
+  if (entropy <= 0) return 0;
+  return Math.min(1, entropy / fullAt);
+}
+
+/**
+ * A rateable's mean-centered score where each rater is weighted by their entropy
+ * confidence: wide-range raters count fully, one-noters fall out, and nobody is
+ * penalized for disagreeing. Clamped once at the end.
+ */
+export function entropyWeightedCenteredAverage(
+  contributions: ReadonlyArray<{ value: number; userMean: number; entropy: number }>,
+  population: PopulationStats,
+  fullAt: number,
+): WeightedAverageResult {
+  let valueSum = 0;
+  let weightSum = 0;
+  let contributingCount = 0;
+  for (const { value, userMean, entropy } of contributions) {
+    const weight = entropyWeight(entropy, fullAt);
+    if (weight <= 0) continue;
+    valueSum += center(value, userMean, population) * weight;
+    weightSum += weight;
+    contributingCount += 1;
+  }
+  return {
+    weightedAverage: weightSum === 0 ? 0 : clampStar(valueSum / weightSum),
+    weightSum,
+    contributingCount,
+  };
+}
+
+export interface WeightedAverageResult {
+  weightedAverage: number;
+  weightSum: number;
+  contributingCount: number;
+}
+
+/** entropy/mean/count for one bucket of a rater's ratings. */
+function statsOfRatings(ratings: ReadonlyArray<ScopedRating>): RaterStats {
+  const values = ratings.map((rating) => rating.value);
+  return {
+    ratingsCount: ratings.length,
+    entropy: ratingEntropy(values),
+    mean: meanOf(values),
+  };
+}
+
+/**
+ * Thresholds that flag a `(rater, era)` bucket as bad-faith: an account that
+ * votes one extreme value across a whole era, a bomber (all ~floor, dragging
+ * shows down) or a fluffer (all ~ceiling, inflating them). Their votes are noise,
+ * not signal, so they're dropped from the calibrated score without hand-policing
+ * accounts. The three gates together flag only deliberate bad faith, not a quiet
+ * fan: ratings must be one-note (low entropy) AND stuck at an extreme (mean
+ * at/below `lowMean` or at/above `highMean`) AND numerous enough (`minCount`) to
+ * judge. The entropy gate is what separates a bomber/fluffer from a thoughtful
+ * harsh/generous rater, who still varies their scores. A rater is excluded only
+ * in the era they vote in bad faith; good-faith ratings in other eras still count.
+ */
+export const EXCLUSION_THRESHOLDS = {
+  /** At/below this entropy (bits) the rater is essentially one-note in the era. */
+  maxEntropy: 0.5,
+  /** Mean at/below this is floor-bombing. */
+  lowMean: 1.0,
+  /** Mean at/above this is ceiling-fluffing. */
+  highMean: 4.75,
+  /** Below this many ratings it's too small a sample to call bad-faith. */
+  minCount: 5,
+};
+
+/** Whether a bucket's stats trip the bad-faith (era-bomber/fluffer) test. */
+export function isExcludedBucket(stats: Pick<RaterStats, "entropy" | "mean" | "ratingsCount">): boolean {
+  return (
+    stats.entropy <= EXCLUSION_THRESHOLDS.maxEntropy &&
+    (stats.mean <= EXCLUSION_THRESHOLDS.lowMean || stats.mean >= EXCLUSION_THRESHOLDS.highMean) &&
+    stats.ratingsCount >= EXCLUSION_THRESHOLDS.minCount
+  );
+}
+
+/** A scope's stats plus whether that era bucket was flagged bad-faith and dropped. */
+export interface ScopeStat extends RaterStats {
+  isExcluded: boolean;
+}
+
+/**
+ * Computes a rater's stats for every scope (each drummer era plus `GLOBAL`) in
+ * two passes: first score each era, then flag the bad-faith era buckets and
+ * rebuild the `GLOBAL` scope from the surviving eras only. This de-poisons a
+ * bimodal rater's global mean (e.g. someone normal in one era but floor-bombing
+ * another), so a single global-scoped scheme can trust them where they're genuine
+ * without their bombing leaking in. Falls back to all ratings for GLOBAL if every
+ * era was excluded (so it never goes empty).
+ */
+export function computeCleanedScopeStats(ratings: ReadonlyArray<ScopedRating>): Map<RaterEra, ScopeStat> {
+  const byEra = new Map<DrummerEra, ScopedRating[]>();
+  for (const rating of ratings) {
+    const bucket = byEra.get(rating.era);
+    if (bucket) bucket.push(rating);
+    else byEra.set(rating.era, [rating]);
+  }
+
+  const result = new Map<RaterEra, ScopeStat>();
+  const excludedEras = new Set<DrummerEra>();
+  for (const [era, bucket] of byEra) {
+    const stats = statsOfRatings(bucket);
+    const isExcluded = isExcludedBucket(stats);
+    if (isExcluded) excludedEras.add(era);
+    result.set(era, { ...stats, isExcluded });
+  }
+
+  const survivors = ratings.filter((rating) => !excludedEras.has(rating.era));
+  const globalBase = survivors.length > 0 ? survivors : ratings;
+  result.set("GLOBAL", { ...statsOfRatings(globalBase), isExcluded: false });
+  return result;
+}

--- a/packages/core/src/ratings/rating-mode.test.ts
+++ b/packages/core/src/ratings/rating-mode.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { resolveRatingMode } from "./rating-mode";
+
+// The single place that decides whether a viewer sees the simple or calibrated
+// score. Master gate wins; then the user's explicit pref; then the app default.
+describe("resolveRatingMode", () => {
+  test("master gate off means everyone sees simple, regardless of pref or default", () => {
+    expect(resolveRatingMode(true, { calibratedEnabled: false, defaultCalibrated: true })).toBe("simple");
+    expect(resolveRatingMode(null, { calibratedEnabled: false, defaultCalibrated: true })).toBe("simple");
+  });
+
+  test("explicit user pref wins over the default when the gate is on", () => {
+    expect(resolveRatingMode(true, { calibratedEnabled: true, defaultCalibrated: false })).toBe("calibrated");
+    expect(resolveRatingMode(false, { calibratedEnabled: true, defaultCalibrated: true })).toBe("simple");
+  });
+
+  test("no explicit pref falls to the app default", () => {
+    expect(resolveRatingMode(null, { calibratedEnabled: true, defaultCalibrated: true })).toBe("calibrated");
+    expect(resolveRatingMode(null, { calibratedEnabled: true, defaultCalibrated: false })).toBe("simple");
+    expect(resolveRatingMode(undefined, { calibratedEnabled: true, defaultCalibrated: false })).toBe("simple");
+  });
+});

--- a/packages/core/src/ratings/rating-mode.ts
+++ b/packages/core/src/ratings/rating-mode.ts
@@ -1,0 +1,19 @@
+export type RatingMode = "simple" | "calibrated";
+
+/**
+ * The one place display mode is decided, used by every rating surface
+ * (show-user-data, Top Rated, cards) so the rule is never inlined twice. Order:
+ * the master gate wins (off means nobody sees the calibrated rating); then the
+ * user's explicit opt-in pref (a DB tri-state, where null means "no choice");
+ * then the app default. Eligibility to SET the pref is gated separately by
+ * `ratings.toggle-visible`, so an ineligible user keeps a null pref and falls to
+ * the default here.
+ */
+export function resolveRatingMode(
+  showCalibratedRatings: boolean | null | undefined,
+  flags: { calibratedEnabled: boolean; defaultCalibrated: boolean },
+): RatingMode {
+  if (!flags.calibratedEnabled) return "simple";
+  if (showCalibratedRatings != null) return showCalibratedRatings ? "calibrated" : "simple";
+  return flags.defaultCalibrated ? "calibrated" : "simple";
+}

--- a/packages/core/src/ratings/rating-service.test.ts
+++ b/packages/core/src/ratings/rating-service.test.ts
@@ -9,6 +9,30 @@ const cacheInvalidation = {
   invalidateShowComprehensive: vi.fn(),
 } as never;
 
+// Build distinct-user rating rows (no dedup collision) for the canonical-average
+// path, which now reads rating.findMany + collapses duplicate accounts. Returns
+// rows shaped like the service's select (value + createdAt + userId + user.username).
+function ratingRows(...values: number[]) {
+  return values.map((value, i) => ({
+    value,
+    createdAt: new Date(2024, 0, 1 + i),
+    userId: `u${i}`,
+    user: { username: `u${i}` },
+  }));
+}
+
+// Same, but tagged with a rateableId for the bulk rebuildAggregatesFor path
+// (one findMany returns rows across many rateables; the service buckets them).
+function taggedRows(rateableId: string, ...values: number[]) {
+  return values.map((value, i) => ({
+    rateableId,
+    value,
+    createdAt: new Date(2024, 0, 1 + i),
+    userId: `${rateableId}-u${i}`,
+    user: { username: `${rateableId}-u${i}` },
+  }));
+}
+
 // Flattens a $queryRaw mock call (TemplateStringsArray + Prisma.Sql
 // interpolations) into a single SQL string so tests can assert on the
 // composed ORDER BY clause. Prisma.Sql exposes its template parts under
@@ -29,6 +53,27 @@ function flattenSqlFromMockCall(call: unknown[]): string {
     }
   }
   return parts.join("");
+}
+
+// rebuildAggregatesFor bulk-writes via `$executeRaw`UPDATE <table> ... ${Prisma.join(rows)}``.
+// Each captured call's interpolations are [Prisma.raw(table), Prisma.join(rows)]: the raw
+// fragment's `strings` carry the table name, the joined fragment's flattened `values` are
+// [id, averageRating, ratingsCount, ...]. Decode them so tests assert the written averages.
+function bulkAverageWrites(executeRaw: ReturnType<typeof vi.fn>) {
+  return executeRaw.mock.calls.map((call) => {
+    const rawFragment = call[1] as { strings: string[] };
+    const joined = call[2] as { values: unknown[] };
+    const table = rawFragment.strings.join("").trim();
+    const tuples: Array<{ id: string; averageRating: number; ratingsCount: number }> = [];
+    for (let i = 0; i + 3 <= joined.values.length; i += 3) {
+      tuples.push({
+        id: joined.values[i] as string,
+        averageRating: joined.values[i + 1] as number,
+        ratingsCount: joined.values[i + 2] as number,
+      });
+    }
+    return { table, tuples };
+  });
 }
 
 type ShowRatingRow = {
@@ -410,13 +455,10 @@ describe("RatingService.clearForUser", () => {
   // runs as on upsert.
   test("deletes the user's rating row and recomputes the rateable's denormalized average", async () => {
     const deleteMany = vi.fn().mockResolvedValue({ count: 1 });
-    const aggregate = vi.fn().mockResolvedValue({
-      _avg: { value: 4.2 },
-      _count: { id: 5 },
-    });
+    const findMany = vi.fn().mockResolvedValue(ratingRows(4, 4, 4, 4, 5)); // 5 distinct raters, avg 4.2
     const showUpdate = vi.fn().mockResolvedValue(undefined);
     const db = {
-      rating: { deleteMany, aggregate },
+      rating: { deleteMany, findMany },
       show: { update: showUpdate },
       track: { update: vi.fn() },
     } as never;
@@ -430,7 +472,7 @@ describe("RatingService.clearForUser", () => {
       where: { userId: "u1", rateableId: "show-1", rateableType: "Show" },
     });
     // Recompute path ran against the same rateable.
-    expect(aggregate).toHaveBeenCalledWith(
+    expect(findMany).toHaveBeenCalledWith(
       expect.objectContaining({ where: { rateableId: "show-1", rateableType: "Show" } }),
     );
     // Denormalized fields on the Show row got the recomputed values.
@@ -449,7 +491,7 @@ describe("RatingService.clearForUser", () => {
     const db = {
       rating: {
         deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
-        aggregate: vi.fn().mockResolvedValue({ _avg: { value: null }, _count: { id: 0 } }),
+        findMany: vi.fn().mockResolvedValue([]), // last rating gone → 0/0
       },
       show: { update: vi.fn() },
       track: { update: vi.fn() },
@@ -469,7 +511,7 @@ describe("RatingService.clearForUser", () => {
     const db = {
       rating: {
         deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
-        aggregate: vi.fn().mockResolvedValue({ _avg: { value: 3.5 }, _count: { id: 2 } }),
+        findMany: vi.fn().mockResolvedValue(ratingRows(3, 4)), // 2 distinct raters, avg 3.5
       },
       show: { update: showUpdate },
       track: { update: trackUpdate },
@@ -495,7 +537,7 @@ describe("RatingService.clearForUser", () => {
     const db = {
       rating: {
         deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
-        aggregate: vi.fn().mockResolvedValue({ _avg: { value: 4.0 }, _count: { id: 1 } }),
+        findMany: vi.fn().mockResolvedValue(ratingRows(4)), // single rater, avg 4.0
       },
       show: { update: vi.fn() },
       track: { update: vi.fn() },
@@ -516,16 +558,17 @@ describe("RatingService.clearForUser", () => {
     expect(invalidate).toHaveBeenCalledWith(undefined, "2024-08-12-cap-theatre", [2024]);
   });
 
-  // Track-type clears must invalidate the show's setlist cache. The cached
-  // setlist payload at CacheKeys.show.data(slug) embeds each track's
-  // averageRating/ratingsCount, so the recompute on Track.update would be
-  // shadowed by the stale Redis payload on the next read.
-  test("invalidates the show cache when clearing a Track rating with a showSlug", async () => {
-    const invalidateShow = vi.fn();
+  // Track-type clears bust the show comprehensively, year-scoped, exactly like
+  // Show clears. Track.averageRating/ratingsCount are embedded in BOTH the
+  // per-show show.data payload AND the year-listing shows:list payload (its
+  // gap-chart view shows track averages), so a track rating change must purge
+  // the year listing too or the listing serves stale "Rate" buttons.
+  test("invalidates the show comprehensively, year-scoped, when clearing a Track rating with a showSlug", async () => {
+    const invalidate = vi.fn();
     const db = {
       rating: {
         deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
-        aggregate: vi.fn().mockResolvedValue({ _avg: { value: 3.5 }, _count: { id: 2 } }),
+        findMany: vi.fn().mockResolvedValue(ratingRows(3, 4)), // 2 distinct raters, avg 3.5
       },
       show: { update: vi.fn() },
       track: { update: vi.fn() },
@@ -533,8 +576,8 @@ describe("RatingService.clearForUser", () => {
 
     const service = new RatingService(db, {
       invalidateAttendanceCaches: vi.fn(),
-      invalidateShow,
-      invalidateShowComprehensive: vi.fn(),
+      invalidateShow: vi.fn(),
+      invalidateShowComprehensive: invalidate,
     } as never);
     await service.clearForUser({
       rateableId: "track-1",
@@ -543,33 +586,31 @@ describe("RatingService.clearForUser", () => {
       showSlug: "2024-08-12-cap-theatre",
     });
 
-    expect(invalidateShow).toHaveBeenCalledWith("2024-08-12-cap-theatre");
+    expect(invalidate).toHaveBeenCalledWith(undefined, "2024-08-12-cap-theatre", [2024]);
   });
 });
 
 describe("RatingService.rebuildAggregatesFor", () => {
-  // Bulk version of updateRateableAverageRating used by the sync script after
-  // importing many ratings at once. Single groupBy per rateableType collapses
-  // N rateables to one query each; per-rateable .update writes the resulting
-  // averageRating / ratingsCount onto Show or Track.
-  test("recomputes Show.averageRating + ratingsCount in one groupBy per type", async () => {
-    const showGroupBy = vi.fn().mockResolvedValue([
-      { rateableId: "show-1", _avg: { value: 4.5 }, _count: { id: 2 } },
-      { rateableId: "show-2", _avg: { value: 3.0 }, _count: { id: 1 } },
+  // Bulk version of updateRateableAverageRating used by the sync/recompute after
+  // importing many ratings. One findMany per rateableType pulls every rating (with
+  // username for dedup); a single bulk `UPDATE ... FROM (VALUES …)` per type writes
+  // the deduped averageRating / ratingsCount onto Show or Track (no per-row round-trip).
+  test("recomputes Show.averageRating + ratingsCount in one bulk write per type", async () => {
+    const showFindMany = vi.fn().mockResolvedValue([
+      ...taggedRows("show-1", 4, 5), // avg 4.5, count 2
+      ...taggedRows("show-2", 3), // avg 3.0, count 1
     ]);
-    const showUpdate = vi.fn().mockResolvedValue(undefined);
-    const trackUpdate = vi.fn();
-    const trackGroupBy = vi.fn();
+    const trackFindMany = vi.fn();
+    const executeRaw = vi.fn().mockResolvedValue(1);
     const db = {
       rating: {
-        groupBy: vi
+        findMany: vi
           .fn()
           .mockImplementation((args: { where: { rateableType: string } }) =>
-            args.where.rateableType === "Show" ? showGroupBy(args) : trackGroupBy(args),
+            args.where.rateableType === "Show" ? showFindMany(args) : trackFindMany(args),
           ),
       },
-      show: { update: showUpdate },
-      track: { update: trackUpdate },
+      $executeRaw: executeRaw,
     } as never;
 
     const service = new RatingService(db, cacheInvalidation);
@@ -578,65 +619,48 @@ describe("RatingService.rebuildAggregatesFor", () => {
       { rateableId: "show-2", rateableType: "Show" },
     ]);
 
-    expect(showUpdate).toHaveBeenCalledTimes(2);
-    expect(showUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: "show-1" },
-        data: expect.objectContaining({ averageRating: 4.5, ratingsCount: 2 }),
-      }),
+    const writes = bulkAverageWrites(executeRaw);
+    expect(writes).toHaveLength(1);
+    expect(writes[0].table).toContain("shows");
+    expect(writes[0].tuples).toEqual(
+      expect.arrayContaining([
+        { id: "show-1", averageRating: 4.5, ratingsCount: 2 },
+        { id: "show-2", averageRating: 3.0, ratingsCount: 1 },
+      ]),
     );
-    expect(showUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: "show-2" },
-        data: expect.objectContaining({ averageRating: 3.0, ratingsCount: 1 }),
-      }),
-    );
-    expect(trackUpdate).not.toHaveBeenCalled();
-    expect(trackGroupBy).not.toHaveBeenCalled();
+    expect(trackFindMany).not.toHaveBeenCalled();
   });
 
-  // Rateables whose ratings dropped to zero (deleted last rating in full
-  // mode) don't appear in the groupBy result. The bulk method must zero
-  // them out anyway, matching what updateRateableAverageRating does for the
-  // single-row delete path.
+  // Rateables whose ratings dropped to zero (deleted last rating in full mode)
+  // don't appear in the findMany result. The bulk method must still zero them out,
+  // matching updateRateableAverageRating's single-row delete behavior.
   test("zeroes out rateables that no longer have any ratings", async () => {
-    const showUpdate = vi.fn();
-    const db = {
-      rating: {
-        groupBy: vi.fn().mockResolvedValue([]),
-      },
-      show: { update: showUpdate },
-      track: { update: vi.fn() },
-    } as never;
+    const executeRaw = vi.fn().mockResolvedValue(1);
+    const db = { rating: { findMany: vi.fn().mockResolvedValue([]) }, $executeRaw: executeRaw } as never;
 
     const service = new RatingService(db, cacheInvalidation);
     await service.rebuildAggregatesFor([{ rateableId: "show-abandoned", rateableType: "Show" }]);
 
-    expect(showUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: "show-abandoned" },
-        data: expect.objectContaining({ averageRating: 0, ratingsCount: 0 }),
-      }),
-    );
+    expect(bulkAverageWrites(executeRaw)[0].tuples).toContainEqual({
+      id: "show-abandoned",
+      averageRating: 0,
+      ratingsCount: 0,
+    });
   });
 
-  // Mixed types in one call: one groupBy hits the Show table, one hits the
-  // Track table. Per-rateable updates land on the matching denormalized row.
-  test("dispatches Show + Track rateables to the right tables", async () => {
-    const showUpdate = vi.fn();
-    const trackUpdate = vi.fn();
+  // Mixed types in one call: one bulk write targets the shows table, one the tracks
+  // table, each carrying the matching deduped averages.
+  test("writes Show + Track rateables to their respective tables", async () => {
+    const executeRaw = vi.fn().mockResolvedValue(1);
     const db = {
       rating: {
-        groupBy: vi
+        findMany: vi
           .fn()
           .mockImplementation(async (args: { where: { rateableType: string } }) =>
-            args.where.rateableType === "Show"
-              ? [{ rateableId: "show-1", _avg: { value: 5.0 }, _count: { id: 3 } }]
-              : [{ rateableId: "track-1", _avg: { value: 3.5 }, _count: { id: 2 } }],
+            args.where.rateableType === "Show" ? taggedRows("show-1", 5, 5, 5) : taggedRows("track-1", 3, 4),
           ),
       },
-      show: { update: showUpdate },
-      track: { update: trackUpdate },
+      $executeRaw: executeRaw,
     } as never;
 
     const service = new RatingService(db, cacheInvalidation);
@@ -645,22 +669,23 @@ describe("RatingService.rebuildAggregatesFor", () => {
       { rateableId: "track-1", rateableType: "Track" },
     ]);
 
-    expect(showUpdate).toHaveBeenCalledWith(expect.objectContaining({ where: { id: "show-1" } }));
-    expect(trackUpdate).toHaveBeenCalledWith(expect.objectContaining({ where: { id: "track-1" } }));
+    const writes = bulkAverageWrites(executeRaw);
+    const showWrite = writes.find((w) => w.table.includes("shows"));
+    const trackWrite = writes.find((w) => w.table.includes("tracks"));
+    expect(showWrite?.tuples.map((t) => t.id)).toContain("show-1");
+    expect(trackWrite?.tuples.map((t) => t.id)).toContain("track-1");
   });
 
   test("no-ops on an empty pair list", async () => {
-    const groupBy = vi.fn();
-    const db = {
-      rating: { groupBy },
-      show: { update: vi.fn() },
-      track: { update: vi.fn() },
-    } as never;
+    const findMany = vi.fn();
+    const executeRaw = vi.fn();
+    const db = { rating: { findMany }, $executeRaw: executeRaw } as never;
 
     const service = new RatingService(db, cacheInvalidation);
     await service.rebuildAggregatesFor([]);
 
-    expect(groupBy).not.toHaveBeenCalled();
+    expect(findMany).not.toHaveBeenCalled();
+    expect(executeRaw).not.toHaveBeenCalled();
   });
 });
 
@@ -726,11 +751,12 @@ describe("RatingService.listForSync", () => {
 });
 
 describe("RatingService.upsert", () => {
-  // Same motivation as the Track-clear case in clearForUser: the show's
-  // cached setlist embeds Track.averageRating/ratingsCount, so the upsert
-  // path has to bust the show cache for the rating mutation to surface.
-  test("invalidates the show cache when upserting a Track rating with a showSlug", async () => {
-    const invalidateShow = vi.fn();
+  // Track ratings bust the show comprehensively, year-scoped, exactly like Show
+  // ratings: Track.averageRating/ratingsCount are embedded in BOTH the per-show
+  // show.data payload AND the year-listing shows:list payload (its gap-chart view
+  // shows track averages), so the year listing must be purged too.
+  test("invalidates the show comprehensively, year-scoped, when upserting a Track rating with a showSlug", async () => {
+    const invalidateShowComprehensive = vi.fn();
     const now = new Date("2024-08-12T00:00:00Z");
     const db = {
       rating: {
@@ -743,7 +769,7 @@ describe("RatingService.upsert", () => {
           createdAt: now,
           updatedAt: now,
         }),
-        aggregate: vi.fn().mockResolvedValue({ _avg: { value: 4.0 }, _count: { id: 1 } }),
+        findMany: vi.fn().mockResolvedValue(ratingRows(4)),
       },
       show: { update: vi.fn() },
       track: { update: vi.fn() },
@@ -751,8 +777,8 @@ describe("RatingService.upsert", () => {
 
     const service = new RatingService(db, {
       invalidateAttendanceCaches: vi.fn(),
-      invalidateShow,
-      invalidateShowComprehensive: vi.fn(),
+      invalidateShow: vi.fn(),
+      invalidateShowComprehensive,
     } as never);
     await service.upsert({
       rateableId: "track-1",
@@ -762,7 +788,7 @@ describe("RatingService.upsert", () => {
       showSlug: "2024-08-12-cap-theatre",
     });
 
-    expect(invalidateShow).toHaveBeenCalledWith("2024-08-12-cap-theatre");
+    expect(invalidateShowComprehensive).toHaveBeenCalledWith(undefined, "2024-08-12-cap-theatre", [2024]);
   });
 
   // Show ratings go through invalidateShowComprehensive — the year is parsed
@@ -783,7 +809,7 @@ describe("RatingService.upsert", () => {
           createdAt: now,
           updatedAt: now,
         }),
-        aggregate: vi.fn().mockResolvedValue({ _avg: { value: 5.0 }, _count: { id: 1 } }),
+        findMany: vi.fn().mockResolvedValue(ratingRows(5)),
       },
       show: { update: vi.fn() },
       track: { update: vi.fn() },
@@ -803,5 +829,190 @@ describe("RatingService.upsert", () => {
     });
 
     expect(invalidateShowComprehensive).toHaveBeenCalledWith(undefined, "2018-07-12-red-rocks", [2018]);
+  });
+});
+
+describe("RatingService experimental rater-weight refresh", () => {
+  // When a RaterWeightService is injected, rating mutations also re-score the
+  // actor and re-roll the rateable in the experimental tables. Without one (the
+  // default), nothing extra happens — the canonical path is unchanged.
+  function makeDb() {
+    const now = new Date("2024-08-12T00:00:00Z");
+    return {
+      rating: {
+        upsert: vi.fn().mockResolvedValue({
+          id: "r1",
+          userId: "u1",
+          rateableId: "show-1",
+          rateableType: "Show",
+          value: 5,
+          createdAt: now,
+          updatedAt: now,
+        }),
+        deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+        findMany: vi.fn().mockResolvedValue([{ value: 5, createdAt: now, userId: "u1", user: { username: "u1" } }]),
+      },
+      show: { update: vi.fn() },
+      track: { update: vi.fn() },
+      ratingSettings: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+    } as never;
+  }
+
+  test("upsert marks the calibrated tables dirty and re-rolls the rateable (not the actor)", async () => {
+    const raterWeights = {
+      recomputeUser: vi.fn().mockResolvedValue(undefined),
+      recomputeRateable: vi.fn().mockResolvedValue(undefined),
+    };
+    const db = makeDb();
+    const service = new RatingService(db, cacheInvalidation, raterWeights as never);
+    await service.upsert({ rateableId: "show-1", rateableType: "Show", userId: "u1", value: 5 });
+
+    // The actor's stats are NOT recomputed on write (the cron handles that); only
+    // the touched rateable is re-rolled, and the tables are flagged dirty.
+    expect(raterWeights.recomputeUser).not.toHaveBeenCalled();
+    expect(raterWeights.recomputeRateable).toHaveBeenCalledWith("Show", "show-1");
+    expect(
+      (db as { ratingSettings: { updateMany: ReturnType<typeof vi.fn> } }).ratingSettings.updateMany,
+    ).toHaveBeenCalledWith({
+      data: { ratingsDirty: true },
+    });
+  });
+
+  test("clearForUser re-rolls the rateable", async () => {
+    const raterWeights = {
+      recomputeUser: vi.fn().mockResolvedValue(undefined),
+      recomputeRateable: vi.fn().mockResolvedValue(undefined),
+    };
+    const service = new RatingService(makeDb(), cacheInvalidation, raterWeights as never);
+    await service.clearForUser({ rateableId: "show-1", rateableType: "Show", userId: "u1" });
+
+    expect(raterWeights.recomputeRateable).toHaveBeenCalledWith("Show", "show-1");
+  });
+
+  test("a rater-weight failure never breaks the rating write", async () => {
+    const raterWeights = {
+      recomputeUser: vi.fn(),
+      recomputeRateable: vi.fn().mockRejectedValue(new Error("side-table boom")),
+    };
+    const service = new RatingService(makeDb(), cacheInvalidation, raterWeights as never);
+
+    await expect(
+      service.upsert({ rateableId: "show-1", rateableType: "Show", userId: "u1", value: 5 }),
+    ).resolves.toMatchObject({ id: "r1" });
+  });
+});
+
+// The displayed community average must be the de-duplicated denormalized column
+// (the same value Top Rated orders by), NOT a live AVG over raw ratings — which
+// would double-count duplicate accounts and disagree with the ranking + count.
+describe("RatingService.getAveragesForRateables", () => {
+  test("reads the de-duplicated Show columns, not a live average", async () => {
+    const db = {
+      show: {
+        findMany: vi.fn().mockResolvedValue([
+          { id: "show-1", averageRating: 4.72, ratingsCount: 18 },
+          { id: "show-2", averageRating: 4.5, ratingsCount: 30 },
+        ]),
+      },
+      // A live AVG would touch rating.* — left undefined so any such call throws.
+    } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    expect(await service.getAveragesForRateables(["show-1", "show-2"], "Show")).toEqual({
+      "show-1": { average: 4.72, count: 18 },
+      "show-2": { average: 4.5, count: 30 },
+    });
+  });
+
+  test("reads the Track columns for track rateables", async () => {
+    const db = {
+      track: { findMany: vi.fn().mockResolvedValue([{ id: "t1", averageRating: 3.5, ratingsCount: 5 }]) },
+    } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    expect(await service.getAveragesForRateables(["t1"], "Track")).toEqual({ t1: { average: 3.5, count: 5 } });
+  });
+
+  test("omits unrated rateables (null average or zero count)", async () => {
+    const db = {
+      show: {
+        findMany: vi.fn().mockResolvedValue([
+          { id: "rated", averageRating: 4.0, ratingsCount: 3 },
+          { id: "null-avg", averageRating: null, ratingsCount: 0 },
+          { id: "zero-count", averageRating: 0, ratingsCount: 0 },
+        ]),
+      },
+    } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    expect(await service.getAveragesForRateables(["rated", "null-avg", "zero-count"], "Show")).toEqual({
+      rated: { average: 4.0, count: 3 },
+    });
+  });
+
+  test("returns empty without querying when given no ids", async () => {
+    const findMany = vi.fn();
+    const service = new RatingService({ show: { findMany } } as never, cacheInvalidation);
+
+    expect(await service.getAveragesForRateables([], "Show")).toEqual({});
+    expect(findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("RatingService.getAverageForRateable", () => {
+  test("returns the de-duplicated column average for a rated rateable", async () => {
+    const db = {
+      show: { findMany: vi.fn().mockResolvedValue([{ id: "s1", averageRating: 4.72, ratingsCount: 18 }]) },
+    } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    expect(await service.getAverageForRateable("s1", "Show")).toBe(4.72);
+  });
+
+  test("returns null for an unrated rateable", async () => {
+    const db = { show: { findMany: vi.fn().mockResolvedValue([]) } } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    expect(await service.getAverageForRateable("s1", "Show")).toBeNull();
+  });
+});
+
+describe("RatingService.getRatingDistribution", () => {
+  // The histogram total sits right next to the deduped count label, so it must
+  // dedupe too — a raw groupBy would over-count one person's duplicate accounts
+  // and the bars would sum higher than the count shown.
+  test("collapses duplicate accounts to one most-recent vote per person", async () => {
+    const db = {
+      rating: {
+        findMany: vi.fn().mockResolvedValue([
+          { value: 5, createdAt: new Date(2024, 0, 1), userId: "u1", user: { username: "Tractorbeam" } },
+          // Same human, case-variant account, newer vote — the 5 above drops, this 2 wins.
+          { value: 2, createdAt: new Date(2024, 0, 5), userId: "u2", user: { username: "tractorbeam" } },
+          { value: 4, createdAt: new Date(2024, 0, 2), userId: "u3", user: { username: "Spaga" } },
+        ]),
+      },
+    } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    const distribution = await service.getRatingDistribution("show-1", "Show");
+    const countByValue = Object.fromEntries(distribution.map((bucket) => [bucket.value, bucket.count]));
+
+    expect(countByValue).toEqual({ 2: 1, 4: 1 });
+    expect(distribution.reduce((sum, bucket) => sum + bucket.count, 0)).toBe(2);
+  });
+
+  // 0 / sub-0.5 rows are "unrated" sentinels, not real votes.
+  test("excludes values below 0.5", async () => {
+    const db = {
+      rating: {
+        findMany: vi.fn().mockResolvedValue([
+          { value: 0, createdAt: new Date(2024, 0, 1), userId: "u1", user: { username: "Helicopters" } },
+          { value: 3, createdAt: new Date(2024, 0, 2), userId: "u2", user: { username: "Crickets" } },
+        ]),
+      },
+    } as never;
+    const service = new RatingService(db, cacheInvalidation);
+
+    expect(await service.getRatingDistribution("show-1", "Show")).toEqual([{ value: 3, count: 1 }]);
   });
 });

--- a/packages/core/src/ratings/rating-service.ts
+++ b/packages/core/src/ratings/rating-service.ts
@@ -3,6 +3,69 @@ import { Prisma } from "@prisma/client";
 import { type CacheInvalidationService, yearFromShowSlug } from "../_shared/cache";
 import type { DbClient, DbRating } from "../_shared/database/models";
 import { setSortKeySql, showOrderBySql } from "../_shared/show-ordering";
+import { aliasKey, mostRecentPerKey } from "./rater-aliases";
+import type { RaterWeightService } from "./rater-weight-service";
+
+interface DedupableRating {
+  value: number;
+  createdAt: Date;
+  userId: string;
+  username: string | null;
+}
+
+/**
+ * Prisma select for any rating row that feeds a dedup-collapsed aggregate. The
+ * username (via the user relation) is what lets {@link dedupeRatings} fold alias
+ * accounts, so every per-rateable aggregate fetch should select this shape.
+ */
+const RATING_DEDUP_SELECT = {
+  value: true,
+  createdAt: true,
+  userId: true,
+  user: { select: { username: true } },
+} as const;
+
+/** Map a {@link RATING_DEDUP_SELECT} row to the shape the dedup helpers consume. */
+function toDedupableRating(row: {
+  value: number;
+  createdAt: Date;
+  userId: string;
+  user: { username: string | null } | null;
+}): DedupableRating {
+  return { value: row.value, createdAt: row.createdAt, userId: row.userId, username: row.user?.username ?? null };
+}
+
+/**
+ * The one-human-one-vote rule, in ONE place: collapse a person's duplicate
+ * accounts (case/space variants, re-registrations) to their single most-recent
+ * vote. Every shared aggregate in this service — average, count, distribution
+ * histogram — must run its rows through this. A raw COUNT/AVG/groupBy over the
+ * Rating table double-counts alias accounts and silently disagrees with the
+ * displayed numbers. (The calibrated score applies the same rule via
+ * buildCanonicalUserMap in rater-weight-service. Aggregate-only — a user's own
+ * ratings history is never deduped.)
+ */
+function dedupeRatings<T extends DedupableRating>(ratings: ReadonlyArray<T>): T[] {
+  return mostRecentPerKey(ratings, (rating) =>
+    rating.username ? aliasKey(rating.username, rating.userId) : rating.userId,
+  );
+}
+
+/** Mean + count of an already-deduped rating set (the displayed canonical pair). */
+function averageOf(deduped: ReadonlyArray<{ value: number }>): { averageRating: number; ratingsCount: number } {
+  const ratingsCount = deduped.length;
+  const averageRating = ratingsCount === 0 ? 0 : deduped.reduce((sum, rating) => sum + rating.value, 0) / ratingsCount;
+  return { averageRating, ratingsCount };
+}
+
+/**
+ * The canonical average + count over a rateable's ratings, deduped first. The
+ * bulk rebuild path uses this on its per-rateable groups; single-rateable callers
+ * go through {@link RatingService.dedupedRatingsFor} + {@link averageOf}.
+ */
+function dedupedAverage(ratings: ReadonlyArray<DedupableRating>): { averageRating: number; ratingsCount: number } {
+  return averageOf(dedupeRatings(ratings));
+}
 
 export type ShowRatingsSort = "date" | "rating" | "modified";
 export type TrackRatingsSort = "date" | "set" | "track" | "song" | "rating" | "modified";
@@ -144,21 +207,51 @@ export class RatingService {
   constructor(
     protected readonly db: DbClient,
     protected readonly cacheInvalidation: CacheInvalidationService,
+    // Optional so existing callers/tests are unaffected. When present, rating
+    // mutations also maintain the calibrated rater-weighting tables.
+    protected readonly raterWeights?: RaterWeightService,
   ) {}
+
+  /**
+   * After a rating mutation: mark the calibrated-rating tables dirty (cheap, so the
+   * hourly cron rebuilds the actor's stats + the cross-show ripple) and do the
+   * one cheap thing inline — recompute the touched rateable's calibrated score from
+   * current stats so the rated show updates immediately. We deliberately do NOT
+   * recompute the actor's stats here: the old delete-then-recreate-per-write was
+   * heavy and could wipe stats on a transient failure. The recompute is
+   * best-effort (swallowed) so it never breaks the live rating write.
+   */
+  private async refreshRaterWeights(rateableId: string, rateableType: string): Promise<void> {
+    if (!this.raterWeights) return;
+    // Flag the calibrated tables dirty so the hourly cron rebuilds stats + the ripple.
+    await this.db.ratingSettings.updateMany({ data: { ratingsDirty: true } });
+    try {
+      await this.raterWeights.recomputeRateable(rateableType, rateableId);
+    } catch {
+      // Calibrated-rating side data; a failure here must not break rating writes.
+    }
+  }
+
+  /**
+   * The single source of deduped ratings for one rateable. EVERY per-rateable
+   * shared aggregate (canonical average, count, distribution histogram) must
+   * source its rows here so the one-human-one-vote dedup can never be skipped by
+   * accident. The bulk {@link rebuildAggregatesFor} path runs the same
+   * {@link dedupeRatings} rule over its multi-rateable fetch.
+   */
+  private async dedupedRatingsFor(rateableId: string, rateableType: string): Promise<DedupableRating[]> {
+    const rows = await this.db.rating.findMany({
+      where: { rateableId, rateableType },
+      select: RATING_DEDUP_SELECT,
+    });
+    return dedupeRatings(rows.map(toDedupableRating));
+  }
 
   private async updateRateableAverageRating(
     rateableId: string,
     rateableType: string,
   ): Promise<{ averageRating: number; ratingsCount: number }> {
-    // Calculate the new average rating and count
-    const stats = await this.db.rating.aggregate({
-      where: { rateableId, rateableType },
-      _avg: { value: true },
-      _count: { id: true },
-    });
-
-    const averageRating = stats._avg.value ?? 0;
-    const ratingsCount = stats._count.id;
+    const { averageRating, ratingsCount } = averageOf(await this.dedupedRatingsFor(rateableId, rateableType));
 
     // Update the appropriate table based on rateable type
     if (rateableType === "Show") {
@@ -200,45 +293,48 @@ export class RatingService {
       else if (rateableType === "Track") trackIds.add(rateableId);
     }
 
-    const now = new Date();
-
-    if (showIds.size > 0) {
-      const rows = await this.db.rating.groupBy({
-        by: ["rateableId"],
-        where: { rateableType: "Show", rateableId: { in: Array.from(showIds) } },
-        _avg: { value: true },
-        _count: { id: true },
+    // Dedup duplicate accounts per rateable (one most-recent vote per person).
+    const groupRatingsByRateable = async (rateableType: string, ids: Set<string>) => {
+      const rows = await this.db.rating.findMany({
+        where: { rateableType, rateableId: { in: Array.from(ids) } },
+        select: { rateableId: true, ...RATING_DEDUP_SELECT },
       });
-      const statsById = new Map(rows.map((r) => [r.rateableId, r]));
-      for (const id of showIds) {
-        const stats = statsById.get(id);
-        const averageRating = stats?._avg.value ?? 0;
-        const ratingsCount = stats?._count.id ?? 0;
-        await this.db.show.update({
-          where: { id },
-          data: { averageRating, ratingsCount, updatedAt: now },
-        });
+      const byRateable = new Map<string, DedupableRating[]>();
+      for (const r of rows) {
+        const bucket = byRateable.get(r.rateableId) ?? [];
+        bucket.push(toDedupableRating(r));
+        byRateable.set(r.rateableId, bucket);
       }
-    }
+      return byRateable;
+    };
 
-    if (trackIds.size > 0) {
-      const rows = await this.db.rating.groupBy({
-        by: ["rateableId"],
-        where: { rateableType: "Track", rateableId: { in: Array.from(trackIds) } },
-        _avg: { value: true },
-        _count: { id: true },
-      });
-      const statsById = new Map(rows.map((r) => [r.rateableId, r]));
-      for (const id of trackIds) {
-        const stats = statsById.get(id);
-        const averageRating = stats?._avg.value ?? 0;
-        const ratingsCount = stats?._count.id ?? 0;
-        await this.db.track.update({
-          where: { id },
-          data: { averageRating, ratingsCount, updatedAt: now },
-        });
+    // One `UPDATE ... FROM (VALUES …)` per chunk instead of an update per rateable:
+    // a full recompute touches ~14k rateables (mostly tracks), where per-row
+    // round-trips dominated the runtime. Rateables with no surviving ratings get
+    // zeroed (dedupedAverage of [] → 0/0).
+    const writeAverages = async (rateableType: string, table: "shows" | "tracks", ids: Set<string>) => {
+      if (ids.size === 0) return;
+      const byRateable = await groupRatingsByRateable(rateableType, ids);
+      const entries = Array.from(ids, (id) => ({ id, ...dedupedAverage(byRateable.get(id) ?? []) }));
+      const CHUNK = 1000;
+      for (let i = 0; i < entries.length; i += CHUNK) {
+        const rows = entries
+          .slice(i, i + CHUNK)
+          .map(
+            (entry) =>
+              Prisma.sql`(${entry.id}::uuid, ${entry.averageRating}::double precision, ${entry.ratingsCount}::int)`,
+          );
+        await this.db.$executeRaw`
+          UPDATE ${Prisma.raw(table)} AS t
+          SET average_rating = v.average_rating, ratings_count = v.ratings_count, updated_at = NOW()
+          FROM (VALUES ${Prisma.join(rows)}) AS v(id, average_rating, ratings_count)
+          WHERE t.id = v.id
+        `;
       }
-    }
+    };
+
+    await writeAverages("Show", "shows", showIds);
+    await writeAverages("Track", "tracks", trackIds);
   }
 
   /**
@@ -322,56 +418,63 @@ export class RatingService {
       },
     });
 
-    if (data.rateableType === "Show" && data.showSlug) {
+    if (data.showSlug) {
+      // Both show and track ratings write denormalized averageRating/ratingsCount
+      // that the cached setlist payloads embed — the per-show show.data payload AND
+      // the year-listing shows:list payload (whose gap-chart view shows track
+      // averages). Comprehensive invalidation busts both, year-scoped for listings.
       const year = yearFromShowSlug(data.showSlug);
       await this.cacheInvalidation.invalidateShowComprehensive(undefined, data.showSlug, year !== null ? [year] : []);
-    } else if (data.rateableType === "Track" && data.showSlug) {
-      // The show's cached setlist payload at CacheKeys.show.data(slug)
-      // embeds Track.averageRating/ratingsCount on each track, so a rating
-      // mutation has to bust that cache for subsequent reads to surface the
-      // new denormalized values.
-      await this.cacheInvalidation.invalidateShow(data.showSlug);
     }
 
     // Update the related show/track average rating and count
     await this.updateRateableAverageRating(data.rateableId, data.rateableType);
+    await this.refreshRaterWeights(data.rateableId, data.rateableType);
 
     return mapRatingToDomainEntity(result);
   }
 
+  /**
+   * The de-duplicated community average for one rateable, read from the
+   * denormalized column via {@link getAveragesForRateables} so it matches the
+   * ranking and honors dedup (a live `AVG()` would double-count duplicate
+   * accounts). Null when the rateable has no ratings.
+   */
   async getAverageForRateable(rateableId: string, rateableType: string): Promise<number | null> {
-    const result = await this.db.rating.aggregate({
-      where: { rateableId, rateableType },
-      _avg: {
-        value: true,
-      },
-    });
-
-    return result._avg.value;
+    const averages = await this.getAveragesForRateables([rateableId], rateableType);
+    return averages[rateableId]?.average ?? null;
   }
 
+  /**
+   * The community average + count for a set of rateables, read from the
+   * denormalized `average_rating`/`ratings_count` columns. Those are the
+   * de-duplicated values (one human, one vote), kept fresh by the rating write
+   * path, and are the same numbers Top Rated orders by, so the displayed average
+   * matches the ranking. A live `AVG()` here would double-count duplicate accounts
+   * and disagree with both.
+   */
   async getAveragesForRateables(
     rateableIds: string[],
     rateableType: string,
   ): Promise<Record<string, { average: number; count: number }>> {
     if (rateableIds.length === 0) return {};
 
-    const results = await this.db.rating.groupBy({
-      by: ["rateableId"],
-      where: {
-        rateableId: { in: rateableIds },
-        rateableType,
-      },
-      _avg: { value: true },
-      _count: { id: true },
-    });
+    const rows =
+      rateableType === "Track"
+        ? await this.db.track.findMany({
+            where: { id: { in: rateableIds } },
+            select: { id: true, averageRating: true, ratingsCount: true },
+          })
+        : await this.db.show.findMany({
+            where: { id: { in: rateableIds } },
+            select: { id: true, averageRating: true, ratingsCount: true },
+          });
 
     const averages: Record<string, { average: number; count: number }> = {};
-    for (const result of results) {
-      averages[result.rateableId] = {
-        average: result._avg.value ?? 0,
-        count: result._count.id,
-      };
+    for (const row of rows) {
+      if (row.averageRating != null && row.ratingsCount > 0) {
+        averages[row.id] = { average: row.averageRating, count: row.ratingsCount };
+      }
     }
 
     return averages;
@@ -563,17 +666,21 @@ export class RatingService {
 
   /**
    * Distribution of a single rateable's ratings by star value, for the
-   * per-show / per-track histograms. Groups by value over the
-   * (rateable_type, rateable_id) index and includes 0.5 ratings so the
-   * chart reflects every vote.
+   * per-show / per-track histograms. Deduped (one human, one vote) so the bar
+   * total matches the deduped count shown beside the chart — a raw groupBy
+   * would over-count duplicate accounts. Not bomber-excluded: this mirrors the
+   * deduped canonical population, and exclusion only ever shapes the calibrated
+   * score, not the displayed average/count. Includes 0.5 ratings so every real
+   * vote shows.
    */
   async getRatingDistribution(rateableId: string, rateableType: string): Promise<RatingValueBucket[]> {
-    const rows = await this.db.rating.groupBy({
-      by: ["value"],
-      where: { rateableId, rateableType, value: { gte: 0.5 } },
-      _count: { id: true },
-    });
-    return rows.map((row) => ({ value: row.value, count: row._count.id }));
+    const deduped = await this.dedupedRatingsFor(rateableId, rateableType);
+    const countByValue = new Map<number, number>();
+    for (const rating of deduped) {
+      if (rating.value < 0.5) continue;
+      countByValue.set(rating.value, (countByValue.get(rating.value) ?? 0) + 1);
+    }
+    return Array.from(countByValue, ([value, count]) => ({ value, count }));
   }
 
   async deleteByRateableId(rateableId: string, rateableType: string): Promise<void> {
@@ -606,15 +713,14 @@ export class RatingService {
     });
 
     const stats = await this.updateRateableAverageRating(data.rateableId, data.rateableType);
+    await this.refreshRaterWeights(data.rateableId, data.rateableType);
 
-    if (data.rateableType === "Show" && data.showSlug) {
+    if (data.showSlug) {
+      // Same as the upsert path: both show and track ratings change denormalized
+      // averages embedded in the show.data AND year-listing shows:list payloads,
+      // so bust both, year-scoped for listings.
       const year = yearFromShowSlug(data.showSlug);
       await this.cacheInvalidation.invalidateShowComprehensive(undefined, data.showSlug, year !== null ? [year] : []);
-    } else if (data.rateableType === "Track" && data.showSlug) {
-      // Same reason as the upsert path: Track.averageRating/ratingsCount
-      // live inside the cached setlist payload, so a recompute has to bust
-      // the show cache.
-      await this.cacheInvalidation.invalidateShow(data.showSlug);
     }
 
     return stats;

--- a/packages/core/src/ratings/recompute-ratings.test.ts
+++ b/packages/core/src/ratings/recompute-ratings.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test, vi } from "vitest";
+import { runRatingsRecompute } from "./recompute-ratings";
+
+// The dirty-gated recompute routine shared by the hourly cron and the deploy
+// entrypoint. The interesting behavior is the no-op-when-clean gate and the
+// orchestration order (recompute calibrated → rebuild deduped canonical averages
+// → stamp the anchor/timestamp and clear the flag).
+function makeServices(dirty: boolean) {
+  const raterWeights = {
+    isDirty: vi.fn().mockResolvedValue(dirty),
+    recomputeAll: vi.fn().mockResolvedValue({ users: 12, rateables: 7 }),
+    allRatedPairs: vi.fn().mockResolvedValue([
+      { rateableId: "show-1", rateableType: "Show" },
+      { rateableId: "track-1", rateableType: "Track" },
+    ]),
+    computeShrinkAnchor: vi.fn().mockResolvedValue(4.11),
+    markRecomputed: vi.fn().mockResolvedValue(undefined),
+  };
+  const ratings = { rebuildAggregatesFor: vi.fn().mockResolvedValue(undefined) };
+  return { raterWeights, ratings };
+}
+
+describe("runRatingsRecompute", () => {
+  test("no-ops when ratings are clean (nothing changed since the last run)", async () => {
+    const { raterWeights, ratings } = makeServices(false);
+    const result = await runRatingsRecompute({ raterWeights: raterWeights as never, ratings: ratings as never });
+
+    expect(result.ran).toBe(false);
+    expect(raterWeights.recomputeAll).not.toHaveBeenCalled();
+    expect(ratings.rebuildAggregatesFor).not.toHaveBeenCalled();
+    expect(raterWeights.markRecomputed).not.toHaveBeenCalled();
+  });
+
+  test("when dirty: recomputes calibrated scores, rebuilds deduped canonical averages, then stamps the anchor", async () => {
+    const { raterWeights, ratings } = makeServices(true);
+    const result = await runRatingsRecompute({ raterWeights: raterWeights as never, ratings: ratings as never });
+
+    expect(raterWeights.recomputeAll).toHaveBeenCalledTimes(1);
+    expect(ratings.rebuildAggregatesFor).toHaveBeenCalledWith([
+      { rateableId: "show-1", rateableType: "Show" },
+      { rateableId: "track-1", rateableType: "Track" },
+    ]);
+    // The anchor is recomputed from the freshly-written weighted ratings, then stamped.
+    expect(raterWeights.computeShrinkAnchor).toHaveBeenCalledTimes(1);
+    expect(raterWeights.markRecomputed).toHaveBeenCalledWith(4.11);
+    expect(result).toMatchObject({ ran: true, users: 12, shows: 7, rateables: 2, anchor: 4.11 });
+  });
+
+  test("rebuilds canonical averages before stamping (so the run is atomic in effect)", async () => {
+    const { raterWeights, ratings } = makeServices(true);
+    await runRatingsRecompute({ raterWeights: raterWeights as never, ratings: ratings as never });
+
+    const rebuildOrder = ratings.rebuildAggregatesFor.mock.invocationCallOrder[0];
+    const stampOrder = raterWeights.markRecomputed.mock.invocationCallOrder[0];
+    expect(rebuildOrder).toBeLessThan(stampOrder);
+  });
+});

--- a/packages/core/src/ratings/recompute-ratings.ts
+++ b/packages/core/src/ratings/recompute-ratings.ts
@@ -1,0 +1,55 @@
+import type { Logger } from "@bip/domain";
+import type { RaterWeightService } from "./rater-weight-service";
+import type { RatingService } from "./rating-service";
+
+export interface RecomputeRatingsDeps {
+  raterWeights: RaterWeightService;
+  ratings: RatingService;
+  logger?: Pick<Logger, "info">;
+}
+
+export interface RecomputeRatingsResult {
+  ran: boolean;
+  reason?: string;
+  users?: number;
+  shows?: number;
+  rateables?: number;
+  anchor?: number;
+}
+
+/**
+ * The dirty-gated full rating recompute, shared by the hourly cron and the deploy
+ * entrypoint. No-ops when nothing has changed since the last run (the cheap common
+ * case), so it's safe to invoke on every deploy. When dirty: rebuild every person's
+ * calibrated-rating stats + each show's `weighted_rating`, rebuild every rateable's
+ * deduped canonical average, then recompute the shrink anchor and stamp
+ * `last_recompute_at` (the rating-cache version key) while clearing the dirty flag.
+ * The `ratings_dirty` flag is seeded true, so the first deploy backfills everything.
+ */
+export async function runRatingsRecompute({
+  raterWeights,
+  ratings,
+  logger,
+}: RecomputeRatingsDeps): Promise<RecomputeRatingsResult> {
+  if (!(await raterWeights.isDirty())) {
+    logger?.info("Ratings unchanged since last recompute; skipping");
+    return { ran: false, reason: "clean" };
+  }
+
+  const counts = await raterWeights.recomputeAll();
+  const pairs = await raterWeights.allRatedPairs();
+  await ratings.rebuildAggregatesFor(pairs);
+  const anchor = await raterWeights.computeShrinkAnchor();
+  await raterWeights.markRecomputed(anchor);
+
+  // No cache invalidation here: the canonical averages embedded in cached setlist
+  // payloads change only when a rateable's own ratings change (handled by the
+  // rating write paths), and the calibrated weighted ratings + shrink anchor this
+  // recompute rewrites are read live (never cached). The cross-show ripple touches
+  // only calibrated scores, so it staleness-busts nothing cached.
+
+  logger?.info(
+    `Recomputed ratings: ${counts.users} raters, ${counts.rateables} shows, ${pairs.length} canonical averages, anchor ${anchor.toFixed(3)}`,
+  );
+  return { ran: true, users: counts.users, shows: counts.rateables, rateables: pairs.length, anchor };
+}

--- a/packages/core/src/users/user-service.test.ts
+++ b/packages/core/src/users/user-service.test.ts
@@ -166,6 +166,8 @@ describe("UserService.listForSync", () => {
       username: true,
       avatarFileId: true,
       avatarFileUrl: true,
+      showCalibratedRatings: true,
+      showRatingComparisonDebug: true,
       createdAt: true,
       updatedAt: true,
     });

--- a/packages/core/src/users/user-service.ts
+++ b/packages/core/src/users/user-service.ts
@@ -32,6 +32,8 @@ function mapUserToDomainEntity(dbUser: DbUser): User {
     avatarUrl: dbUser.avatarFileUrl ?? null,
     createdAt: dbUser.createdAt,
     updatedAt: dbUser.updatedAt,
+    showCalibratedRatings: dbUser.showCalibratedRatings ?? null,
+    showRatingComparisonDebug: dbUser.showRatingComparisonDebug ?? null,
   };
 }
 
@@ -477,6 +479,9 @@ export class UserService {
       username: string | null;
       avatarFileId: string | null;
       avatarFileUrl: string | null;
+      // Rating-display opt-in prefs, mirrored to local so prod adoption can be inspected.
+      showCalibratedRatings: boolean | null;
+      showRatingComparisonDebug: boolean | null;
       createdAt: Date;
       updatedAt: Date;
     }>
@@ -499,6 +504,8 @@ export class UserService {
         username: true,
         avatarFileId: true,
         avatarFileUrl: true,
+        showCalibratedRatings: true,
+        showRatingComparisonDebug: true,
         createdAt: true,
         updatedAt: true,
       },

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -15,7 +15,8 @@
     "build": "tsup src/index.ts --format esm --dts",
     "dev": "tsup src/index.ts --watch",
     "typecheck": "tsc --noEmit",
-    "lint": "biome lint"
+    "lint": "biome lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "zod": "^4.2.1"

--- a/packages/domain/src/drummer-era.test.ts
+++ b/packages/domain/src/drummer-era.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { DRUMMER_ERAS, drummerEraForDate } from "./drummer-era";
+
+// drummerEraForDate buckets a show by who was on drums, derived purely from the
+// date. Boundaries are the successor drummer's first-show date, frozen from the
+// lineup data: Aucoin debuts 2005-12-28, Marlon debuts 2025-10-31.
+describe("drummerEraForDate", () => {
+  test("dates before Aucoin's debut are the Altman era", () => {
+    expect(drummerEraForDate("1995-02-11")).toBe("ALTMAN");
+    expect(drummerEraForDate("2004-12-31")).toBe("ALTMAN");
+  });
+
+  test("Aucoin's debut date opens the Aucoin era (boundary is inclusive)", () => {
+    expect(drummerEraForDate("2005-12-27")).toBe("ALTMAN");
+    expect(drummerEraForDate("2005-12-28")).toBe("AUCOIN");
+  });
+
+  test("Altman sit-ins during the Aucoin era still bucket by date, not lineup", () => {
+    // Altman has lineup rows as late as 2010; by date these are Aucoin-era shows.
+    expect(drummerEraForDate("2010-12-30")).toBe("AUCOIN");
+  });
+
+  test("Marlon's debut date opens the Marlon era (boundary is inclusive)", () => {
+    expect(drummerEraForDate("2025-10-30")).toBe("AUCOIN");
+    expect(drummerEraForDate("2025-10-31")).toBe("MARLON");
+    expect(drummerEraForDate("2026-06-13")).toBe("MARLON");
+  });
+});
+
+describe("vocabulary constants", () => {
+  test("the three drummer eras are the canonical drummer list", () => {
+    expect(DRUMMER_ERAS).toEqual(["ALTMAN", "AUCOIN", "MARLON"]);
+  });
+});

--- a/packages/domain/src/drummer-era.ts
+++ b/packages/domain/src/drummer-era.ts
@@ -1,0 +1,89 @@
+/**
+ * Disco Biscuits drummer eras: the span each drummer held the drum seat in the
+ * band. Era is a property of the period, not of an individual show, so it's
+ * derived from the show date rather than the show's own lineup: a one-off guest
+ * or sit-in doesn't change whose era a date falls in.
+ */
+
+export const DRUMMER_ERAS = ["ALTMAN", "AUCOIN", "MARLON"] as const;
+export type DrummerEra = (typeof DRUMMER_ERAS)[number];
+
+/**
+ * Canonical drummer-era data: the single source of truth for era boundaries, the
+ * drummer who defines each era, and the labels used across the app. `start` is the
+ * drummer's first show, the inclusive boundary that opens the era for date
+ * bucketing; `end` is their last show, used by windowed lineup/filter checks that
+ * intentionally exclude the gap between drummers. The opening era has no `start`,
+ * the current era has no `end`. ISO `YYYY-MM-DD` strings compare with `>=`.
+ *
+ * Consumed by drummerEraForDate, the musicians GUI (lineup windows in
+ * musicians-constants), and the song-filter era options, so these dates live in
+ * exactly one place.
+ */
+export interface DrummerEraInfo {
+  era: DrummerEra;
+  /** The drummer's musician slug, matching the musicians table. */
+  musicianSlug: string;
+  /** Full drummer name, for display. */
+  drummerName: string;
+  /** Stable key for the song-filter era option. */
+  filterKey: string;
+  /** Human label for the era filter. */
+  filterLabel: string;
+  /** First show, inclusive (YYYY-MM-DD). Absent for the opening era. */
+  start?: string;
+  /** Last show, inclusive (YYYY-MM-DD). Absent for the current era. */
+  end?: string;
+}
+
+export const DRUMMER_ERA_INFO: readonly DrummerEraInfo[] = [
+  {
+    era: "ALTMAN",
+    musicianSlug: "sam-altman",
+    drummerName: "Sam Altman",
+    filterKey: "sammy",
+    filterLabel: "Sammy Era",
+    end: "2005-08-27",
+  },
+  {
+    era: "AUCOIN",
+    musicianSlug: "allen-aucoin",
+    drummerName: "Allen Aucoin",
+    filterKey: "allen",
+    filterLabel: "Allen Era",
+    start: "2005-12-28",
+    end: "2025-09-07",
+  },
+  {
+    era: "MARLON",
+    musicianSlug: "marlon-lewis",
+    drummerName: "Marlon Lewis",
+    filterKey: "marlon",
+    filterLabel: "Marlon Era",
+    start: "2025-10-31",
+  },
+];
+
+// Successor first-show dates, latest-first, so the first start a date reaches wins.
+const ERA_STARTS = DRUMMER_ERA_INFO.filter(
+  (info): info is DrummerEraInfo & { start: string } => info.start != null,
+).sort((a, b) => (a.start < b.start ? 1 : -1));
+
+export function drummerEraForDate(date: string): DrummerEra {
+  for (const { era, start } of ERA_STARTS) {
+    if (date >= start) return era;
+  }
+  // Before any successor's first show: the opening era (the one with no start).
+  return "ALTMAN";
+}
+
+/**
+ * An era's bounds as `Date` objects, omitting an absent side, for the windowed
+ * lineup/filter checks that work in `Date`s rather than the canonical ISO strings.
+ */
+export function eraDateWindow(info: DrummerEraInfo): { startDate?: Date; endDate?: Date } {
+  const window: { startDate?: Date; endDate?: Date } = {};
+  if (info.start) window.startDate = new Date(info.start);
+  if (info.end) window.endDate = new Date(info.end);
+  return window;
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./archive-dot-org";
 export * from "./cache-keys";
+export * from "./drummer-era";
 export * from "./duration";
 export * from "./math";
 export * from "./models/annotation";

--- a/packages/domain/src/math.test.ts
+++ b/packages/domain/src/math.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { average, median } from "./math";
+import { average, median, shrinkToward } from "./math";
 
 describe("average", () => {
   // Empty input returns null so callers can branch on "render the value
@@ -44,5 +44,33 @@ describe("median", () => {
   // pair up in the gap-chart UI.)
   test("is unmoved by a single outlier value", () => {
     expect(median([1, 2, 3, 4, 1000])).toBe(3);
+  });
+});
+
+describe("shrinkToward", () => {
+  // No sample falls all the way back to the anchor (avoids 0/0 and lets a
+  // ratingless show read as the population baseline rather than NaN).
+  test("returns the anchor when count is zero or negative", () => {
+    expect(shrinkToward(5, 3, 0, 3)).toBe(3);
+    expect(shrinkToward(5, 3, -2, 3)).toBe(3);
+  });
+
+  // weight = count/(count+k): at count === k the value and anchor are weighted
+  // equally, so the result is their midpoint.
+  test("weights value and anchor equally when count equals k", () => {
+    expect(shrinkToward(5, 3, 3, 3)).toBe(4);
+  });
+
+  // Few ratings leave the anchor dominant; many let the value dominate.
+  test("shifts from anchor-dominated to value-dominated as count grows", () => {
+    expect(shrinkToward(5, 3, 1, 3)).toBe(3.5); // w = 0.25
+    expect(shrinkToward(5, 3, 9, 3)).toBe(4.5); // w = 0.75
+  });
+
+  // A larger k holds the value near the anchor for longer (more shrinkage at
+  // the same count).
+  test("larger k means more shrinkage toward the anchor", () => {
+    expect(shrinkToward(5, 3, 3, 3)).toBe(4); // w = 0.5
+    expect(shrinkToward(5, 3, 3, 9)).toBe(3.5); // w = 0.25
   });
 });

--- a/packages/domain/src/math.ts
+++ b/packages/domain/src/math.ts
@@ -17,3 +17,17 @@ export function median(values: readonly number[]): number | null {
   const mid = sorted.length >>> 1;
   return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }
+
+/**
+ * Pull a value toward a stable anchor by a weight that grows with the sample
+ * size: `w = count/(count+k)`. With few ratings the anchor dominates; with many,
+ * the value does. Used by the Calibrated Show Rating for count-shrinkage (toward
+ * the global average) and cold-start (a rater's mean toward the population mean,
+ * their entropy toward full weight), on both the server compute and client
+ * display paths so the formula stays identical.
+ */
+export function shrinkToward(value: number, anchor: number, count: number, k: number): number {
+  if (count <= 0) return anchor;
+  const weight = count / (count + k);
+  return weight * value + (1 - weight) * anchor;
+}

--- a/packages/domain/src/models/user.ts
+++ b/packages/domain/src/models/user.ts
@@ -8,6 +8,9 @@ export const userSchema = z.object({
   username: z.string(),
   avatarFileId: z.string().uuid().nullable(),
   avatarUrl: z.string().url().nullable(),
+  // Rating-display prefs (tri-state: null = no explicit choice → app default).
+  showCalibratedRatings: z.boolean().nullable(),
+  showRatingComparisonDebug: z.boolean().nullable(),
 });
 
 export const userMinimalSchema = userSchema

--- a/packages/domain/vitest.config.ts
+++ b/packages/domain/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/quonfig/feature-flags/ratings.calibrated-enabled.json
+++ b/quonfig/feature-flags/ratings.calibrated-enabled.json
@@ -1,0 +1,21 @@
+{
+  "key": "ratings.calibrated-enabled",
+  "description": "Master gate / kill switch for the calibrated show-rating feature. ON: the feature runs (cron computes scores, columns populate) but visibility is still restricted by ratings.toggle-visible. OFF: everyone sees the simple community average and the opt-in toggle is hidden. Launch state: ON.",
+  "type": "feature_flag",
+  "valueType": "bool",
+  "default": {
+    "rules": [
+      {
+        "criteria": [
+          {
+            "operator": "ALWAYS_TRUE"
+          }
+        ],
+        "value": {
+          "type": "bool",
+          "value": true
+        }
+      }
+    ]
+  }
+}

--- a/quonfig/feature-flags/ratings.compare-visible.json
+++ b/quonfig/feature-flags/ratings.compare-visible.json
@@ -1,0 +1,36 @@
+{
+  "key": "ratings.compare-visible",
+  "description": "Whether a user sees the author comparison/debug overlay toggle, which shows the community vs calibrated score and rank delta on show cards and the show page. This is intended to be for debugging only. Targeted to the rating-beta segment. The user's on/off choice is stored in User.show_rating_compare. Launch state: rating-beta segment only.",
+  "type": "feature_flag",
+  "valueType": "bool",
+  "default": {
+    "rules": [
+      {
+        "criteria": [
+          {
+            "operator": "IN_SEG",
+            "valueToMatch": {
+              "type": "string",
+              "value": "rating-beta"
+            }
+          }
+        ],
+        "value": {
+          "type": "bool",
+          "value": true
+        }
+      },
+      {
+        "criteria": [
+          {
+            "operator": "ALWAYS_TRUE"
+          }
+        ],
+        "value": {
+          "type": "bool",
+          "value": false
+        }
+      }
+    ]
+  }
+}

--- a/quonfig/feature-flags/ratings.default-calibrated.json
+++ b/quonfig/feature-flags/ratings.default-calibrated.json
@@ -1,0 +1,21 @@
+{
+  "key": "ratings.default-calibrated",
+  "description": "The app-wide default display mode for users who have no explicit preference set. true = calibrated by default (users opt out), false = simple community average by default (users opt in). Only affects users whose preference is unset; an explicit per-user preference always wins. Launch state: false.",
+  "type": "feature_flag",
+  "valueType": "bool",
+  "default": {
+    "rules": [
+      {
+        "criteria": [
+          {
+            "operator": "ALWAYS_TRUE"
+          }
+        ],
+        "value": {
+          "type": "bool",
+          "value": false
+        }
+      }
+    ]
+  }
+}

--- a/quonfig/feature-flags/ratings.explainer-nav-link.json
+++ b/quonfig/feature-flags/ratings.explainer-nav-link.json
@@ -1,0 +1,21 @@
+{
+  "key": "ratings.explainer-nav-link",
+  "description": "Whether to show the footer navigation link to the /show-rating-algorithm explainer page. The page itself is ALWAYS reachable by direct URL (and linked from the profile rating-display settings); this flag only controls the public footer link. Launch state: false.",
+  "type": "feature_flag",
+  "valueType": "bool",
+  "default": {
+    "rules": [
+      {
+        "criteria": [
+          {
+            "operator": "ALWAYS_TRUE"
+          }
+        ],
+        "value": {
+          "type": "bool",
+          "value": false
+        }
+      }
+    ]
+  }
+}

--- a/quonfig/feature-flags/ratings.recompute-enabled.json
+++ b/quonfig/feature-flags/ratings.recompute-enabled.json
@@ -1,0 +1,21 @@
+{
+  "key": "ratings.recompute-enabled",
+  "description": "Gates the rating recompute that runs hourly (cron endpoint /api/cron/recompute-ratings) and at deploy (scripts/recompute-ratings.ts). ON: the dirty-gated recompute runs (rebuilds rater stats, weighted ratings, deduped averages, and the shrink anchor). OFF: kill switch (no recompute, scores go stale). Launch state: ON.",
+  "type": "feature_flag",
+  "valueType": "bool",
+  "default": {
+    "rules": [
+      {
+        "criteria": [
+          {
+            "operator": "ALWAYS_TRUE"
+          }
+        ],
+        "value": {
+          "type": "bool",
+          "value": true
+        }
+      }
+    ]
+  }
+}

--- a/quonfig/feature-flags/ratings.toggle-visible.json
+++ b/quonfig/feature-flags/ratings.toggle-visible.json
@@ -1,0 +1,36 @@
+{
+  "key": "ratings.toggle-visible",
+  "description": "Whether a user sees the opt-in control for the calibrated show rating (the toggle in profile settings). Targeted to the rating-beta segment; flip the segment rule to ALWAYS_TRUE to let anyone opt in. Users without the toggle keep an unset preference and fall to ratings.default-calibrated. Launch state: rating-beta segment only.",
+  "type": "feature_flag",
+  "valueType": "bool",
+  "default": {
+    "rules": [
+      {
+        "criteria": [
+          {
+            "operator": "IN_SEG",
+            "valueToMatch": {
+              "type": "string",
+              "value": "rating-beta"
+            }
+          }
+        ],
+        "value": {
+          "type": "bool",
+          "value": true
+        }
+      },
+      {
+        "criteria": [
+          {
+            "operator": "ALWAYS_TRUE"
+          }
+        ],
+        "value": {
+          "type": "bool",
+          "value": false
+        }
+      }
+    ]
+  }
+}

--- a/quonfig/quonfig.json
+++ b/quonfig/quonfig.json
@@ -1,0 +1,3 @@
+{
+  "environments": ["development", "production"]
+}

--- a/quonfig/segments/rating-beta.json
+++ b/quonfig/segments/rating-beta.json
@@ -1,0 +1,37 @@
+{
+  "key": "rating-beta",
+  "description": "Beta-access segment for the calibrated-show-rating rollout. Matches users whose username is in the list. Referenced by ratings.toggle-visible and ratings.compare-visible via IN_SEG. Widen access by adding usernames here, or open it to everyone by flipping those flags' rules to ALWAYS_TRUE.",
+  "type": "segment",
+  "valueType": "bool",
+  "default": {
+    "rules": [
+      {
+        "criteria": [
+          {
+            "operator": "PROP_IS_ONE_OF",
+            "propertyName": "user.username",
+            "valueToMatch": {
+              "type": "string_list",
+              "value": ["evan"]
+            }
+          }
+        ],
+        "value": {
+          "type": "bool",
+          "value": true
+        }
+      },
+      {
+        "criteria": [
+          {
+            "operator": "ALWAYS_TRUE"
+          }
+        ],
+        "value": {
+          "type": "bool",
+          "value": false
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What this adds

Every show keeps its **community average** (the plain mean of fans' star ratings). This adds an opt-in **Calibrated Show Rating** that measures the same thing, how good the show was, while being much harder to skew. Everyone sees the community average by default; users turn the calibrated rating on in profile settings.

The calibrated score:
- **Weights raters by how they rate** (entropy: full-scale raters count more than one-note raters; good-faith dissent is never penalized).
- **Removes each rater's bias** (centers each vote on that rater's own mean).
- **Drops clear bad-faith raters** (per-era bombers and fluffers).
- **Counts each person once** (collapses duplicate accounts to one most-recent vote; this also fixes the community average).
- **Does not over-reward thin shows** (count-shrinks toward a cleaned global anchor).
- **Treats new raters fairly** (cold-start blends a low-volume rater toward the typical rater so a first vote still moves the number).

Also ships: a Top Rated reorder in the viewer's mode, an author-only comparison/debug overlay, deduped per-show and per-track rating-distribution histograms, and an explainer page at `/show-rating-algorithm`.

## Rollout (feature-flagged, local quonfig)

Launch posture: the feature runs in production (the cron computes scores) but the opt-in toggle and overlay are visible only to a `rating-beta` segment (the author). The master kill switch (`ratings.calibrated-enabled`), per-user opt-in visibility (`ratings.toggle-visible`), the app default (`ratings.default-calibrated`), the recompute gate, the compare overlay, and the explainer nav link are all flags in the committed `quonfig/` workspace. Every flag was verified on and off in the browser (including the kill switch overriding the default, and the default flipping anonymous viewers to calibrated).

## Recompute

An hourly cron and a deploy-time step recompute the calibrated scores, dirty-gated so they no-op (~0.5s) when nothing changed. The recompute was taken from ~32s to ~3.3s by replacing two N+1 loops (per-show scoring, and ~14k per-rateable canonical-average updates) with bulk `UPDATE ... FROM (VALUES ...)` writes; a before/after golden-master diff confirmed zero value changes.

## Validity

`make rating-validity-eval` (kept harness) measures the Spearman rank correlation of each score against community jam-chart / all-timer signals. The calibrated rating tracks both the count and the total length of a show's all-timer tracks more closely than the raw average (0.58 / 0.56 vs 0.54 / 0.53 over ~1,150 shows with at least 10 ratings).

## Notes for the reviewer

- **De-dup vs exclusion:** de-duplication (one human, one vote) is universal, applying to the community average and the calibrated score alike. Bad-faith exclusion shapes only the calibrated score, never the displayed average, count, or histogram. The dedup rule lives in one place (`dedupeRatings` / `dedupedRatingsFor`), with a guard documented in `packages/core/CLAUDE.md` so a future change cannot reintroduce a raw, non-deduped aggregate.
- **One fix folded in:** the calibrated score previously looked up a rater's stats by their original account id, so a multi-account rater whose latest vote on a show came from a secondary account was scored as brand-new. Now looked up by canonical id. This shifted ~25% of shows' calibrated scores (max 0.114) and nudged the validity correlations up.
- **Caching:** calibrated scores are read live (never Redis-cached); only the canonical averages embedded in cached setlist payloads need busting, which the rating write paths handle. A deferred follow-up (tracked separately) would stop embedding ratings in the structural cache entirely.
- **Migration:** one idempotent migration adds `Show.weighted_rating` / `weighted_ratings_count`, the `rating_settings` singleton, and the `User` opt-in columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
