### PR TITLE
Stop embedding ratings in the structural setlist cache

### DIFF
--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -17,7 +17,11 @@ vi.mock("~/hooks/use-show-user-data", () => ({
 // view; that path calls useTrackUserRatings which needs a QueryClient. Stub
 // it so the table renders without any React Query setup.
 vi.mock("~/hooks/use-track-user-ratings", () => ({
-  useTrackUserRatings: vi.fn(() => ({ userRatingMap: new Map<string, number>(), isLoading: false })),
+  useTrackUserRatings: vi.fn(() => ({
+    userRatingMap: new Map<string, number>(),
+    averageRatingMap: new Map<string, { average: number; count: number }>(),
+    isLoading: false,
+  })),
 }));
 // SetlistTable also fetches the catalog play-dates blob for the Played
 // Before column; stub it so the gap-chart view renders without React Query.
@@ -87,8 +91,6 @@ function makeSetlist(overrides: { showDate?: string } = {}): SetlistLight {
             likesCount: 0,
             note: null,
             allTimer: false,
-            averageRating: null,
-            ratingsCount: 0,
             gap: null,
             previousPerformanceShowId: null,
             duration: null,
@@ -423,10 +425,11 @@ describe("SetlistCard", () => {
     expect(onViewChange).not.toHaveBeenCalled();
   });
 
-  // Calibrated mode passes the post-exclusion count via showRatingCount, which must
-  // override the embedded deduped ratingsCount on the rating badge — so a calibrated
-  // viewer sees "· 33", not the deduped "· 10". (makeSetlist embeds ratingsCount=10.)
-  test("showRatingCount overrides the embedded ratingsCount on the rating badge", async () => {
+  // The count beside the ★ comes entirely from the live showRatingCount prop
+  // (canonical in simple mode, post-exclusion in calibrated mode). Ratings no
+  // longer ride in the setlist blob, so the badge shows "· 33", and the
+  // blob's stale ratingsCount=10 is never read.
+  test("rating badge shows the live showRatingCount", async () => {
     await setupWithRouter(
       <SetlistCard
         setlist={makeSetlist()}
@@ -440,13 +443,14 @@ describe("SetlistCard", () => {
     expect(screen.queryByText("10")).not.toBeInTheDocument();
   });
 
-  // Simple mode (no showRatingCount): the badge falls back to the embedded deduped
-  // ratingsCount (10).
-  test("rating badge falls back to the embedded ratingsCount when showRatingCount is absent", async () => {
+  // No live count prop: the badge shows no count. The embedded ratingsCount (10)
+  // is NOT a fallback anymore — rating values were removed from the structural
+  // blob, so nothing reads setlist.show.ratingsCount.
+  test("rating badge does not fall back to the embedded ratingsCount", async () => {
     await setupWithRouter(
       <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={4.0} />,
     );
-    expect(screen.getAllByText("10").length).toBeGreaterThan(0);
+    expect(screen.queryByText("10")).not.toBeInTheDocument();
   });
 
   // averageSongGap=null happens for all-debut/all-repeat shows. The summary

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -34,6 +34,14 @@ interface SetlistCardProps {
    * (post-exclusion) contributing count; absent ⇒ the canonical deduped count.
    */
   showRatingCount?: number | null;
+  /**
+   * The canonical (deduped community) average, read live from useShowUserData.
+   * Used by the calibrated/rank comparison summary, which always compares
+   * against the canonical score regardless of the viewer's display mode.
+   * Ratings no longer ride in the structural setlist blob, so this is supplied
+   * by the parent rather than read off `setlist.show`.
+   */
+  canonicalRating?: number | null;
   externalSources?: ShowExternalSources;
   /**
    * Simple→calibrated score + rank summary for this show. Rendered next to the ★
@@ -67,6 +75,7 @@ function SetlistCardComponent({
   userRating,
   showRating,
   showRatingCount,
+  canonicalRating,
   externalSources,
   rankComparison,
   collapsible = false,
@@ -139,15 +148,16 @@ function SetlistCardComponent({
   // Resolve the user's rating from either of the supported prop shapes
   // (a Rating object or a bare number) into a single value for the badge.
   const resolvedUserRating = typeof userRating === "number" ? userRating : (userRating?.value ?? null);
-  const displayedRating = showRating ?? setlist.show.averageRating ?? null;
+  const displayedRating = showRating ?? null;
   // In calibrated mode the count is the post-exclusion contributing count (passed
-  // alongside the calibrated score); otherwise the canonical deduped count.
-  const displayedCount = showRatingCount ?? setlist.show.ratingsCount ?? null;
+  // alongside the calibrated score); otherwise the canonical deduped count. Both
+  // arrive live from useShowUserData — ratings no longer live in the setlist blob.
+  const displayedCount = showRatingCount ?? null;
 
   // Compact calibrated-score + rank summary, rendered to the right of the ★ score.
   const summaryEl = rankComparison ? (
     <div className="text-[10px] leading-tight sm:text-xs">
-      <CalibratedSummary canonical={setlist.show.averageRating ?? null} rank={rankComparison} compact />
+      <CalibratedSummary canonical={canonicalRating ?? null} rank={rankComparison} compact />
     </div>
   ) : null;
 

--- a/apps/web/app/components/setlist/setlist-columns-personal.tsx
+++ b/apps/web/app/components/setlist/setlist-columns-personal.tsx
@@ -27,6 +27,7 @@ export function createPersonalSetlistColumns(
 ): ColumnDef<PersonalSetlistTableRow, unknown>[] {
   const ratingCtx: SetlistRatingContext = {
     showSlug: ctx?.showSlug ?? "",
+    averageRatingMap: ctx?.averageRatingMap ?? new Map(),
     userRatingMap: ctx?.userRatingMap ?? new Map(),
     isAuthenticated: ctx?.isAuthenticated ?? false,
   };

--- a/apps/web/app/components/setlist/setlist-columns.test.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.test.tsx
@@ -37,8 +37,6 @@ function makeTrack(
     likesCount: 0,
     note: null,
     allTimer: false,
-    averageRating: overrides.averageRating ?? null,
-    ratingsCount: overrides.ratingsCount ?? 0,
     gap: overrides.gap ?? null,
     previousPerformanceShowId: overrides.previousPerformanceShowId ?? null,
     duration: overrides.duration ?? null,
@@ -52,6 +50,12 @@ function makeTrack(
     song: overrides.song ?? { id: overrides.songId, title: "Basis for a Day", slug: "basis-for-a-day" },
     priorPerformanceCount: overrides.priorPerformanceCount ?? 0,
   };
+}
+
+// Build the community-average map the rating column reads. Track ratings no
+// longer live on the row — they come from the live tier-2 fetch (averageRatingMap).
+function avgMap(entries: Array<[id: string, average: number, count: number]>) {
+  return new Map(entries.map(([id, average, count]) => [id, { average, count }]));
 }
 
 // Renders the column definitions through a real table so we exercise the cell
@@ -250,34 +254,22 @@ describe("createSetlistColumns", () => {
   // canonical setlist order.
   test("sorting by Rating tiebreaks on vote count when averages match", async () => {
     const user = userEvent.setup();
-    await renderTable([
-      // Two tracks tied at 4.5; "Confrontation" has more votes so it should
-      // sort ahead of "Crickets" when the table sorts rating descending.
-      makeTrack({
-        songId: "a",
-        position: 1,
-        set: "S1",
-        averageRating: 4.5,
-        ratingsCount: 3,
-        song: { id: "a", title: "Crickets", slug: "c" },
-      }),
-      makeTrack({
-        songId: "b",
-        position: 2,
-        set: "S1",
-        averageRating: 4.5,
-        ratingsCount: 50,
-        song: { id: "b", title: "Confrontation", slug: "co" },
-      }),
-      makeTrack({
-        songId: "c",
-        position: 3,
-        set: "S1",
-        averageRating: 3.0,
-        ratingsCount: 100,
-        song: { id: "c", title: "Above the Waves", slug: "a" },
-      }),
-    ]);
+    await renderTable(
+      [
+        // Two tracks tied at 4.5; "Confrontation" has more votes so it should
+        // sort ahead of "Crickets" when the table sorts rating descending.
+        makeTrack({ songId: "a", position: 1, set: "S1", song: { id: "a", title: "Crickets", slug: "c" } }),
+        makeTrack({ songId: "b", position: 2, set: "S1", song: { id: "b", title: "Confrontation", slug: "co" } }),
+        makeTrack({ songId: "c", position: 3, set: "S1", song: { id: "c", title: "Above the Waves", slug: "a" } }),
+      ],
+      {
+        averageRatingMap: avgMap([
+          ["t-1", 4.5, 3],
+          ["t-2", 4.5, 50],
+          ["t-3", 3.0, 100],
+        ]),
+      },
+    );
     // First click on Rating sorts descending ("best first" via sortDescFirst).
     await user.click(screen.getByRole("button", { name: /Rating/i }));
     const songCells = screen.getAllByRole("cell").filter((_, i) => i % 9 === 3);
@@ -297,31 +289,12 @@ describe("createSetlistColumns", () => {
   // columns: tiebreak direction follows primary direction.
   test("sorting by Rating with identical rating+votes falls back to set+position", async () => {
     const user = userEvent.setup();
+    // No averageRatingMap entries → every row is unrated, so the rating axis ties
+    // and the sort falls through to set+position.
     await renderTable([
-      makeTrack({
-        songId: "a",
-        position: 3,
-        set: "S1",
-        averageRating: null,
-        ratingsCount: 0,
-        song: { id: "a", title: "Crickets", slug: "c" },
-      }),
-      makeTrack({
-        songId: "b",
-        position: 1,
-        set: "S1",
-        averageRating: null,
-        ratingsCount: 0,
-        song: { id: "b", title: "Above the Waves", slug: "a" },
-      }),
-      makeTrack({
-        songId: "c",
-        position: 2,
-        set: "S1",
-        averageRating: null,
-        ratingsCount: 0,
-        song: { id: "c", title: "Basis for a Day", slug: "b" },
-      }),
+      makeTrack({ songId: "a", position: 3, set: "S1", song: { id: "a", title: "Crickets", slug: "c" } }),
+      makeTrack({ songId: "b", position: 1, set: "S1", song: { id: "b", title: "Above the Waves", slug: "a" } }),
+      makeTrack({ songId: "c", position: 2, set: "S1", song: { id: "c", title: "Basis for a Day", slug: "b" } }),
     ]);
     await user.click(screen.getByRole("button", { name: /Rating/i }));
     const songCells = screen.getAllByRole("cell").filter((_, i) => i % 9 === 3);
@@ -553,19 +526,21 @@ describe("createSetlistColumns", () => {
         makeTrack({
           songId: "song-basis",
           position: 1,
-          averageRating: 4.2,
-          ratingsCount: 17,
           song: { id: "song-basis", title: "Basis for a Day", slug: "basis-for-a-day" },
         }),
         makeTrack({
           songId: "song-munchkin",
           position: 2,
-          averageRating: null,
-          ratingsCount: 0,
           song: { id: "song-munchkin", title: "Munchkin Invasion", slug: "munchkin-invasion" },
         }),
       ],
-      { showSlug: "2024-07-19-camden", userRatingMap, isAuthenticated: true },
+      {
+        showSlug: "2024-07-19-camden",
+        // t-1 has a community average; t-2 is unrated (absent from the map → null).
+        averageRatingMap: avgMap([["t-1", 4.2, 17]]),
+        userRatingMap,
+        isAuthenticated: true,
+      },
     );
 
     expectAllMockedShallowComponent("TrackRatingCell", [
@@ -580,8 +555,10 @@ describe("createSetlistColumns", () => {
       {
         trackId: "t-2",
         showSlug: "2024-07-19-camden",
+        // Absent from averageRatingMap → both the average and its count are null
+        // (the row no longer carries a default ratingsCount of 0).
         initialRating: null,
-        ratingsCount: 0,
+        ratingsCount: null,
         userRating: null,
         isAuthenticated: true,
       },
@@ -592,15 +569,16 @@ describe("createSetlistColumns", () => {
   // handled inside RatingBadgeButton). The factory must forward
   // isAuthenticated=false without crashing when no userRatingMap is given.
   test("Rating cells render with anonymous viewer (no userRatingMap)", async () => {
-    await renderTable([
-      makeTrack({
-        songId: "song-crickets",
-        position: 1,
-        averageRating: 3.8,
-        ratingsCount: 5,
-        song: { id: "song-crickets", title: "Crickets", slug: "crickets" },
-      }),
-    ]);
+    await renderTable(
+      [
+        makeTrack({
+          songId: "song-crickets",
+          position: 1,
+          song: { id: "song-crickets", title: "Crickets", slug: "crickets" },
+        }),
+      ],
+      { averageRatingMap: avgMap([["t-1", 3.8, 5]]) },
+    );
 
     expectAllMockedShallowComponent("TrackRatingCell", [
       {

--- a/apps/web/app/components/setlist/setlist-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.tsx
@@ -30,6 +30,7 @@ export type SetlistTableRow = TrackLight & { priorPerformanceCount: number | nul
 export function createSetlistColumns(ctx?: Partial<SetlistRatingContext>): ColumnDef<SetlistTableRow, unknown>[] {
   const ratingCtx: SetlistRatingContext = {
     showSlug: ctx?.showSlug ?? "",
+    averageRatingMap: ctx?.averageRatingMap ?? new Map(),
     userRatingMap: ctx?.userRatingMap ?? new Map(),
     isAuthenticated: ctx?.isAuthenticated ?? false,
   };

--- a/apps/web/app/components/setlist/setlist-common-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-common-columns.tsx
@@ -27,12 +27,15 @@ function withSetPositionTiebreak<T extends TrackLight>(primary: (a: T, b: T) => 
 
 /**
  * Per-row inputs the rating column needs that the row itself doesn't carry:
- * the show slug (target of any rating mutation), the viewer's rating map
- * (resolved from useTrackUserRatings at the table level), and the auth
- * state. Identical between the catalog and personal column factories.
+ * the show slug (target of any rating mutation), the community average map and
+ * the viewer's rating map (both resolved live from useTrackUserRatings at the
+ * table level — community averages no longer ride in the structural setlist
+ * blob), and the auth state. Identical between the catalog and personal column
+ * factories.
  */
 export interface SetlistRatingContext {
   showSlug: string;
+  averageRatingMap: Map<string, { average: number; count: number }>;
   userRatingMap: Map<string, number>;
   isAuthenticated: boolean;
 }
@@ -49,7 +52,7 @@ export function createRatingColumn<T extends TrackLight>(ctx: SetlistRatingConte
   // so they cluster at the bottom on desc and the top on asc. First click
   // sorts descending — "best rated first" matches the mental model when
   // scanning a setlist for highlights.
-  return columnHelper.accessor((row) => row.averageRating ?? Number.NEGATIVE_INFINITY, {
+  return columnHelper.accessor((row) => ctx.averageRatingMap.get(row.id)?.average ?? Number.NEGATIVE_INFINITY, {
     id: "rating",
     header: ({ column }) => <SortableHeader column={column} label="Rating" />,
     // Sized for the busiest badge form: "★ 5.00 · 999 | 4½" — community
@@ -67,20 +70,23 @@ export function createRatingColumn<T extends TrackLight>(ctx: SetlistRatingConte
     // setlist shares the same show date, so date can't disambiguate here —
     // set+position is the canonical narrative tiebreak instead.
     sortingFn: withSetPositionTiebreak<T>((a, b) => {
-      const aRating = a.averageRating ?? Number.NEGATIVE_INFINITY;
-      const bRating = b.averageRating ?? Number.NEGATIVE_INFINITY;
+      const aAvg = ctx.averageRatingMap.get(a.id);
+      const bAvg = ctx.averageRatingMap.get(b.id);
+      const aRating = aAvg?.average ?? Number.NEGATIVE_INFINITY;
+      const bRating = bAvg?.average ?? Number.NEGATIVE_INFINITY;
       if (aRating !== bRating) return aRating - bRating;
-      return (a.ratingsCount ?? 0) - (b.ratingsCount ?? 0);
+      return (aAvg?.count ?? 0) - (bAvg?.count ?? 0);
     }),
     sortDescFirst: true,
     cell: (info) => {
       const row = info.row.original;
+      const average = ctx.averageRatingMap.get(row.id) ?? null;
       return (
         <TrackRatingCell
           trackId={row.id}
           showSlug={ctx.showSlug}
-          initialRating={row.averageRating ?? null}
-          ratingsCount={row.ratingsCount ?? null}
+          initialRating={average?.average ?? null}
+          ratingsCount={average?.count ?? null}
           userRating={ctx.userRatingMap.get(row.id) ?? null}
           isAuthenticated={ctx.isAuthenticated}
         />

--- a/apps/web/app/components/setlist/setlist-list.test.tsx
+++ b/apps/web/app/components/setlist/setlist-list.test.tsx
@@ -72,8 +72,6 @@ function makeSetlist(id: string, title: string, averageRating: number | null = 4
             likesCount: 0,
             note: null,
             allTimer: false,
-            averageRating: null,
-            ratingsCount: 0,
             gap: null,
             previousPerformanceShowId: null,
             duration: null,
@@ -181,10 +179,11 @@ describe("SetlistList", () => {
     expect(setlistCardMock.mock.calls[1][0].userRating).toBe(5);
   });
 
-  // averageRatingMap (live data from the client query) wins when present;
-  // otherwise we fall back to the statically-denormalized setlist.show.averageRating
-  // so ratings still display on first render before the client query resolves.
-  test("showRating prefers averageRatingMap over the denormalized value, falls back when missing", async () => {
+  // showRating comes from the live averageRatingMap (loader-prefetched, then the
+  // client query). Ratings no longer ride in the structural setlist blob, so a
+  // show absent from the map renders no ★ rather than a stale denormalized value.
+  // canonicalRating mirrors the canonical average for the comparison summary.
+  test("showRating comes from averageRatingMap and is null when the show is absent", async () => {
     setMockReturn({
       averageRatingMap: new Map([["show-1", { average: 4.75, count: 20 }]]),
     });
@@ -197,7 +196,9 @@ describe("SetlistList", () => {
     );
 
     expect(setlistCardMock.mock.calls[0][0].showRating).toBe(4.75);
-    expect(setlistCardMock.mock.calls[1][0].showRating).toBe(3.2);
+    expect(setlistCardMock.mock.calls[0][0].canonicalRating).toBe(4.75);
+    expect(setlistCardMock.mock.calls[1][0].showRating).toBeNull();
+    expect(setlistCardMock.mock.calls[1][0].canonicalRating).toBeNull();
   });
 
   // SetlistList must hand the hook every show id so the batched POST fetches

--- a/apps/web/app/components/setlist/setlist-list.tsx
+++ b/apps/web/app/components/setlist/setlist-list.tsx
@@ -52,7 +52,7 @@ export function SetlistList({
 
   const renderCard = (setlist: Setlist | SetlistLight, index: number) => {
     const showId = setlist.show.id;
-    const liveAverage = averageRatingMap.get(showId)?.average;
+    const live = averageRatingMap.get(showId);
     // The displayed ★ is the viewer's calibrated score when their mode resolves to
     // calibrated (server only sends it then), else the live/canonical average.
     const displayed = displayedRatingMap.get(showId);
@@ -61,8 +61,9 @@ export function SetlistList({
         setlist={setlist}
         userAttendance={attendanceMap.get(showId) ?? null}
         userRating={userRatingMap.get(showId) ?? null}
-        showRating={displayed?.rating ?? liveAverage ?? setlist.show.averageRating ?? null}
-        showRatingCount={displayed?.count ?? null}
+        showRating={displayed?.rating ?? live?.average ?? null}
+        showRatingCount={displayed?.count ?? live?.count ?? null}
+        canonicalRating={live?.average ?? null}
         externalSources={externalSources[showId]}
         rankComparison={rankComparisonMap.get(showId)}
         collapsible={collapsible}

--- a/apps/web/app/components/setlist/setlist-table-personal.test.tsx
+++ b/apps/web/app/components/setlist/setlist-table-personal.test.tsx
@@ -9,7 +9,11 @@ vi.mock("~/hooks/use-session", () => ({
   useSession: vi.fn(() => ({ user: null, supabase: null, loading: false })),
 }));
 vi.mock("~/hooks/use-track-user-ratings", () => ({
-  useTrackUserRatings: vi.fn(() => ({ userRatingMap: new Map<string, number>(), isLoading: false })),
+  useTrackUserRatings: vi.fn(() => ({
+    userRatingMap: new Map<string, number>(),
+    averageRatingMap: new Map<string, { average: number; count: number }>(),
+    isLoading: false,
+  })),
 }));
 // Stub the rating cell so the row's rating column has a deterministic
 // presence we can assert on without exercising RatingBadgeButton.
@@ -54,8 +58,6 @@ function makeTrack(overrides: Partial<TrackLight> & { id: string; songId: string
     likesCount: 0,
     note: null,
     allTimer: false,
-    averageRating: null,
-    ratingsCount: 0,
     gap: null,
     previousPerformanceShowId: null,
     duration: overrides.duration ?? null,

--- a/apps/web/app/components/setlist/setlist-table-personal.tsx
+++ b/apps/web/app/components/setlist/setlist-table-personal.tsx
@@ -30,7 +30,7 @@ export function SetlistTablePersonal({ tracks, showSlug, showDate, onSummaryChan
   const { user } = useSession();
   const isAuthenticated = !!user;
   const trackIds = useMemo(() => tracks.map((t) => t.id), [tracks]);
-  const { userRatingMap } = useTrackUserRatings(trackIds);
+  const { userRatingMap, averageRatingMap } = useTrackUserRatings(trackIds);
 
   const setlistTracks = useMemo(
     () => tracks.map((t) => ({ id: t.id, songId: t.songId, set: t.set, position: t.position })),
@@ -51,8 +51,8 @@ export function SetlistTablePersonal({ tracks, showSlug, showDate, onSummaryChan
   }, [tracks, data, setlistTracks, showDate]);
 
   const columns = useMemo(
-    () => createPersonalSetlistColumns({ showSlug, userRatingMap, isAuthenticated }),
-    [showSlug, userRatingMap, isAuthenticated],
+    () => createPersonalSetlistColumns({ showSlug, averageRatingMap, userRatingMap, isAuthenticated }),
+    [showSlug, averageRatingMap, userRatingMap, isAuthenticated],
   );
 
   // Hoist the summary up to the parent so it can render alongside the

--- a/apps/web/app/components/setlist/setlist-table.test.tsx
+++ b/apps/web/app/components/setlist/setlist-table.test.tsx
@@ -10,7 +10,11 @@ vi.mock("~/hooks/use-session", () => ({
   useSession: vi.fn(() => ({ user: null, supabase: null })),
 }));
 vi.mock("~/hooks/use-track-user-ratings", () => ({
-  useTrackUserRatings: vi.fn(() => ({ userRatingMap: new Map<string, number>(), isLoading: false })),
+  useTrackUserRatings: vi.fn(() => ({
+    userRatingMap: new Map<string, number>(),
+    averageRatingMap: new Map<string, { average: number; count: number }>(),
+    isLoading: false,
+  })),
 }));
 vi.mock("~/hooks/use-song-play-dates", () => ({
   useSongPlayDates: vi.fn(() => ({ data: {} as Record<string, string[]>, isLoading: false })),
@@ -37,8 +41,6 @@ function makeTrack(overrides: Partial<TrackLight> & { songId: string; position: 
     likesCount: 0,
     note: null,
     allTimer: false,
-    averageRating: null,
-    ratingsCount: 0,
     gap: overrides.gap ?? null,
     previousPerformanceShowId: overrides.previousPerformanceShowId ?? null,
     duration: overrides.duration ?? null,
@@ -128,11 +130,12 @@ describe("SetlistTable", () => {
     expect(screen.getByRole("link", { name: "Confrontation" })).toBeInTheDocument();
   });
 
-  // SetlistTable threads the viewer's per-track ratings into the column
-  // factory so the rightmost Rating column knows which tracks the viewer
-  // has already rated. useTrackUserRatings is invoked with the row's
-  // trackIds; its userRatingMap shows up in each TrackRatingCell.
-  test("passes useTrackUserRatings map and auth state into rating cells", async () => {
+  // SetlistTable threads useTrackUserRatings into the column factory so the
+  // rightmost Rating column gets BOTH the live community average (from
+  // averageRatingMap — track ratings no longer ride in the row/blob) and the
+  // viewer's own rating (userRatingMap). useTrackUserRatings is invoked with
+  // the row's trackIds; both maps show up in each TrackRatingCell.
+  test("passes the live average + user-rating maps and auth state into rating cells", async () => {
     vi.mocked(useSession).mockReturnValue({
       // biome-ignore lint/suspicious/noExplicitAny: minimal mock; test only reads `user`
       user: { id: "user-1" } as any,
@@ -141,6 +144,7 @@ describe("SetlistTable", () => {
     });
     vi.mocked(useTrackUserRatings).mockReturnValue({
       userRatingMap: new Map([["t-1", 5]]),
+      averageRatingMap: new Map([["t-1", { average: 4.4, count: 22 }]]),
       isLoading: false,
     });
 
@@ -152,8 +156,6 @@ describe("SetlistTable", () => {
           makeTrack({
             songId: "song-basis",
             position: 1,
-            averageRating: 4.4,
-            ratingsCount: 22,
             song: { id: "song-basis", title: "Basis for a Day", slug: "basis-for-a-day" },
           }),
         ]}
@@ -162,9 +164,13 @@ describe("SetlistTable", () => {
 
     expect(useTrackUserRatings).toHaveBeenCalledWith(["t-1"]);
     expect(screen.getByTestId("TrackRatingCell")).toBeInTheDocument();
-    expect(screen.getByTestId("TrackRatingCell").textContent).toContain('"showSlug":"2024-07-19-camden"');
-    expect(screen.getByTestId("TrackRatingCell").textContent).toContain('"userRating":5');
-    expect(screen.getByTestId("TrackRatingCell").textContent).toContain('"isAuthenticated":true');
+    const cell = screen.getByTestId("TrackRatingCell").textContent ?? "";
+    expect(cell).toContain('"showSlug":"2024-07-19-camden"');
+    expect(cell).toContain('"userRating":5');
+    expect(cell).toContain('"isAuthenticated":true');
+    // The community average + count come from the tier-2 map, not the row.
+    expect(cell).toContain('"initialRating":4.4');
+    expect(cell).toContain('"ratingsCount":22');
   });
 
   // Wiring: SetlistTable threads each row's songId into the catalog blob,

--- a/apps/web/app/components/setlist/setlist-table.tsx
+++ b/apps/web/app/components/setlist/setlist-table.tsx
@@ -36,7 +36,7 @@ export function SetlistTable({ tracks, showSlug, showDate }: SetlistTableProps) 
   const { user } = useSession();
   const isAuthenticated = !!user;
   const trackIds = useMemo(() => tracks.map((t) => t.id), [tracks]);
-  const { userRatingMap } = useTrackUserRatings(trackIds);
+  const { userRatingMap, averageRatingMap } = useTrackUserRatings(trackIds);
   const { data: songPlayDates, isLoading: isPlayDatesLoading } = useSongPlayDates();
 
   const rows: SetlistTableRow[] = useMemo(() => {
@@ -47,8 +47,8 @@ export function SetlistTable({ tracks, showSlug, showDate }: SetlistTableProps) 
   }, [tracks, songPlayDates, isPlayDatesLoading, showDate]);
 
   const columns = useMemo(
-    () => createSetlistColumns({ showSlug, userRatingMap, isAuthenticated }),
-    [showSlug, userRatingMap, isAuthenticated],
+    () => createSetlistColumns({ showSlug, averageRatingMap, userRatingMap, isAuthenticated }),
+    [showSlug, averageRatingMap, userRatingMap, isAuthenticated],
   );
   return (
     <DataTable

--- a/apps/web/app/hooks/use-track-user-ratings.ts
+++ b/apps/web/app/hooks/use-track-user-ratings.ts
@@ -5,9 +5,10 @@ import { trackUserRatingsQueryKey } from "~/lib/query-keys";
 import type { TrackUserRatingsResponse } from "~/server/track-user-ratings";
 
 function mergeTrackUserRatings(results: TrackUserRatingsResponse[]): TrackUserRatingsResponse {
-  const merged: TrackUserRatingsResponse = { userRatings: {} };
+  const merged: TrackUserRatingsResponse = { userRatings: {}, averageRatings: {} };
   for (const result of results) {
     Object.assign(merged.userRatings, result.userRatings);
+    Object.assign(merged.averageRatings, result.averageRatings);
   }
   return merged;
 }
@@ -41,5 +42,15 @@ export function useTrackUserRatings(trackIds: string[]) {
     return map;
   }, [data?.userRatings]);
 
-  return { userRatingMap, isLoading };
+  const averageRatingMap = useMemo(() => {
+    const map = new Map<string, { average: number; count: number }>();
+    if (data?.averageRatings) {
+      for (const [trackId, value] of Object.entries(data.averageRatings)) {
+        map.set(trackId, value);
+      }
+    }
+    return map;
+  }, [data?.averageRatings]);
+
+  return { userRatingMap, averageRatingMap, isLoading };
 }

--- a/apps/web/app/routes/shows/$slug.tsx
+++ b/apps/web/app/routes/shows/$slug.tsx
@@ -28,13 +28,14 @@ import { notFound } from "~/lib/errors";
 import { EXTERNAL_SOURCE_DOMAINS } from "~/lib/favicon";
 import { deriveShowLineupNotes } from "~/lib/lineup-notes";
 import { logger } from "~/lib/logger";
-import { showUserDataQueryKey } from "~/lib/query-keys";
+import { showUserDataQueryKey, trackUserRatingsQueryKey } from "~/lib/query-keys";
 import { createPrefetchClient } from "~/lib/query-prefetch";
 import { getShowMeta, getShowStructuredData } from "~/lib/seo";
 import { formatDateLong, formatMonthDay } from "~/lib/utils";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
 import { computeShowUserData } from "~/server/show-user-data";
+import { computeTrackUserRatings } from "~/server/track-user-ratings";
 import { resolveViewerRatingMode } from "~/server/viewer-rating";
 
 interface ShowLoaderData {
@@ -116,6 +117,17 @@ export const loader = publicLoader(async ({ params, context }): Promise<ShowLoad
     queryFn: () => computeShowUserData(context, showIds),
   });
 
+  // Prefetch per-track community averages (and the viewer's own ratings) keyed
+  // exactly as the gap-chart table's useTrackUserRatings call, so opening the
+  // setlist via `?view=gap-chart` paints the Rating column with no flash. Track
+  // ratings no longer ride in the cached setlist blob, so this live read is
+  // their first-paint source.
+  const trackIds = setlist.sets.flatMap((set) => set.tracks.map((track) => track.id));
+  await queryClient.prefetchQuery({
+    queryKey: trackUserRatingsQueryKey(trackIds),
+    queryFn: () => computeTrackUserRatings(context, trackIds),
+  });
+
   const nugsLinks: ExternalLink[] = nugsReleases.map((release) => ({
     url: release.url,
     label: `Listen on nugs.net${release.artistName === "Tractorbeam" ? " (Tractorbeam)" : ""}`,
@@ -161,13 +173,18 @@ export default function Show() {
   const { user } = useSession();
   const revalidator = useRevalidator();
   const [setlistView, setSetlistView] = useSetlistView();
-  const { userRatingMap, attendanceMap, displayedRatingMap, rankComparisonMap } = useShowUserData([setlist.show.id]);
+  const { userRatingMap, attendanceMap, averageRatingMap, displayedRatingMap, rankComparisonMap } = useShowUserData([
+    setlist.show.id,
+  ]);
   const userRating = userRatingMap.get(setlist.show.id) ?? null;
+  // The canonical (deduped) community average + count, read live — ratings no
+  // longer ride in the structural setlist blob.
+  const canonicalAverage = averageRatingMap.get(setlist.show.id);
   // Displayed ★ is the viewer's calibrated score when their mode resolves to calibrated
   // (server sends it only then), else the canonical average. In calibrated mode the
   // count beside it is the post-exclusion contributing count, not the deduped count.
   const displayed = displayedRatingMap.get(setlist.show.id);
-  const displayedShowRating = displayed?.rating ?? setlist.show.averageRating;
+  const displayedShowRating = displayed?.rating ?? canonicalAverage?.average ?? null;
   // Comparison overlay data, present only for viewers with the overlay enabled.
   const rankComparison = rankComparisonMap.get(setlist.show.id) ?? null;
   const userAttendance = attendanceMap.get(setlist.show.id) ?? null;
@@ -330,7 +347,8 @@ export default function Show() {
             userAttendance={userAttendance}
             userRating={userRating}
             showRating={displayedShowRating}
-            showRatingCount={displayed?.count ?? null}
+            showRatingCount={displayed?.count ?? canonicalAverage?.count ?? null}
+            canonicalRating={canonicalAverage?.average ?? null}
             rankComparison={rankComparison}
             externalSources={externalSources}
             defaultView={setlistView}

--- a/apps/web/app/server/track-user-ratings.test.ts
+++ b/apps/web/app/server/track-user-ratings.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const findManyByUserIdAndRateableIds = vi.fn();
+const getAveragesForRateables = vi.fn();
 const findByEmail = vi.fn();
 
 vi.mock("~/server/services", () => ({
   services: {
     ratings: {
       findManyByUserIdAndRateableIds: (...args: unknown[]) => findManyByUserIdAndRateableIds(...args),
+      getAveragesForRateables: (...args: unknown[]) => getAveragesForRateables(...args),
     },
     users: {
       findByEmail: (...args: unknown[]) => findByEmail(...args),
@@ -23,42 +25,54 @@ import { computeTrackUserRatings } from "./track-user-ratings";
 describe("computeTrackUserRatings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getAveragesForRateables.mockResolvedValue({});
   });
 
   // Empty input avoids a DB round-trip. Loaders pass [] when the page renders
   // no performance/setlist rows (e.g. a venue with no tracked shows yet).
   test("returns empty response and makes no service calls when trackIds is empty", async () => {
     const result = await computeTrackUserRatings({ currentUser: undefined }, []);
-    expect(result).toEqual({ userRatings: {} });
+    expect(result).toEqual({ userRatings: {}, averageRatings: {} });
     expect(findManyByUserIdAndRateableIds).not.toHaveBeenCalled();
+    expect(getAveragesForRateables).not.toHaveBeenCalled();
     expect(findByEmail).not.toHaveBeenCalled();
   });
 
-  // Anonymous browsers have no personal rating data; the loader still calls
-  // this so the dehydrated cache entry exists with the right key, but the
-  // payload is just the empty skeleton.
-  test("returns empty response without DB calls when currentUser is missing", async () => {
+  // The community average + count is public — anonymous browsers still see it,
+  // so averages are fetched without a session. Only the personal userRatings
+  // map stays empty (and no user-scoped query runs) when unauthenticated.
+  test("fetches public averages but no personal ratings when currentUser is missing", async () => {
+    getAveragesForRateables.mockResolvedValue({ t1: { average: 4.5, count: 12 } });
     const result = await computeTrackUserRatings({ currentUser: undefined }, ["t1", "t2"]);
-    expect(result).toEqual({ userRatings: {} });
+    expect(result.averageRatings).toEqual({ t1: { average: 4.5, count: 12 } });
+    expect(result.userRatings).toEqual({});
+    expect(getAveragesForRateables).toHaveBeenCalledWith(["t1", "t2"], "Track");
     expect(findByEmail).not.toHaveBeenCalled();
+    expect(findManyByUserIdAndRateableIds).not.toHaveBeenCalled();
   });
 
   // Edge case: Supabase session exists but the local users row was never
-  // created. Don't blow up; return the empty skeleton.
-  test("returns empty response when local users record is missing", async () => {
+  // created. Don't blow up; still surface public averages, empty personal map.
+  test("returns public averages with empty personal map when local users record is missing", async () => {
+    getAveragesForRateables.mockResolvedValue({ t1: { average: 3, count: 2 } });
     findByEmail.mockResolvedValue(null);
     const result = await computeTrackUserRatings(
       { currentUser: { id: "auth-1", email: "evan@foo.net", isAdmin: false } },
       ["t1"],
     );
+    expect(result.averageRatings).toEqual({ t1: { average: 3, count: 2 } });
     expect(result.userRatings).toEqual({});
     expect(findManyByUserIdAndRateableIds).not.toHaveBeenCalled();
   });
 
-  // Happy path: only the tracks the user has rated appear in the response.
-  // Other ids requested but not rated are simply absent from the map (not
-  // explicitly null), matching the previous API route's contract.
-  test("populates userRatings for tracks the user has rated", async () => {
+  // Happy path: community averages plus only the tracks the user has rated.
+  // Other ids requested but not rated are simply absent from the personal map
+  // (not explicitly null), matching the previous API route's contract.
+  test("populates averages and userRatings for an authenticated rater", async () => {
+    getAveragesForRateables.mockResolvedValue({
+      t1: { average: 5, count: 8 },
+      t3: { average: 4, count: 4 },
+    });
     findByEmail.mockResolvedValue({ id: "user-1", email: "evan@foo.net" });
     findManyByUserIdAndRateableIds.mockResolvedValue([
       { rateableId: "t1", rateableType: "Track", value: 5, userId: "user-1" },
@@ -70,6 +84,10 @@ describe("computeTrackUserRatings", () => {
       ["t1", "t2", "t3"],
     );
 
+    expect(result.averageRatings).toEqual({
+      t1: { average: 5, count: 8 },
+      t3: { average: 4, count: 4 },
+    });
     expect(result.userRatings).toEqual({ t1: 5, t3: 3 });
   });
 });

--- a/apps/web/app/server/track-user-ratings.ts
+++ b/apps/web/app/server/track-user-ratings.ts
@@ -3,26 +3,38 @@ import { logger } from "~/lib/logger";
 import { services } from "~/server/services";
 
 export interface TrackUserRatingsResponse {
+  /** The current user's own rating per track (absent when unrated/unauthenticated). */
   userRatings: Record<string, number | null>;
+  /**
+   * The deduped community average + count per track, read live from the
+   * denormalized columns. Public, so it's populated for anonymous visitors too.
+   * Lives here rather than in the structural setlist cache so a rating write
+   * never staleness-busts the (long-lived) setlist blob.
+   */
+  averageRatings: Record<string, { average: number; count: number }>;
 }
 
 /**
- * Fetches the current user's ratings for a batch of tracks. Returns an empty
- * `userRatings` map for unauthenticated visitors (track ratings are
- * user-scoped — there is no public aggregate to surface here, unlike shows).
- * Shared by the `/api/tracks/user-ratings` action and any loader that wants
- * to seed React Query's cache so PerformanceTable / setlist gap-chart views
- * render personal ratings on first paint.
+ * Fetches the live per-track rating data a setlist/performance view needs that
+ * doesn't belong in the structural cache: the public community average+count
+ * (everyone, every request) and the current user's own rating (authenticated
+ * only). Shared by the `/api/tracks/user-ratings` action and any loader that
+ * wants to seed React Query's cache so PerformanceTable / setlist gap-chart
+ * views render ratings on first paint.
  */
 export async function computeTrackUserRatings(
   context: Pick<PublicContext, "currentUser">,
   trackIds: string[],
 ): Promise<TrackUserRatingsResponse> {
-  const response: TrackUserRatingsResponse = { userRatings: {} };
+  const response: TrackUserRatingsResponse = { userRatings: {}, averageRatings: {} };
 
-  if (trackIds.length === 0 || !context.currentUser) return response;
+  if (trackIds.length === 0) return response;
 
   try {
+    response.averageRatings = await services.ratings.getAveragesForRateables(trackIds, "Track");
+
+    if (!context.currentUser) return response;
+
     const user = await services.users.findByEmail(context.currentUser.email);
     if (!user) return response;
 

--- a/packages/core/scripts/recompute-ratings.ts
+++ b/packages/core/scripts/recompute-ratings.ts
@@ -1,7 +1,5 @@
-import { CacheInvalidationService, CacheService } from "../src/_shared/cache";
 import prisma from "../src/_shared/prisma/client";
 import { getFeatureFlags } from "../src/_shared/quonfig";
-import { RedisService } from "../src/_shared/redis";
 import { createTestLogger } from "../src/_shared/test-logger";
 import { RaterWeightService } from "../src/ratings/rater-weight-service";
 import { RatingService } from "../src/ratings/rating-service";
@@ -24,19 +22,12 @@ async function main(): Promise<void> {
     return;
   }
 
-  const redisUrl = process.env.REDIS_URL;
-  const redis = redisUrl ? new RedisService(redisUrl, logger) : null;
-  if (redis) await redis.connect();
-  const cache = redis ? new CacheService(redis, logger) : null;
-  const cacheInvalidation = cache ? new CacheInvalidationService(cache, logger) : undefined;
-
   const raterWeights = new RaterWeightService(prisma);
-  const ratings = new RatingService(prisma, cacheInvalidation as never, raterWeights);
+  const ratings = new RatingService(prisma, raterWeights);
 
   try {
     await runRatingsRecompute({ raterWeights, ratings, logger });
   } finally {
-    await redis?.disconnect();
     await prisma.$disconnect();
   }
 }

--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -332,16 +332,6 @@ export interface McpBlogPost {
 const SYNC_PAGE_LIMIT = 2000;
 
 /**
- * No-op CacheInvalidationService used when the script runs without REDIS.
- * RatingService.rebuildAggregatesFor doesn't call any of these methods, but
- * the constructor still requires the dependency.
- */
-function createNoopCacheInvalidation(): Record<string, () => Promise<void>> {
-  const noop = async () => {};
-  return new Proxy({}, { get: () => noop }) as Record<string, () => Promise<void>>;
-}
-
-/**
  * Synthetic email used for every stub user mirrored from prod. The real
  * email never leaves prod, but User.email is NOT NULL UNIQUE, so we
  * generate a deterministic placeholder from the prod uuid. Tests assert
@@ -2556,14 +2546,10 @@ async function syncMissingShows(): Promise<void> {
   // RatingService.rebuildAggregatesFor is the bulk version of the per-row
   // recompute used by the live mutation path. The user-activity pass calls
   // it once at the end for every (rateableType, rateableId) it touched.
-  // cacheInvalidation is only used by the per-row mutation methods (upsert /
-  // clearForUser), not by rebuildAggregatesFor — the script does its own
-  // outer invalidation pass on changedSlugs — so a no-op stub is sufficient
-  // in REDIS-less local runs.
-  const ratingService = new RatingService(
-    prisma,
-    cacheInvalidation ?? (createNoopCacheInvalidation() as unknown as CacheInvalidationService),
-  );
+  // RatingService needs no cache-invalidation dependency: the sync only calls
+  // rebuildAggregatesFor (rating writes no longer bust any structural cache),
+  // and it does its own outer invalidation pass on changedSlugs.
+  const ratingService = new RatingService(prisma);
   // Synced ratings change rater stats and every show's calibrated weighted_rating,
   // but they bypass the live write path that flags the recompute dirty, so the
   // sync runs the calibrated recompute itself at the end (see below).

--- a/packages/core/src/_shared/services.ts
+++ b/packages/core/src/_shared/services.ts
@@ -114,7 +114,7 @@ export function createServices(container: ServiceContainer): Services {
     personalSongHistory: new PersonalSongHistoryService(container.db, container.cache),
     reviews: new ReviewService(container.db, container.logger),
     rockOperas: rockOperaService,
-    ratings: new RatingService(container.db, container.cacheInvalidation, raterWeightService),
+    ratings: new RatingService(container.db, raterWeightService),
     raterWeights: raterWeightService,
     attendances: new AttendanceService(container.db, container.logger),
     songPageComposer: new SongPageComposer(container.db, songService, statsService),

--- a/packages/core/src/ratings/rating-service.test.ts
+++ b/packages/core/src/ratings/rating-service.test.ts
@@ -1,14 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 import { RatingService } from "./rating-service";
 
-// Minimal stub — service only invalidates caches at write paths; the read
-// methods under test don't touch it.
-const cacheInvalidation = {
-  invalidateAttendanceCaches: vi.fn(),
-  invalidateShow: vi.fn(),
-  invalidateShowComprehensive: vi.fn(),
-} as never;
-
 // Build distinct-user rating rows (no dedup collision) for the canonical-average
 // path, which now reads rating.findMany + collapses duplicate accounts. Returns
 // rows shaped like the service's select (value + createdAt + userId + user.username).
@@ -110,7 +102,7 @@ describe("RatingService.findShowRatingsByUserId", () => {
   test("default sort=date desc orders via showOrderBySql with createdAt tiebreaker", async () => {
     const queryRaw = vi.fn().mockResolvedValue([]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     await service.findShowRatingsByUserId("u1");
 
@@ -127,7 +119,7 @@ describe("RatingService.findShowRatingsByUserId", () => {
   test("maps rows into the slim shape (no userId/rateableId/updatedAt)", async () => {
     const queryRaw = vi.fn().mockResolvedValue([showRatingRow()]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     const result = await service.findShowRatingsByUserId("u1");
 
@@ -157,7 +149,7 @@ describe("RatingService.findShowRatingsByUserId", () => {
       .fn()
       .mockResolvedValue([showRatingRow({ venue_name: null, venue_city: null, venue_state: null })]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     const result = await service.findShowRatingsByUserId("u1");
 
@@ -171,7 +163,7 @@ describe("RatingService.findShowRatingsByUserId", () => {
   test("supports skip/take pagination via LIMIT/OFFSET", async () => {
     const queryRaw = vi.fn().mockResolvedValue([]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     await service.findShowRatingsByUserId("u1", { skip: 200, take: 100 });
 
@@ -192,7 +184,7 @@ describe("RatingService.findShowRatingsByUserId", () => {
   test("uses INNER JOIN against shows so orphaned ratings drop", async () => {
     const queryRaw = vi.fn().mockResolvedValue([]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     await service.findShowRatingsByUserId("u1");
 
@@ -206,7 +198,7 @@ describe("RatingService.findShowRatingsByUserId", () => {
   test("sort=rating desc orders by r.value then showOrderBySql DESC then createdAt", async () => {
     const queryRaw = vi.fn().mockResolvedValue([]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     await service.findShowRatingsByUserId("u1", { sort: "rating", direction: "desc" });
 
@@ -220,7 +212,7 @@ describe("RatingService.findShowRatingsByUserId", () => {
   test("sort=modified asc orders by r.created_at then showOrderBySql ASC", async () => {
     const queryRaw = vi.fn().mockResolvedValue([]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     await service.findShowRatingsByUserId("u1", { sort: "modified", direction: "asc" });
 
@@ -270,7 +262,7 @@ describe("RatingService.findTrackRatingsByUserId", () => {
   test("default sort=date desc orders by showOrderBySql DESC then set + position DESC", async () => {
     const queryRaw = vi.fn().mockResolvedValue([]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     await service.findTrackRatingsByUserId("u1");
 
@@ -288,7 +280,7 @@ describe("RatingService.findTrackRatingsByUserId", () => {
   test("maps rows into the slim shape", async () => {
     const queryRaw = vi.fn().mockResolvedValue([trackRatingRow()]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     const result = await service.findTrackRatingsByUserId("u1");
 
@@ -320,7 +312,7 @@ describe("RatingService.findTrackRatingsByUserId", () => {
   test("returns track.show.venue = null when venue_name is null", async () => {
     const queryRaw = vi.fn().mockResolvedValue([trackRatingRow({ venue_name: null })]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     const result = await service.findTrackRatingsByUserId("u1");
 
@@ -330,7 +322,7 @@ describe("RatingService.findTrackRatingsByUserId", () => {
   test("supports skip/take pagination via LIMIT/OFFSET", async () => {
     const queryRaw = vi.fn().mockResolvedValue([]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     await service.findTrackRatingsByUserId("u1", { skip: 100, take: 100 });
 
@@ -343,7 +335,7 @@ describe("RatingService.findTrackRatingsByUserId", () => {
   test("sort=set asc orders by setSortKeySql ASC then position ASC then showOrderBySql ASC", async () => {
     const queryRaw = vi.fn().mockResolvedValue([]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     await service.findTrackRatingsByUserId("u1", { sort: "set", direction: "asc" });
 
@@ -357,7 +349,7 @@ describe("RatingService.findTrackRatingsByUserId", () => {
   test("sort=track asc orders by position ASC then setSortKeySql ASC then showOrderBySql ASC", async () => {
     const queryRaw = vi.fn().mockResolvedValue([]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     await service.findTrackRatingsByUserId("u1", { sort: "track", direction: "asc" });
 
@@ -371,7 +363,7 @@ describe("RatingService.findTrackRatingsByUserId", () => {
   test("sort=song asc orders by LOWER(song.title)", async () => {
     const queryRaw = vi.fn().mockResolvedValue([]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     await service.findTrackRatingsByUserId("u1", { sort: "song", direction: "asc" });
 
@@ -383,7 +375,7 @@ describe("RatingService.findTrackRatingsByUserId", () => {
   test("sort=rating desc orders by r.value then showOrderBySql then set/position", async () => {
     const queryRaw = vi.fn().mockResolvedValue([]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     await service.findTrackRatingsByUserId("u1", { sort: "rating", direction: "desc" });
 
@@ -396,7 +388,7 @@ describe("RatingService.findTrackRatingsByUserId", () => {
   test("sort=modified asc orders by r.created_at then showOrderBySql ASC", async () => {
     const queryRaw = vi.fn().mockResolvedValue([]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     await service.findTrackRatingsByUserId("u1", { sort: "modified", direction: "asc" });
 
@@ -411,7 +403,7 @@ describe("RatingService.findTrackRatingsByUserId", () => {
   test("projects encores_in_set via a per-row tracks subquery", async () => {
     const queryRaw = vi.fn().mockResolvedValue([]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     await service.findTrackRatingsByUserId("u1");
 
@@ -427,7 +419,7 @@ describe("RatingService.findTrackRatingsByUserId", () => {
   test("exposes encoresInSet on the returned track shape", async () => {
     const queryRaw = vi.fn().mockResolvedValue([trackRatingRow({ track_set: "E1", encores_in_set: 1 })]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     const result = await service.findTrackRatingsByUserId("u1");
 
@@ -437,7 +429,7 @@ describe("RatingService.findTrackRatingsByUserId", () => {
   test("INNER JOINs tracks/shows/songs so orphan ratings drop", async () => {
     const queryRaw = vi.fn().mockResolvedValue([]);
     const db = { $queryRaw: queryRaw } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     await service.findTrackRatingsByUserId("u1");
 
@@ -463,7 +455,7 @@ describe("RatingService.clearForUser", () => {
       track: { update: vi.fn() },
     } as never;
 
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
     const result = await service.clearForUser({ rateableId: "show-1", rateableType: "Show", userId: "u1" });
 
     expect(result).toEqual({ averageRating: 4.2, ratingsCount: 5 });
@@ -497,7 +489,7 @@ describe("RatingService.clearForUser", () => {
       track: { update: vi.fn() },
     } as never;
 
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
     const result = await service.clearForUser({ rateableId: "show-1", rateableType: "Show", userId: "u1" });
 
     expect(result).toEqual({ averageRating: 0, ratingsCount: 0 });
@@ -517,7 +509,7 @@ describe("RatingService.clearForUser", () => {
       track: { update: trackUpdate },
     } as never;
 
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
     await service.clearForUser({ rateableId: "track-1", rateableType: "Track", userId: "u1" });
 
     expect(trackUpdate).toHaveBeenCalledWith(
@@ -527,66 +519,6 @@ describe("RatingService.clearForUser", () => {
       }),
     );
     expect(showUpdate).not.toHaveBeenCalled();
-  });
-
-  // Show-type clears invalidate the show's comprehensive cache the same
-  // way upsert does, so the next read of the show payload sees the new
-  // averageRating + ratingsCount.
-  test("invalidates the show cache when clearing a Show rating with a showSlug", async () => {
-    const invalidate = vi.fn();
-    const db = {
-      rating: {
-        deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
-        findMany: vi.fn().mockResolvedValue(ratingRows(4)), // single rater, avg 4.0
-      },
-      show: { update: vi.fn() },
-      track: { update: vi.fn() },
-    } as never;
-
-    const service = new RatingService(db, {
-      invalidateAttendanceCaches: vi.fn(),
-      invalidateShow: vi.fn(),
-      invalidateShowComprehensive: invalidate,
-    } as never);
-    await service.clearForUser({
-      rateableId: "show-1",
-      rateableType: "Show",
-      userId: "u1",
-      showSlug: "2024-08-12-cap-theatre",
-    });
-
-    expect(invalidate).toHaveBeenCalledWith(undefined, "2024-08-12-cap-theatre", [2024]);
-  });
-
-  // Track-type clears bust the show comprehensively, year-scoped, exactly like
-  // Show clears. Track.averageRating/ratingsCount are embedded in BOTH the
-  // per-show show.data payload AND the year-listing shows:list payload (its
-  // gap-chart view shows track averages), so a track rating change must purge
-  // the year listing too or the listing serves stale "Rate" buttons.
-  test("invalidates the show comprehensively, year-scoped, when clearing a Track rating with a showSlug", async () => {
-    const invalidate = vi.fn();
-    const db = {
-      rating: {
-        deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
-        findMany: vi.fn().mockResolvedValue(ratingRows(3, 4)), // 2 distinct raters, avg 3.5
-      },
-      show: { update: vi.fn() },
-      track: { update: vi.fn() },
-    } as never;
-
-    const service = new RatingService(db, {
-      invalidateAttendanceCaches: vi.fn(),
-      invalidateShow: vi.fn(),
-      invalidateShowComprehensive: invalidate,
-    } as never);
-    await service.clearForUser({
-      rateableId: "track-1",
-      rateableType: "Track",
-      userId: "u1",
-      showSlug: "2024-08-12-cap-theatre",
-    });
-
-    expect(invalidate).toHaveBeenCalledWith(undefined, "2024-08-12-cap-theatre", [2024]);
   });
 });
 
@@ -613,7 +545,7 @@ describe("RatingService.rebuildAggregatesFor", () => {
       $executeRaw: executeRaw,
     } as never;
 
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
     await service.rebuildAggregatesFor([
       { rateableId: "show-1", rateableType: "Show" },
       { rateableId: "show-2", rateableType: "Show" },
@@ -638,7 +570,7 @@ describe("RatingService.rebuildAggregatesFor", () => {
     const executeRaw = vi.fn().mockResolvedValue(1);
     const db = { rating: { findMany: vi.fn().mockResolvedValue([]) }, $executeRaw: executeRaw } as never;
 
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
     await service.rebuildAggregatesFor([{ rateableId: "show-abandoned", rateableType: "Show" }]);
 
     expect(bulkAverageWrites(executeRaw)[0].tuples).toContainEqual({
@@ -663,7 +595,7 @@ describe("RatingService.rebuildAggregatesFor", () => {
       $executeRaw: executeRaw,
     } as never;
 
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
     await service.rebuildAggregatesFor([
       { rateableId: "show-1", rateableType: "Show" },
       { rateableId: "track-1", rateableType: "Track" },
@@ -681,7 +613,7 @@ describe("RatingService.rebuildAggregatesFor", () => {
     const executeRaw = vi.fn();
     const db = { rating: { findMany }, $executeRaw: executeRaw } as never;
 
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
     await service.rebuildAggregatesFor([]);
 
     expect(findMany).not.toHaveBeenCalled();
@@ -697,7 +629,7 @@ describe("RatingService.listForSync", () => {
     const findMany = vi.fn().mockResolvedValue([]);
     const db = { rating: { findMany } } as never;
 
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
     const since = new Date("2024-01-01T00:00:00Z");
     await service.listForSync({ since, limit: 100 });
 
@@ -712,7 +644,7 @@ describe("RatingService.listForSync", () => {
     const findMany = vi.fn().mockResolvedValue([]);
     const db = { rating: { findMany } } as never;
 
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
     const cursorUpdatedAt = new Date("2024-05-01T00:00:00Z");
     await service.listForSync({
       since: new Date(0),
@@ -735,7 +667,7 @@ describe("RatingService.listForSync", () => {
     const findMany = vi.fn().mockResolvedValue([]);
     const db = { rating: { findMany } } as never;
 
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
     await service.listForSync({ since: new Date(0), limit: 100 });
 
     expect(findMany.mock.calls[0][0].select).toEqual({
@@ -751,53 +683,13 @@ describe("RatingService.listForSync", () => {
 });
 
 describe("RatingService.upsert", () => {
-  // Track ratings bust the show comprehensively, year-scoped, exactly like Show
-  // ratings: Track.averageRating/ratingsCount are embedded in BOTH the per-show
-  // show.data payload AND the year-listing shows:list payload (its gap-chart view
-  // shows track averages), so the year listing must be purged too.
-  test("invalidates the show comprehensively, year-scoped, when upserting a Track rating with a showSlug", async () => {
-    const invalidateShowComprehensive = vi.fn();
+  // Writing a rating recomputes and persists the deduped denormalized
+  // averageRating/ratingsCount on the rateable row — the value setlist views
+  // read live afterward. (Rating writes no longer touch any structural cache;
+  // there is no cache-invalidation dependency to exercise.)
+  test("recomputes and writes the rateable's denormalized average", async () => {
     const now = new Date("2024-08-12T00:00:00Z");
-    const db = {
-      rating: {
-        upsert: vi.fn().mockResolvedValue({
-          id: "r1",
-          userId: "u1",
-          rateableId: "track-1",
-          rateableType: "Track",
-          value: 4,
-          createdAt: now,
-          updatedAt: now,
-        }),
-        findMany: vi.fn().mockResolvedValue(ratingRows(4)),
-      },
-      show: { update: vi.fn() },
-      track: { update: vi.fn() },
-    } as never;
-
-    const service = new RatingService(db, {
-      invalidateAttendanceCaches: vi.fn(),
-      invalidateShow: vi.fn(),
-      invalidateShowComprehensive,
-    } as never);
-    await service.upsert({
-      rateableId: "track-1",
-      rateableType: "Track",
-      userId: "u1",
-      value: 4,
-      showSlug: "2024-08-12-cap-theatre",
-    });
-
-    expect(invalidateShowComprehensive).toHaveBeenCalledWith(undefined, "2024-08-12-cap-theatre", [2024]);
-  });
-
-  // Show ratings go through invalidateShowComprehensive — the year is parsed
-  // from the slug's leading `YYYY-MM-DD-` so the past-year edge entry on
-  // `/shows/year/YYYY` gets purged. Without the right year, a 2018 rating
-  // would clear Redis but leave the 24h-cached year listing stale.
-  test("passes the slug's year to invalidateShowComprehensive on a Show rating", async () => {
-    const invalidateShowComprehensive = vi.fn();
-    const now = new Date("2018-07-12T00:00:00Z");
+    const showUpdate = vi.fn().mockResolvedValue(undefined);
     const db = {
       rating: {
         upsert: vi.fn().mockResolvedValue({
@@ -805,30 +697,25 @@ describe("RatingService.upsert", () => {
           userId: "u1",
           rateableId: "show-1",
           rateableType: "Show",
-          value: 5,
+          value: 4,
           createdAt: now,
           updatedAt: now,
         }),
-        findMany: vi.fn().mockResolvedValue(ratingRows(5)),
+        findMany: vi.fn().mockResolvedValue(ratingRows(4, 4, 4, 5)), // 4 distinct raters, avg 4.25
       },
-      show: { update: vi.fn() },
+      show: { update: showUpdate },
       track: { update: vi.fn() },
     } as never;
 
-    const service = new RatingService(db, {
-      invalidateAttendanceCaches: vi.fn(),
-      invalidateShow: vi.fn(),
-      invalidateShowComprehensive,
-    } as never);
-    await service.upsert({
-      rateableId: "show-1",
-      rateableType: "Show",
-      userId: "u1",
-      value: 5,
-      showSlug: "2018-07-12-red-rocks",
-    });
+    const service = new RatingService(db);
+    await service.upsert({ rateableId: "show-1", rateableType: "Show", userId: "u1", value: 4 });
 
-    expect(invalidateShowComprehensive).toHaveBeenCalledWith(undefined, "2018-07-12-red-rocks", [2018]);
+    expect(showUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "show-1" },
+        data: expect.objectContaining({ averageRating: 4.25, ratingsCount: 4 }),
+      }),
+    );
   });
 });
 
@@ -864,7 +751,7 @@ describe("RatingService experimental rater-weight refresh", () => {
       recomputeRateable: vi.fn().mockResolvedValue(undefined),
     };
     const db = makeDb();
-    const service = new RatingService(db, cacheInvalidation, raterWeights as never);
+    const service = new RatingService(db, raterWeights as never);
     await service.upsert({ rateableId: "show-1", rateableType: "Show", userId: "u1", value: 5 });
 
     // The actor's stats are NOT recomputed on write (the cron handles that); only
@@ -883,7 +770,7 @@ describe("RatingService experimental rater-weight refresh", () => {
       recomputeUser: vi.fn().mockResolvedValue(undefined),
       recomputeRateable: vi.fn().mockResolvedValue(undefined),
     };
-    const service = new RatingService(makeDb(), cacheInvalidation, raterWeights as never);
+    const service = new RatingService(makeDb(), raterWeights as never);
     await service.clearForUser({ rateableId: "show-1", rateableType: "Show", userId: "u1" });
 
     expect(raterWeights.recomputeRateable).toHaveBeenCalledWith("Show", "show-1");
@@ -894,7 +781,7 @@ describe("RatingService experimental rater-weight refresh", () => {
       recomputeUser: vi.fn(),
       recomputeRateable: vi.fn().mockRejectedValue(new Error("side-table boom")),
     };
-    const service = new RatingService(makeDb(), cacheInvalidation, raterWeights as never);
+    const service = new RatingService(makeDb(), raterWeights as never);
 
     await expect(
       service.upsert({ rateableId: "show-1", rateableType: "Show", userId: "u1", value: 5 }),
@@ -916,7 +803,7 @@ describe("RatingService.getAveragesForRateables", () => {
       },
       // A live AVG would touch rating.* — left undefined so any such call throws.
     } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     expect(await service.getAveragesForRateables(["show-1", "show-2"], "Show")).toEqual({
       "show-1": { average: 4.72, count: 18 },
@@ -928,7 +815,7 @@ describe("RatingService.getAveragesForRateables", () => {
     const db = {
       track: { findMany: vi.fn().mockResolvedValue([{ id: "t1", averageRating: 3.5, ratingsCount: 5 }]) },
     } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     expect(await service.getAveragesForRateables(["t1"], "Track")).toEqual({ t1: { average: 3.5, count: 5 } });
   });
@@ -943,7 +830,7 @@ describe("RatingService.getAveragesForRateables", () => {
         ]),
       },
     } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     expect(await service.getAveragesForRateables(["rated", "null-avg", "zero-count"], "Show")).toEqual({
       rated: { average: 4.0, count: 3 },
@@ -952,7 +839,7 @@ describe("RatingService.getAveragesForRateables", () => {
 
   test("returns empty without querying when given no ids", async () => {
     const findMany = vi.fn();
-    const service = new RatingService({ show: { findMany } } as never, cacheInvalidation);
+    const service = new RatingService({ show: { findMany } } as never);
 
     expect(await service.getAveragesForRateables([], "Show")).toEqual({});
     expect(findMany).not.toHaveBeenCalled();
@@ -964,14 +851,14 @@ describe("RatingService.getAverageForRateable", () => {
     const db = {
       show: { findMany: vi.fn().mockResolvedValue([{ id: "s1", averageRating: 4.72, ratingsCount: 18 }]) },
     } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     expect(await service.getAverageForRateable("s1", "Show")).toBe(4.72);
   });
 
   test("returns null for an unrated rateable", async () => {
     const db = { show: { findMany: vi.fn().mockResolvedValue([]) } } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     expect(await service.getAverageForRateable("s1", "Show")).toBeNull();
   });
@@ -992,7 +879,7 @@ describe("RatingService.getRatingDistribution", () => {
         ]),
       },
     } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     const distribution = await service.getRatingDistribution("show-1", "Show");
     const countByValue = Object.fromEntries(distribution.map((bucket) => [bucket.value, bucket.count]));
@@ -1011,7 +898,7 @@ describe("RatingService.getRatingDistribution", () => {
         ]),
       },
     } as never;
-    const service = new RatingService(db, cacheInvalidation);
+    const service = new RatingService(db);
 
     expect(await service.getRatingDistribution("show-1", "Show")).toEqual([{ value: 3, count: 1 }]);
   });

--- a/packages/core/src/ratings/rating-service.ts
+++ b/packages/core/src/ratings/rating-service.ts
@@ -1,6 +1,5 @@
 import type { Rating } from "@bip/domain";
 import { Prisma } from "@prisma/client";
-import { type CacheInvalidationService, yearFromShowSlug } from "../_shared/cache";
 import type { DbClient, DbRating } from "../_shared/database/models";
 import { setSortKeySql, showOrderBySql } from "../_shared/show-ordering";
 import { aliasKey, mostRecentPerKey } from "./rater-aliases";
@@ -207,7 +206,6 @@ function mapRatingToDomainEntity(dbRating: DbRating): Rating {
 export class RatingService {
   constructor(
     protected readonly db: DbClient,
-    protected readonly cacheInvalidation: CacheInvalidationService,
     // Optional so existing callers/tests are unaffected. When present, rating
     // mutations also maintain the calibrated rater-weighting tables.
     protected readonly raterWeights?: RaterWeightService,
@@ -419,16 +417,12 @@ export class RatingService {
       },
     });
 
-    if (data.showSlug) {
-      // Both show and track ratings write denormalized averageRating/ratingsCount
-      // that the cached setlist payloads embed — the per-show show.data payload AND
-      // the year-listing shows:list payload (whose gap-chart view shows track
-      // averages). Comprehensive invalidation busts both, year-scoped for listings.
-      const year = yearFromShowSlug(data.showSlug);
-      await this.cacheInvalidation.invalidateShowComprehensive(undefined, data.showSlug, year !== null ? [year] : []);
-    }
-
-    // Update the related show/track average rating and count
+    // No cache invalidation here. Rating values no longer live in the structural
+    // setlist caches (show.data / shows:list): setlist views read the community
+    // average live via the show/track tier-2 read paths (computeShowUserData,
+    // computeTrackUserRatings), which see this denormalized-column update on the
+    // very next request. Decoupling rating writes from the structural caches is
+    // the point of the tier split — busting them here was the old band-aid.
     await this.updateRateableAverageRating(data.rateableId, data.rateableType);
     await this.refreshRaterWeights(data.rateableId, data.rateableType);
 
@@ -711,14 +705,8 @@ export class RatingService {
     const stats = await this.updateRateableAverageRating(data.rateableId, data.rateableType);
     await this.refreshRaterWeights(data.rateableId, data.rateableType);
 
-    if (data.showSlug) {
-      // Same as the upsert path: both show and track ratings change denormalized
-      // averages embedded in the show.data AND year-listing shows:list payloads,
-      // so bust both, year-scoped for listings.
-      const year = yearFromShowSlug(data.showSlug);
-      await this.cacheInvalidation.invalidateShowComprehensive(undefined, data.showSlug, year !== null ? [year] : []);
-    }
-
+    // No cache invalidation — see the note in `upsert`. Rating values are read
+    // live from the tier-2 paths, not from the structural setlist caches.
     return stats;
   }
 }

--- a/packages/core/src/setlists/setlist-service.ts
+++ b/packages/core/src/setlists/setlist-service.ts
@@ -75,8 +75,6 @@ type DbTrackLight = {
   likesCount: number;
   note: string | null;
   allTimer: boolean | null;
-  averageRating: number | null;
-  ratingsCount: number;
   gap: number | null;
   previousPerformanceShowId: string | null;
   duration: number | null;
@@ -384,6 +382,11 @@ export function mapTrackToDomainEntity(
     createdAt,
     updatedAt,
     slug,
+    // Dropped from the structural blob: rating values change far more often
+    // than the setlist and would otherwise staleness-bust this cache. Setlist
+    // views read the live community average via the track tier-2 path instead.
+    averageRating: _averageRating,
+    ratingsCount: _ratingsCount,
     previousPerformanceShow,
     trackFlags,
     segueRecurrences,
@@ -605,8 +608,6 @@ function mapTrackLightToDomainEntity(track: DbTrackLight): TrackLight {
     likesCount: track.likesCount,
     note: track.note,
     allTimer: track.allTimer,
-    averageRating: track.averageRating,
-    ratingsCount: track.ratingsCount,
     gap: track.gap,
     previousPerformanceShowId: track.previousPerformanceShowId,
     duration: track.duration,
@@ -1024,8 +1025,6 @@ export class SetlistService {
             likesCount: true,
             note: true,
             allTimer: true,
-            averageRating: true,
-            ratingsCount: true,
             gap: true,
             previousPerformanceShowId: true,
             duration: true,

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -11,8 +11,10 @@ export const CacheKeys = {
    * Show-related cache keys
    */
   show: {
-    /** Complete show + setlist data for show page */
-    data: (slug: string) => `show:${slug}:data:v13`,
+    /** Complete show + setlist data for show page. :v14 — tracks no longer
+     *  embed averageRating/ratingsCount (rating values moved to the live
+     *  tier-2 read path so rating writes don't staleness-bust this blob). */
+    data: (slug: string) => `show:${slug}:data:v14`,
 
     // Note: Reviews are loaded fresh from DB, not cached
 
@@ -31,7 +33,9 @@ export const CacheKeys = {
     /** Paginated show listings with filters */
     list: (filters: CacheFilters) => {
       const filterHash = hashFilters(filters);
-      return `shows:list:${filterHash}:v13`;
+      // :v14 — tracks dropped averageRating/ratingsCount (rating values moved
+      // to the live tier-2 read path). See CacheKeys.show.data.
+      return `shows:list:${filterHash}:v14`;
     },
 
     /** All show listing caches (for pattern deletion) */
@@ -45,8 +49,9 @@ export const CacheKeys = {
    * Setlist cache keys
    */
   setlist: {
-    /** Complete setlist data with tracks and annotations */
-    data: (slug: string) => `setlist:${slug}:data:v13`,
+    /** Complete setlist data with tracks and annotations. :v14 — tracks no
+     *  longer embed averageRating/ratingsCount (moved to live tier-2). */
+    data: (slug: string) => `setlist:${slug}:data:v14`,
   },
 
   /**
@@ -137,7 +142,7 @@ export const CacheKeys = {
      * have 400+ attended shows and the un-paginated payload is large enough
      * to be slow to deserialize/transport even from Redis.
      */
-    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}:v12`,
+    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}:v13`,
     /** All pages of a single user's attended-setlists caches (for per-user invalidation). */
     allAttendedSetlistsForUser: (userId: string) => `user:${userId}:attended-setlists:*`,
     /** All per-user attended-setlists caches (for pattern deletion on broad show mutations). */
@@ -162,7 +167,7 @@ export const CacheKeys = {
    */
   rockOperas: {
     /** Resource-page list payload: setlists + external sources for one rock opera. */
-    performances: (slug: string) => `rock-operas:performances:${slug}:v10`,
+    performances: (slug: string) => `rock-operas:performances:${slug}:v11`,
     /** Pattern for invalidating every performances cache (broad mutations). */
     allPerformances: () => "rock-operas:performances:*",
   },
@@ -172,7 +177,7 @@ export const CacheKeys = {
    */
   home: {
     /** Recent setlists for home page (limit + sort direction) */
-    recentSetlists: (limit: number) => `home:recent-setlists:${limit}:v12`,
+    recentSetlists: (limit: number) => `home:recent-setlists:${limit}:v13`,
   },
 
   /**

--- a/packages/domain/src/models/track.ts
+++ b/packages/domain/src/models/track.ts
@@ -92,8 +92,13 @@ export const trackSchema = z.object({
   allTimer: z.boolean().nullable().default(false),
   previousTrackId: z.string().uuid().nullable(),
   nextTrackId: z.string().uuid().nullable(),
-  averageRating: z.number().default(0.0).nullable(),
-  ratingsCount: z.number().default(0),
+  // Live rating values, populated only by fresh single-track reads
+  // (track-service → /api/tracks/:id). The structural setlist payloads
+  // deliberately omit them so a rating write never staleness-busts the
+  // (long-lived) setlist cache; setlist views read averages live via the
+  // track tier-2 path instead. See cache-keys "tier split".
+  averageRating: z.number().nullable().optional(),
+  ratingsCount: z.number().optional(),
   gap: z.number().nullable(),
   previousPerformanceShowId: z.string().uuid().nullable(),
   duration: z.number().nullable(),
@@ -142,8 +147,6 @@ export const trackLightSchema = z.object({
   likesCount: z.number().default(0),
   note: z.string().nullable(),
   allTimer: z.boolean().nullable().default(false),
-  averageRating: z.number().default(0.0).nullable(),
-  ratingsCount: z.number().default(0),
   gap: z.number().nullable(),
   previousPerformanceShowId: z.string().uuid().nullable(),
   duration: z.number().nullable(),


### PR DESCRIPTION
Rating a track or a show no longer busts the structural setlist caches. The
community average now comes from a live, per-request read instead of being baked
into the long-lived `shows:list` / `show.data` blobs, so a rating write just
updates its denormalized column and invalidates nothing. Same numbers on screen,
far less cache churn, and a class of "did we remember to bust the structural
cache after a rating?" staleness bugs is gone.

## What changed

- **Track ratings** now load from the tier-2 path the gap chart already used for
  the viewer's own ratings: `computeTrackUserRatings` / `/api/tracks/user-ratings`
  also returns the public community average+count, and `useTrackUserRatings`
  exposes an `averageRatingMap`. The show loader prefetches it so the gap-chart
  Rating column paints with no first-paint flash on `?view=gap-chart`.
- **Show ratings** already had a live path (`useShowUserData`); the setlist
  card/list and show page drop the `setlist.show.averageRating` fallback and read
  the average (and a new `canonicalRating` for the comparison summary) live.
- **The blob is rating-free**: `findManyLight`, the light + heavy setlist mappers,
  and `TrackLight` no longer carry `averageRating`/`ratingsCount`. The base
  `Track` fields stay (optional) for the live `/api/tracks/:id` + MCP reads.
- **Rating writes stop invalidating**: `RatingService.upsert` / `clearForUser` no
  longer call `invalidateShowComprehensive`, and the now-unused `cacheInvalidation`
  dependency is removed from `RatingService` (and its scripts/tests/container).
- **Cache keys bumped** for every setlist-bearing payload (`show.data`,
  `shows.list`, `setlist.data`, `users.attendedSetlists`, `rockOperas.performances`,
  `home.recentSetlists`).

## Notes for the reviewer

- **Tier-2 is a live column read, not a new Redis cache.** The denormalized
  `average_rating`/`ratings_count` columns are read per request (the same pattern
  shows already used), so a live rating write is reflected on the next request
  with no timestamp-keyed cache to reconcile. A Redis tier-2 can slot behind the
  same `getAveragesForRateables` seam later if the read ever proves hot.
- **First-paint vs toggle.** The gap-chart table only mounts on first paint via
  the show page's `?view=gap-chart`, which is prefetched (no flash). Toggling into
  the gap chart on a list page now does a sub-second async load of the averages
  instead of reading them from SSR — the table there is lazy and most visits never
  open it, so per-show prefetching every card was not worth it.
- **`Track.averageRating`/`ratingsCount` are optional on the domain type**: the
  setlist read paths omit them, while `track-service` (→ `/api/tracks/:id`) and
  MCP still populate them from fresh reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
