### PR TITLE
Cap app memory to contain host-freeze outages; add cache-census and app-logs ops actions

### DIFF
--- a/.github/workflows/ops.yml
+++ b/.github/workflows/ops.yml
@@ -8,6 +8,8 @@ on:
         type: choice
         options:
           - diagnose
+          - cache-census
+          - app-logs
           - restart-redis
           - prune-docker
 
@@ -96,12 +98,47 @@ jobs:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         continue-on-error: true
 
-      - name: App logs
+      # Run logs on a public repo are world-readable, so only error/warn lines
+      # may be printed — never raw request logs.
+      - name: App logs (errors only)
         if: inputs.action == 'diagnose'
-        run: kamal app logs --lines 50
+        run: kamal app logs --lines 500 2>&1 | grep -iE "error|warn|fatal" | tail -100 || echo "No error lines in the last 500"
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         continue-on-error: true
+
+      # Deeper errors-only log pull (same public-visibility rule as above).
+      - name: App logs (errors only, deep)
+        if: inputs.action == 'app-logs'
+        run: kamal app logs --lines 5000 2>&1 | grep -iE "error|warn|fatal" | tail -300 || echo "No error lines in the last 5000"
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
+      # Census of what's resident in redis: keys, MB, and average idle time per
+      # key family, plus the biggest individual keys. MEMORY USAGE and OBJECT
+      # IDLETIME don't touch LRU access times, so the census doesn't distort
+      # what it measures.
+      - name: Redis cache census
+        if: inputs.action == 'cache-census'
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+        run: |
+          kamal server exec "docker exec bip-web-redis sh -c 'redis-cli --scan | while read -r k; do echo \"\$(redis-cli MEMORY USAGE \"\$k\") \$(redis-cli OBJECT IDLETIME \"\$k\") \$k\"; done'" > census-raw.txt
+          grep -E '^[0-9]+ [0-9]+ ' census-raw.txt > census.txt || { echo "No census lines returned"; exit 1; }
+          echo "=== By key family (sorted by MB) ==="
+          awk '{ split($3, seg, ":"); fam = seg[1];
+                 count[fam]++; bytes[fam] += $1; idle[fam] += $2 }
+               END { for (f in count)
+                       printf "%-22s %6d keys %9.1f MB  avg idle %6.1f h\n",
+                              f, count[f], bytes[f]/1048576, idle[f]/count[f]/3600 }' census.txt \
+            | sort -k4 -rn
+          echo ""
+          echo "=== Top 15 keys by size ==="
+          sort -rn census.txt | head -15 \
+            | awk '{ printf "%8.2f MB  idle %7.1f h  %s\n", $1/1048576, $2/3600, $3 }'
+          echo ""
+          echo "=== Totals ==="
+          awk '{ n++; b += $1 } END { printf "%d keys, %.1f MB\n", n, b/1048576 }' census.txt
 
       - name: Reboot redis accessory
         if: inputs.action == 'restart-redis'

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -5,6 +5,13 @@ servers:
   web:
     hosts:
       - 5.161.124.129
+    options:
+      # Contain app memory growth: the 3.7GB no-swap host freezes for ~30min
+      # when any process exhausts RAM (2026-07-14 outage). Under a limit,
+      # docker OOM-kills just the app and the restart policy revives it in
+      # seconds. Headroom: redis is capped at 512mb, postgres/proxy/other
+      # tenants use roughly another 1gb.
+      memory: 1536m
 
 proxy:
   ssl: true


### PR DESCRIPTION
Contains the outage class we hit on 2026-07-13 and 2026-07-14: the app process grew until it exhausted the 3.7GB no-swap host, freezing the entire box (including sshd, which locks out every deploy-pipeline ops lever) for ~30 minutes until the kernel OOM killer executed the app and docker revived it.

- **App container capped at 1536m** (`servers.web.options.memory`). A runaway app now gets OOM-killed and restarted by docker in seconds, contained to itself, instead of freezing the host. Same medicine redis got in #203. Headroom math: 3.7GB total, redis capped at 512mb, postgres/kamal-proxy/other tenants roughly another 1gb. Takes effect on this merge's own deploy.
- **New `cache-census` ops action**: keys, MB, and average idle hours per cache-key family, top 15 keys by size, and totals — for judging which cache families earn their memory and which churn. Uses `MEMORY USAGE`/`OBJECT IDLETIME`, which don't touch LRU access times, so the census doesn't distort what it measures.
- **New `app-logs` ops action** (error/warn/fatal lines only, capped at 300), and the diagnose app-log step now filters the same way. Actions run logs on a public repo are world-readable, so raw request logs must never be printed.

The memory cap contains the symptom; the cause (what makes the app balloon at night — leak vs. heavy request) is a follow-up, now debuggable via the errors-only log actions while the site stays up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
