### PR TITLE
Serve setlist list views from the lean payload everywhere

### DIFF
--- a/apps/web/app/routes/musicians/$slug.tsx
+++ b/apps/web/app/routes/musicians/$slug.tsx
@@ -124,7 +124,7 @@ export const loader = publicLoader(async ({ params, context }): Promise<LoaderDa
             ...(era?.startDate ? { excludeRangeStart: era.startDate } : {}),
             ...(era?.endDate ? { excludeRangeEnd: era.endDate } : {}),
           }),
-          services.setlists.findManyByShowIds(showIds, { sort: [{ field: "date", direction: "desc" }] }),
+          services.setlists.findManyByShowIdsLight(showIds, { sort: [{ field: "date", direction: "desc" }] }),
         ]);
 
         songs = songsPlayed;

--- a/apps/web/app/routes/resources/rock-opera-performances.test.ts
+++ b/apps/web/app/routes/resources/rock-opera-performances.test.ts
@@ -1,11 +1,11 @@
-import type { Setlist } from "@bip/domain";
+import type { SetlistLight } from "@bip/domain";
 import { type DehydratedState, QueryClient } from "@tanstack/react-query";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const cacheGetOrSet = vi.fn();
 const findPerformanceShowIds = vi.fn();
 const findPerformancesForShow = vi.fn();
-const findManyByShowIds = vi.fn();
+const findManyByShowIdsLight = vi.fn();
 const computeShowExternalSourcesFn = vi.fn();
 const computeShowUserDataFn = vi.fn();
 const prefetchQuery = vi.fn();
@@ -17,7 +17,7 @@ vi.mock("~/server/services", () => ({
       findPerformanceShowIds: (...args: unknown[]) => findPerformanceShowIds(...args),
       findPerformancesForShow: (...args: unknown[]) => findPerformancesForShow(...args),
     },
-    setlists: { findManyByShowIds: (...args: unknown[]) => findManyByShowIds(...args) },
+    setlists: { findManyByShowIdsLight: (...args: unknown[]) => findManyByShowIdsLight(...args) },
   },
 }));
 
@@ -46,10 +46,10 @@ vi.mock("~/lib/query-prefetch", async (importOriginal) => {
 
 const { getRockOperaPerformances } = await import("./rock-opera-performances");
 
-function makeSetlist(showId: string, date: string): Setlist {
+function makeSetlist(showId: string, date: string): SetlistLight {
   return {
-    show: { id: showId, slug: `${date}-show`, date } as Setlist["show"],
-    venue: { id: "v-1", slug: "v", name: "Venue", city: "City", state: "ST", country: "US" } as Setlist["venue"],
+    show: { id: showId, slug: `${date}-show`, date } as SetlistLight["show"],
+    venue: { id: "v-1", slug: "v", name: "Venue", city: "City", state: "ST", country: "US" } as SetlistLight["venue"],
     sets: [],
     annotations: [],
     averageSongGap: null,
@@ -68,7 +68,7 @@ describe("getRockOperaPerformances", () => {
     cacheGetOrSet.mockReset();
     findPerformanceShowIds.mockReset();
     findPerformancesForShow.mockReset();
-    findManyByShowIds.mockReset();
+    findManyByShowIdsLight.mockReset();
     computeShowExternalSourcesFn.mockReset();
     computeShowUserDataFn.mockReset();
     prefetchQuery.mockReset();
@@ -87,7 +87,7 @@ describe("getRockOperaPerformances", () => {
 
     expect(result.performances).toEqual([]);
     expect(result.externalSources).toEqual({});
-    expect(findManyByShowIds).not.toHaveBeenCalled();
+    expect(findManyByShowIdsLight).not.toHaveBeenCalled();
     expect(prefetchQuery).not.toHaveBeenCalled();
   });
 
@@ -102,6 +102,10 @@ describe("getRockOperaPerformances", () => {
 
     const usedKey = cacheGetOrSet.mock.calls[0][0] as string;
     expect(usedKey).toMatch(/^rock-operas:performances:hot-air-balloon/);
+    // v12 = the SetlistLight shape (lean track songs, no lyrics/history).
+    // A payload-shape change without a version bump would serve stale-shape
+    // blobs from deployed instances until TTL (the cache-versioning rule).
+    expect(usedKey).toContain(":v12");
   });
 
   // Setlists must be loaded by show id in chronological-asc order so the
@@ -109,21 +113,24 @@ describe("getRockOperaPerformances", () => {
   // Drives the resource page's display contract.
   test("requests setlists ordered by date asc", async () => {
     findPerformanceShowIds.mockResolvedValue(["show-1", "show-2"]);
-    findManyByShowIds.mockResolvedValue([makeSetlist("show-1", "1998-12-31"), makeSetlist("show-2", "1999-01-24")]);
+    findManyByShowIdsLight.mockResolvedValue([
+      makeSetlist("show-1", "1998-12-31"),
+      makeSetlist("show-2", "1999-01-24"),
+    ]);
     findPerformancesForShow.mockResolvedValue([]);
     computeShowExternalSourcesFn.mockResolvedValue({});
 
     await getRockOperaPerformances("hot-air-balloon", context);
 
-    expect(findManyByShowIds).toHaveBeenCalledWith(["show-1", "show-2"], {
+    expect(findManyByShowIdsLight).toHaveBeenCalledWith(["show-1", "show-2"], {
       sort: [{ field: "date", direction: "asc" }],
     });
   });
 
   // SetlistService now overlays rockOperaPerformances on every returned
-  // setlist (in findManyByShowIds), so the loader just passes its result
+  // setlist (in findManyByShowIdsLight), so the loader just passes its result
   // through untouched. The loader itself no longer makes annotation
-  // lookups — verified by mocking findManyByShowIds with already-overlay'd
+  // lookups — verified by mocking findManyByShowIdsLight with already-overlay'd
   // setlists and asserting they pass through verbatim.
   test("passes through rockOperaPerformances populated by SetlistService", async () => {
     findPerformanceShowIds.mockResolvedValue(["show-1", "show-2"]);
@@ -151,7 +158,7 @@ describe("getRockOperaPerformances", () => {
         ],
       },
     ];
-    findManyByShowIds.mockResolvedValue(setlistsWithAnnotations);
+    findManyByShowIdsLight.mockResolvedValue(setlistsWithAnnotations);
     computeShowExternalSourcesFn.mockResolvedValue({});
 
     const result = await getRockOperaPerformances("hot-air-balloon", context);
@@ -169,7 +176,7 @@ describe("getRockOperaPerformances", () => {
   test("computes external sources from every performance's show in one call", async () => {
     findPerformanceShowIds.mockResolvedValue(["show-1", "show-2"]);
     const setlists = [makeSetlist("show-1", "1998-12-31"), makeSetlist("show-2", "1999-01-24")];
-    findManyByShowIds.mockResolvedValue(setlists);
+    findManyByShowIdsLight.mockResolvedValue(setlists);
     findPerformancesForShow.mockResolvedValue([]);
     computeShowExternalSourcesFn.mockResolvedValue({ "show-1": {}, "show-2": {} });
 
@@ -186,7 +193,10 @@ describe("getRockOperaPerformances", () => {
   // resolves. Same pattern as /shows/top-rated.
   test("prefetches show user data keyed by every performance's show id", async () => {
     findPerformanceShowIds.mockResolvedValue(["show-1", "show-2"]);
-    findManyByShowIds.mockResolvedValue([makeSetlist("show-1", "1998-12-31"), makeSetlist("show-2", "1999-01-24")]);
+    findManyByShowIdsLight.mockResolvedValue([
+      makeSetlist("show-1", "1998-12-31"),
+      makeSetlist("show-2", "1999-01-24"),
+    ]);
     findPerformancesForShow.mockResolvedValue([]);
     computeShowExternalSourcesFn.mockResolvedValue({});
 
@@ -214,7 +224,7 @@ describe("getRockOperaPerformances", () => {
     const result = await getRockOperaPerformances("hot-air-balloon", context);
 
     expect(findPerformanceShowIds).not.toHaveBeenCalled();
-    expect(findManyByShowIds).not.toHaveBeenCalled();
+    expect(findManyByShowIdsLight).not.toHaveBeenCalled();
     expect(findPerformancesForShow).not.toHaveBeenCalled();
     expect(computeShowExternalSourcesFn).not.toHaveBeenCalled();
     expect(result.performances).toBe(cachedPayload.performances);

--- a/apps/web/app/routes/resources/rock-opera-performances.ts
+++ b/apps/web/app/routes/resources/rock-opera-performances.ts
@@ -1,4 +1,4 @@
-import { CacheKeys, type Setlist } from "@bip/domain";
+import { CacheKeys, type SetlistLight } from "@bip/domain";
 import type { DehydratedState } from "@tanstack/react-query";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
 import type { PublicContext } from "~/lib/base-loaders";
@@ -14,7 +14,7 @@ export interface RockOperaPerformancesLoaderData {
    * The 1st-ever performance is the FIRST item; SetlistList renders this
    * order directly with `numbered`, so the gutter naturally shows 1..N.
    */
-  performances: Setlist[];
+  performances: SetlistLight[];
   externalSources: Record<string, ShowExternalSources>;
   dehydratedState: DehydratedState;
 }
@@ -35,13 +35,13 @@ export async function getRockOperaPerformances(
   const cached = await services.cache.getOrSet(cacheKey, async () => {
     const showIds = await services.rockOperas.findPerformanceShowIds(rockOperaSlug);
     if (showIds.length === 0) {
-      return { performances: [] as Setlist[], externalSources: {} };
+      return { performances: [] as SetlistLight[], externalSources: {} };
     }
     // Sort ASC so the oldest (1st-ever full performance) lands first in
     // the array — SetlistList's `numbered` gutter then displays 1..N
     // naturally. SetlistService overlays rockOperaPerformances on every
     // returned setlist, so no further annotation lookup is needed here.
-    const setlists = await services.setlists.findManyByShowIds(showIds, {
+    const setlists = await services.setlists.findManyByShowIdsLight(showIds, {
       sort: [{ field: "date", direction: "asc" }],
     });
     const externalSources = await computeShowExternalSources(setlists.map((s) => s.show));

--- a/apps/web/app/routes/shows/top-rated-shows.ts
+++ b/apps/web/app/routes/shows/top-rated-shows.ts
@@ -1,5 +1,5 @@
 import type { RatingMode } from "@bip/core";
-import type { Setlist } from "@bip/domain";
+import type { SetlistLight } from "@bip/domain";
 import type { DehydratedState } from "@tanstack/react-query";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
 import type { PublicContext } from "~/lib/base-loaders";
@@ -14,7 +14,7 @@ const MIN_SHOW_RATINGS = 10;
 const TOP_RATED_LIMIT = 100;
 
 export interface TopRatedShowsLoaderData {
-  setlists: Setlist[];
+  setlists: SetlistLight[];
   year: number | null;
   mode: RatingMode;
   minShowRatings: number;
@@ -43,11 +43,11 @@ export async function getTopRatedShows(
 
   const inScope = year ? ranked.filter((show) => showYear(show.date) === year) : ranked;
   const showIds = inScope.slice(0, TOP_RATED_LIMIT).map((show) => show.id);
-  const rawSetlists = await services.setlists.findManyByShowIds(showIds);
-  // findManyByShowIds defaults to `date DESC` ordering, which wipes out the
-  // rank order from the shows query. Reindex back into rank order here.
+  const rawSetlists = await services.setlists.findManyByShowIdsLight(showIds);
+  // findManyByShowIdsLight defaults to `date DESC` ordering, which wipes out
+  // the rank order from the shows query. Reindex back into rank order here.
   const byShowId = new Map(rawSetlists.map((s) => [s.show.id, s]));
-  const setlists = showIds.map((id) => byShowId.get(id)).filter((s): s is Setlist => s !== undefined);
+  const setlists = showIds.map((id) => byShowId.get(id)).filter((s): s is SetlistLight => s !== undefined);
 
   const externalSources = await computeShowExternalSources(setlists.map((s) => s.show));
 

--- a/apps/web/app/routes/shows/year/$year.tsx
+++ b/apps/web/app/routes/shows/year/$year.tsx
@@ -94,7 +94,7 @@ export const loader = publicLoader(async ({ request, params, context }): Promise
 
     if (shows.length > 0) {
       const showIds = shows.map((show) => show.id);
-      setlists = await services.setlists.findManyByShowIds(showIds);
+      setlists = await services.setlists.findManyByShowIdsLight(showIds);
     }
 
     const searchShowIds = setlists.map((s) => s.show.id);

--- a/apps/web/app/routes/users/$username.tsx
+++ b/apps/web/app/routes/users/$username.tsx
@@ -169,7 +169,7 @@ async function loadUserProfile({ params, request, context }: LoaderFunctionArgs 
 
   const { attendedSetlists, attendedExternalSources } = pageShowIds.length
     ? await services.cache.getOrSet(CacheKeys.users.attendedSetlists(user.id, clampedAttendedPage), async () => {
-        const setlists = await services.setlists.findManyByShowIds(pageShowIds);
+        const setlists = await services.setlists.findManyByShowIdsLight(pageShowIds);
         const externalSources: Record<string, ShowExternalSources> = await computeShowExternalSources(
           setlists.map((s) => s.show),
         );

--- a/packages/core/src/setlists/setlist-service.test.ts
+++ b/packages/core/src/setlists/setlist-service.test.ts
@@ -359,6 +359,70 @@ describe("SetlistService.findManyLight", () => {
   });
 });
 
+describe("SetlistService.findManyByShowIdsLight", () => {
+  // The light by-ids query backs cached list payloads (attended-setlists,
+  // rock-opera performances). Its whole reason to exist is that the song
+  // select stays lean: the cached blob can't embed lyrics/history text the
+  // DB never returns. Guards the 7-10MB-per-page regression this replaced.
+  test("selects only lean song fields, no lyrics/history/notes/tabs", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never, makeRockOperaStub());
+
+    await service.findManyByShowIdsLight(["show-1"]);
+
+    const songSelect = db.show.findMany.mock.calls[0][0].include.tracks.select.song.select;
+    expect(songSelect.id).toBe(true);
+    expect(songSelect.title).toBe(true);
+    expect(songSelect.slug).toBe(true);
+    expect(songSelect.kind).toBe(true);
+    expect(songSelect.lyrics).toBeUndefined();
+    expect(songSelect.history).toBeUndefined();
+    expect(songSelect.notes).toBeUndefined();
+    expect(songSelect.tabs).toBeUndefined();
+  });
+
+  // Only the requested shows, and orphan placeholder shows (no venue) dropped
+  // at the SQL boundary: the id list can include a stub (e.g. top-rated
+  // joins), which would otherwise render as a blank row.
+  test("filters to the requested show ids and excludes venue-less stubs", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never, makeRockOperaStub());
+
+    await service.findManyByShowIdsLight(["show-1", "show-2"]);
+
+    const call = db.show.findMany.mock.calls[0][0];
+    expect(call.where.id).toEqual({ in: ["show-1", "show-2"] });
+    expect(call.where.venueId).toEqual({ not: null });
+  });
+
+  // Newest-first by default (most list views want recent shows on top); an
+  // explicit sort option overrides it (rock opera pages want oldest-first
+  // numbering).
+  test("orders date desc by default and honors a sort override", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never, makeRockOperaStub());
+
+    await service.findManyByShowIdsLight(["show-1"]);
+    await service.findManyByShowIdsLight(["show-1"], { sort: [{ field: "date", direction: "asc" }] });
+
+    const [defaultCall, sortedCall] = db.show.findMany.mock.calls;
+    expect(defaultCall[0].orderBy[0]).toEqual({ date: "desc" });
+    expect(sortedCall[0].orderBy[0]).toEqual({ date: "asc" });
+  });
+
+  // Empty input short-circuits with no query, e.g. a user with no attended
+  // shows on the page.
+  test("returns [] without querying when given no show ids", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never, makeRockOperaStub());
+
+    const result = await service.findManyByShowIdsLight([]);
+
+    expect(result).toEqual([]);
+    expect(db.show.findMany).not.toHaveBeenCalled();
+  });
+});
+
 describe("eligibleGapsForAggregation", () => {
   // Debuts (gap === null) are excluded so they don't drag the eventual
   // average down to "we never played this".
@@ -801,20 +865,6 @@ describe("SetlistService.findMany stub filtering", () => {
     expect(trackInclude.completionsAsLater).toBeDefined();
     expect(trackInclude.trackMusicians).toBeDefined();
     expect(call.include.showMusicians).toBeDefined();
-  });
-});
-
-describe("SetlistService.findManyByShowIds stub filtering", () => {
-  // Same post-pagination undercount as findMany: the id list can include a stub
-  // (e.g. top-rated joins), so exclude venueless shows in the query.
-  test("excludes venueless stubs at the SQL boundary", async () => {
-    const db = makeMockDb();
-    const service = new SetlistService(db as never, makeRockOperaStub());
-
-    await service.findManyByShowIds(["show-1", "show-2"]);
-
-    const call = db.show.findMany.mock.calls[0][0];
-    expect(call.where.venueId).toEqual({ not: null });
   });
 });
 

--- a/packages/core/src/setlists/setlist-service.ts
+++ b/packages/core/src/setlists/setlist-service.ts
@@ -800,6 +800,48 @@ const HEAVY_SETLIST_INCLUDE = {
   ...SINGLE_SHOW_PERFORMER_INCLUDE,
 } as const;
 
+// Light counterpart of HEAVY_SETLIST_INCLUDE: everything the light mapper
+// (mapSetlistLightToDomainEntity) reads, with the track's song narrowed to the
+// lean list-view fields. The song select deliberately omits the text-heavy
+// columns (lyrics, history, notes, tabs): light payloads back redis-cached
+// list views, and those columns dominated the blob size while nothing in a
+// list view reads them. Shared by every query that returns SetlistLight so
+// the joins stay in lockstep with the mapper.
+const LIGHT_SETLIST_INCLUDE = {
+  tracks: {
+    select: {
+      id: true,
+      showId: true,
+      songId: true,
+      set: true,
+      position: true,
+      segue: true,
+      likesCount: true,
+      note: true,
+      allTimer: true,
+      gap: true,
+      previousPerformanceShowId: true,
+      duration: true,
+      durationSource: true,
+      previousPerformanceShow: { select: { date: true, slug: true } },
+      ...TRACK_FLAGS_AND_COMPLETIONS_INCLUDE,
+      ...TRACK_PERFORMER_INCLUDE,
+      song: {
+        select: {
+          id: true,
+          title: true,
+          slug: true,
+          kind: true,
+          ...SONG_AUTHORS_SETLIST_INCLUDE,
+        },
+      },
+      annotations: true,
+    },
+  },
+  venue: true,
+  ...SINGLE_SHOW_PERFORMER_INCLUDE,
+} as const;
+
 export class SetlistService {
   constructor(
     private readonly db: DbClient,
@@ -859,18 +901,20 @@ export class SetlistService {
   }
 
   /**
-   * Find setlists by an array of show IDs
-   * @param showIds Array of show IDs to find setlists for
-   * @param options Optional query options for pagination, sorting, etc.
-   * @returns An array of setlists for the specified show IDs
+   * Find setlists for a set of show ids in the lean list-view shape: each
+   * track's song carries only id/title/slug/kind/authors, no lyrics/history
+   * text. Every by-ids consumer is a list view (attended-shows pages, rock
+   * opera performances, top-rated, musician appearances), and the redis-cached
+   * ones ran to multiple MB per cached page when the full song objects rode
+   * along. Single-show pages needing full data use findByShowSlug/findByShowId.
    */
-  async findManyByShowIds(
+  async findManyByShowIdsLight(
     showIds: string[],
     options?: {
       pagination?: PaginationOptions;
       sort?: SortOptions<Show>[];
     },
-  ): Promise<Setlist[]> {
+  ): Promise<SetlistLight[]> {
     if (!showIds.length) return [];
 
     const orderBy = resolveShowOrderBy(options?.sort, SHOW_ORDER_DESC);
@@ -882,9 +926,7 @@ export class SetlistService {
 
     const results = await this.db.show.findMany({
       where: {
-        id: {
-          in: showIds,
-        },
+        id: { in: showIds },
         // Drop orphan placeholder shows with no venue so they never reach a
         // listing (and so pagination counts stay exact).
         venueId: NON_STUB_SHOWS_WHERE.venueId,
@@ -892,19 +934,16 @@ export class SetlistService {
       orderBy,
       skip,
       take,
-      // Single LATERAL-joined query instead of 5 batched roundtrips. With
-      // 100 shows × ~25 tracks each + relations, the per-roundtrip latency
-      // dominates the page load on un-cached routes (top-rated etc).
       relationLoadStrategy: "join",
-      include: HEAVY_SETLIST_INCLUDE,
+      include: LIGHT_SETLIST_INCLUDE,
     });
 
     const setlists = results
-      .filter((show) => show.venue !== null)
+      .filter((result): result is typeof result & { venue: NonNullable<typeof result.venue> } => result.venue !== null)
       .map((show) =>
-        mapSetlistToDomainEntity({
+        mapSetlistLightToDomainEntity({
           ...show,
-          venue: show.venue as DbVenue,
+          venue: show.venue,
           tracks: show.tracks.map((track) => ({
             ...track,
             annotations: track.annotations || [],
@@ -1013,40 +1052,7 @@ export class SetlistService {
       skip,
       take,
       relationLoadStrategy: "join",
-      include: {
-        tracks: {
-          select: {
-            id: true,
-            showId: true,
-            songId: true,
-            set: true,
-            position: true,
-            segue: true,
-            likesCount: true,
-            note: true,
-            allTimer: true,
-            gap: true,
-            previousPerformanceShowId: true,
-            duration: true,
-            durationSource: true,
-            previousPerformanceShow: { select: { date: true, slug: true } },
-            ...TRACK_FLAGS_AND_COMPLETIONS_INCLUDE,
-            ...TRACK_PERFORMER_INCLUDE,
-            song: {
-              select: {
-                id: true,
-                title: true,
-                slug: true,
-                kind: true,
-                ...SONG_AUTHORS_SETLIST_INCLUDE,
-              },
-            },
-            annotations: true,
-          },
-        },
-        venue: true,
-        ...SINGLE_SHOW_PERFORMER_INCLUDE,
-      },
+      include: LIGHT_SETLIST_INCLUDE,
     });
 
     const setlists = results

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -140,9 +140,10 @@ export const CacheKeys = {
      * Pre-built SetlistList payload (setlists + external sources) for one
      * page of a user's attended shows. Paginated because the heaviest users
      * have 400+ attended shows and the un-paginated payload is large enough
-     * to be slow to deserialize/transport even from Redis.
+     * to be slow to deserialize/transport even from Redis. :v14 bump:
+     * setlists are SetlistLight (lean track songs; no lyrics/history text).
      */
-    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}:v13`,
+    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}:v14`,
     /** All pages of a single user's attended-setlists caches (for per-user invalidation). */
     allAttendedSetlistsForUser: (userId: string) => `user:${userId}:attended-setlists:*`,
     /** All per-user attended-setlists caches (for pattern deletion on broad show mutations). */
@@ -166,8 +167,10 @@ export const CacheKeys = {
    * shows.list / users.attendedSetlists payloads.
    */
   rockOperas: {
-    /** Resource-page list payload: setlists + external sources for one rock opera. */
-    performances: (slug: string) => `rock-operas:performances:${slug}:v11`,
+    /** Resource-page list payload: setlists + external sources for one rock
+     *  opera. :v12 bump: setlists are SetlistLight (lean track songs; no
+     *  lyrics/history text). */
+    performances: (slug: string) => `rock-operas:performances:${slug}:v12`,
     /** Pattern for invalidating every performances cache (broad mutations). */
     allPerformances: () => "rock-operas:performances:*",
   },


### PR DESCRIPTION
Setlist list views stop hauling megabytes of dead song text; nothing changes visually. The prod redis census flagged attended-shows cache pages at 7-10MB each because every track embedded its song's full lyrics/history/notes, which no list view reads.

- Every by-show-ids setlist read (attended-shows pages, rock opera performances, top-rated, year-page search, musician appearances) now uses a new `findManyByShowIdsLight`, returning the same `SetlistLight` shape the homepage, year, and on-this-day pages already render through the identical components. Measured locally: attended-setlists page 1 for the heaviest user (469 shows) is 1.8MB, the hot-air-balloon performances payload 384KB.
- Cache keys bumped for the shape change: `users.attendedSetlists` v13 -> v14, `rockOperas.performances` v11 -> v12.
- The heavy `findManyByShowIds` had no remaining callers and is removed. Single-show pages keep the full shape via `findByShowSlug`/`findByShowId`; slimming those is a follow-up since nothing reads the fat fields there either, but it touches the show page, edit page, and MCP sync at once.

Verification: red/green tests (lean-select assertions in setlist-service.test.ts; loader wiring + v12 key in rock-opera-performances.test.ts), `make tc` + `make test` green, and live checks of the profile Shows tab, hot-air-balloon, top-rated, and year search in both card and gap-chart views (footnotes and the Gap / Last Played / Played Before columns all render, no console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
