### PR TITLE
Slim and memoize the homepage setlist cache; add stop-builder ops action

### DIFF
--- a/.github/workflows/ops.yml
+++ b/.github/workflows/ops.yml
@@ -13,6 +13,7 @@ on:
           - memory-timeline
           - restart-redis
           - prune-docker
+          - stop-builder
 
 concurrency:
   group: deploy-web-app
@@ -167,6 +168,25 @@ jobs:
       - name: Prune unused Docker data
         if: inputs.action == 'prune-docker'
         run: kamal server exec 'docker system prune -af'
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
+      # The co-located coaching-tree app deploys via a Kamal remote builder,
+      # which leaves its buildx builder container running (and holding
+      # ~645MiB) between deploys. Stopping it is safe: buildx bootstraps a
+      # fresh builder on the next remote build, and the running app container
+      # is untouched.
+      - name: Stop idle buildx builder containers
+        if: inputs.action == 'stop-builder'
+        run: kamal server exec 'docker ps -q --filter name=buildx_buildkit | xargs -r docker stop'
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
+      - name: Memory after builder stop
+        if: inputs.action == 'stop-builder'
+        run: |
+          kamal server exec 'docker stats --no-stream'
+          kamal server exec 'free -h'
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 

--- a/apps/web/app/routes/_index.tsx
+++ b/apps/web/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import { type BlogPostWithUser, CacheKeys, type Setlist, type TourDate } from "@bip/domain";
+import { type BlogPostWithUser, CacheKeys, type SetlistLight, type TourDate } from "@bip/domain";
 import type { DehydratedState } from "@tanstack/react-query";
 import { Calendar } from "lucide-react";
 import { Link } from "react-router-dom";
@@ -21,12 +21,12 @@ import { computeShowUserData } from "~/server/show-user-data";
 
 interface LoaderData {
   tourDates: TourDate[];
-  mobileRecentShows: Setlist[];
-  desktopRecentShows: Setlist[];
+  mobileRecentShows: SetlistLight[];
+  desktopRecentShows: SetlistLight[];
   recentBlogPosts: Array<BlogPostWithUser>;
   latestEpisode: AcastEpisode | null;
   nextTourDate: TourDate | null;
-  recentShows: Setlist[];
+  recentShows: SetlistLight[];
   onThisDayCounts: { showCount: number; allTimerCount: number };
   externalSources: Record<string, ShowExternalSources>;
   dehydratedState: DehydratedState;
@@ -44,14 +44,23 @@ export const loader = publicLoader<LoaderData>(async ({ context }) => {
   const threeDaysAgo = new Date();
   threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
 
-  // Cache the recent setlists (core show data only - user-specific data handled separately)
-  const recentSetlists = await services.cache.getOrSet(CacheKeys.home.recentSetlists(15), async () => {
-    logger.info("Loading recent setlists from DB for home page");
-    return await services.setlists.findMany({
-      pagination: { limit: 15 },
-      sort: [{ field: "date", direction: "desc" }],
-    });
-  });
+  // Cache the recent setlists (core show data only - user-specific data
+  // handled separately). Light payload: the cards use none of the full
+  // Track/song weight (lyrics, histories), and this key is read on every
+  // homepage request, so it must stay small. The memo skips re-parsing it
+  // per request; admin setlist edits still show immediately (invalidation
+  // clears the memo).
+  const recentSetlists = await services.cache.getOrSet(
+    CacheKeys.home.recentSetlists(15),
+    async () => {
+      logger.info("Loading recent setlists from DB for home page");
+      return await services.setlists.findManyLight({
+        pagination: { limit: 15 },
+        sort: [{ field: "date", direction: "desc" }],
+      });
+    },
+    { memoTtlSeconds: 300 },
+  );
 
   logger.info(`Home page setlists loaded: ${recentSetlists.length} shows`);
 

--- a/packages/core/src/_shared/cache/cache-service.test.ts
+++ b/packages/core/src/_shared/cache/cache-service.test.ts
@@ -1,0 +1,156 @@
+import type { Logger } from "@bip/domain";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { RedisService } from "../redis";
+import { CacheService } from "./cache-service";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as unknown as Logger;
+
+function makeRedisMock() {
+  const store = new Map<string, unknown>();
+  return {
+    get: vi.fn(async <T>(key: string): Promise<T | null> => (store.has(key) ? (store.get(key) as T) : null)),
+    set: vi.fn(async <T>(key: string, value: T): Promise<void> => {
+      store.set(key, value);
+    }),
+    del: vi.fn(async (key: string): Promise<void> => {
+      store.delete(key);
+    }),
+    delPattern: vi.fn(async (pattern: string): Promise<number> => {
+      // Mirror Redis KEYS glob semantics (* matches any run of characters).
+      const regex = new RegExp(`^${pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*")}$`);
+      let deleted = 0;
+      for (const key of [...store.keys()]) {
+        if (regex.test(key)) {
+          store.delete(key);
+          deleted++;
+        }
+      }
+      return deleted;
+    }),
+    __store: store,
+  } as unknown as RedisService & { __store: Map<string, unknown> };
+}
+
+describe("CacheService in-process memo", () => {
+  let redis: ReturnType<typeof makeRedisMock>;
+  let cache: CacheService;
+
+  beforeEach(() => {
+    redis = makeRedisMock();
+    cache = new CacheService(redis, logger);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Multi-hundred-KB payloads (the homepage setlists) get JSON.parsed out of
+  // Redis on every request; a memoized getOrSet pays that once per window.
+  test("getOrSet with memoTtlSeconds serves repeat calls without touching Redis", async () => {
+    const fetcher = vi.fn(async () => ({ opener: "Helicopters" }));
+
+    const first = await cache.getOrSet("home:test", fetcher, { ttl: 60, memoTtlSeconds: 300 });
+    const second = await cache.getOrSet("home:test", fetcher, { ttl: 60, memoTtlSeconds: 300 });
+
+    expect(first).toEqual({ opener: "Helicopters" });
+    expect(second).toBe(first);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(redis.get).toHaveBeenCalledTimes(1);
+  });
+
+  // Without the option, getOrSet behaves exactly as before: every call reads
+  // Redis. Existing callers must see zero behavior change.
+  test("getOrSet without memoTtlSeconds reads Redis every call", async () => {
+    const fetcher = vi.fn(async () => "value");
+
+    await cache.getOrSet("home:test", fetcher, { ttl: 60 });
+    await cache.getOrSet("home:test", fetcher, { ttl: 60 });
+
+    expect(redis.get).toHaveBeenCalledTimes(2);
+  });
+
+  // The memo TTL backstops deletes that bypass the app (redis-cli surgery
+  // like `make clear-show-cache`): after expiry the next call re-reads Redis.
+  test("memo expires after its TTL and re-reads Redis", async () => {
+    const fetcher = vi.fn(async () => "value");
+    const nowSpy = vi.spyOn(Date, "now");
+
+    nowSpy.mockReturnValue(1_000_000);
+    await cache.getOrSet("home:test", fetcher, { memoTtlSeconds: 300 });
+    nowSpy.mockReturnValue(1_000_000 + 300 * 1000 + 1);
+    await cache.getOrSet("home:test", fetcher, { memoTtlSeconds: 300 });
+
+    expect(redis.get).toHaveBeenCalledTimes(2);
+  });
+
+  // Cache invalidation flows through del/delPattern; both must drop the memo
+  // so an admin edit is visible on the very next request, not after the TTL.
+  test("del clears the memo entry", async () => {
+    const fetcher = vi.fn(async () => "stale");
+    await cache.getOrSet("home:test", fetcher, { memoTtlSeconds: 300 });
+
+    await cache.del("home:test");
+    const fresh = await cache.getOrSet("home:test", async () => "fresh", { memoTtlSeconds: 300 });
+
+    expect(fresh).toBe("fresh");
+  });
+
+  test("delPattern clears matching memo entries and spares the rest", async () => {
+    await cache.getOrSet("home:recent", async () => "home-v1", { memoTtlSeconds: 300 });
+    await cache.getOrSet("shows:list", async () => "shows-v1", { memoTtlSeconds: 300 });
+
+    await cache.delPattern("home:*");
+    const home = await cache.getOrSet("home:recent", async () => "home-v2", { memoTtlSeconds: 300 });
+    const shows = await cache.getOrSet("shows:list", async () => "shows-v2", { memoTtlSeconds: 300 });
+
+    expect(home).toBe("home-v2");
+    expect(shows).toBe("shows-v1");
+  });
+
+  // Several invalidation patterns carry mid-string wildcards
+  // (show:*:data:*, user:*:song-history); the memo must match them like
+  // Redis does, not just trailing-star prefixes.
+  test("delPattern with mid-pattern wildcards clears matching memo entries", async () => {
+    await cache.getOrSet("show:aceetobee:data:v14", async () => "old", { memoTtlSeconds: 300 });
+    await cache.getOrSet("show-unrelated", async () => "keep", { memoTtlSeconds: 300 });
+
+    await cache.delPattern("show:*:data:*");
+    const show = await cache.getOrSet("show:aceetobee:data:v14", async () => "new", { memoTtlSeconds: 300 });
+    const unrelated = await cache.getOrSet("show-unrelated", async () => "clobbered", { memoTtlSeconds: 300 });
+
+    expect(show).toBe("new");
+    expect(unrelated).toBe("keep");
+  });
+
+  // A direct set() through the service must not leave a stale memo behind.
+  test("set clears the memo entry so the next read sees the new value", async () => {
+    await cache.getOrSet("home:test", async () => "old", { memoTtlSeconds: 300 });
+
+    await cache.set("home:test", "new", { ttl: 60 });
+    const value = await cache.getOrSet("home:test", async () => "unused", { memoTtlSeconds: 300 });
+
+    expect(value).toBe("new");
+  });
+
+  // The memoized object is shared by every request in the window; a mutating
+  // caller must throw at the mutation site instead of corrupting the others.
+  test("memoized values are deeply frozen", async () => {
+    const value = await cache.getOrSet("home:test", async () => ({ sets: [{ label: "S1" }] }), {
+      memoTtlSeconds: 300,
+    });
+
+    expect(Object.isFrozen(value)).toBe(true);
+    expect(Object.isFrozen(value.sets[0])).toBe(true);
+  });
+
+  // getOrSet treats null as a miss (it refetches next call), so memoizing a
+  // null would change semantics; it must not be remembered.
+  test("null fetcher results are not memoized", async () => {
+    const fetcher = vi.fn(async () => null);
+
+    await cache.getOrSet("home:test", fetcher, { memoTtlSeconds: 300 });
+    await cache.getOrSet("home:test", fetcher, { memoTtlSeconds: 300 });
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/_shared/cache/cache-service.ts
+++ b/packages/core/src/_shared/cache/cache-service.ts
@@ -1,18 +1,48 @@
 import type { Logger } from "@bip/domain";
+import { deepFreeze } from "../deep-freeze";
 import type { RedisService } from "../redis";
 
 export interface CacheOptions {
   /** TTL in seconds. Defaults to 86400 (24 hours) */
   ttl?: number;
+  /**
+   * Also keep the parsed value in process memory for this many seconds, so
+   * repeat getOrSet calls skip the Redis read AND the JSON.parse. Use for
+   * hot, multi-hundred-KB payloads (e.g. the homepage setlists) where the
+   * per-request parse is real allocation pressure.
+   *
+   * Coherence: del/delPattern/set drop matching memo entries, so app-driven
+   * invalidation is visible on the next request (prod runs a single process,
+   * so the invalidating request and every reader share this memory). The TTL
+   * only bounds staleness from deletes that bypass the app entirely
+   * (redis-cli surgery like `make clear-show-cache`). Memoized values are
+   * deep-frozen because every request in the window shares the same object.
+   */
+  memoTtlSeconds?: number;
 }
 
 export class CacheService {
   private readonly DEFAULT_TTL = 86400; // 24 hours
+  private readonly memo = new Map<string, { value: unknown; expiresAt: number }>();
 
   constructor(
     private readonly redis: RedisService,
     private readonly logger: Logger,
   ) {}
+
+  private memoGet<T>(key: string): T | null {
+    const entry = this.memo.get(key);
+    if (!entry) return null;
+    if (Date.now() >= entry.expiresAt) {
+      this.memo.delete(key);
+      return null;
+    }
+    return entry.value as T;
+  }
+
+  private memoSet<T>(key: string, value: T, ttlSeconds: number): void {
+    this.memo.set(key, { value: deepFreeze(value), expiresAt: Date.now() + ttlSeconds * 1000 });
+  }
 
   async get<T>(key: string): Promise<T | null> {
     try {
@@ -32,6 +62,7 @@ export class CacheService {
   }
 
   async set<T>(key: string, value: T, options?: CacheOptions): Promise<void> {
+    this.memo.delete(key);
     try {
       const ttl = options?.ttl ?? this.DEFAULT_TTL;
       await this.redis.set(key, value, { EX: ttl });
@@ -45,6 +76,7 @@ export class CacheService {
   }
 
   async del(key: string): Promise<void> {
+    this.memo.delete(key);
     try {
       await this.redis.del(key);
       this.logger.debug(`Cache delete: ${key}`);
@@ -56,6 +88,14 @@ export class CacheService {
   }
 
   async delPattern(pattern: string): Promise<number> {
+    // Drop memo entries with the same glob semantics Redis applies to its
+    // keys (`*` matches any run of characters, including mid-pattern as in
+    // show:*:data:*), so a memoized key can never survive an invalidation
+    // that removed its Redis twin.
+    const regex = new RegExp(`^${pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*")}$`);
+    for (const key of [...this.memo.keys()]) {
+      if (regex.test(key)) this.memo.delete(key);
+    }
     try {
       const deletedCount = await this.redis.delPattern(pattern);
       this.logger.debug(`Cache pattern delete: ${pattern} (${deletedCount} keys)`);
@@ -83,13 +123,23 @@ export class CacheService {
    * Cache-aside pattern helper. Gets value from cache, or executes fetcher and caches result.
    */
   async getOrSet<T>(key: string, fetcher: () => Promise<T>, options?: CacheOptions): Promise<T> {
+    const memoTtlSeconds = options?.memoTtlSeconds;
+    if (memoTtlSeconds) {
+      const memoized = this.memoGet<T>(key);
+      if (memoized !== null) return memoized;
+    }
+
     const cached = await this.get<T>(key);
     if (cached !== null) {
+      if (memoTtlSeconds) this.memoSet(key, cached, memoTtlSeconds);
       return cached;
     }
 
     const value = await fetcher();
     await this.set(key, value, options);
+    // After set() (which drops any memo entry), so the memo holds the value
+    // just written. Null is a getOrSet miss by contract; never memoize it.
+    if (memoTtlSeconds && value !== null) this.memoSet(key, value, memoTtlSeconds);
     return value;
   }
 }

--- a/packages/core/src/_shared/catalog/date-indexed-catalog.ts
+++ b/packages/core/src/_shared/catalog/date-indexed-catalog.ts
@@ -1,4 +1,5 @@
 import type { Logger } from "@bip/domain";
+import { deepFreeze } from "../deep-freeze";
 import type { RedisService } from "../redis";
 
 /**
@@ -16,22 +17,6 @@ export const CATALOG_TTL_SECONDS = 60 * 60 * 24;
  * window. Minutes-scale so a catalog refreshed in Redis is picked up promptly.
  */
 export const MEMO_TTL_SECONDS = 60 * 5;
-
-/**
- * Recursively freeze a parsed catalog map. The memo hands the same object to
- * every request for the memo window, so an accidental mutation by one caller
- * would silently corrupt what all other requests see; freezing makes it throw
- * at the mutation site instead. Values are plain JSON (no cycles).
- */
-function deepFreeze<T>(value: T): T {
-  if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
-    Object.freeze(value);
-    for (const key of Object.keys(value)) {
-      deepFreeze((value as Record<string, unknown>)[key]);
-    }
-  }
-  return value;
-}
 
 /**
  * Shared caching layer for external catalogs that are small enough to fetch in

--- a/packages/core/src/_shared/deep-freeze.test.ts
+++ b/packages/core/src/_shared/deep-freeze.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import { deepFreeze } from "./deep-freeze";
+
+describe("deepFreeze", () => {
+  // The whole point over Object.freeze: a memoized payload's nested arrays
+  // and objects (sets, tracks) must also reject mutation, not just the root.
+  test("freezes nested objects and arrays so mutation throws at any depth", () => {
+    const value = deepFreeze({
+      show: { date: "1999-12-31" },
+      sets: [{ label: "S1", tracks: [{ title: "Munchkin Invasion" }] }],
+    });
+
+    expect(Object.isFrozen(value)).toBe(true);
+    expect(Object.isFrozen(value.sets)).toBe(true);
+    expect(Object.isFrozen(value.sets[0].tracks[0])).toBe(true);
+    expect(() => {
+      (value.show as { date: string }).date = "2000-01-01";
+    }).toThrow(TypeError);
+    expect(() => {
+      (value.sets as unknown[]).push({ label: "E" });
+    }).toThrow(TypeError);
+  });
+
+  // Callers memoize the return value directly, so it must be the same
+  // reference, not a frozen copy.
+  test("returns the same reference it was given", () => {
+    const value = { sets: [] };
+
+    expect(deepFreeze(value)).toBe(value);
+  });
+
+  // Leaf values inside JSON payloads (strings, numbers, null) reach the
+  // recursion; they must pass through without error.
+  test("passes primitives and null through unchanged", () => {
+    expect(deepFreeze(null)).toBeNull();
+    expect(deepFreeze(42)).toBe(42);
+    expect(deepFreeze("Aceetobee")).toBe("Aceetobee");
+  });
+
+  // Re-freezing (e.g. a memo refresh handing back the same object) must be
+  // a harmless no-op, not an error.
+  test("is idempotent on an already-frozen value", () => {
+    const value = deepFreeze({ sets: [{ label: "S1" }] });
+
+    expect(deepFreeze(value)).toBe(value);
+    expect(Object.isFrozen(value.sets[0])).toBe(true);
+  });
+});

--- a/packages/core/src/_shared/deep-freeze.ts
+++ b/packages/core/src/_shared/deep-freeze.ts
@@ -1,0 +1,15 @@
+/**
+ * Recursively freeze a value that an in-process memo will hand to every
+ * request for its lifetime. An accidental mutation by one caller would
+ * silently corrupt what all other requests see; freezing makes it throw at
+ * the mutation site instead. Callers pass plain JSON-shaped data (no cycles).
+ */
+export function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const key of Object.keys(value)) {
+      deepFreeze((value as Record<string, unknown>)[key]);
+    }
+  }
+  return value;
+}

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -177,7 +177,7 @@ export const CacheKeys = {
    */
   home: {
     /** Recent setlists for home page (limit + sort direction) */
-    recentSetlists: (limit: number) => `home:recent-setlists:${limit}:v13`,
+    recentSetlists: (limit: number) => `home:recent-setlists:${limit}:v14`,
   },
 
   /**


### PR DESCRIPTION
Follow-up to #206/#207: removes the largest remaining per-request allocation.
The homepage renders identically.

- The homepage's recent-setlists cache drops from 2MB to 524KB: it now uses
  `findManyLight`/`SetlistLight`, the same lean payload the year and
  on-this-day pages already render the identical SetlistCard UI from. The
  heavy query's full Track/song objects (lyrics, histories) were never used
  by the cards. Cache key bumped v13 -> v14.

- That payload was also JSON.parsed out of Redis on every homepage request.
  `CacheService.getOrSet` gains an opt-in `memoTtlSeconds` that keeps the
  parsed value in process (deep-frozen, since all requests share it); the
  homepage uses 5 minutes. Invalidation coherence: `del`/`delPattern`/`set`
  drop matching memo entries (delPattern matches with full Redis-glob
  semantics, including mid-pattern wildcards like `show:*:data:*`), so admin
  setlist edits (which invalidate `home:*`) show on the very next request;
  the TTL only bounds staleness for deletes that bypass the app, like
  `make clear-show-cache` via redis-cli. Callers that don't pass the option
  are byte-for-byte unchanged.

- New `stop-builder` Server Ops action: the co-located coaching-tree app
  deploys through a Kamal remote builder that leaves its buildx container
  running between deploys, idling at ~645MiB on a 3.7GB host. Stopping it is
  safe (buildx bootstraps a fresh builder on the next remote build; the
  running app is untouched) and now takes one workflow dispatch.

Verified against the local prod restore: homepage renders identically from
the light payload (cards, 116 footnote markers, recurrence/flag footnote
text, badges, set times), no console errors across repeat loads within the
memo window, and the new v14 key measures 524KB vs v13's 2,097KB. Memo
coherence (del/delPattern/set clearing, glob matching, TTL expiry, null
handling, deep freeze) is unit-tested in cache-service.test.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
