### PR TITLE
Build the community page on demand and trim homepage loader waste

### DIFF
--- a/.github/workflows/cron-jobs.yml
+++ b/.github/workflows/cron-jobs.yml
@@ -7,10 +7,9 @@ on:
       job:
         description: 'Cron job to run'
         required: true
-        default: 'community-refresh'
+        default: 'recompute-ratings'
         type: choice
         options:
-          - community-refresh
           - recompute-ratings
       timeout:
         description: 'Timeout in minutes'
@@ -20,7 +19,8 @@ on:
   
   # Scheduled triggers
   schedule:
-    # Run community refresh every hour
+    # Run the ratings recompute every hour (dirty-gated server-side, so it's
+    # a cheap no-op when no ratings changed)
     - cron: '0 * * * *'
 
 env:
@@ -35,8 +35,8 @@ jobs:
     steps:
       - name: Set job from schedule
         if: github.event_name == 'schedule'
-        run: echo "CRON_JOB=community-refresh" >> $GITHUB_ENV
-      
+        run: echo "CRON_JOB=recompute-ratings" >> $GITHUB_ENV
+
       - name: Set job from manual trigger
         if: github.event_name == 'workflow_dispatch'
         run: echo "CRON_JOB=${{ github.event.inputs.job }}" >> $GITHUB_ENV
@@ -66,28 +66,3 @@ jobs:
             exit 1
           fi
 
-      # The hourly schedule also drives the rating recompute (dirty-gated server-side,
-      # so it's a cheap no-op when no ratings changed). Manual runs select it via the
-      # job input instead, which the step above handles.
-      - name: Run ratings recompute (scheduled)
-        if: github.event_name == 'schedule'
-        run: |
-          response=$(curl -s -w "\n%{http_code}" -X POST \
-            "${{ env.PRODUCTION_URL }}/api/cron/recompute-ratings" \
-            -H "Content-Type: application/json" \
-            --max-time 600)
-
-          http_code=$(echo "$response" | tail -n1)
-          body=$(echo "$response" | head -n -1)
-
-          echo "HTTP Status: $http_code"
-          echo "Response: $body"
-
-          if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
-            echo "✅ Ratings recompute completed successfully"
-            echo "$body" | jq '.' || echo "$body"
-          else
-            echo "❌ Ratings recompute failed with status $http_code"
-            echo "$body" | jq '.' || echo "$body"
-            exit 1
-          fi

--- a/apps/web/app/components/layout/errors.test.tsx
+++ b/apps/web/app/components/layout/errors.test.tsx
@@ -1,0 +1,21 @@
+import { setupWithRouter } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { NotFound } from "./errors";
+
+describe("NotFound", () => {
+  // "let us know" is the report-a-problem affordance; it must open the same
+  // contact dialog as the footer's Contact link, not deep-link to the
+  // community leaderboards (which also gave crawlers a path to that page
+  // from every dead URL).
+  test("'let us know' opens the contact dialog instead of linking to /community", async () => {
+    const { user } = await setupWithRouter(<NotFound />);
+
+    const links = screen.queryAllByRole("link");
+    expect(links.map((link) => link.getAttribute("href"))).not.toContain("/community");
+
+    await user.click(screen.getByRole("button", { name: /let us know/i }));
+
+    expect(await screen.findByText("Get in Touch")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/layout/errors.tsx
+++ b/apps/web/app/components/layout/errors.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, Ghost } from "lucide-react";
 import { isRouteErrorResponse, Link, useRouteError } from "react-router-dom";
+import { ContactDialog } from "~/components/contact/contact-dialog";
 import { Button } from "../ui/button";
 
 function getErrorMessage(error: unknown): string {
@@ -59,9 +60,11 @@ export function NotFound() {
 
       <p className="mt-8 max-w-md text-sm text-muted-foreground">
         If you think this is a mistake, please{" "}
-        <Link to="/community" className="text-primary underline-offset-4 hover:underline">
-          let us know
-        </Link>
+        <ContactDialog>
+          <button type="button" className="text-primary underline-offset-4 hover:underline">
+            let us know
+          </button>
+        </ContactDialog>
         .
       </p>
     </div>

--- a/apps/web/app/routes/_index.tsx
+++ b/apps/web/app/routes/_index.tsx
@@ -14,20 +14,10 @@ import { showUserDataQueryKey } from "~/lib/query-keys";
 import { createPrefetchClient, dehydrateAndClear } from "~/lib/query-prefetch";
 import { ROCK_OPERA_SLUG, rockOperaPath } from "~/lib/rock-operas";
 import { getHomeMeta } from "~/lib/seo";
+import { type AcastEpisode, getLatestPodcastEpisode } from "~/server/latest-podcast-episode";
 import { services } from "~/server/services";
 import { computeShowExternalSources } from "~/server/show-external-sources";
 import { computeShowUserData } from "~/server/show-user-data";
-
-interface AcastEpisode {
-  id: string;
-  title: string;
-  description: string;
-  publishDate: string;
-  duration: number;
-  mediaUrl: string;
-  image: string;
-  url: string;
-}
 
 interface LoaderData {
   tourDates: TourDate[];
@@ -43,9 +33,8 @@ interface LoaderData {
 }
 
 export const loader = publicLoader<LoaderData>(async ({ context }) => {
-  const allTourDates = Array.isArray(await services.tourDatesService.getTourDates())
-    ? await services.tourDatesService.getTourDates()
-    : [];
+  const tourDatesResult = await services.tourDatesService.getTourDates();
+  const allTourDates = Array.isArray(tourDatesResult) ? tourDatesResult : [];
 
   // Find next tour date (first upcoming show)
   const now = new Date();
@@ -119,17 +108,7 @@ export const loader = publicLoader<LoaderData>(async ({ context }) => {
     queryFn: () => computeShowUserData(context, allShowIds),
   });
 
-  // Fetch latest podcast episode
-  let latestEpisode: AcastEpisode | null = null;
-  try {
-    const response = await fetch(
-      "https://feeder.acast.com/api/v1/shows/d690923d-524e-5c8b-b29f-d66517615b5b?limit=1&from=0",
-    );
-    const data = await response.json();
-    latestEpisode = data.episodes?.[0] || null;
-  } catch (error) {
-    logger.error("Error fetching latest episode", { error });
-  }
+  const latestEpisode = await getLatestPodcastEpisode();
 
   const today = new Date();
   const monthDay = `${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;

--- a/apps/web/app/routes/api/cron/$action.test.ts
+++ b/apps/web/app/routes/api/cron/$action.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("~/server/services", () => ({ services: {} }));
+
+const { action } = await import("./$action");
+
+function cronRequest(actionName: string, userAgent = "curl/8.0 GitHub-Actions") {
+  return {
+    request: new Request(`http://localhost/api/cron/${actionName}`, {
+      method: "POST",
+      headers: { "user-agent": userAgent },
+    }),
+    params: { action: actionName },
+    context: {} as never,
+  };
+}
+
+describe("cron action route", () => {
+  // The community page now builds its own cache on demand; the hourly cron
+  // job is gone and hitting the old action must say so instead of silently
+  // doing nothing.
+  test("community-refresh is no longer a known action", async () => {
+    const response = (await action(cronRequest("community-refresh") as never)) as Response;
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error).toContain("Unknown cron action: community-refresh");
+    expect(body.error).toContain("recompute-ratings");
+  });
+
+  // Cron endpoints are only reachable by the GitHub Actions curl; anything
+  // else is rejected before any job runs.
+  test("rejects requests without the GitHub Actions user agent", async () => {
+    const response = (await action(cronRequest("recompute-ratings", "Mozilla/5.0") as never)) as Response;
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/apps/web/app/routes/api/cron/$action.tsx
+++ b/apps/web/app/routes/api/cron/$action.tsx
@@ -10,71 +10,6 @@ interface CronJobResult {
   timestamp: string;
 }
 
-async function refreshCommunityCache(): Promise<CronJobResult> {
-  const startTime = Date.now();
-
-  try {
-    logger.info("Starting community cache refresh...");
-
-    // Clear existing cache
-    const redis = services.redis;
-    await redis.del("community-page-data");
-
-    // Fetch fresh data (same logic as community route loader)
-    const [allUserStats, communityTotals, topReviewers, topAttenders, topRaters, topBloggers] = await Promise.all([
-      services.users.getUserStats(),
-      services.users.getCommunityTotals(),
-      services.users.getTopUsersByMetric("reviews", 5),
-      services.users.getTopUsersByMetric("attendance", 5),
-      services.users.getTopUsersByMetric("ratings", 5),
-      services.users.getTopUsersByMetric("blogPostCount", 5),
-    ]);
-
-    const result = {
-      allUserStats: allUserStats, // Show all users, no limit
-      topReviewers,
-      topAttenders,
-      topRaters,
-      topBloggers,
-      communityTotals,
-      lastUpdated: new Date().toISOString(),
-    };
-
-    // Debug: Log a sample user to see the structure
-    if (allUserStats.length > 0) {
-      logger.info("COMMUNITY_SCORE_DEBUG", { communityScore: allUserStats[0].communityScore });
-      logger.info("BADGES_DEBUG", { badges: allUserStats[0].badges });
-      logger.info("REVIEW_COUNT_DEBUG", { reviewCount: allUserStats[0].reviewCount });
-    }
-
-    // Cache the fresh data (no expiration - refreshed by cron)
-    await redis.set("community-page-data", result);
-
-    // Store last execution timestamp separately
-    await redis.set("community-last-updated", new Date().toISOString());
-
-    const duration = Date.now() - startTime;
-    logger.info(`Community cache refreshed successfully in ${duration}ms`);
-
-    return {
-      success: true,
-      message: `Community cache refreshed successfully. Cached ${allUserStats.length} user stats.`,
-      duration,
-      timestamp: new Date().toISOString(),
-    };
-  } catch (error) {
-    const duration = Date.now() - startTime;
-    logger.error("Failed to refresh community cache", { error });
-
-    return {
-      success: false,
-      message: `Failed to refresh community cache: ${error instanceof Error ? error.message : "Unknown error"}`,
-      duration,
-      timestamp: new Date().toISOString(),
-    };
-  }
-}
-
 /**
  * Hourly full rating recompute (and deploy-time backfill via the same routine).
  * Gated by the `ratings.recompute-enabled` flag, then dirty-gated internally so it
@@ -118,9 +53,9 @@ async function recomputeRatings(): Promise<CronJobResult> {
   }
 }
 
-// Map of available cron jobs
+// Map of available cron jobs. The community page builds its own cache on
+// demand (see ~/server/community-page), so no cron warms it anymore.
 const cronJobs: Record<string, () => Promise<CronJobResult>> = {
-  "community-refresh": refreshCommunityCache,
   "recompute-ratings": recomputeRatings,
 };
 

--- a/apps/web/app/routes/community.tsx
+++ b/apps/web/app/routes/community.tsx
@@ -9,78 +9,11 @@ import { Input } from "~/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
-import { logger } from "~/lib/logger";
-import { services } from "~/server/services";
+import { type CommunityPageData, getCommunityPageData } from "~/server/community-page";
 
-interface LoaderData {
-  allUserStats: UserStats[];
-  topReviewers: UserStats[];
-  topAttenders: UserStats[];
-  topRaters: UserStats[];
-  topBloggers: UserStats[];
-  communityTotals: {
-    totalUsers: number;
-    totalReviews: number;
-    totalAttendances: number;
-    totalRatings: number;
-  };
-  lastUpdated?: string;
-}
+type LoaderData = CommunityPageData;
 
-export const loader = publicLoader<LoaderData>(async () => {
-  const cacheKey = "community-page-data";
-
-  // Always try to get from cache first
-  try {
-    const redis = services.redis;
-    const [cached, lastUpdated] = await Promise.all([
-      redis.get<Omit<LoaderData, "lastUpdated">>(cacheKey),
-      redis.get<string>("community-last-updated"),
-    ]);
-
-    if (cached) {
-      logger.info("Community data served from Redis cache");
-      // Debug: Log a sample user to see what we got from cache
-      if (cached.allUserStats && cached.allUserStats.length > 0) {
-        logger.info("Sample cached user stats", { userStats: cached.allUserStats[0] });
-      }
-      return {
-        ...cached,
-        lastUpdated: lastUpdated || undefined,
-      };
-    }
-  } catch (error) {
-    logger.error("Redis cache read failed for community page", { error });
-  }
-
-  // If no cache exists, return minimal fallback data
-  // The cron job should populate the cache soon
-  logger.warn("No community cache found - returning minimal fallback data");
-
-  // Still try to get the last updated timestamp even without cached data
-  let lastUpdated: string | undefined;
-  try {
-    const redis = services.redis;
-    lastUpdated = (await redis.get<string>("community-last-updated")) || undefined;
-  } catch (error) {
-    logger.error("Failed to get last updated timestamp", { error });
-  }
-
-  return {
-    allUserStats: [],
-    topReviewers: [],
-    topAttenders: [],
-    topRaters: [],
-    topBloggers: [],
-    communityTotals: {
-      totalUsers: 0,
-      totalReviews: 0,
-      totalAttendances: 0,
-      totalRatings: 0,
-    },
-    lastUpdated,
-  };
-});
+export const loader = publicLoader<LoaderData>(async () => getCommunityPageData());
 
 export function meta() {
   return [
@@ -89,6 +22,9 @@ export function meta() {
       name: "description",
       content: "Meet the Disco Biscuits community - our most active reviewers, show-goers, and contributors.",
     },
+    // Nothing links here in normal navigation; keep crawlers from indexing it
+    // so search engines stop sending bots back to rebuild the cache.
+    { name: "robots", content: "noindex" },
   ];
 }
 

--- a/apps/web/app/server/community-page.test.ts
+++ b/apps/web/app/server/community-page.test.ts
@@ -1,0 +1,84 @@
+import type { UserStats } from "@bip/core";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const getUserStats = vi.fn();
+const getCommunityTotals = vi.fn();
+const getOrSet = vi.fn();
+const redisDel = vi.fn();
+
+vi.mock("~/server/services", () => ({
+  services: {
+    cache: { getOrSet: (...args: unknown[]) => getOrSet(...args) },
+    redis: { del: (...args: unknown[]) => redisDel(...args) },
+    users: {
+      getUserStats: (...args: unknown[]) => getUserStats(...args),
+      getCommunityTotals: (...args: unknown[]) => getCommunityTotals(...args),
+    },
+  },
+}));
+
+const { COMMUNITY_PAGE_CACHE_TTL_SECONDS, getCommunityPageData } = await import("./community-page");
+
+function makeStats(username: string, counts: Partial<UserStats>): UserStats {
+  return {
+    user: { username } as UserStats["user"],
+    reviewCount: 0,
+    attendanceCount: 0,
+    ratingCount: 0,
+    averageRating: null,
+    badges: [],
+    communityScore: 0,
+    blogPostCount: 0,
+    ...counts,
+  } as UserStats;
+}
+
+describe("getCommunityPageData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Pass-through cache: exercise the builder, capture the getOrSet wiring.
+    getOrSet.mockImplementation(async (_key: string, fetcher: () => Promise<unknown>) => fetcher());
+    getCommunityTotals.mockResolvedValue({ totalUsers: 2, totalReviews: 9, totalAttendances: 4, totalRatings: 7 });
+    getUserStats.mockResolvedValue([
+      makeStats("magner", { reviewCount: 3, attendanceCount: 1, ratingCount: 5, blogPostCount: 2 }),
+      makeStats("barber", { reviewCount: 8, attendanceCount: 0, ratingCount: 1, blogPostCount: 0 }),
+    ]);
+  });
+
+  // The page has no hourly cron anymore: the first visitor inside a TTL
+  // window pays one stats pass and everyone else reads the cached payload.
+  test("builds through the cache with a TTL on a versioned key", async () => {
+    await getCommunityPageData();
+
+    expect(getOrSet).toHaveBeenCalledTimes(1);
+    const [key, , options] = getOrSet.mock.calls[0];
+    expect(key).toBe("community-page-data:v2");
+    expect(options).toEqual({ ttl: COMMUNITY_PAGE_CACHE_TTL_SECONDS });
+  });
+
+  // One stats pass feeds the full user list and all four leaderboards, and
+  // the build stamps its own lastUpdated so the page can show freshness
+  // without a second Redis key.
+  test("derives the four leaderboards from a single stats pass", async () => {
+    const data = await getCommunityPageData();
+
+    expect(getUserStats).toHaveBeenCalledTimes(1);
+    expect(data.allUserStats).toHaveLength(2);
+    expect(data.topReviewers.map((s) => s.user.username)).toEqual(["barber", "magner"]);
+    expect(data.topAttenders.map((s) => s.user.username)).toEqual(["magner"]);
+    expect(data.topRaters.map((s) => s.user.username)).toEqual(["magner", "barber"]);
+    expect(data.topBloggers.map((s) => s.user.username)).toEqual(["magner"]);
+    expect(data.communityTotals.totalUsers).toBe(2);
+    expect(new Date(data.lastUpdated).getTime()).not.toBeNaN();
+  });
+
+  // The retired hourly cron left a TTL-less ~786KB key (plus its timestamp
+  // sibling) in prod Redis; each rebuild clears them so they don't sit there
+  // forever.
+  test("deletes the legacy cron-era cache keys on rebuild", async () => {
+    await getCommunityPageData();
+
+    expect(redisDel).toHaveBeenCalledWith("community-page-data");
+    expect(redisDel).toHaveBeenCalledWith("community-last-updated");
+  });
+});

--- a/apps/web/app/server/community-page.ts
+++ b/apps/web/app/server/community-page.ts
@@ -1,0 +1,61 @@
+import { topUsersByMetric, type UserStats } from "@bip/core";
+import { services } from "~/server/services";
+
+const CACHE_KEY = "community-page-data:v2";
+
+/**
+ * The community page is not linked from anywhere in normal navigation, so the
+ * key is absent from Redis most of the time; an hour bounds how often the
+ * all-users stats pass (~260ms) can run when something is hitting the page.
+ */
+export const COMMUNITY_PAGE_CACHE_TTL_SECONDS = 60 * 60;
+
+/** Cache keys written by the retired hourly community-refresh cron. The main
+ * one is ~786KB with no TTL, so it never expires on its own. */
+const LEGACY_CACHE_KEYS = ["community-page-data", "community-last-updated"];
+
+export interface CommunityPageData {
+  allUserStats: UserStats[];
+  topReviewers: UserStats[];
+  topAttenders: UserStats[];
+  topRaters: UserStats[];
+  topBloggers: UserStats[];
+  communityTotals: {
+    totalUsers: number;
+    totalReviews: number;
+    totalAttendances: number;
+    totalRatings: number;
+  };
+  lastUpdated: string;
+}
+
+/**
+ * Community-page payload, built on demand and cached for an hour. Replaces
+ * the hourly community-refresh cron, which rebuilt this 24 times a day
+ * whether or not anyone visited. The first request inside a TTL window pays
+ * one all-users stats pass; every other request reads Redis.
+ */
+export async function getCommunityPageData(): Promise<CommunityPageData> {
+  return services.cache.getOrSet<CommunityPageData>(CACHE_KEY, buildCommunityPageData, {
+    ttl: COMMUNITY_PAGE_CACHE_TTL_SECONDS,
+  });
+}
+
+async function buildCommunityPageData(): Promise<CommunityPageData> {
+  await Promise.all(LEGACY_CACHE_KEYS.map((key) => services.redis.del(key)));
+
+  const [allUserStats, communityTotals] = await Promise.all([
+    services.users.getUserStats(),
+    services.users.getCommunityTotals(),
+  ]);
+
+  return {
+    allUserStats,
+    topReviewers: topUsersByMetric(allUserStats, "reviews", 5),
+    topAttenders: topUsersByMetric(allUserStats, "attendance", 5),
+    topRaters: topUsersByMetric(allUserStats, "ratings", 5),
+    topBloggers: topUsersByMetric(allUserStats, "blogPostCount", 5),
+    communityTotals,
+    lastUpdated: new Date().toISOString(),
+  };
+}

--- a/apps/web/app/server/latest-podcast-episode.test.ts
+++ b/apps/web/app/server/latest-podcast-episode.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const getOrSet = vi.fn();
+
+vi.mock("~/server/services", () => ({
+  services: {
+    cache: { getOrSet: (...args: unknown[]) => getOrSet(...args) },
+  },
+}));
+
+const { PODCAST_EPISODE_CACHE_TTL_SECONDS, getLatestPodcastEpisode } = await import("./latest-podcast-episode");
+
+// Trimmed slice of a real feeder.acast.com response (2026-07-14). The episode
+// carries many fields the homepage never reads (checkSum, acastSettings,
+// contentLength, ...); the fixture keeps a few of those to prove the mapper
+// drops them from the cached payload.
+const ACAST_FIXTURE = {
+  id: "d690923d-524e-5c8b-b29f-d66517615b5b",
+  count: 120,
+  episodes: [
+    {
+      id: "69b83e33a0bc40a270d6e41d",
+      title: "E120 - 2026 And Beyond (w/Marc Brownstein)",
+      subtitle: "DJ Brownie on the future of The Disco Biscuits",
+      description:
+        '<p>E120 - 2026 And Beyond - <a href="https://www.instagram.com/marcbrownstein">Marc Brownstein</a> returns to discuss The Disco Biscuits\' new lineup.</p>',
+      publishDate: "2026-03-17T19:15:09.000Z",
+      duration: 4916,
+      image:
+        "https://assets.pippa.io/shows/61b7acde1695626467e95304/1773682146361-0956c916-71ab-4ee9-be32-0a58fcca3ce2.jpeg",
+      url: "https://sphinx.acast.com/p/acast/s/touchdownsallday/e/69b83e33a0bc40a270d6e41d/media.mp3",
+      episodeUrl: "e120",
+      contentLength: 59019685,
+      checkSum: "abc123",
+    },
+  ],
+};
+
+function mockFetchResponse(body: unknown, ok = true): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok, status: ok ? 200 : 502, json: async () => body })),
+  );
+}
+
+describe("getLatestPodcastEpisode", () => {
+  beforeEach(() => {
+    // Pass-through cache: exercise the fetcher, capture the getOrSet wiring.
+    getOrSet.mockImplementation(async (_key: string, fetcher: () => Promise<unknown>) => fetcher());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  // The raw acast episode is ~15KB of fields the page never uses. Only the
+  // six rendered fields may reach the cache and the loader payload.
+  test("maps the newest episode to exactly the rendered fields", async () => {
+    mockFetchResponse(ACAST_FIXTURE);
+
+    const episode = await getLatestPodcastEpisode();
+
+    expect(episode).toEqual({
+      title: "E120 - 2026 And Beyond (w/Marc Brownstein)",
+      description: ACAST_FIXTURE.episodes[0].description,
+      publishDate: "2026-03-17T19:15:09.000Z",
+      duration: 4916,
+      image: ACAST_FIXTURE.episodes[0].image,
+      url: ACAST_FIXTURE.episodes[0].url,
+    });
+  });
+
+  // The fetch goes through the Redis cache so the homepage stops hitting
+  // acast on every request; a podcast feed does not need sub-30-minute
+  // freshness.
+  test("reads through the cache with a TTL", async () => {
+    mockFetchResponse(ACAST_FIXTURE);
+
+    await getLatestPodcastEpisode();
+
+    expect(getOrSet).toHaveBeenCalledTimes(1);
+    const [key, , options] = getOrSet.mock.calls[0];
+    expect(key).toContain("podcast");
+    expect(options).toEqual({ ttl: PODCAST_EPISODE_CACHE_TTL_SECONDS });
+  });
+
+  // Acast being down or returning junk must degrade to "no podcast card",
+  // never break the homepage.
+  test("returns null on a non-OK response", async () => {
+    mockFetchResponse({}, false);
+
+    expect(await getLatestPodcastEpisode()).toBeNull();
+  });
+
+  test("returns null when the feed has no episodes", async () => {
+    mockFetchResponse({ episodes: [] });
+
+    expect(await getLatestPodcastEpisode()).toBeNull();
+  });
+
+  test("returns null when fetch throws", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+
+    expect(await getLatestPodcastEpisode()).toBeNull();
+  });
+});

--- a/apps/web/app/server/latest-podcast-episode.ts
+++ b/apps/web/app/server/latest-podcast-episode.ts
@@ -1,0 +1,76 @@
+import { logger } from "~/lib/logger";
+import { services } from "~/server/services";
+
+/** Touchdowns All Day feed on acast; limit=1 returns only the newest episode. */
+const ACAST_FEED_URL = "https://feeder.acast.com/api/v1/shows/d690923d-524e-5c8b-b29f-d66517615b5b?limit=1&from=0";
+
+const CACHE_KEY = "home:latest-podcast-episode:v1";
+
+/** A podcast posts roughly weekly; half an hour of staleness is invisible. */
+export const PODCAST_EPISODE_CACHE_TTL_SECONDS = 60 * 30;
+
+/**
+ * The slice of an acast episode the homepage podcast card actually renders.
+ * The raw feed entry is ~15KB of extra fields (checksums, acast settings,
+ * content lengths); trimming here keeps the Redis payload and the loader
+ * data small.
+ */
+export interface AcastEpisode {
+  title: string;
+  /** HTML fragment; rendered with dangerouslySetInnerHTML, line-clamped. */
+  description: string;
+  publishDate: string;
+  /** Whole seconds. */
+  duration: number;
+  image?: string;
+  /** Direct media URL; the card's "Listen" link target. */
+  url: string;
+}
+
+/** Raw episode shape from feeder.acast.com; only the fields we map. */
+interface AcastFeedEpisode {
+  title?: string;
+  description?: string;
+  publishDate?: string;
+  duration?: number;
+  image?: string;
+  url?: string;
+}
+
+/**
+ * Newest podcast episode for the homepage card, read through Redis so the
+ * feed is fetched at most once per TTL instead of once per homepage request.
+ * Any failure (acast down, junk payload, cache error) degrades to null and
+ * the card simply doesn't render.
+ */
+export async function getLatestPodcastEpisode(): Promise<AcastEpisode | null> {
+  try {
+    return await services.cache.getOrSet<AcastEpisode | null>(CACHE_KEY, fetchLatestEpisode, {
+      ttl: PODCAST_EPISODE_CACHE_TTL_SECONDS,
+    });
+  } catch (error) {
+    logger.error("Error fetching latest podcast episode", { error });
+    return null;
+  }
+}
+
+async function fetchLatestEpisode(): Promise<AcastEpisode | null> {
+  const response = await fetch(ACAST_FEED_URL);
+  if (!response.ok) {
+    logger.error("Acast feed responded non-OK", { status: response.status });
+    return null;
+  }
+
+  const data: { episodes?: AcastFeedEpisode[] } = await response.json();
+  const episode = data.episodes?.[0];
+  if (!episode?.title || !episode.url) return null;
+
+  return {
+    title: episode.title,
+    description: episode.description ?? "",
+    publishDate: episode.publishDate ?? "",
+    duration: episode.duration ?? 0,
+    image: episode.image,
+    url: episode.url,
+  };
+}

--- a/packages/core/src/users/user-service.test.ts
+++ b/packages/core/src/users/user-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
-import { UserService } from "./user-service";
+import { topUsersByMetric, UserService, type UserStats } from "./user-service";
 
 const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
 
@@ -199,5 +199,63 @@ describe("UserService.listForSync", () => {
       OR: [{ updatedAt: { gt: cursorUpdatedAt } }, { AND: [{ updatedAt: cursorUpdatedAt }, { id: { gt: "u-uuid" } }] }],
     });
     expect(findMany.mock.calls[0][0].orderBy).toEqual([{ updatedAt: "asc" }, { id: "asc" }]);
+  });
+});
+
+/** Minimal UserStats fixture; only the count fields matter to the ranking. */
+function makeStats(
+  username: string,
+  counts: Partial<Pick<UserStats, "reviewCount" | "attendanceCount" | "ratingCount" | "blogPostCount">>,
+): UserStats {
+  return {
+    user: { username } as UserStats["user"],
+    reviewCount: 0,
+    attendanceCount: 0,
+    ratingCount: 0,
+    averageRating: null,
+    badges: [],
+    communityScore: 0,
+    blogPostCount: 0,
+    ...counts,
+  };
+}
+
+describe("topUsersByMetric", () => {
+  // The community page build derives all four leaderboards from ONE
+  // getUserStats() pass. The ranking itself is pure: drop users with a zero
+  // count for the metric, sort by that count descending, cap at the limit.
+  test("filters zero-count users, sorts descending, and applies the limit", () => {
+    const stats = [
+      makeStats("magner", { reviewCount: 2 }),
+      makeStats("barber", { reviewCount: 9 }),
+      makeStats("brownie", { reviewCount: 0 }),
+      makeStats("allen", { reviewCount: 5 }),
+    ];
+
+    const top = topUsersByMetric(stats, "reviews", 2);
+
+    expect(top.map((s) => s.user.username)).toEqual(["barber", "allen"]);
+  });
+
+  // Each metric must rank by its own count; a heavy reviewer with zero blog
+  // posts belongs on the reviews board and not the bloggers board.
+  test("ranks by the requested metric only", () => {
+    const stats = [
+      makeStats("magner", { reviewCount: 50, blogPostCount: 0 }),
+      makeStats("barber", { reviewCount: 1, blogPostCount: 3 }),
+    ];
+
+    expect(topUsersByMetric(stats, "blogPostCount", 5).map((s) => s.user.username)).toEqual(["barber"]);
+    expect(topUsersByMetric(stats, "attendance", 5)).toEqual([]);
+  });
+
+  // The ranking must not reorder the caller's array in place; the page build
+  // reuses the same stats array for four metrics and for the full user list.
+  test("does not mutate the input array", () => {
+    const stats = [makeStats("magner", { ratingCount: 1 }), makeStats("barber", { ratingCount: 7 })];
+
+    topUsersByMetric(stats, "ratings", 5);
+
+    expect(stats.map((s) => s.user.username)).toEqual(["magner", "barber"]);
   });
 });

--- a/packages/core/src/users/user-service.ts
+++ b/packages/core/src/users/user-service.ts
@@ -22,6 +22,30 @@ export interface UserStats {
   blogPostCount: number;
 }
 
+export type UserStatsMetric = "reviews" | "attendance" | "ratings" | "blogPostCount";
+
+const METRIC_COUNT: Record<UserStatsMetric, (stats: UserStats) => number> = {
+  reviews: (stats) => stats.reviewCount,
+  attendance: (stats) => stats.attendanceCount,
+  ratings: (stats) => stats.ratingCount,
+  blogPostCount: (stats) => stats.blogPostCount,
+};
+
+/**
+ * Rank already-loaded user stats by one activity metric. Pure so the
+ * community page build can derive every leaderboard from a single
+ * getUserStats() pass instead of re-querying per metric. Users with a zero
+ * count for the metric are dropped, not ranked last. Does not mutate the
+ * input.
+ */
+export function topUsersByMetric(userStats: UserStats[], metric: UserStatsMetric, limit: number): UserStats[] {
+  const count = METRIC_COUNT[metric];
+  return userStats
+    .filter((stats) => count(stats) > 0)
+    .sort((a, b) => count(b) - count(a))
+    .slice(0, limit);
+}
+
 // Mapper functions
 function mapUserToDomainEntity(dbUser: DbUser): User {
   return {
@@ -385,14 +409,6 @@ export class UserService {
         user._count.blogPosts,
       );
 
-      // Debug: Check if methods are returning undefined
-      this.logger.info("User stats calculated", {
-        username: user.username,
-        badges,
-        communityScore,
-        blogPostCount: user._count.blogPosts,
-      });
-
       return {
         user: mapUserToDomainEntity(user),
         reviewCount: user._count.reviews,
@@ -404,67 +420,6 @@ export class UserService {
         blogPostCount: user._count.blogPosts,
       };
     });
-  }
-
-  async getTopUsersByMetric(
-    metric: "reviews" | "attendance" | "ratings" | "blogPostCount",
-    limit: number = 10,
-  ): Promise<UserStats[]> {
-    const userStats = await this.getUserStats();
-
-    // Filter out users with 0 count for the specific metric
-    const filteredStats = userStats.filter((stats) => {
-      switch (metric) {
-        case "reviews":
-          return stats.reviewCount > 0;
-        case "attendance":
-          return stats.attendanceCount > 0;
-        case "ratings":
-          return stats.ratingCount > 0;
-        case "blogPostCount": {
-          const hasBlogs = stats.blogPostCount > 0;
-          this.logger.info("Checking blogPostCount filter", {
-            username: stats.user.username,
-            blogPostCount: stats.blogPostCount,
-            hasBlogs,
-          });
-          return hasBlogs;
-        }
-        default:
-          return true;
-      }
-    });
-
-    this.logger.info("Metric filter applied", {
-      metric,
-      totalUsers: userStats.length,
-      filteredUsers: filteredStats.length,
-    });
-
-    if (metric === "blogPostCount") {
-      this.logger.info("Top bloggers after filter", {
-        topBloggers: filteredStats
-          .slice(0, 3)
-          .map((s) => ({ username: s.user.username, blogPostCount: s.blogPostCount })),
-      });
-    }
-
-    const sortedStats = filteredStats.sort((a, b) => {
-      switch (metric) {
-        case "reviews":
-          return b.reviewCount - a.reviewCount;
-        case "attendance":
-          return b.attendanceCount - a.attendanceCount;
-        case "ratings":
-          return b.ratingCount - a.ratingCount;
-        case "blogPostCount":
-          return b.blogPostCount - a.blogPostCount;
-        default:
-          return 0;
-      }
-    });
-
-    return sortedStats.slice(0, limit);
   }
 
   /**


### PR DESCRIPTION
Follow-up to #206. The /community page turned out to be linked from nowhere
except the 404 page (mislabeled "let us know"), yet an hourly cron rebuilt
its 786KB TTL-less Redis payload 24 times a day. This makes the page pay its
own way and cleans up the other loader waste found during the OOM
investigation. Pages render identically.

- /community now builds its payload on first visit and caches it for an hour,
  so the key is absent from Redis most of the time and a crawler burst costs
  at most one ~260ms build per hour. The hourly community-refresh cron job,
  its GitHub workflow leg, and the manual dispatch option are deleted (the
  hourly schedule still drives the dirty-gated ratings recompute). Rebuilds
  also delete the legacy cron-era keys, which never expired on their own.

- One getUserStats() pass feeds the full user list and all four top-5
  leaderboards (new pure `topUsersByMetric` in core). The old per-metric
  method re-ran the full stats query each call, so the cron did five
  concurrent passes over all ~1,400 users and ~58k ratings. Per-user debug
  logging (~7k lines per run) is gone too.

- The page gets a robots noindex meta tag, and the 404 page's "let us know"
  now opens the contact dialog (same as the footer's Contact) instead of
  linking to /community. That link was both a content bug and the only path
  by which crawlers kept discovering the page.

- Homepage: the Acast podcast feed is fetched through Redis (30 min TTL)
  instead of per request, trimmed to the six fields the card renders; and a
  double `getTourDates()` await is now one call.

Verified against the local prod restore: /community cold-builds and renders
all leaderboards with `community-page-data:v2` at TTL ~3600 and both legacy
keys deleted; the page HTML carries `robots: noindex`; the 404 page's
"let us know" opens the contact dialog; `POST /api/cron/community-refresh`
returns 404 listing recompute-ratings as the only action; the homepage
podcast card renders from the cached, trimmed payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
