### PR TITLE
Reduce per-request server memory and add a prod memory timeline

### DIFF
--- a/.github/workflows/ops.yml
+++ b/.github/workflows/ops.yml
@@ -10,6 +10,7 @@ on:
           - diagnose
           - cache-census
           - app-logs
+          - memory-timeline
           - restart-redis
           - prune-docker
 
@@ -111,6 +112,15 @@ jobs:
       - name: App logs (errors only, deep)
         if: inputs.action == 'app-logs'
         run: kamal app logs --lines 5000 2>&1 | grep -iE "error|warn|fatal" | tail -300 || echo "No error lines in the last 5000"
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
+      # The app emits one "process memory" line per minute (entry.server.tsx).
+      # These are four flat integers with no request data, so printing them in
+      # a public run log is safe. 1440 lines ≈ a full day of RSS/heap timeline.
+      - name: App memory timeline
+        if: inputs.action == 'memory-timeline'
+        run: kamal app logs --lines 20000 2>&1 | grep -F '"process memory"' | tail -1440 || echo "No memory lines found"
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 

--- a/apps/web/app/entry.server.tsx
+++ b/apps/web/app/entry.server.tsx
@@ -6,9 +6,14 @@ import { renderToPipeableStream } from "react-dom/server";
 import type { AppLoadContext, EntryContext } from "react-router";
 import { ServerRouter } from "react-router";
 import honeybadger from "~/lib/honeybadger";
-import { logger } from "~/server/logger";
+import { createLogger, logger } from "~/server/logger";
+import { startMemoryLogging } from "~/server/memory-log";
 
 export const streamTimeout = 5_000;
+
+// Dedicated info-level logger: production's default level is `warn`, which
+// would swallow the memory timeline the line exists to produce.
+startMemoryLogging(createLogger({ level: "info" }));
 
 export default function handleRequest(
   request: Request,

--- a/apps/web/app/lib/noteworthy-performance-loader.ts
+++ b/apps/web/app/lib/noteworthy-performance-loader.ts
@@ -1,8 +1,8 @@
 import type { AllTimersPageView } from "@bip/domain";
-import { type DehydratedState, dehydrate } from "@tanstack/react-query";
+import type { DehydratedState } from "@tanstack/react-query";
 import { type PublicContext, publicLoader } from "~/lib/base-loaders";
 import { showUserDataQueryKey, trackUserRatingsQueryKey } from "~/lib/query-keys";
-import { createPrefetchClient } from "~/lib/query-prefetch";
+import { createPrefetchClient, dehydrateAndClear } from "~/lib/query-prefetch";
 import { services } from "~/server/services";
 import { computeShowUserData } from "~/server/show-user-data";
 import { computeTrackUserRatings } from "~/server/track-user-ratings";
@@ -46,6 +46,6 @@ export function createNoteworthyLoader({
       }),
     ]);
 
-    return { ...view, dehydratedState: dehydrate(queryClient) };
+    return { ...view, dehydratedState: dehydrateAndClear(queryClient) };
   });
 }

--- a/apps/web/app/lib/query-prefetch.test.ts
+++ b/apps/web/app/lib/query-prefetch.test.ts
@@ -1,7 +1,7 @@
 import { dehydrate } from "@tanstack/react-query";
 import { describe, expect, test } from "vitest";
 import { showUserDataQueryKey } from "./query-keys";
-import { createPrefetchClient, mergeDehydratedStates } from "./query-prefetch";
+import { createPrefetchClient, dehydrateAndClear, mergeDehydratedStates } from "./query-prefetch";
 
 describe("createPrefetchClient", () => {
   // Loaders must get a fresh client per request. A module-level singleton
@@ -25,6 +25,26 @@ describe("createPrefetchClient", () => {
     const state = dehydrate(client);
     expect(state.queries.length).toBe(1);
     expect(state.queries[0].queryKey).toEqual(showUserDataQueryKey(["show-1"]));
+  });
+});
+
+describe("dehydrateAndClear", () => {
+  // Loaders dehydrate a per-request client and then have no further use for
+  // it, but React Query pins every prefetched query in memory for gcTime
+  // (5 min) via a scheduled GC timer. Clearing at dehydrate time releases the
+  // payload with the response instead of five minutes later.
+  test("returns the dehydrated queries and empties the client cache", async () => {
+    const client = createPrefetchClient();
+    await client.prefetchQuery({
+      queryKey: ["setlist", "basis-for-a-day"],
+      queryFn: async () => ({ opener: "Basis for a Day" }),
+    });
+
+    const state = dehydrateAndClear(client);
+
+    expect(state.queries).toHaveLength(1);
+    expect(state.queries[0].state.data).toEqual({ opener: "Basis for a Day" });
+    expect(client.getQueryCache().getAll()).toHaveLength(0);
   });
 });
 

--- a/apps/web/app/lib/query-prefetch.ts
+++ b/apps/web/app/lib/query-prefetch.ts
@@ -1,4 +1,4 @@
-import { type DehydratedState, QueryClient } from "@tanstack/react-query";
+import { type DehydratedState, dehydrate, QueryClient } from "@tanstack/react-query";
 
 /**
  * Per-request `QueryClient` for loader-side prefetching. Each call returns a
@@ -19,6 +19,21 @@ export function createPrefetchClient(): QueryClient {
       },
     },
   });
+}
+
+/**
+ * Dehydrate a per-request prefetch client and immediately release everything
+ * it holds. React Query schedules a gcTime (5 min) timer on each prefetched
+ * query even when nothing observes it, so an un-cleared client pins its
+ * payloads in server memory for five minutes after the response is gone;
+ * at peak traffic that's minutes of requests held on the heap. `dehydrate`
+ * copies the data first, so the returned state (and client-side hydration)
+ * is unaffected. Loaders must use this instead of bare `dehydrate`.
+ */
+export function dehydrateAndClear(queryClient: QueryClient): DehydratedState {
+  const state = dehydrate(queryClient);
+  queryClient.clear();
+  return state;
 }
 
 /**

--- a/apps/web/app/routes/_index.tsx
+++ b/apps/web/app/routes/_index.tsx
@@ -1,5 +1,5 @@
 import { type BlogPostWithUser, CacheKeys, type Setlist, type TourDate } from "@bip/domain";
-import { type DehydratedState, dehydrate } from "@tanstack/react-query";
+import type { DehydratedState } from "@tanstack/react-query";
 import { Calendar } from "lucide-react";
 import { Link } from "react-router-dom";
 import { BlogCard } from "~/components/blog/blog-card";
@@ -11,7 +11,7 @@ import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
 import { logger } from "~/lib/logger";
 import { showUserDataQueryKey } from "~/lib/query-keys";
-import { createPrefetchClient } from "~/lib/query-prefetch";
+import { createPrefetchClient, dehydrateAndClear } from "~/lib/query-prefetch";
 import { ROCK_OPERA_SLUG, rockOperaPath } from "~/lib/rock-operas";
 import { getHomeMeta } from "~/lib/seo";
 import { services } from "~/server/services";
@@ -157,7 +157,7 @@ export const loader = publicLoader<LoaderData>(async ({ context }) => {
     recentShows,
     onThisDayCounts,
     externalSources,
-    dehydratedState: dehydrate(queryClient),
+    dehydratedState: dehydrateAndClear(queryClient),
   };
 });
 

--- a/apps/web/app/routes/musicians/$slug.tsx
+++ b/apps/web/app/routes/musicians/$slug.tsx
@@ -1,6 +1,6 @@
 import type { Instrument, Musician, MusicianAppearanceShow, Song, SongPagePerformance } from "@bip/domain";
 import { CacheKeys } from "@bip/domain/cache-keys";
-import { type DehydratedState, dehydrate } from "@tanstack/react-query";
+import type { DehydratedState } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Pencil } from "lucide-react";
 import { useMemo } from "react";
@@ -29,7 +29,7 @@ import {
   musicianTablePreset,
 } from "~/lib/musicians-constants";
 import { showUserDataQueryKey, trackUserRatingsQueryKey } from "~/lib/query-keys";
-import { createPrefetchClient } from "~/lib/query-prefetch";
+import { createPrefetchClient, dehydrateAndClear } from "~/lib/query-prefetch";
 import { getMusicianMeta } from "~/lib/seo";
 import { fetchFilteredSongs } from "~/lib/song-utilities";
 import { services } from "~/server/services";
@@ -175,7 +175,7 @@ export const loader = publicLoader(async ({ params, context }): Promise<LoaderDa
     }),
   ]);
 
-  return { ...data, dehydratedState: dehydrate(queryClient) };
+  return { ...data, dehydratedState: dehydrateAndClear(queryClient) };
 });
 
 export function meta({ data }: { data?: LoaderData }) {

--- a/apps/web/app/routes/on-this-day.$monthDay.tsx
+++ b/apps/web/app/routes/on-this-day.$monthDay.tsx
@@ -1,5 +1,5 @@
 import { CacheKeys, type SetlistLight, type SongPagePerformance } from "@bip/domain";
-import { type DehydratedState, dehydrate } from "@tanstack/react-query";
+import type { DehydratedState } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight, Flame } from "lucide-react";
 import type { ClientLoaderFunctionArgs } from "react-router";
 import { Link, redirect } from "react-router";
@@ -12,7 +12,7 @@ import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-perfor
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
 import { showUserDataQueryKey, trackUserRatingsQueryKey } from "~/lib/query-keys";
-import { createPrefetchClient } from "~/lib/query-prefetch";
+import { createPrefetchClient, dehydrateAndClear } from "~/lib/query-prefetch";
 import { addDaysYearAgnostic, formatMonthDay, formatMonthDayShort, isValidMonthDay } from "~/lib/utils";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
@@ -104,7 +104,7 @@ export const loader = publicLoader(async ({ params, context }): Promise<LoaderDa
     previousMonthDay,
     nextMonthDay,
     externalSources: await computeShowExternalSources(setlists.map((s) => s.show)),
-    dehydratedState: dehydrate(queryClient),
+    dehydratedState: dehydrateAndClear(queryClient),
   };
 });
 

--- a/apps/web/app/routes/resources/rock-opera-performances.test.ts
+++ b/apps/web/app/routes/resources/rock-opera-performances.test.ts
@@ -29,16 +29,20 @@ vi.mock("~/server/show-user-data", () => ({
   computeShowUserData: (...args: unknown[]) => computeShowUserDataFn(...args),
 }));
 
-// Use a real QueryClient so dehydrate() can call getDefaultOptions(),
-// but spy on `prefetchQuery` so tests can assert what the loader queued
-// for hydration.
-vi.mock("~/lib/query-prefetch", () => ({
-  createPrefetchClient: () => {
-    const client = new QueryClient();
-    client.prefetchQuery = prefetchQuery as never;
-    return client;
-  },
-}));
+// Use a real QueryClient (and the real dehydrateAndClear) so dehydration
+// behaves as in production, but spy on `prefetchQuery` so tests can assert
+// what the loader queued for hydration.
+vi.mock("~/lib/query-prefetch", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/lib/query-prefetch")>();
+  return {
+    ...actual,
+    createPrefetchClient: () => {
+      const client = new QueryClient();
+      client.prefetchQuery = prefetchQuery as never;
+      return client;
+    },
+  };
+});
 
 const { getRockOperaPerformances } = await import("./rock-opera-performances");
 

--- a/apps/web/app/routes/resources/rock-opera-performances.ts
+++ b/apps/web/app/routes/resources/rock-opera-performances.ts
@@ -1,9 +1,9 @@
 import { CacheKeys, type Setlist } from "@bip/domain";
-import { type DehydratedState, dehydrate } from "@tanstack/react-query";
+import type { DehydratedState } from "@tanstack/react-query";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
 import type { PublicContext } from "~/lib/base-loaders";
 import { showUserDataQueryKey } from "~/lib/query-keys";
-import { createPrefetchClient } from "~/lib/query-prefetch";
+import { createPrefetchClient, dehydrateAndClear } from "~/lib/query-prefetch";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
 import { computeShowUserData } from "~/server/show-user-data";
@@ -62,6 +62,6 @@ export async function getRockOperaPerformances(
   return {
     performances: cached.performances,
     externalSources: cached.externalSources,
-    dehydratedState: dehydrate(queryClient),
+    dehydratedState: dehydrateAndClear(queryClient),
   };
 }

--- a/apps/web/app/routes/shows/$slug.tsx
+++ b/apps/web/app/routes/shows/$slug.tsx
@@ -1,6 +1,6 @@
 import type { RatingValueBucket, ShowNavItem } from "@bip/core";
 import { type ArchiveDotOrgRecording, CacheKeys, type ReviewMinimal, type Setlist, type ShowFile } from "@bip/domain";
-import { type DehydratedState, dehydrate } from "@tanstack/react-query";
+import type { DehydratedState } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight, Edit } from "lucide-react";
 import { Link, useRevalidator } from "react-router-dom";
 import { toast } from "sonner";
@@ -29,7 +29,7 @@ import { EXTERNAL_SOURCE_DOMAINS } from "~/lib/favicon";
 import { deriveShowLineupNotes } from "~/lib/lineup-notes";
 import { logger } from "~/lib/logger";
 import { showUserDataQueryKey, trackUserRatingsQueryKey } from "~/lib/query-keys";
-import { createPrefetchClient } from "~/lib/query-prefetch";
+import { createPrefetchClient, dehydrateAndClear } from "~/lib/query-prefetch";
 import { getShowMeta, getShowStructuredData } from "~/lib/seo";
 import { formatDateLong, formatMonthDay } from "~/lib/utils";
 import { services } from "~/server/services";
@@ -149,7 +149,7 @@ export const loader = publicLoader(async ({ params, context }): Promise<ShowLoad
     photos,
     adjacentShows,
     ratingDistribution,
-    dehydratedState: dehydrate(queryClient),
+    dehydratedState: dehydrateAndClear(queryClient),
   };
 });
 

--- a/apps/web/app/routes/shows/top-rated-shows.ts
+++ b/apps/web/app/routes/shows/top-rated-shows.ts
@@ -1,10 +1,10 @@
 import type { RatingMode } from "@bip/core";
 import type { Setlist } from "@bip/domain";
-import { type DehydratedState, dehydrate } from "@tanstack/react-query";
+import type { DehydratedState } from "@tanstack/react-query";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
 import type { PublicContext } from "~/lib/base-loaders";
 import { showUserDataQueryKey } from "~/lib/query-keys";
-import { createPrefetchClient } from "~/lib/query-prefetch";
+import { createPrefetchClient, dehydrateAndClear } from "~/lib/query-prefetch";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
 import { computeShowUserData } from "~/server/show-user-data";
@@ -78,6 +78,6 @@ export async function getTopRatedShows(
     countsByYear,
     allCount,
     externalSources,
-    dehydratedState: dehydrate(queryClient),
+    dehydratedState: dehydrateAndClear(queryClient),
   };
 }

--- a/apps/web/app/routes/shows/year/$year.tsx
+++ b/apps/web/app/routes/shows/year/$year.tsx
@@ -1,5 +1,5 @@
 import { CacheKeys, type SetlistLight } from "@bip/domain";
-import { type DehydratedState, dehydrate } from "@tanstack/react-query";
+import type { DehydratedState } from "@tanstack/react-query";
 import { ArrowUp, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { ClientLoaderFunctionArgs } from "react-router";
@@ -17,7 +17,7 @@ import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
 import { logger } from "~/lib/logger";
 import { showUserDataQueryKey } from "~/lib/query-keys";
-import { createPrefetchClient } from "~/lib/query-prefetch";
+import { createPrefetchClient, dehydrateAndClear } from "~/lib/query-prefetch";
 import { getShowsMeta } from "~/lib/seo";
 import { parseTriState, type TriState, triStateToBoolean } from "~/lib/tri-state-filter";
 import { cn } from "~/lib/utils";
@@ -111,7 +111,7 @@ export const loader = publicLoader(async ({ request, params, context }): Promise
       showCountsByYear: emptyCounts,
       monthCounts: emptyCounts,
       filters,
-      dehydratedState: dehydrate(searchClient),
+      dehydratedState: dehydrateAndClear(searchClient),
     };
   }
 
@@ -169,7 +169,7 @@ export const loader = publicLoader(async ({ request, params, context }): Promise
     showCountsByYear,
     monthCounts,
     filters,
-    dehydratedState: dehydrate(queryClient),
+    dehydratedState: dehydrateAndClear(queryClient),
   };
 });
 

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -1,5 +1,5 @@
 import { compareByShowDate, type SongPageView } from "@bip/domain";
-import { type DehydratedState, dehydrate } from "@tanstack/react-query";
+import type { DehydratedState } from "@tanstack/react-query";
 import { BarChart3, FileTextIcon, Flame, GuitarIcon, History, ListMusic, Pencil } from "lucide-react";
 import { type ReactNode, useMemo, useState } from "react";
 import type { LoaderFunctionArgs } from "react-router";
@@ -24,7 +24,7 @@ import { publicLoader } from "~/lib/base-loaders";
 import { formatVenueLocation } from "~/lib/format-venue";
 import { pickGapTier } from "~/lib/gap-tier";
 import { showUserDataQueryKey, trackUserRatingsQueryKey } from "~/lib/query-keys";
-import { createPrefetchClient } from "~/lib/query-prefetch";
+import { createPrefetchClient, dehydrateAndClear } from "~/lib/query-prefetch";
 import { getSongMeta, getSongStructuredData } from "~/lib/seo";
 import { services } from "~/server/services";
 import { computeShowUserData } from "~/server/show-user-data";
@@ -52,7 +52,7 @@ export const loader = publicLoader(async ({ params, context }: LoaderFunctionArg
     }),
   ]);
 
-  return { ...view, dehydratedState: dehydrate(queryClient) };
+  return { ...view, dehydratedState: dehydrateAndClear(queryClient) };
 });
 
 function ReviewNote({ notes }: { notes: string }) {

--- a/apps/web/app/routes/users/$username.tsx
+++ b/apps/web/app/routes/users/$username.tsx
@@ -1,6 +1,5 @@
 import type { RatingWithShow, RatingWithTrack, ShowRatingsSort, TrackRatingsSort } from "@bip/core";
 import { CacheKeys, compareByShowDate } from "@bip/domain";
-import { dehydrate } from "@tanstack/react-query";
 import { CalendarDays, Edit, MessageSquare, Star, Users } from "lucide-react";
 import { useState } from "react";
 import type { LoaderFunctionArgs, MetaFunction } from "react-router-dom";
@@ -22,7 +21,7 @@ import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { type PublicContext, publicLoader } from "~/lib/base-loaders";
 import { formatVenueLocation } from "~/lib/format-venue";
 import { showUserDataQueryKey } from "~/lib/query-keys";
-import { createPrefetchClient } from "~/lib/query-prefetch";
+import { createPrefetchClient, dehydrateAndClear } from "~/lib/query-prefetch";
 import { formatDateLong, formatDateShort, formatDateShortMobile } from "~/lib/utils";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
@@ -193,7 +192,7 @@ async function loadUserProfile({ params, request, context }: LoaderFunctionArgs 
     blogPosts,
     attendedSetlists,
     attendedExternalSources,
-    dehydratedState: dehydrate(queryClient),
+    dehydratedState: dehydrateAndClear(queryClient),
     attendedPagination: {
       page: clampedAttendedPage,
       pageSize: ATTENDED_SHOWS_PAGE_SIZE,

--- a/apps/web/app/routes/venues/$slug.tsx
+++ b/apps/web/app/routes/venues/$slug.tsx
@@ -1,5 +1,5 @@
 import type { Setlist, Venue } from "@bip/domain";
-import { type DehydratedState, dehydrate } from "@tanstack/react-query";
+import type { DehydratedState } from "@tanstack/react-query";
 import { CalendarDays, Edit, MapPin, Ticket } from "lucide-react";
 import { AdminOnly } from "~/components/admin/admin-only";
 import { SetlistList } from "~/components/setlist/setlist-list";
@@ -12,7 +12,7 @@ import { StatBox } from "~/components/ui/stat-box";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
 import { showUserDataQueryKey } from "~/lib/query-keys";
-import { createPrefetchClient } from "~/lib/query-prefetch";
+import { createPrefetchClient, dehydrateAndClear } from "~/lib/query-prefetch";
 import { getVenueMeta, getVenueStructuredData } from "~/lib/seo";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
@@ -66,7 +66,7 @@ export const loader = publicLoader(async ({ params, context }): Promise<LoaderDa
     queryFn: () => computeShowUserData(context, showIds),
   });
 
-  return { venue, setlists, stats, externalSources, dehydratedState: dehydrate(queryClient) };
+  return { venue, setlists, stats, externalSources, dehydratedState: dehydrateAndClear(queryClient) };
 });
 
 export function meta({ data }: { data: LoaderData }) {

--- a/apps/web/app/server/memory-log.test.ts
+++ b/apps/web/app/server/memory-log.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { logMemoryUsage, MEMORY_LOG_INTERVAL_MS, startMemoryLogging } from "./memory-log";
+
+function makeLoggerMock() {
+  return { info: vi.fn() };
+}
+
+describe("logMemoryUsage", () => {
+  // The line exists to graph heap growth from container logs, so the payload
+  // must be flat integers in MB: greppable and small, not raw byte counts.
+  test("emits one line with rss/heap fields rounded to whole MB", () => {
+    const logger = makeLoggerMock();
+
+    logMemoryUsage(logger);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    const [message, fields] = logger.info.mock.calls[0];
+    expect(message).toBe("process memory");
+    for (const key of ["rssMb", "heapTotalMb", "heapUsedMb", "externalMb"]) {
+      expect(fields[key]).toBeTypeOf("number");
+      expect(Number.isInteger(fields[key])).toBe(true);
+    }
+    expect(fields.rssMb).toBeGreaterThan(0);
+  });
+});
+
+describe("startMemoryLogging", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // One line per interval, forever, from a single registration.
+  test("logs once per interval", () => {
+    const logger = makeLoggerMock();
+    const stop = startMemoryLogging(logger);
+
+    vi.advanceTimersByTime(MEMORY_LOG_INTERVAL_MS * 3);
+    stop();
+
+    expect(logger.info).toHaveBeenCalledTimes(3);
+  });
+
+  // entry.server can be re-evaluated (dev-server module invalidation); a
+  // second start must not stack a second interval and double the log volume.
+  test("second start while active is a no-op", () => {
+    const logger = makeLoggerMock();
+    const stop = startMemoryLogging(logger);
+    const stopAgain = startMemoryLogging(logger);
+
+    vi.advanceTimersByTime(MEMORY_LOG_INTERVAL_MS);
+    stop();
+    stopAgain();
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/app/server/memory-log.ts
+++ b/apps/web/app/server/memory-log.ts
@@ -1,0 +1,52 @@
+import type { Logger } from "@bip/domain";
+
+export const MEMORY_LOG_INTERVAL_MS = 60_000;
+
+const BYTES_PER_MB = 1024 * 1024;
+
+/**
+ * Emit one flat, greppable line of process memory stats. Exists so container
+ * logs carry a minute-by-minute RSS/heap timeline: the evidence needed to
+ * tell a slow leak from allocation churn ratcheting the heap high-water mark
+ * (see the 2026-07 OOM incidents).
+ */
+export function logMemoryUsage(logger: Pick<Logger, "info">): void {
+  const usage = process.memoryUsage();
+  logger.info("process memory", {
+    rssMb: Math.round(usage.rss / BYTES_PER_MB),
+    heapTotalMb: Math.round(usage.heapTotal / BYTES_PER_MB),
+    heapUsedMb: Math.round(usage.heapUsed / BYTES_PER_MB),
+    externalMb: Math.round(usage.external / BYTES_PER_MB),
+  });
+}
+
+// Keyed on globalThis (not module scope) because the dev server re-evaluates
+// server modules on invalidation; a fresh module instance must still see that
+// an interval is already running or every reload would stack another one.
+const ACTIVE_INTERVAL_KEY = Symbol.for("bip.memoryLogInterval");
+type GlobalWithMemoryLog = typeof globalThis & {
+  [ACTIVE_INTERVAL_KEY]?: ReturnType<typeof setInterval>;
+};
+
+/**
+ * Start the once-a-minute memory log line. Idempotent while active. Returns
+ * a stop function (used by tests; production never stops).
+ */
+export function startMemoryLogging(
+  logger: Pick<Logger, "info">,
+  intervalMs: number = MEMORY_LOG_INTERVAL_MS,
+): () => void {
+  const globalState = globalThis as GlobalWithMemoryLog;
+  if (globalState[ACTIVE_INTERVAL_KEY]) return () => {};
+
+  const interval = setInterval(() => logMemoryUsage(logger), intervalMs);
+  interval.unref?.();
+  globalState[ACTIVE_INTERVAL_KEY] = interval;
+
+  return () => {
+    clearInterval(interval);
+    if (globalState[ACTIVE_INTERVAL_KEY] === interval) {
+      delete globalState[ACTIVE_INTERVAL_KEY];
+    }
+  };
+}

--- a/packages/core/src/_shared/catalog/date-indexed-catalog.test.ts
+++ b/packages/core/src/_shared/catalog/date-indexed-catalog.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { RedisService } from "../redis";
-import { DateIndexedCatalog } from "./date-indexed-catalog";
+import { DateIndexedCatalog, MEMO_TTL_SECONDS } from "./date-indexed-catalog";
 
 interface SongRecord {
   song: string;
@@ -127,6 +127,68 @@ describe("DateIndexedCatalog", () => {
     const result = await catalog.findByDate("1999-04-09");
 
     expect(result).toBeUndefined();
+  });
+
+  // Every Redis read of a catalog deserializes the whole multi-MB map, and the
+  // hottest pages do it several times per request. The in-process memo must
+  // absorb repeat reads within its window so per-request allocation stays flat.
+  test("memo: repeat lookups within the memo window read Redis once", async () => {
+    const fetcher = vi.fn(async () => SAMPLE_MAP);
+    redis.__store.set("catalog:test", SAMPLE_MAP);
+    const catalog = new DateIndexedCatalog<SongRecord>(redis, "catalog:test", fetcher);
+
+    await catalog.findByDate("2007-12-28");
+    await catalog.findByDate("2001-09-01");
+    await catalog.getAll();
+
+    expect(redis.get).toHaveBeenCalledTimes(1);
+  });
+
+  // The memo must expire so a catalog refreshed in Redis (daily TTL) is picked
+  // up within minutes, not held until the process restarts.
+  test("memo: expires after its TTL and re-reads Redis", async () => {
+    const fetcher = vi.fn(async () => SAMPLE_MAP);
+    redis.__store.set("catalog:test", SAMPLE_MAP);
+    const catalog = new DateIndexedCatalog<SongRecord>(redis, "catalog:test", fetcher);
+    const nowSpy = vi.spyOn(Date, "now");
+
+    nowSpy.mockReturnValue(1_000_000);
+    await catalog.findByDate("2007-12-28");
+    nowSpy.mockReturnValue(1_000_000 + MEMO_TTL_SECONDS * 1000 + 1);
+    await catalog.findByDate("2007-12-28");
+
+    expect(redis.get).toHaveBeenCalledTimes(2);
+  });
+
+  // A cold-cache fetch must seed the memo too: the request that pays for the
+  // upstream fetch shouldn't be followed by a Redis re-read from the next one.
+  test("memo: a successful cold-cache fetch seeds the memo", async () => {
+    const fetcher = vi.fn(async () => SAMPLE_MAP);
+    const catalog = new DateIndexedCatalog<SongRecord>(redis, "catalog:test", fetcher);
+
+    await catalog.findByDate("2007-12-28");
+    const result = await catalog.findByDate("2001-09-01");
+
+    expect(result).toEqual({ song: "Aceetobee" });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(redis.get).toHaveBeenCalledTimes(1);
+  });
+
+  // The memoized map is shared by every request for the memo window, so a
+  // caller mutating it would corrupt what other requests see. Freezing turns
+  // that bug into a loud TypeError at the mutation site.
+  test("memo: the shared map is deeply frozen", async () => {
+    const fetcher = vi.fn(async () => ({ "2007-12-28": { song: "Basis for a Day" } }));
+    const catalog = new DateIndexedCatalog<SongRecord>(redis, "catalog:test", fetcher);
+
+    const all = await catalog.getAll();
+    const entry = await catalog.findByDate("2007-12-28");
+
+    expect(Object.isFrozen(all)).toBe(true);
+    expect(Object.isFrozen(entry)).toBe(true);
+    expect(() => {
+      (all as Record<string, SongRecord>)["1999-12-31"] = { song: "Munchkin Invasion" };
+    }).toThrow(TypeError);
   });
 
   // The catalog applies a one-day TTL to every successful fetch — external

--- a/packages/core/src/_shared/catalog/date-indexed-catalog.ts
+++ b/packages/core/src/_shared/catalog/date-indexed-catalog.ts
@@ -10,15 +10,42 @@ import type { RedisService } from "../redis";
 export const CATALOG_TTL_SECONDS = 60 * 60 * 24;
 
 /**
+ * Lifetime of the in-process copy of the parsed map. Every Redis read
+ * deserializes the whole multi-MB catalog, and the hottest pages read several
+ * catalogs per request; the memo caps that at one parse per instance per
+ * window. Minutes-scale so a catalog refreshed in Redis is picked up promptly.
+ */
+export const MEMO_TTL_SECONDS = 60 * 5;
+
+/**
+ * Recursively freeze a parsed catalog map. The memo hands the same object to
+ * every request for the memo window, so an accidental mutation by one caller
+ * would silently corrupt what all other requests see; freezing makes it throw
+ * at the mutation site instead. Values are plain JSON (no cycles).
+ */
+function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const key of Object.keys(value)) {
+      deepFreeze((value as Record<string, unknown>)[key]);
+    }
+  }
+  return value;
+}
+
+/**
  * Shared caching layer for external catalogs that are small enough to fetch in
  * one bulk request and index by ISO date (YYYY-MM-DD). Exists so every external
  * integration (nugs.net, archive.org) doesn't reinvent read-through Redis with
- * single-flight and empty-result handling. Treat the fetcher as slow and
- * expensive — the whole point is that each catalog refresh pays that cost once
- * per instance per TTL window, not once per user request.
+ * single-flight, empty-result handling, and an in-process memo of the parsed
+ * map. Treat the fetcher as slow and expensive (each catalog refresh pays that
+ * cost once per instance per TTL window, not once per user request) and the
+ * Redis payload as large: without the memo every request re-deserializes the
+ * full multi-MB map.
  */
 export class DateIndexedCatalog<T> {
   private inFlight: Promise<Record<string, T>> | null = null;
+  private memo: { map: Record<string, T>; expiresAt: number } | null = null;
 
   /**
    * @param redis Shared Redis client. The catalog persists its entire date-indexed
@@ -58,8 +85,13 @@ export class DateIndexedCatalog<T> {
   }
 
   private async getMap(): Promise<Record<string, T>> {
+    if (this.memo && Date.now() < this.memo.expiresAt) return this.memo.map;
+
     const cached = await this.redis.get<Record<string, T>>(this.cacheKey);
-    if (cached) return cached;
+    if (cached) {
+      this.remember(cached);
+      return cached;
+    }
 
     if (this.inFlight) return this.inFlight;
 
@@ -76,11 +108,21 @@ export class DateIndexedCatalog<T> {
       const map = await this.fetcher();
       if (Object.keys(map).length > 0) {
         await this.redis.set<Record<string, T>>(this.cacheKey, map, { EX: CATALOG_TTL_SECONDS });
+        this.remember(map);
       }
       return map;
     } catch (error) {
       this.logger?.error("DateIndexedCatalog fetch failed", { cacheKey: this.cacheKey, error });
       return {};
     }
+  }
+
+  /**
+   * Keep the parsed map in process memory for {@link MEMO_TTL_SECONDS}. Only
+   * non-empty maps are remembered: an empty result means the fetch failed or
+   * returned nothing, and memoizing it would suppress the retry.
+   */
+  private remember(map: Record<string, T>): void {
+    this.memo = { map: deepFreeze(map), expiresAt: Date.now() + MEMO_TTL_SECONDS * 1000 };
   }
 }


### PR DESCRIPTION
The app container OOM'd during the evening peaks of 7/12 and 7/13, the second
time freezing the whole host. This removes the two biggest per-request memory
costs and adds the instrumentation to watch the effect in prod.

- Show and listing pages no longer re-parse whole external catalogs on every
  request. Each page read up to four full catalogs (nugs x2, archive.org,
  relisten) out of Redis per request, and every read deserialized a multi-MB
  JSON map (archive.org is ~10k rows). `DateIndexedCatalog` now keeps the
  parsed map in process for 5 minutes, so those reads cost a lookup instead
  of an allocation storm. Because that one map is shared by every request in
  the window, it is deep-frozen at memo time: an accidentally mutating caller
  throws at the mutation site instead of corrupting other requests. Staleness
  cost is nil in practice; this data already tolerates 24h staleness (daily
  Redis TTL, no invalidation path), and the memo adds at most 5 minutes on
  top.

- Loader prefetch data is released with the response instead of 5 minutes
  later. React Query schedules a gcTime timer on every prefetched query even
  when nothing observes it, so each request's dehydrated payloads stayed
  pinned on the heap for 5 minutes. The new `dehydrateAndClear` helper clears
  the per-request client at dehydrate time; the dehydrated state and client
  hydration are unchanged.

- The server now logs one `process memory` line per minute (rss / heap /
  external, whole MB), and Server Ops gains a `memory-timeline` action that
  prints the last ~24h of those lines. The line is four integers with no
  request data, so it is safe for public run logs. This is the evidence
  needed to tell a slow leak from churn ratcheting the heap high-water mark.

Verified end to end against the local prod restore: homepage, show page,
year listing, and 404 all render with external-source badges intact, no
console errors, and the memory line appears once per minute in server logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
