### PR TITLE
Cap redis at 512mb with LRU eviction to stop OOM kills

### DIFF
--- a/.github/workflows/ops.yml
+++ b/.github/workflows/ops.yml
@@ -61,9 +61,9 @@ jobs:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         continue-on-error: true
 
-      - name: Redis memory info
+      - name: Redis info (memory, hit rate, evictions)
         if: inputs.action == 'diagnose'
-        run: kamal server exec 'docker exec bip-web-redis redis-cli INFO memory'
+        run: kamal server exec 'docker exec bip-web-redis redis-cli INFO'
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         continue-on-error: true

--- a/.github/workflows/ops.yml
+++ b/.github/workflows/ops.yml
@@ -47,6 +47,27 @@ jobs:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         continue-on-error: true
 
+      - name: Memory usage
+        if: inputs.action == 'diagnose'
+        run: kamal server exec 'free -h'
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+        continue-on-error: true
+
+      - name: Container memory usage
+        if: inputs.action == 'diagnose'
+        run: kamal server exec 'docker stats --no-stream'
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+        continue-on-error: true
+
+      - name: Redis memory info
+        if: inputs.action == 'diagnose'
+        run: kamal server exec 'docker exec bip-web-redis redis-cli INFO memory'
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+        continue-on-error: true
+
       - name: All containers
         if: inputs.action == 'diagnose'
         run: kamal server exec 'docker ps -a'

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -59,7 +59,9 @@ accessories:
     port: "127.0.0.1:6379:6379"
     directories:
       - bip-web-redis-data:/data
-    cmd: redis-server --appendonly yes
+    # Cap memory and evict LRU: everything cached is rebuildable, and an
+    # uncapped redis grows until the kernel OOM-kills it (2026-07-07 outage).
+    cmd: redis-server --appendonly yes --maxmemory 512mb --maxmemory-policy allkeys-lru
 
   postgres:
     image: postgres:18-alpine


### PR DESCRIPTION
Stops the intermittent outages: redis had no `maxmemory`, so the cache grew unbounded until the kernel OOM-killed it, crash-looping the app and serving 502/522s. Tonight it hit 1.09 GB across 3,822 keys and was killed three times in two hours.

- The redis accessory is now capped at **512mb with `allkeys-lru` eviction**. Everything cached is rebuildable (setlist/listing blobs with a 24h TTL), so evicting least-recently-used entries is the correct behavior. Takes effect on the next `restart-redis` ops run.
- The ops `diagnose` action now reports memory: host `free -h`, `docker stats`, and full `redis-cli INFO` (used memory vs cap, hit rate, evictions), so both memory pressure and cache-thrash are visible before they hurt.

Why now: since #199, rating writes no longer purge the listing/show caches on every vote, so the cache grows to its natural 24h working set instead of being constantly emptied. That change is working as designed — the missing piece was an eviction policy.

After merge: run **Server Ops → restart-redis** to apply the new redis command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
