### PR TITLE
Make the show rating histogram match the viewer's rating mode

### DIFF
--- a/apps/web/app/routes/shows/$slug.tsx
+++ b/apps/web/app/routes/shows/$slug.tsx
@@ -35,6 +35,7 @@ import { formatDateLong, formatMonthDay } from "~/lib/utils";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
 import { computeShowUserData } from "~/server/show-user-data";
+import { resolveViewerRatingMode } from "~/server/viewer-rating";
 
 interface ShowLoaderData {
   setlist: Setlist;
@@ -78,13 +79,21 @@ export const loader = publicLoader(async ({ params, context }): Promise<ShowLoad
   });
 
   // Load reviews, photos, adjacent shows, and the rating distribution fresh
-  // (not cached - simple indexed queries). The distribution feeds the
-  // right-rail histogram; one groupBy over the ratings index is cheap.
+  // (not cached - simple indexed queries). The distribution feeds the right-rail
+  // histogram and tracks the viewer's rating mode: calibrated viewers see the
+  // contributing set (bombers/fluffers dropped) so the bar total matches the
+  // calibrated count beside the score; everyone else sees the deduped community
+  // distribution.
+  const { mode } = await resolveViewerRatingMode(context);
+  const ratingDistributionQuery =
+    mode === "calibrated"
+      ? services.raterWeights.getCalibratedDistribution(setlist.show.id)
+      : services.ratings.getRatingDistribution(setlist.show.id, "Show");
   const [reviews, photos, adjacentShows, ratingDistribution] = await Promise.all([
     services.reviews.findByShowId(setlist.show.id),
     services.files.findByShowId(setlist.show.id),
     services.shows.findAdjacentShows(setlist.show.date, setlist.show.slug),
-    services.ratings.getRatingDistribution(setlist.show.id, "Show"),
+    ratingDistributionQuery,
   ]);
 
   logger.info(`Show data loaded for ${slug} - setlist cached, reviews fresh`);

--- a/packages/core/src/ratings/rater-weight-service.test.ts
+++ b/packages/core/src/ratings/rater-weight-service.test.ts
@@ -312,3 +312,104 @@ describe("RaterWeightService.getDisplayedForShows", () => {
     expect(await new RaterWeightService(db).getDisplayedForShows(["s1"])).toEqual({});
   });
 });
+
+describe("RaterWeightService.getCalibratedDistribution", () => {
+  // A MARLON-era show (2026-01-01) rated by a full-range credible rater, a middle
+  // one-note rater (always 3, NOT a bomber), and a flagged floor-bomber.
+  function makeDb(overrides?: { bomberExcluded?: boolean; onenoteExcluded?: boolean }) {
+    const ratingFindMany = vi.fn().mockResolvedValue([
+      { userId: "credible", value: 5, createdAt: new Date("2026-01-02") },
+      { userId: "onenote", value: 3, createdAt: new Date("2026-01-03") },
+      { userId: "bomber", value: 0.5, createdAt: new Date("2026-01-04") },
+    ]);
+    const showFindMany = vi.fn().mockResolvedValue([{ id: "s1", date: "2026-01-01" }]);
+    const raterStatsFindMany = vi.fn().mockResolvedValue([
+      { userId: "credible", era: "GLOBAL", mean: 4, entropy: 2, ratingsCount: 20, isExcluded: false },
+      {
+        userId: "onenote",
+        era: "MARLON",
+        mean: 3,
+        entropy: 0,
+        ratingsCount: 12,
+        isExcluded: overrides?.onenoteExcluded ?? false,
+      },
+      {
+        userId: "bomber",
+        era: "MARLON",
+        mean: 0.5,
+        entropy: 0,
+        ratingsCount: 28,
+        isExcluded: overrides?.bomberExcluded ?? true,
+      },
+    ]);
+    const showUpdate = vi.fn().mockResolvedValue(undefined);
+    const db = {
+      user: { findMany: vi.fn().mockResolvedValue([]) }, // no alias dedup in this fixture
+      rating: { findMany: ratingFindMany, groupBy: vi.fn().mockResolvedValue([]) },
+      show: { findMany: showFindMany, update: showUpdate },
+      track: { findMany: vi.fn() },
+      raterStats: { findMany: raterStatsFindMany },
+      ratingSettings: { findFirst: vi.fn().mockResolvedValue(null) },
+      $queryRaw: vi.fn().mockResolvedValue([{ mean: 2.75 }]), // populationStats (recompute path only)
+    } as never;
+    return { db, showUpdate };
+  }
+
+  function asMap(buckets: Array<{ value: number; count: number }>): Record<number, number> {
+    return Object.fromEntries(buckets.map((b) => [b.value, b.count]));
+  }
+
+  test("drops the era-flagged bomber but keeps a middle one-note rater (raw star values)", async () => {
+    const { db } = makeDb();
+    const buckets = await new RaterWeightService(db).getCalibratedDistribution("s1");
+    // bomber (0.5) excluded; credible (5) and the non-extreme one-note (3) remain.
+    expect(asMap(buckets)).toEqual({ 5: 1, 3: 1 });
+  });
+
+  test("its bar total equals the weighted_ratings_count the score path writes", async () => {
+    const { db, showUpdate } = makeDb();
+    const service = new RaterWeightService(db);
+    const buckets = await service.getCalibratedDistribution("s1");
+    await service.recomputeRateable("Show", "s1");
+    const total = buckets.reduce((sum, b) => sum + b.count, 0);
+    const written = (showUpdate.mock.calls[0][0] as { data: { weightedRatingsCount: number } }).data
+      .weightedRatingsCount;
+    expect(total).toBe(written);
+  });
+
+  test("falls back to the full deduped set when every rater is excluded (never empty)", async () => {
+    const db = {
+      user: { findMany: vi.fn().mockResolvedValue([]) },
+      rating: {
+        findMany: vi.fn().mockResolvedValue([
+          { userId: "credible", value: 5, createdAt: new Date("2026-01-02") },
+          { userId: "onenote", value: 3, createdAt: new Date("2026-01-03") },
+          { userId: "bomber", value: 0.5, createdAt: new Date("2026-01-04") },
+        ]),
+        groupBy: vi.fn().mockResolvedValue([]),
+      },
+      show: { findMany: vi.fn().mockResolvedValue([{ id: "s1", date: "2026-01-01" }]) },
+      track: { findMany: vi.fn() },
+      raterStats: {
+        findMany: vi.fn().mockResolvedValue([
+          { userId: "credible", era: "MARLON", mean: 5, entropy: 0, ratingsCount: 10, isExcluded: true },
+          { userId: "onenote", era: "MARLON", mean: 3, entropy: 0, ratingsCount: 12, isExcluded: true },
+          { userId: "bomber", era: "MARLON", mean: 0.5, entropy: 0, ratingsCount: 28, isExcluded: true },
+        ]),
+      },
+    } as never;
+    const buckets = await new RaterWeightService(db).getCalibratedDistribution("s1");
+    expect(asMap(buckets)).toEqual({ 5: 1, 3: 1, 0.5: 1 });
+  });
+
+  test("returns no buckets for an unrated show", async () => {
+    const db = {
+      user: { findMany: vi.fn().mockResolvedValue([]) },
+      rating: { findMany: vi.fn().mockResolvedValue([]), groupBy: vi.fn().mockResolvedValue([]) },
+      show: { findMany: vi.fn().mockResolvedValue([{ id: "s1", date: "2026-01-01" }]) },
+      track: { findMany: vi.fn() },
+      raterStats: { findMany: vi.fn().mockResolvedValue([]) },
+    } as never;
+    expect(await new RaterWeightService(db).getCalibratedDistribution("s1")).toEqual([]);
+  });
+});

--- a/packages/core/src/ratings/rater-weight-service.ts
+++ b/packages/core/src/ratings/rater-weight-service.ts
@@ -3,6 +3,7 @@ import { Prisma } from "@prisma/client";
 import type { DbClient } from "../_shared/database/models";
 import { aliasKey, mostRecentPerKey } from "./rater-aliases";
 import {
+  bucketRatingValues,
   COLD_START_ENTROPY_K,
   COLD_START_RATER_K,
   computeCleanedScopeStats,
@@ -17,7 +18,9 @@ import {
   rateableKindFromType,
   type ScopedRating,
   SHRINK_K,
+  selectContributingRatings,
 } from "./rater-weighting";
+import type { RatingValueBucket } from "./rating-service";
 
 interface RateableRef {
   rateableType: string;
@@ -146,14 +149,11 @@ function computeShowWeighted(
   statByUserEra: StatByUserEra,
   pop: PopulationStats,
 ): { weightedRating: number | null; weightedRatingsCount: number } {
-  const excludedHere = new Set<string>();
-  if (showEra) {
-    for (const rating of ratings) {
-      if (statByUserEra(rating.userId, showEra)?.isExcluded) excludedHere.add(rating.userId);
-    }
-  }
-  const activeRatings = ratings.filter((rating) => !excludedHere.has(rating.userId));
-  const used = activeRatings.length > 0 ? activeRatings : ratings;
+  const used = selectContributingRatings(
+    ratings,
+    showEra,
+    (userId, era) => statByUserEra(userId, era)?.isExcluded ?? false,
+  );
 
   const result = entropyWeightedCenteredAverage(
     used.map((rating) => {
@@ -292,6 +292,31 @@ export class RaterWeightService {
       };
     }
     return byId;
+  }
+
+  /**
+   * The calibrated histogram for one show: raw-star-value buckets of the exact
+   * contributing set the calibrated score is built from (deduped, era bombers/
+   * fluffers dropped). Bars stay raw star values; only membership differs from the
+   * community distribution, so the bar total equals the displayed
+   * `weighted_ratings_count` — both derive from the same
+   * {@link loadCanonicalShowRatings} + {@link selectContributingRatings}. With no
+   * `rater_stats` yet (or no exclusions) it degrades to the full deduped set, matching
+   * the canonical distribution the headline falls back to. Empty when unrated.
+   */
+  async getCalibratedDistribution(showId: string): Promise<RatingValueBucket[]> {
+    const ratings = await this.loadCanonicalShowRatings("Show", showId);
+    if (ratings.length === 0) return [];
+    const { era, statByUserEra } = await this.loadShowExclusionContext(
+      showId,
+      ratings.map((rating) => rating.userId),
+    );
+    const used = selectContributingRatings(
+      ratings,
+      era,
+      (userId, scopeEra) => statByUserEra(userId, scopeEra)?.isExcluded ?? false,
+    );
+    return bucketRatingValues(used.map((rating) => rating.value));
   }
 
   /**
@@ -444,48 +469,47 @@ export class RaterWeightService {
   }
 
   /**
-   * Recompute one show's calibrated score (`shows.weighted_rating`) from current
-   * rater_stats. Show-only — tracks have no denormalized calibrated column. The
-   * batch passes `population` + the prebuilt canonical map to skip per-call work.
+   * The show's deduped ratings under the one-human-one-vote rule: pull every raw
+   * vote, remap each to its canonical account FIRST so a multi-account rater is one
+   * person (and their stats, stored under the canonical id, are found regardless of
+   * which account cast the latest vote), then keep one most-recent vote per person.
+   * The single deduped source for both the calibrated score and the calibrated
+   * histogram, so they can never disagree on the population. Empty when unrated.
    */
-  async recomputeRateable(
+  private async loadCanonicalShowRatings(
     rateableType: string,
     rateableId: string,
-    population?: PopulationStats,
     canonicalUsers?: Map<string, string>,
-  ): Promise<void> {
-    if (rateableType !== "Show") return;
-
+  ): Promise<Array<{ userId: string; value: number; createdAt: Date }>> {
     const rawRatings = await this.db.rating.findMany({
       where: { rateableType, rateableId },
       select: { userId: true, value: true, createdAt: true },
     });
-    if (rawRatings.length === 0) {
-      await this.db.show.update({
-        where: { id: rateableId },
-        data: { weightedRating: null, weightedRatingsCount: 0 },
-      });
-      return;
-    }
-
-    // Collapse duplicate accounts to one (most recent) vote per person, remapping each
-    // vote to its canonical account FIRST so the rater's stats (stored under the
-    // canonical id) are found — a multi-account rater is one person, scored once with
-    // their real stats regardless of which account cast the latest vote.
+    if (rawRatings.length === 0) return [];
     const canonical = canonicalUsers ?? (await this.buildCanonicalUserMap());
-    const ratings = mostRecentPerKey(
+    return mostRecentPerKey(
       rawRatings.map((rating) => ({ ...rating, userId: canonical.get(rating.userId) ?? rating.userId })),
       (rating) => rating.userId,
     );
+  }
 
-    const kind = rateableKindFromType(rateableType);
-    const meta = await this.loadRateableMeta([{ rateableType, rateableId }]);
-    const date = meta.get(rateableKey(rateableType, rateableId))?.date;
+  /**
+   * The bad-faith-exclusion context for scoring/bucketing one show: its drummer era
+   * (null when the date is unknown) plus a `(userId, era) → stats` lookup over the
+   * show-kind `rater_stats`. Shared by the calibrated score and histogram so both read
+   * the same exclusion flags. The histogram only needs `isExcluded`; the score also
+   * reads the mean/entropy off the same rows, so one query serves both.
+   */
+  private async loadShowExclusionContext(
+    showId: string,
+    userIds: string[],
+  ): Promise<{ era: RaterEra | null; statByUserEra: StatByUserEra }> {
+    const meta = await this.loadRateableMeta([{ rateableType: "Show", rateableId: showId }]);
+    const date = meta.get(rateableKey("Show", showId))?.date;
     const era = date ? drummerEraForDate(date) : null;
-    const pop = population ?? (await this.populationStats(kind));
 
     const statRows = await this.db.raterStats.findMany({
-      where: { userId: { in: ratings.map((rating) => rating.userId) }, kind },
+      where: { userId: { in: userIds }, kind: "SHOW" },
       select: { userId: true, era: true, mean: true, entropy: true, ratingsCount: true, isExcluded: true },
     });
     const byUserEra = new Map<string, RaterScopeStat>();
@@ -498,6 +522,36 @@ export class RaterWeightService {
       });
     }
     const statByUserEra: StatByUserEra = (userId, scopeEra) => byUserEra.get(`${userId}:${scopeEra}`);
+    return { era, statByUserEra };
+  }
+
+  /**
+   * Recompute one show's calibrated score (`shows.weighted_rating`) from current
+   * rater_stats. Show-only — tracks have no denormalized calibrated column. The
+   * batch passes `population` + the prebuilt canonical map to skip per-call work.
+   */
+  async recomputeRateable(
+    rateableType: string,
+    rateableId: string,
+    population?: PopulationStats,
+    canonicalUsers?: Map<string, string>,
+  ): Promise<void> {
+    if (rateableType !== "Show") return;
+
+    const ratings = await this.loadCanonicalShowRatings(rateableType, rateableId, canonicalUsers);
+    if (ratings.length === 0) {
+      await this.db.show.update({
+        where: { id: rateableId },
+        data: { weightedRating: null, weightedRatingsCount: 0 },
+      });
+      return;
+    }
+
+    const { era, statByUserEra } = await this.loadShowExclusionContext(
+      rateableId,
+      ratings.map((rating) => rating.userId),
+    );
+    const pop = population ?? (await this.populationStats(rateableKindFromType(rateableType)));
 
     const { weightedRating, weightedRatingsCount } = computeShowWeighted(ratings, era, statByUserEra, pop);
     await this.db.show.update({

--- a/packages/core/src/ratings/rater-weighting.test.ts
+++ b/packages/core/src/ratings/rater-weighting.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  bucketRatingValues,
   center,
   computeCleanedScopeStats,
   entropyWeight,
@@ -9,6 +10,7 @@ import {
   RATER_ERAS,
   ratingEntropy,
   type ScopedRating,
+  selectContributingRatings,
 } from "./rater-weighting";
 
 // ratingEntropy — Shannon information entropy over a rater's value distribution.
@@ -174,5 +176,42 @@ describe("computeCleanedScopeStats", () => {
     const scopes = computeCleanedScopeStats(ratings);
     expect(scopes.get("GLOBAL")?.mean).toBe(0.5);
     expect(scopes.get("GLOBAL")?.isExcluded).toBe(false);
+  });
+});
+
+// selectContributingRatings — the "who counts" rule shared by the calibrated score
+// and histogram: drop the era's bad-faith raters, but never empty the show.
+describe("selectContributingRatings", () => {
+  const ratings = [
+    { userId: "credible", value: 5 },
+    { userId: "bomber", value: 0.5 },
+  ];
+
+  test("drops raters flagged bad-faith in the show's era", () => {
+    const used = selectContributingRatings(ratings, "MARLON", (userId) => userId === "bomber");
+    expect(used).toEqual([{ userId: "credible", value: 5 }]);
+  });
+
+  test("keeps everyone when the show has no era (date unknown)", () => {
+    const used = selectContributingRatings(ratings, null, () => true);
+    expect(used).toEqual(ratings);
+  });
+
+  test("falls back to all ratings when exclusion would empty the show", () => {
+    const used = selectContributingRatings(ratings, "MARLON", () => true);
+    expect(used).toEqual(ratings);
+  });
+});
+
+// bucketRatingValues — the single per-rateable histogram bucketing rule: group by
+// star value, skipping the sub-0.5 "unrated" sentinel.
+describe("bucketRatingValues", () => {
+  test("counts each star value and skips sub-0.5 sentinels", () => {
+    const buckets = bucketRatingValues([5, 5, 4, 0.5, 0.25, 0]);
+    expect(Object.fromEntries(buckets.map((b) => [b.value, b.count]))).toEqual({ 5: 2, 4: 1, 0.5: 1 });
+  });
+
+  test("returns no buckets for an empty set", () => {
+    expect(bucketRatingValues([])).toEqual([]);
   });
 });

--- a/packages/core/src/ratings/rater-weighting.ts
+++ b/packages/core/src/ratings/rater-weighting.ts
@@ -270,3 +270,41 @@ export function computeCleanedScopeStats(ratings: ReadonlyArray<ScopedRating>): 
   result.set("GLOBAL", { ...statsOfRatings(globalBase), isExcluded: false });
   return result;
 }
+
+/**
+ * The contributing set of a show's deduped ratings: the votes that actually feed
+ * the calibrated score. Drops raters flagged bad-faith in this show's era; falls
+ * back to all ratings if that empties the show (so a score/distribution always
+ * exists). The single source of the "who counts" rule, shared by
+ * {@link computeShowWeighted} (which sums them) and the calibrated histogram
+ * (which counts them by raw value) so the two can never disagree on membership.
+ */
+export function selectContributingRatings<T extends { userId: string }>(
+  ratings: ReadonlyArray<T>,
+  showEra: RaterEra | null,
+  isExcludedInEra: (userId: string, era: RaterEra) => boolean,
+): T[] {
+  const excludedHere = new Set<string>();
+  if (showEra) {
+    for (const rating of ratings) {
+      if (isExcludedInEra(rating.userId, showEra)) excludedHere.add(rating.userId);
+    }
+  }
+  const active = ratings.filter((rating) => !excludedHere.has(rating.userId));
+  return active.length > 0 ? active : [...ratings];
+}
+
+/**
+ * Group raw star values into per-value `{ value, count }` buckets, skipping the
+ * sub-0.5 "unrated" sentinel. The single bucketing rule behind every per-rateable
+ * histogram (the deduped community distribution and the calibrated contributing
+ * distribution) so both bucket and floor-filter identically.
+ */
+export function bucketRatingValues(values: ReadonlyArray<number>): Array<{ value: number; count: number }> {
+  const countByValue = new Map<number, number>();
+  for (const value of values) {
+    if (value < 0.5) continue;
+    countByValue.set(value, (countByValue.get(value) ?? 0) + 1);
+  }
+  return Array.from(countByValue, ([value, count]) => ({ value, count }));
+}

--- a/packages/core/src/ratings/rating-service.ts
+++ b/packages/core/src/ratings/rating-service.ts
@@ -5,6 +5,7 @@ import type { DbClient, DbRating } from "../_shared/database/models";
 import { setSortKeySql, showOrderBySql } from "../_shared/show-ordering";
 import { aliasKey, mostRecentPerKey } from "./rater-aliases";
 import type { RaterWeightService } from "./rater-weight-service";
+import { bucketRatingValues } from "./rater-weighting";
 
 interface DedupableRating {
   value: number;
@@ -675,12 +676,7 @@ export class RatingService {
    */
   async getRatingDistribution(rateableId: string, rateableType: string): Promise<RatingValueBucket[]> {
     const deduped = await this.dedupedRatingsFor(rateableId, rateableType);
-    const countByValue = new Map<number, number>();
-    for (const rating of deduped) {
-      if (rating.value < 0.5) continue;
-      countByValue.set(rating.value, (countByValue.get(rating.value) ?? 0) + 1);
-    }
-    return Array.from(countByValue, ([value, count]) => ({ value, count }));
+    return bucketRatingValues(deduped.map((rating) => rating.value));
   }
 
   async deleteByRateableId(rateableId: string, rateableType: string): Promise<void> {


### PR DESCRIPTION
Calibrated viewers now see a show's rating histogram built from the same votes
that feed the calibrated score. Before, the right-rail "Rating distribution"
chart always showed the full deduped community population, so in calibrated mode
its bar total disagreed with the calibrated "N ratings" headline beside the
score. Now a calibrated viewer's histogram drops the era-flagged
bombers/fluffers, so the bar total matches the headline; simple-mode viewers see
the deduped community distribution as before. Bars stay raw star values in both
modes; only which voters are included changes.

This is the deferred half of the Calibrated Show Rating work (#197).

## How to see it

On a show with a flagged bomber rating: as a simple-mode viewer the histogram
total matches the community count; toggle **Calibrated show rating** in profile
settings and reload, and the bomber's bar drops out so the total matches the
calibrated count. Per-track hover histograms are unchanged (calibration is
show-only).

## Implementation note

The histogram total and the displayed `weighted_ratings_count` are derived from
one code path rather than two parallel ones, so they can't silently drift. The
contributor selection (`loadCanonicalShowRatings` + `selectContributingRatings`)
is shared by the calibrated score (`computeShowWeighted`) and the new
`RaterWeightService.getCalibratedDistribution`; the existing
`getRatingDistribution` adopts the same shared `bucketRatingValues`. The simple
path keeps its own cheaper per-show dedup loader (it doesn't need the global
canonical-account map the calibrated stats lookup requires); the two dedups
provably yield the same value-distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
