### PR TITLE
Add venueState, ratingsCount, and calibratedRatingsCount to get_shows_by_year MCP tool

### DIFF
--- a/apps/web/app/routes/mcp/index.tsx
+++ b/apps/web/app/routes/mcp/index.tsx
@@ -612,10 +612,15 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
           date: show.date,
           venueName: show.venue?.name || "",
           venueCity: show.venue?.city || "",
+          venueState: show.venue?.state || "",
           averageRating: show.averageRating,
+          ratingsCount: show.ratingsCount,
           // Calibrated Show Rating (entropy-weighted, bias-centered, count-shrunk);
           // null until the rating recompute has populated it.
           calibratedRating: calibratedByShowId[show.id]?.rating ?? null,
+          // contributing rater count for the calibrated score (post-exclusion, so
+          // smaller than ratingsCount); null when calibratedRating is null.
+          calibratedRatingsCount: calibratedByShowId[show.id]?.count ?? null,
         })),
       };
     }


### PR DESCRIPTION
## Summary

`get_shows_by_year` now returns three more fields per show, so a client can build a full ratings row from a single MCP call, no joins against other endpoints:

- `venueState`: the venue's state
- `ratingsCount`: community rater count
- `calibratedRatingsCount`: contributing rater count behind the calibrated score (post-exclusion, so smaller than `ratingsCount`; `null` when `calibratedRating` is `null`)

## Verification

- `biome check` on the changed file: clean
- `apps/web` typecheck (`react-router typegen && gen-root && tsc`): exit 0
- pre-commit lint across the repo: passed

No test change: the MCP route has no existing test and `handleToolCall` is module-private with no harness to extend.
