### PR TITLE
Fix restart-redis ops action: drop invalid -y flag

### DIFF
--- a/.github/workflows/ops.yml
+++ b/.github/workflows/ops.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Reboot redis accessory
         if: inputs.action == 'restart-redis'
-        run: kamal accessory reboot redis -y
+        run: kamal accessory reboot redis
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 


### PR DESCRIPTION
Makes the `restart-redis` ops action work: `kamal accessory reboot` takes no `-y` flag and errored on it, so the previous run failed before touching the host. The command runs without confirmation prompts, so the flag is simply dropped.

After merge, re-run **Server Ops → restart-redis** to recreate the redis container (fresh kamal-network attachment, loopback port binding, data volume preserved), then re-run the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
