### PR TITLE
Serve every setlist from one lean payload; delete the heavy path

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "web",
+      "runtimeExecutable": "make",
+      "runtimeArgs": ["web"],
+      "port": 5173
+    }
+  ]
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,3 +1,5 @@
 #!/bin/bash
-# Before committing, ensure linting passes.
-bun run lint
+# Before committing, ensure linting and formatting pass. CI enforces both
+# (bun run lint + bun run format:check), so catching them here avoids a
+# red build for a fixable-in-place diff.
+bun run lint && bun run format:check

--- a/apps/web/app/components/setlist/footnotes.tsx
+++ b/apps/web/app/components/setlist/footnotes.tsx
@@ -1,11 +1,4 @@
-import type {
-  Annotation,
-  SegueRecurrenceKind,
-  Setlist,
-  SetlistLight,
-  SongPagePerformance,
-  TrackMusicianDelta,
-} from "@bip/domain";
+import type { Annotation, SegueRecurrenceKind, Setlist, SongPagePerformance, TrackMusicianDelta } from "@bip/domain";
 import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import {
@@ -713,7 +706,7 @@ export function dataDrivenFootnoteSources(
  * debut suppression, and numbers them. Both the public setlist view and the
  * admin show-edit view derive through this so their wording can never diverge.
  */
-export function buildShowFootnotes(setlist: Setlist | SetlistLight): DerivedFootnotes {
+export function buildShowFootnotes(setlist: Setlist): DerivedFootnotes {
   const allTracks = setlist.sets.flatMap((set) => set.tracks);
   // Whole-show guests are surfaced in the show-level lineup note, so their
   // per-track "with" footnotes are suppressed; for guests below 100% coverage

--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -1,4 +1,4 @@
-import type { SetlistLight } from "@bip/domain";
+import type { Setlist } from "@bip/domain";
 import { expectMockedShallowComponent, mockShallowComponent, setupWithRouter } from "@test/test-utils";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -45,7 +45,7 @@ vi.mock("./anniversary-badge", () => ({
 
 import { SetlistCard } from "./setlist-card";
 
-function makeSetlist(overrides: { showDate?: string } = {}): SetlistLight {
+function makeSetlist(overrides: { showDate?: string } = {}): Setlist {
   return {
     show: {
       id: "show-1",

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -1,5 +1,5 @@
 import type { ShowRankComparison } from "@bip/core";
-import type { Attendance, Rating, Setlist, SetlistLight } from "@bip/domain";
+import type { Attendance, Rating, Setlist } from "@bip/domain";
 import { Check } from "lucide-react";
 import { memo, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
@@ -25,7 +25,7 @@ import { ShowExternalBadges, type ShowExternalSources } from "./show-external-ba
 export type SetlistView = "setlist" | "gap-chart" | "personal";
 
 interface SetlistCardProps {
-  setlist: Setlist | SetlistLight;
+  setlist: Setlist;
   userAttendance: Attendance | null;
   userRating: Rating | number | null;
   showRating: number | null;

--- a/apps/web/app/components/setlist/setlist-flow.test.tsx
+++ b/apps/web/app/components/setlist/setlist-flow.test.tsx
@@ -1,4 +1,4 @@
-import type { SetlistLight } from "@bip/domain";
+import type { Setlist } from "@bip/domain";
 import { setupWithRouter } from "@test/test-utils";
 import { screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
@@ -61,14 +61,14 @@ function flowSetlist(
   sets: Array<{ label: string; tracks: ReturnType<typeof durTrack>[] }>,
   annotations: Array<{ trackId: string; desc: string }> = [],
   showDate?: string,
-): SetlistLight {
+): Setlist {
   return {
     show: { id: "show-1", date: showDate },
     sets: sets.map((s, i) => ({ label: s.label, sort: i + 1, tracks: s.tracks })),
     annotations,
     trackMusicianDeltas: [],
     lineup: [],
-  } as unknown as SetlistLight;
+  } as unknown as Setlist;
 }
 
 describe("SetlistFlow", () => {

--- a/apps/web/app/components/setlist/setlist-flow.tsx
+++ b/apps/web/app/components/setlist/setlist-flow.tsx
@@ -1,4 +1,4 @@
-import type { Setlist, SetlistLight } from "@bip/domain";
+import type { Setlist } from "@bip/domain";
 import { formatDuration } from "@bip/domain";
 import { Link } from "react-router-dom";
 import { NoteworthyMarker } from "~/components/track/noteworthy-marker";
@@ -15,7 +15,7 @@ import { TrackRatingOverlay } from "./track-rating-overlay";
  * can be rendered and tested on its own, apart from the rating/attendance/
  * view-toggle machinery around it.
  */
-export function SetlistFlow({ setlist }: { setlist: Setlist | SetlistLight }) {
+export function SetlistFlow({ setlist }: { setlist: Setlist }) {
   const allTracks = setlist.sets.flatMap((set) => set.tracks);
   const { trackFootnoteIndices, orderedFootnotes } = buildShowFootnotes(setlist);
 

--- a/apps/web/app/components/setlist/setlist-list.test.tsx
+++ b/apps/web/app/components/setlist/setlist-list.test.tsx
@@ -1,4 +1,4 @@
-import type { Attendance, SetlistLight } from "@bip/domain";
+import type { Attendance, Setlist } from "@bip/domain";
 import { setupWithRouter } from "@test/test-utils";
 import { screen } from "@testing-library/react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
@@ -26,7 +26,7 @@ vi.mock("~/hooks/use-show-user-data", () => ({
 
 import { SetlistList } from "./setlist-list";
 
-function makeSetlist(id: string, title: string, averageRating: number | null = 4.0, date = "2021-04-14"): SetlistLight {
+function makeSetlist(id: string, title: string, averageRating: number | null = 4.0, date = "2021-04-14"): Setlist {
   return {
     show: {
       id,

--- a/apps/web/app/components/setlist/setlist-list.tsx
+++ b/apps/web/app/components/setlist/setlist-list.tsx
@@ -1,4 +1,4 @@
-import type { Setlist, SetlistLight } from "@bip/domain";
+import type { Setlist } from "@bip/domain";
 import { Fragment, type ReactNode, useMemo } from "react";
 import { useShowUserData } from "~/hooks/use-show-user-data";
 import { SetlistCard } from "./setlist-card";
@@ -15,7 +15,7 @@ import type { ShowExternalSources } from "./show-external-badges";
  * this component mounts, so attendance / rating badges paint with the HTML.
  */
 interface SetlistListProps {
-  setlists: Array<Setlist | SetlistLight>;
+  setlists: Array<Setlist>;
   externalSources: Record<string, ShowExternalSources>;
   /** Rendered when `setlists` is empty. Defaults to nothing. */
   empty?: ReactNode;
@@ -50,7 +50,7 @@ export function SetlistList({
     return <>{empty ?? null}</>;
   }
 
-  const renderCard = (setlist: Setlist | SetlistLight, index: number) => {
+  const renderCard = (setlist: Setlist, index: number) => {
     const showId = setlist.show.id;
     const live = averageRatingMap.get(showId);
     // The displayed ★ is the viewer's calibrated score when their mode resolves to
@@ -85,7 +85,7 @@ export function SetlistList({
   };
 
   if (groupByMonth) {
-    const groups = new Map<number, Array<Setlist | SetlistLight>>();
+    const groups = new Map<number, Array<Setlist>>();
     for (const setlist of setlists) {
       const month = new Date(setlist.show.date).getMonth();
       const bucket = groups.get(month);

--- a/apps/web/app/components/show/debut-year-chart.tsx
+++ b/apps/web/app/components/show/debut-year-chart.tsx
@@ -12,7 +12,7 @@ type SongRef = { title: string; slug: string };
 
 export type DebutYearTrack = {
   songId: string;
-  song?: { title: string; slug: string; dateFirstPlayed: Date | null } | null;
+  song?: { title: string; slug: string; dateFirstPlayed?: Date | null } | null;
 };
 
 export type DebutYearSetlist = {

--- a/apps/web/app/routes/_index.tsx
+++ b/apps/web/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import { type BlogPostWithUser, CacheKeys, type SetlistLight, type TourDate } from "@bip/domain";
+import { type BlogPostWithUser, CacheKeys, type Setlist, type TourDate } from "@bip/domain";
 import type { DehydratedState } from "@tanstack/react-query";
 import { Calendar } from "lucide-react";
 import { Link } from "react-router-dom";
@@ -21,12 +21,12 @@ import { computeShowUserData } from "~/server/show-user-data";
 
 interface LoaderData {
   tourDates: TourDate[];
-  mobileRecentShows: SetlistLight[];
-  desktopRecentShows: SetlistLight[];
+  mobileRecentShows: Setlist[];
+  desktopRecentShows: Setlist[];
   recentBlogPosts: Array<BlogPostWithUser>;
   latestEpisode: AcastEpisode | null;
   nextTourDate: TourDate | null;
-  recentShows: SetlistLight[];
+  recentShows: Setlist[];
   onThisDayCounts: { showCount: number; allTimerCount: number };
   externalSources: Record<string, ShowExternalSources>;
   dehydratedState: DehydratedState;
@@ -54,7 +54,7 @@ export const loader = publicLoader<LoaderData>(async ({ context }) => {
     CacheKeys.home.recentSetlists(15),
     async () => {
       logger.info("Loading recent setlists from DB for home page");
-      return await services.setlists.findManyLight({
+      return await services.setlists.findMany({
         pagination: { limit: 15 },
         sort: [{ field: "date", direction: "desc" }],
       });

--- a/apps/web/app/routes/musicians/$slug.tsx
+++ b/apps/web/app/routes/musicians/$slug.tsx
@@ -124,7 +124,7 @@ export const loader = publicLoader(async ({ params, context }): Promise<LoaderDa
             ...(era?.startDate ? { excludeRangeStart: era.startDate } : {}),
             ...(era?.endDate ? { excludeRangeEnd: era.endDate } : {}),
           }),
-          services.setlists.findManyByShowIdsLight(showIds, { sort: [{ field: "date", direction: "desc" }] }),
+          services.setlists.findManyByShowIds(showIds, { sort: [{ field: "date", direction: "desc" }] }),
         ]);
 
         songs = songsPlayed;

--- a/apps/web/app/routes/on-this-day.$monthDay.tsx
+++ b/apps/web/app/routes/on-this-day.$monthDay.tsx
@@ -1,4 +1,4 @@
-import { CacheKeys, type SetlistLight, type SongPagePerformance } from "@bip/domain";
+import { CacheKeys, type Setlist, type SongPagePerformance } from "@bip/domain";
 import type { DehydratedState } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight, Flame } from "lucide-react";
 import type { ClientLoaderFunctionArgs } from "react-router";
@@ -20,7 +20,7 @@ import { computeShowUserData } from "~/server/show-user-data";
 import { computeTrackUserRatings } from "~/server/track-user-ratings";
 
 interface LoaderData {
-  setlists: SetlistLight[];
+  setlists: Setlist[];
   performances: SongPagePerformance[];
   monthDay: string;
   displayLabel: string;
@@ -58,7 +58,7 @@ export const loader = publicLoader(async ({ params, context }): Promise<LoaderDa
 
   const [setlists, jamChartsResult] = await Promise.all([
     services.cache.getOrSet(setlistsCacheKey, async () => {
-      return services.setlists.findManyLight({
+      return services.setlists.findMany({
         filters: { monthDay },
         sort: [{ field: "date", direction: "desc" }],
       });

--- a/apps/web/app/routes/resources/rock-opera-performances.test.ts
+++ b/apps/web/app/routes/resources/rock-opera-performances.test.ts
@@ -1,11 +1,11 @@
-import type { SetlistLight } from "@bip/domain";
+import type { Setlist } from "@bip/domain";
 import { type DehydratedState, QueryClient } from "@tanstack/react-query";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const cacheGetOrSet = vi.fn();
 const findPerformanceShowIds = vi.fn();
 const findPerformancesForShow = vi.fn();
-const findManyByShowIdsLight = vi.fn();
+const findManyByShowIds = vi.fn();
 const computeShowExternalSourcesFn = vi.fn();
 const computeShowUserDataFn = vi.fn();
 const prefetchQuery = vi.fn();
@@ -17,7 +17,7 @@ vi.mock("~/server/services", () => ({
       findPerformanceShowIds: (...args: unknown[]) => findPerformanceShowIds(...args),
       findPerformancesForShow: (...args: unknown[]) => findPerformancesForShow(...args),
     },
-    setlists: { findManyByShowIdsLight: (...args: unknown[]) => findManyByShowIdsLight(...args) },
+    setlists: { findManyByShowIds: (...args: unknown[]) => findManyByShowIds(...args) },
   },
 }));
 
@@ -46,10 +46,10 @@ vi.mock("~/lib/query-prefetch", async (importOriginal) => {
 
 const { getRockOperaPerformances } = await import("./rock-opera-performances");
 
-function makeSetlist(showId: string, date: string): SetlistLight {
+function makeSetlist(showId: string, date: string): Setlist {
   return {
-    show: { id: showId, slug: `${date}-show`, date } as SetlistLight["show"],
-    venue: { id: "v-1", slug: "v", name: "Venue", city: "City", state: "ST", country: "US" } as SetlistLight["venue"],
+    show: { id: showId, slug: `${date}-show`, date } as Setlist["show"],
+    venue: { id: "v-1", slug: "v", name: "Venue", city: "City", state: "ST", country: "US" } as Setlist["venue"],
     sets: [],
     annotations: [],
     averageSongGap: null,
@@ -68,7 +68,7 @@ describe("getRockOperaPerformances", () => {
     cacheGetOrSet.mockReset();
     findPerformanceShowIds.mockReset();
     findPerformancesForShow.mockReset();
-    findManyByShowIdsLight.mockReset();
+    findManyByShowIds.mockReset();
     computeShowExternalSourcesFn.mockReset();
     computeShowUserDataFn.mockReset();
     prefetchQuery.mockReset();
@@ -87,7 +87,7 @@ describe("getRockOperaPerformances", () => {
 
     expect(result.performances).toEqual([]);
     expect(result.externalSources).toEqual({});
-    expect(findManyByShowIdsLight).not.toHaveBeenCalled();
+    expect(findManyByShowIds).not.toHaveBeenCalled();
     expect(prefetchQuery).not.toHaveBeenCalled();
   });
 
@@ -102,10 +102,10 @@ describe("getRockOperaPerformances", () => {
 
     const usedKey = cacheGetOrSet.mock.calls[0][0] as string;
     expect(usedKey).toMatch(/^rock-operas:performances:hot-air-balloon/);
-    // v12 = the SetlistLight shape (lean track songs, no lyrics/history).
+    // v13 = the Setlist shape with dateFirstPlayed on the lean song.
     // A payload-shape change without a version bump would serve stale-shape
     // blobs from deployed instances until TTL (the cache-versioning rule).
-    expect(usedKey).toContain(":v12");
+    expect(usedKey).toContain(":v13");
   });
 
   // Setlists must be loaded by show id in chronological-asc order so the
@@ -113,24 +113,21 @@ describe("getRockOperaPerformances", () => {
   // Drives the resource page's display contract.
   test("requests setlists ordered by date asc", async () => {
     findPerformanceShowIds.mockResolvedValue(["show-1", "show-2"]);
-    findManyByShowIdsLight.mockResolvedValue([
-      makeSetlist("show-1", "1998-12-31"),
-      makeSetlist("show-2", "1999-01-24"),
-    ]);
+    findManyByShowIds.mockResolvedValue([makeSetlist("show-1", "1998-12-31"), makeSetlist("show-2", "1999-01-24")]);
     findPerformancesForShow.mockResolvedValue([]);
     computeShowExternalSourcesFn.mockResolvedValue({});
 
     await getRockOperaPerformances("hot-air-balloon", context);
 
-    expect(findManyByShowIdsLight).toHaveBeenCalledWith(["show-1", "show-2"], {
+    expect(findManyByShowIds).toHaveBeenCalledWith(["show-1", "show-2"], {
       sort: [{ field: "date", direction: "asc" }],
     });
   });
 
   // SetlistService now overlays rockOperaPerformances on every returned
-  // setlist (in findManyByShowIdsLight), so the loader just passes its result
+  // setlist (in findManyByShowIds), so the loader just passes its result
   // through untouched. The loader itself no longer makes annotation
-  // lookups — verified by mocking findManyByShowIdsLight with already-overlay'd
+  // lookups — verified by mocking findManyByShowIds with already-overlay'd
   // setlists and asserting they pass through verbatim.
   test("passes through rockOperaPerformances populated by SetlistService", async () => {
     findPerformanceShowIds.mockResolvedValue(["show-1", "show-2"]);
@@ -158,7 +155,7 @@ describe("getRockOperaPerformances", () => {
         ],
       },
     ];
-    findManyByShowIdsLight.mockResolvedValue(setlistsWithAnnotations);
+    findManyByShowIds.mockResolvedValue(setlistsWithAnnotations);
     computeShowExternalSourcesFn.mockResolvedValue({});
 
     const result = await getRockOperaPerformances("hot-air-balloon", context);
@@ -176,7 +173,7 @@ describe("getRockOperaPerformances", () => {
   test("computes external sources from every performance's show in one call", async () => {
     findPerformanceShowIds.mockResolvedValue(["show-1", "show-2"]);
     const setlists = [makeSetlist("show-1", "1998-12-31"), makeSetlist("show-2", "1999-01-24")];
-    findManyByShowIdsLight.mockResolvedValue(setlists);
+    findManyByShowIds.mockResolvedValue(setlists);
     findPerformancesForShow.mockResolvedValue([]);
     computeShowExternalSourcesFn.mockResolvedValue({ "show-1": {}, "show-2": {} });
 
@@ -193,10 +190,7 @@ describe("getRockOperaPerformances", () => {
   // resolves. Same pattern as /shows/top-rated.
   test("prefetches show user data keyed by every performance's show id", async () => {
     findPerformanceShowIds.mockResolvedValue(["show-1", "show-2"]);
-    findManyByShowIdsLight.mockResolvedValue([
-      makeSetlist("show-1", "1998-12-31"),
-      makeSetlist("show-2", "1999-01-24"),
-    ]);
+    findManyByShowIds.mockResolvedValue([makeSetlist("show-1", "1998-12-31"), makeSetlist("show-2", "1999-01-24")]);
     findPerformancesForShow.mockResolvedValue([]);
     computeShowExternalSourcesFn.mockResolvedValue({});
 
@@ -224,7 +218,7 @@ describe("getRockOperaPerformances", () => {
     const result = await getRockOperaPerformances("hot-air-balloon", context);
 
     expect(findPerformanceShowIds).not.toHaveBeenCalled();
-    expect(findManyByShowIdsLight).not.toHaveBeenCalled();
+    expect(findManyByShowIds).not.toHaveBeenCalled();
     expect(findPerformancesForShow).not.toHaveBeenCalled();
     expect(computeShowExternalSourcesFn).not.toHaveBeenCalled();
     expect(result.performances).toBe(cachedPayload.performances);

--- a/apps/web/app/routes/resources/rock-opera-performances.ts
+++ b/apps/web/app/routes/resources/rock-opera-performances.ts
@@ -1,4 +1,4 @@
-import { CacheKeys, type SetlistLight } from "@bip/domain";
+import { CacheKeys, type Setlist } from "@bip/domain";
 import type { DehydratedState } from "@tanstack/react-query";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
 import type { PublicContext } from "~/lib/base-loaders";
@@ -14,7 +14,7 @@ export interface RockOperaPerformancesLoaderData {
    * The 1st-ever performance is the FIRST item; SetlistList renders this
    * order directly with `numbered`, so the gutter naturally shows 1..N.
    */
-  performances: SetlistLight[];
+  performances: Setlist[];
   externalSources: Record<string, ShowExternalSources>;
   dehydratedState: DehydratedState;
 }
@@ -35,13 +35,13 @@ export async function getRockOperaPerformances(
   const cached = await services.cache.getOrSet(cacheKey, async () => {
     const showIds = await services.rockOperas.findPerformanceShowIds(rockOperaSlug);
     if (showIds.length === 0) {
-      return { performances: [] as SetlistLight[], externalSources: {} };
+      return { performances: [] as Setlist[], externalSources: {} };
     }
     // Sort ASC so the oldest (1st-ever full performance) lands first in
     // the array — SetlistList's `numbered` gutter then displays 1..N
     // naturally. SetlistService overlays rockOperaPerformances on every
     // returned setlist, so no further annotation lookup is needed here.
-    const setlists = await services.setlists.findManyByShowIdsLight(showIds, {
+    const setlists = await services.setlists.findManyByShowIds(showIds, {
       sort: [{ field: "date", direction: "asc" }],
     });
     const externalSources = await computeShowExternalSources(setlists.map((s) => s.show));

--- a/apps/web/app/routes/shows/$slug.edit.tsx
+++ b/apps/web/app/routes/shows/$slug.edit.tsx
@@ -40,11 +40,11 @@ export const loader = adminLoader(async ({ params }) => {
   // Get venues for the venue selector
   const venues = await services.venues.findMany({});
 
-  // Get tracks for this show. The edit forms use this lighter shape; the
-  // read-only footnotes derive from the heavier setlist below.
+  // Get tracks for this show. The edit forms use this flat shape; the
+  // read-only footnotes derive from the full setlist structure below.
   const tracks = await services.tracks.findByShowId(show.id);
 
-  // The full setlist carries flags/performers/completions/recurrence per track,
+  // The setlist carries flags/performers/completions/recurrence per track,
   // which TrackManager runs through the same footnote engine as the public
   // setlist so admins see the current derived state before editing.
   const footnoteSetlist = await services.setlists.findByShowSlug(slug as string);

--- a/apps/web/app/routes/shows/$slug.tsx
+++ b/apps/web/app/routes/shows/$slug.tsx
@@ -1,11 +1,5 @@
 import type { RatingValueBucket, ShowNavItem } from "@bip/core";
-import {
-  type ArchiveDotOrgRecording,
-  CacheKeys,
-  type ReviewMinimal,
-  type Setlist,
-  type ShowFile,
-} from "@bip/domain";
+import { type ArchiveDotOrgRecording, CacheKeys, type ReviewMinimal, type Setlist, type ShowFile } from "@bip/domain";
 import type { DehydratedState } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight, Edit } from "lucide-react";
 import { Link, useRevalidator } from "react-router-dom";

--- a/apps/web/app/routes/shows/$slug.tsx
+++ b/apps/web/app/routes/shows/$slug.tsx
@@ -1,5 +1,11 @@
 import type { RatingValueBucket, ShowNavItem } from "@bip/core";
-import { type ArchiveDotOrgRecording, CacheKeys, type ReviewMinimal, type Setlist, type ShowFile } from "@bip/domain";
+import {
+  type ArchiveDotOrgRecording,
+  CacheKeys,
+  type ReviewMinimal,
+  type Setlist,
+  type ShowFile,
+} from "@bip/domain";
 import type { DehydratedState } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight, Edit } from "lucide-react";
 import { Link, useRevalidator } from "react-router-dom";

--- a/apps/web/app/routes/shows/top-rated-shows.ts
+++ b/apps/web/app/routes/shows/top-rated-shows.ts
@@ -1,5 +1,5 @@
 import type { RatingMode } from "@bip/core";
-import type { SetlistLight } from "@bip/domain";
+import type { Setlist } from "@bip/domain";
 import type { DehydratedState } from "@tanstack/react-query";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
 import type { PublicContext } from "~/lib/base-loaders";
@@ -14,7 +14,7 @@ const MIN_SHOW_RATINGS = 10;
 const TOP_RATED_LIMIT = 100;
 
 export interface TopRatedShowsLoaderData {
-  setlists: SetlistLight[];
+  setlists: Setlist[];
   year: number | null;
   mode: RatingMode;
   minShowRatings: number;
@@ -43,11 +43,11 @@ export async function getTopRatedShows(
 
   const inScope = year ? ranked.filter((show) => showYear(show.date) === year) : ranked;
   const showIds = inScope.slice(0, TOP_RATED_LIMIT).map((show) => show.id);
-  const rawSetlists = await services.setlists.findManyByShowIdsLight(showIds);
-  // findManyByShowIdsLight defaults to `date DESC` ordering, which wipes out
+  const rawSetlists = await services.setlists.findManyByShowIds(showIds);
+  // findManyByShowIds defaults to `date DESC` ordering, which wipes out
   // the rank order from the shows query. Reindex back into rank order here.
   const byShowId = new Map(rawSetlists.map((s) => [s.show.id, s]));
-  const setlists = showIds.map((id) => byShowId.get(id)).filter((s): s is SetlistLight => s !== undefined);
+  const setlists = showIds.map((id) => byShowId.get(id)).filter((s): s is Setlist => s !== undefined);
 
   const externalSources = await computeShowExternalSources(setlists.map((s) => s.show));
 

--- a/apps/web/app/routes/shows/year/$year.tsx
+++ b/apps/web/app/routes/shows/year/$year.tsx
@@ -1,4 +1,4 @@
-import { CacheKeys, type SetlistLight } from "@bip/domain";
+import { CacheKeys, type Setlist } from "@bip/domain";
 import type { DehydratedState } from "@tanstack/react-query";
 import { ArrowUp, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -28,7 +28,7 @@ import { computeShowExternalSources } from "~/server/show-external-sources";
 import { computeShowUserData } from "~/server/show-user-data";
 
 interface LoaderData {
-  setlists: SetlistLight[];
+  setlists: Setlist[];
   year: number;
   searchQuery?: string;
   externalSources: Record<string, ShowExternalSources>;
@@ -84,7 +84,7 @@ export const loader = publicLoader(async ({ request, params, context }): Promise
   };
   const emptyCounts: Record<number, number> = {};
 
-  let setlists: SetlistLight[] = [];
+  let setlists: Setlist[] = [];
 
   // If there's a search query with at least MIN_SEARCH_CHARS characters, use the search functionality.
   // Source filters are hidden in this branch — year-page browse nav is replaced by search results.
@@ -94,7 +94,7 @@ export const loader = publicLoader(async ({ request, params, context }): Promise
 
     if (shows.length > 0) {
       const showIds = shows.map((show) => show.id);
-      setlists = await services.setlists.findManyByShowIdsLight(showIds);
+      setlists = await services.setlists.findManyByShowIds(showIds);
     }
 
     const searchShowIds = setlists.map((s) => s.show.id);
@@ -129,7 +129,7 @@ export const loader = publicLoader(async ({ request, params, context }): Promise
 
   setlists = await services.cache.getOrSet(yearCacheKey, async () => {
     logger.info(`Loading shows from DB for year: ${yearInt}`);
-    return await services.setlists.findManyLight({
+    return await services.setlists.findMany({
       filters: {
         year: yearInt,
         hasPhotos: triStateToBoolean(filters.photos),

--- a/apps/web/app/routes/users/$username.tsx
+++ b/apps/web/app/routes/users/$username.tsx
@@ -169,7 +169,7 @@ async function loadUserProfile({ params, request, context }: LoaderFunctionArgs 
 
   const { attendedSetlists, attendedExternalSources } = pageShowIds.length
     ? await services.cache.getOrSet(CacheKeys.users.attendedSetlists(user.id, clampedAttendedPage), async () => {
-        const setlists = await services.setlists.findManyByShowIdsLight(pageShowIds);
+        const setlists = await services.setlists.findManyByShowIds(pageShowIds);
         const externalSources: Record<string, ShowExternalSources> = await computeShowExternalSources(
           setlists.map((s) => s.show),
         );

--- a/apps/web/app/server/apply-external-source-filters.test.ts
+++ b/apps/web/app/server/apply-external-source-filters.test.ts
@@ -3,7 +3,7 @@ import type { ShowExternalSources } from "~/components/setlist/show-external-bad
 import { applyExternalSourceFilters } from "./apply-external-source-filters";
 
 // Minimal setlist-like shape accepted by the helper — it only needs `show.id`.
-// Using `as never` casts in tests so we don't build out a full SetlistLight.
+// Using `as never` casts in tests so we don't build out a full Setlist.
 function setlist(id: string) {
   return { show: { id } } as never;
 }

--- a/apps/web/app/server/apply-external-source-filters.ts
+++ b/apps/web/app/server/apply-external-source-filters.ts
@@ -1,4 +1,4 @@
-import type { SetlistLight } from "@bip/domain";
+import type { Setlist } from "@bip/domain";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
 import type { TriState } from "~/lib/tri-state-filter";
 
@@ -26,7 +26,7 @@ function isActive(state: TriState | undefined): boolean {
  * callers can use it unconditionally on every request without breaking
  * downstream reference equality.
  */
-export function applyExternalSourceFilters<T extends Pick<SetlistLight, "show">>(
+export function applyExternalSourceFilters<T extends Pick<Setlist, "show">>(
   setlists: T[],
   externalSources: Record<string, ShowExternalSources>,
   flags: ExternalSourceFilterFlags,

--- a/apps/web/app/server/show-external-sources.ts
+++ b/apps/web/app/server/show-external-sources.ts
@@ -3,7 +3,7 @@ import { services } from "~/server/services";
 
 /**
  * Minimal show shape accepted by {@link computeShowExternalSources}. Defined
- * loosely so every kind of setlist/show fixture (Setlist, SetlistLight, etc.)
+ * loosely so every kind of setlist/show fixture (Setlist, etc.)
  * can satisfy it without coercion.
  */
 interface ShowLike {

--- a/packages/core/src/_shared/cache/cache-invalidation-service.ts
+++ b/packages/core/src/_shared/cache/cache-invalidation-service.ts
@@ -33,7 +33,7 @@ export class CacheInvalidationService {
   async invalidateShow(slug: string): Promise<void> {
     this.logger.info(`Invalidating show cache for slug: ${slug}`);
 
-    await Promise.all([this.cache.del(CacheKeys.show.data(slug)), this.cache.del(CacheKeys.setlist.data(slug))]);
+    await this.cache.del(CacheKeys.show.data(slug));
   }
 
   /**
@@ -49,7 +49,7 @@ export class CacheInvalidationService {
 
     this.logger.info(`Invalidating show cache for ID: ${showId}, slug: ${slug}`);
 
-    await Promise.all([this.cache.del(CacheKeys.show.data(slug)), this.cache.del(CacheKeys.setlist.data(slug))]);
+    await this.cache.del(CacheKeys.show.data(slug));
   }
 
   /**
@@ -83,11 +83,11 @@ export class CacheInvalidationService {
       // Per-user song-history embeds the catalog of tracks at each attended
       // show; a show metadata or tracks change can shift values.
       this.cache.delPattern(CacheKeys.users.allSongHistory()),
-      // Rock opera resource pages embed full Setlists (with tracks,
-      // annotations, ratings, notes, date) for every tagged show. Any
+      // Rock opera resource pages embed Setlist payloads (tracks,
+      // annotations, notes, date) for every tagged show. Any
       // show-affecting mutation can stale them.
       this.cache.delPattern(CacheKeys.rockOperas.allPerformances()),
-      // show.data caches per-slug Setlists with rockOperaPerformances
+      // show.data caches per-slug setlists with rockOperaPerformances
       // baked in (SetlistService overlays them in findByShowSlug etc.).
       // When a tagged show's date moves or any rock opera assignment
       // changes, neighbors' annotations (rank/prev/next) shift — wipe

--- a/packages/core/src/setlists/setlist-service.test.ts
+++ b/packages/core/src/setlists/setlist-service.test.ts
@@ -216,13 +216,13 @@ function makeRockOperaStub(): RockOperaService {
   } as unknown as RockOperaService;
 }
 
-describe("SetlistService.findManyLight", () => {
+describe("SetlistService.findMany", () => {
   // monthDay filter passes endsWith to Prisma's date where clause
   test("applies endsWith date filter when monthDay is provided", async () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never, makeRockOperaStub());
 
-    await service.findManyLight({
+    await service.findMany({
       filters: { monthDay: "04-04" },
       sort: [{ field: "date", direction: "desc" }],
     });
@@ -237,7 +237,7 @@ describe("SetlistService.findManyLight", () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never, makeRockOperaStub());
 
-    await service.findManyLight({
+    await service.findMany({
       filters: { year: 2024 },
     });
 
@@ -250,7 +250,7 @@ describe("SetlistService.findManyLight", () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never, makeRockOperaStub());
 
-    await service.findManyLight({ filters: {} });
+    await service.findMany({ filters: {} });
 
     const call = db.show.findMany.mock.calls[0][0];
     expect(call.where.date).toBeUndefined();
@@ -264,7 +264,7 @@ describe("SetlistService.findManyLight", () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never, makeRockOperaStub());
 
-    await service.findManyLight({ filters: { year: 2024 } });
+    await service.findMany({ filters: { year: 2024 } });
 
     const call = db.show.findMany.mock.calls[0][0];
     expect(call.include.showMusicians).toBeDefined();
@@ -277,7 +277,7 @@ describe("SetlistService.findManyLight", () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never, makeRockOperaStub());
 
-    await service.findManyLight({
+    await service.findMany({
       filters: { year: 2024, hasYoutube: true },
     });
 
@@ -292,7 +292,7 @@ describe("SetlistService.findManyLight", () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never, makeRockOperaStub());
 
-    await service.findManyLight({
+    await service.findMany({
       filters: { year: 2024, hasYoutube: false },
     });
 
@@ -306,7 +306,7 @@ describe("SetlistService.findManyLight", () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never, makeRockOperaStub());
 
-    await service.findManyLight({
+    await service.findMany({
       filters: { year: 2024, hasPhotos: false },
     });
 
@@ -320,7 +320,7 @@ describe("SetlistService.findManyLight", () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never, makeRockOperaStub());
 
-    await service.findManyLight({ filters: { year: 2024 } });
+    await service.findMany({ filters: { year: 2024 } });
 
     const call = db.show.findMany.mock.calls[0][0];
     expect(call.where.showYoutubesCount).toBeUndefined();
@@ -334,7 +334,7 @@ describe("SetlistService.findManyLight", () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never, makeRockOperaStub());
 
-    await service.findManyLight({
+    await service.findMany({
       filters: { year: 2024, hasPhotos: true, hasYoutube: false },
     });
 
@@ -352,14 +352,14 @@ describe("SetlistService.findManyLight", () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never, makeRockOperaStub());
 
-    await service.findManyLight({ filters: { year: 2024 } });
+    await service.findMany({ filters: { year: 2024 } });
 
     const call = db.show.findMany.mock.calls[0][0];
     expect(call.where.venueId).toEqual({ not: null });
   });
 });
 
-describe("SetlistService.findManyByShowIdsLight", () => {
+describe("SetlistService.findManyByShowIds", () => {
   // The light by-ids query backs cached list payloads (attended-setlists,
   // rock-opera performances). Its whole reason to exist is that the song
   // select stays lean: the cached blob can't embed lyrics/history text the
@@ -368,7 +368,7 @@ describe("SetlistService.findManyByShowIdsLight", () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never, makeRockOperaStub());
 
-    await service.findManyByShowIdsLight(["show-1"]);
+    await service.findManyByShowIds(["show-1"]);
 
     const songSelect = db.show.findMany.mock.calls[0][0].include.tracks.select.song.select;
     expect(songSelect.id).toBe(true);
@@ -388,7 +388,7 @@ describe("SetlistService.findManyByShowIdsLight", () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never, makeRockOperaStub());
 
-    await service.findManyByShowIdsLight(["show-1", "show-2"]);
+    await service.findManyByShowIds(["show-1", "show-2"]);
 
     const call = db.show.findMany.mock.calls[0][0];
     expect(call.where.id).toEqual({ in: ["show-1", "show-2"] });
@@ -402,8 +402,8 @@ describe("SetlistService.findManyByShowIdsLight", () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never, makeRockOperaStub());
 
-    await service.findManyByShowIdsLight(["show-1"]);
-    await service.findManyByShowIdsLight(["show-1"], { sort: [{ field: "date", direction: "asc" }] });
+    await service.findManyByShowIds(["show-1"]);
+    await service.findManyByShowIds(["show-1"], { sort: [{ field: "date", direction: "asc" }] });
 
     const [defaultCall, sortedCall] = db.show.findMany.mock.calls;
     expect(defaultCall[0].orderBy[0]).toEqual({ date: "desc" });
@@ -416,7 +416,7 @@ describe("SetlistService.findManyByShowIdsLight", () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never, makeRockOperaStub());
 
-    const result = await service.findManyByShowIdsLight([]);
+    const result = await service.findManyByShowIds([]);
 
     expect(result).toEqual([]);
     expect(db.show.findMany).not.toHaveBeenCalled();
@@ -523,7 +523,7 @@ describe("SetlistService.findByShowSlug", () => {
     await service.findByShowSlug("2024-07-26-red-rocks-amphitheatre-morrison-co");
 
     const call = db.show.findUnique.mock.calls[0][0];
-    expect(call.include.tracks.include.previousPerformanceShow).toEqual({
+    expect(call.include.tracks.select.previousPerformanceShow).toEqual({
       select: { date: true, slug: true },
     });
   });
@@ -790,18 +790,105 @@ describe("SetlistService.findByShowSlug", () => {
     const setlist = await service.findByShowSlug("2026-03-20");
     const track = setlist?.sets.flatMap((s) => s.tracks).find((t) => t.id === "t-1");
     expect(track?.song?.authorName).toBe("Chris Lorenzo, Eats Everything");
-    expect(track?.song?.authors.map((a) => a.name)).toEqual(["Chris Lorenzo", "Eats Everything"]);
+  });
+
+  // The show-page cache (show:<slug>:data) stores this payload verbatim, so
+  // the query must not select the text-heavy song columns: they dominated
+  // the blob size and nothing on the show page reads them. The one extra
+  // field beyond the list-view lean set is dateFirstPlayed, which the show
+  // page's debut-year chart derives from.
+  test("selects only the lean song fields, never the text-heavy columns", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never, makeRockOperaStub());
+
+    await service.findByShowSlug("2024-07-26-red-rocks-amphitheatre-morrison-co");
+
+    const call = db.show.findUnique.mock.calls[0][0];
+    const songSelect = call.include.tracks.select?.song?.select;
+    expect(songSelect).toBeDefined();
+    expect(songSelect).toMatchObject({ id: true, title: true, slug: true, kind: true, dateFirstPlayed: true });
+    for (const heavyColumn of ["lyrics", "history", "notes", "tabs", "featuredLyric", "yearlyPlayData"]) {
+      expect(songSelect).not.toHaveProperty(heavyColumn);
+    }
+  });
+
+  // Even when the DB row carries the heavy song columns (e.g. a stale query
+  // shape), the mapper must not thread them into the cached payload, and it
+  // must thread dateFirstPlayed through for the debut-year chart.
+  test("maps the track song to the lean shape with dateFirstPlayed", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never, makeRockOperaStub());
+    db.show.findUnique.mockResolvedValue({
+      id: "show-1",
+      slug: "2024-12-31",
+      date: "2024-12-31",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      venueId: "v-1",
+      bandId: "b-1",
+      tracks: [
+        {
+          id: "t-1",
+          showId: "show-1",
+          songId: "song-a",
+          set: "S1",
+          position: 1,
+          segue: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          likesCount: 0,
+          slug: "t-1",
+          note: null,
+          allTimer: false,
+          previousTrackId: null,
+          nextTrackId: null,
+          averageRating: 0,
+          ratingsCount: 0,
+          gap: 5,
+          previousPerformanceShowId: null,
+          previousPerformanceShow: null,
+          duration: null,
+          durationSource: null,
+          song: {
+            id: "song-a",
+            title: "Above the Waves",
+            slug: "above-the-waves",
+            kind: "original",
+            dateFirstPlayed: new Date("2001-04-21"),
+            lyrics: "row upon row of lyric text",
+            history: "paragraphs of history",
+            songAuthors: [],
+          },
+          annotations: [],
+        },
+      ],
+      venue: {
+        id: "v-1",
+        name: "Red Rocks",
+        slug: "red-rocks",
+        city: "Morrison",
+        country: "US",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    const setlist = await service.findByShowSlug("2024-12-31");
+    const song = setlist?.sets.flatMap((s) => s.tracks).find((t) => t.id === "t-1")?.song;
+    expect(song?.dateFirstPlayed).toEqual(new Date("2001-04-21"));
+    expect(song).not.toHaveProperty("lyrics");
+    expect(song).not.toHaveProperty("history");
   });
 });
 
-describe("SetlistService.findManyLight", () => {
-  // findManyLight powers the list pages (year, top-rated, etc.). The gap-chart
+describe("SetlistService.findMany", () => {
+  // findMany powers the list pages (year, top-rated, etc.). The gap-chart
   // toggle on those pages needs the same prior-show pointer + averageSongGap.
   test("includes previousPerformanceShow date+slug on tracks", async () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never, makeRockOperaStub());
 
-    await service.findManyLight({ filters: { year: 2024 } });
+    await service.findMany({ filters: { year: 2024 } });
 
     const call = db.show.findMany.mock.calls[0][0];
     expect(call.include.tracks.select.previousPerformanceShow).toEqual({
@@ -810,13 +897,24 @@ describe("SetlistService.findManyLight", () => {
     expect(call.include.tracks.select.gap).toBe(true);
     expect(call.include.tracks.select.previousPerformanceShowId).toBe(true);
   });
+
+  // SongLight carries dateFirstPlayed (the show page's debut-year chart reads
+  // it), and every light query shares one include, so the select must load it.
+  test("selects dateFirstPlayed on the lean track song", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never, makeRockOperaStub());
+
+    await service.findMany({ filters: { year: 2024 } });
+
+    const call = db.show.findMany.mock.calls[0][0];
+    expect(call.include.tracks.select.song.select.dateFirstPlayed).toBe(true);
+  });
 });
 
 describe("SetlistService.findMany stub filtering", () => {
-  // findMany dropped venueless stub shows in JS *after* pagination, so a stub
-  // landing on a page silently shrank it below the page size. Filter at the SQL
-  // boundary instead (mirroring findManyLight) so pagination counts stay exact
-  // and stubs never reach the listing.
+  // Stubs must be filtered at the SQL boundary, not in JS after pagination,
+  // so a venueless stub landing on a page can't silently shrink it below the
+  // page size and pagination counts stay exact.
   test("excludes venueless stubs at the SQL boundary when no venue filter is given", async () => {
     const db = makeMockDb();
     const service = new SetlistService(db as never, makeRockOperaStub());
@@ -837,34 +935,6 @@ describe("SetlistService.findMany stub filtering", () => {
 
     const call = db.show.findMany.mock.calls[0][0];
     expect(call.where.venueId).toBe("venue-1");
-  });
-
-  // The homepage and venue pages build setlists via findMany and render them
-  // with the heavy mapper, so the query must join every relation that mapper
-  // reads — the song author (debut-footnote text), structured flags / segue
-  // recurrences / completions, and the track + show performer lineups — or those
-  // footnotes silently vanish (the mapper defaults each absent relation to []).
-  test("joins every relation the heavy setlist mapper renders", async () => {
-    const db = makeMockDb();
-    const service = new SetlistService(db as never, makeRockOperaStub());
-
-    await service.findMany({ filters: { year: 2024 } });
-
-    const call = db.show.findMany.mock.calls[0][0];
-    const trackInclude = call.include.tracks.include;
-    expect(trackInclude.song).toEqual({
-      include: {
-        songAuthors: {
-          select: { position: true, author: { select: { id: true, name: true, slug: true } } },
-          orderBy: { position: "asc" },
-        },
-      },
-    });
-    expect(trackInclude.trackFlags).toBeDefined();
-    expect(trackInclude.segueRecurrences).toBeDefined();
-    expect(trackInclude.completionsAsLater).toBeDefined();
-    expect(trackInclude.trackMusicians).toBeDefined();
-    expect(call.include.showMusicians).toBeDefined();
   });
 });
 

--- a/packages/core/src/setlists/setlist-service.ts
+++ b/packages/core/src/setlists/setlist-service.ts
@@ -12,7 +12,6 @@ import {
   type SegueRecurrence,
   type SegueRecurrenceKind,
   type Setlist,
-  type SetlistLight,
   type Show,
   type ShowLineupMember,
   type SongAuthor,
@@ -109,6 +108,7 @@ type DbTrackLight = {
     title: string;
     slug: string;
     kind: string | null;
+    dateFirstPlayed: Date | string | null;
     songAuthors?: SongAuthorRow[];
   } | null;
   annotations: DbAnnotation[];
@@ -538,65 +538,6 @@ function getSetSortOrder(setLabel: string): number {
   return 999;
 }
 
-function mapSetlistToDomainEntity(
-  show: DbShow & {
-    tracks: (DbTrack & {
-      song: DbSong | null;
-      annotations: DbAnnotation[];
-      previousPerformanceShow?: { date: string; slug: string | null } | null;
-      trackMusicians?: DbTrackMusicianWithRelations[];
-    })[];
-    venue: DbVenue;
-    showMusicians?: DbShowMusicianWithRelations[];
-  },
-): Setlist {
-  const tracks = show.tracks ?? [];
-  const setGroups = new Map<string, (DbTrack & { song: DbSong | null; annotations: DbAnnotation[] })[]>();
-
-  // Group tracks by set label
-  for (const track of tracks) {
-    const setTracks = setGroups.get(track.set) ?? [];
-    setTracks.push(track);
-    setGroups.set(track.set, setTracks);
-  }
-
-  // Convert the grouped tracks into sets
-  const sets = Array.from(setGroups.entries()).map(([label, setTracks]) => {
-    // Sort tracks by position within each set
-    const sortedTracks = [...setTracks].sort((a, b) => {
-      // Ensure we're sorting numerically by position
-      const posA = Number(a.position);
-      const posB = Number(b.position);
-      return posA - posB;
-    });
-
-    return {
-      label,
-      sort: getSetSortOrder(label),
-      tracks: sortedTracks.map((t) => mapTrackToDomainEntity(t)),
-    };
-  });
-
-  // Sort sets by their sort order
-  sets.sort((a, b) => a.sort - b.sort);
-
-  const eligible = eligibleGapsForAggregation(tracks);
-  return {
-    show: mapShowToDomainEntity(show),
-    venue: mapVenueToDomainEntity(show.venue),
-    sets,
-    annotations: tracks.flatMap((t) => t.annotations ?? []).map((a) => mapAnnotationToDomainEntity(a)),
-    averageSongGap: average(eligible),
-    medianSongGap: median(eligible),
-    debutCount: computeDebutCount(tracks),
-    rockOperaPerformances: [],
-    lineup: (show.showMusicians ?? []).map(mapShowMusicianToLineupMember),
-    trackMusicianDeltas: tracks.flatMap((track) =>
-      (track.trackMusicians ?? []).map((tm) => mapTrackMusicianToDelta(tm, track.id)),
-    ),
-  };
-}
-
 function mapTrackLightToDomainEntity(track: DbTrackLight): TrackLight {
   return {
     id: track.id,
@@ -653,18 +594,19 @@ function mapTrackLightToDomainEntity(track: DbTrackLight): TrackLight {
           slug: track.song.slug,
           kind: narrowSongKind(track.song.kind),
           authorName: joinAuthorNames(track.song.songAuthors),
+          dateFirstPlayed: track.song.dateFirstPlayed ? new Date(track.song.dateFirstPlayed) : null,
         }
       : undefined,
   };
 }
 
-function mapSetlistLightToDomainEntity(
+function mapSetlistToDomainEntity(
   show: DbShow & {
     tracks: DbTrackLight[];
     venue: DbVenue;
     showMusicians?: DbShowMusicianWithRelations[];
   },
-): SetlistLight {
+): Setlist {
   const tracks = show.tracks ?? [];
   const setGroups = new Map<string, DbTrackLight[]>();
 
@@ -780,34 +722,16 @@ export const TRACK_FOOTNOTE_INCLUDE = {
   ...TRACK_FLAGS_AND_COMPLETIONS_INCLUDE,
 } as const;
 
-// Every show + track relation the heavy mapper (mapSetlistToDomainEntity) reads:
-// the song author for debut-footnote text, the structured flags / segue
-// recurrences / completion links, and the per-track plus whole-show performer
-// lineups. Shared by every query that returns a heavy Setlist so the joins stay
-// in lockstep — a query missing one silently blanks that footnote category,
-// since the mapper defaults each absent relation to an empty array.
-const HEAVY_SETLIST_INCLUDE = {
-  tracks: {
-    include: {
-      song: { include: { ...SONG_AUTHORS_SETLIST_INCLUDE } },
-      annotations: true,
-      previousPerformanceShow: { select: { date: true, slug: true } },
-      ...TRACK_PERFORMER_INCLUDE,
-      ...TRACK_FLAGS_AND_COMPLETIONS_INCLUDE,
-    },
-  },
-  venue: true,
-  ...SINGLE_SHOW_PERFORMER_INCLUDE,
-} as const;
-
-// Light counterpart of HEAVY_SETLIST_INCLUDE: everything the light mapper
-// (mapSetlistLightToDomainEntity) reads, with the track's song narrowed to the
-// lean list-view fields. The song select deliberately omits the text-heavy
-// columns (lyrics, history, notes, tabs): light payloads back redis-cached
-// list views, and those columns dominated the blob size while nothing in a
-// list view reads them. Shared by every query that returns SetlistLight so
-// the joins stay in lockstep with the mapper.
-const LIGHT_SETLIST_INCLUDE = {
+// Everything the setlist mapper (mapSetlistToDomainEntity) reads, with
+// the track's song narrowed to the lean fields (plus dateFirstPlayed for the
+// show page's debut-year chart). The song select deliberately omits the
+// text-heavy columns (lyrics, history, notes, tabs): these payloads back
+// redis-cached list views and the show page, and those columns dominated the
+// blob size while nothing reading the payload uses them. Shared by every
+// setlist query so the joins stay in lockstep with the mapper; a query
+// missing a relation silently blanks that footnote category, since the
+// mapper defaults each absent relation to an empty array.
+const SETLIST_INCLUDE = {
   tracks: {
     select: {
       id: true,
@@ -832,6 +756,7 @@ const LIGHT_SETLIST_INCLUDE = {
           title: true,
           slug: true,
           kind: true,
+          dateFirstPlayed: true,
           ...SONG_AUTHORS_SETLIST_INCLUDE,
         },
       },
@@ -855,7 +780,7 @@ export class SetlistService {
     private readonly rockOperas: RockOperaService,
   ) {}
 
-  private async overlayRockOperaAnnotations<T extends Setlist | SetlistLight>(setlists: T[]): Promise<T[]> {
+  private async overlayRockOperaAnnotations<T extends Setlist>(setlists: T[]): Promise<T[]> {
     if (setlists.length === 0) return setlists;
     const annotations = await this.rockOperas.findPerformancesForShows(setlists.map((s) => s.show.id));
     if (annotations.size === 0) return setlists;
@@ -866,28 +791,18 @@ export class SetlistService {
     return setlists;
   }
 
-  async findByShowId(id: string): Promise<Setlist | null> {
-    const show = await this.db.show.findUnique({
-      where: { id },
-      relationLoadStrategy: "join",
-      include: HEAVY_SETLIST_INCLUDE,
-    });
-
-    if (!show || !show.venue) return null;
-
-    const setlist = mapSetlistToDomainEntity({
-      ...show,
-      venue: show.venue,
-    });
-    await this.overlayRockOperaAnnotations([setlist]);
-    return setlist;
-  }
-
+  /**
+   * Find one show's setlist in the lean shape: each track's song carries only
+   * id/title/slug/kind/authors/dateFirstPlayed, no lyrics/history text. This
+   * payload is cached verbatim under show:<slug>:data and feeds the show
+   * page, the show edit page's footnotes, and the MCP setlist getters, none
+   * of which read the text-heavy song columns.
+   */
   async findByShowSlug(slug: string): Promise<Setlist | null> {
     const result = await this.db.show.findUnique({
       where: { slug },
       relationLoadStrategy: "join",
-      include: HEAVY_SETLIST_INCLUDE,
+      include: SETLIST_INCLUDE,
     });
 
     if (!result || !result.venue) return null;
@@ -901,20 +816,20 @@ export class SetlistService {
   }
 
   /**
-   * Find setlists for a set of show ids in the lean list-view shape: each
-   * track's song carries only id/title/slug/kind/authors, no lyrics/history
+   * Find setlists for a set of show ids in the lean shape: each track's song
+   * carries only id/title/slug/kind/authors/dateFirstPlayed, no lyrics/history
    * text. Every by-ids consumer is a list view (attended-shows pages, rock
    * opera performances, top-rated, musician appearances), and the redis-cached
    * ones ran to multiple MB per cached page when the full song objects rode
-   * along. Single-show pages needing full data use findByShowSlug/findByShowId.
+   * along.
    */
-  async findManyByShowIdsLight(
+  async findManyByShowIds(
     showIds: string[],
     options?: {
       pagination?: PaginationOptions;
       sort?: SortOptions<Show>[];
     },
-  ): Promise<SetlistLight[]> {
+  ): Promise<Setlist[]> {
     if (!showIds.length) return [];
 
     const orderBy = resolveShowOrderBy(options?.sort, SHOW_ORDER_DESC);
@@ -935,63 +850,7 @@ export class SetlistService {
       skip,
       take,
       relationLoadStrategy: "join",
-      include: LIGHT_SETLIST_INCLUDE,
-    });
-
-    const setlists = results
-      .filter((result): result is typeof result & { venue: NonNullable<typeof result.venue> } => result.venue !== null)
-      .map((show) =>
-        mapSetlistLightToDomainEntity({
-          ...show,
-          venue: show.venue,
-          tracks: show.tracks.map((track) => ({
-            ...track,
-            annotations: track.annotations || [],
-          })),
-        }),
-      );
-    return this.overlayRockOperaAnnotations(setlists);
-  }
-
-  async findMany(options?: {
-    pagination?: PaginationOptions;
-    sort?: SortOptions<Show>[];
-    filters?: SetlistFilter;
-  }): Promise<Setlist[]> {
-    const year = options?.filters?.year;
-    const monthDay = options?.filters?.monthDay;
-    const venueId = options?.filters?.venueId;
-    const hasPhotos = options?.filters?.hasPhotos;
-    const hasYoutube = options?.filters?.hasYoutube;
-
-    const orderBy = resolveShowOrderBy(options?.sort, SHOW_ORDER_ASC);
-    const skip =
-      options?.pagination?.page && options?.pagination?.limit
-        ? (options.pagination.page - 1) * options.pagination.limit
-        : undefined;
-    const take = options?.pagination?.limit;
-
-    const results = await this.db.show.findMany({
-      where: {
-        // Explicit caller venueId (the venue-detail page) wins; otherwise apply
-        // the stub filter to drop orphan placeholder shows that have no venue.
-        venueId: venueId !== undefined ? venueId : NON_STUB_SHOWS_WHERE.venueId,
-        date: monthDay
-          ? { endsWith: `-${monthDay}` }
-          : year
-            ? {
-                gte: `${year}-01-01`,
-                lt: `${year + 1}-01-01`,
-              }
-            : undefined,
-        showPhotosCount: countFilter(hasPhotos),
-        showYoutubesCount: countFilter(hasYoutube),
-      },
-      orderBy,
-      skip,
-      take,
-      relationLoadStrategy: "join",
-      include: HEAVY_SETLIST_INCLUDE,
+      include: SETLIST_INCLUDE,
     });
 
     const setlists = results
@@ -1010,14 +869,14 @@ export class SetlistService {
   }
 
   /**
-   * Find setlists with minimal song data (id, title, slug only).
-   * Use this for list views where full song objects (lyrics, history) aren't needed.
+   * Find setlists by year / calendar-day / venue / media filters. Powers the
+   * homepage recents and the year, on-this-day, and venue-detail listings.
    */
-  async findManyLight(options?: {
+  async findMany(options?: {
     pagination?: PaginationOptions;
     sort?: SortOptions<Show>[];
     filters?: SetlistFilter;
-  }): Promise<SetlistLight[]> {
+  }): Promise<Setlist[]> {
     const year = options?.filters?.year;
     const monthDay = options?.filters?.monthDay;
     const venueId = options?.filters?.venueId;
@@ -1052,13 +911,13 @@ export class SetlistService {
       skip,
       take,
       relationLoadStrategy: "join",
-      include: LIGHT_SETLIST_INCLUDE,
+      include: SETLIST_INCLUDE,
     });
 
     const setlists = results
       .filter((result): result is typeof result & { venue: NonNullable<typeof result.venue> } => result.venue !== null)
       .map((show) =>
-        mapSetlistLightToDomainEntity({
+        mapSetlistToDomainEntity({
           ...show,
           venue: show.venue,
           tracks: show.tracks.map((track) => ({

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -11,10 +11,10 @@ export const CacheKeys = {
    * Show-related cache keys
    */
   show: {
-    /** Complete show + setlist data for show page. :v14 — tracks no longer
-     *  embed averageRating/ratingsCount (rating values moved to the live
-     *  tier-2 read path so rating writes don't staleness-bust this blob). */
-    data: (slug: string) => `show:${slug}:data:v14`,
+    /** Complete show + setlist data for show page. :v15 bump: the payload is
+     *  now Setlist, so track songs carry only the lean fields (id/title/
+     *  slug/kind/authors/dateFirstPlayed), no lyrics/history/notes/tabs text. */
+    data: (slug: string) => `show:${slug}:data:v15`,
 
     // Note: Reviews are loaded fresh from DB, not cached
 
@@ -33,9 +33,8 @@ export const CacheKeys = {
     /** Paginated show listings with filters */
     list: (filters: CacheFilters) => {
       const filterHash = hashFilters(filters);
-      // :v14 — tracks dropped averageRating/ratingsCount (rating values moved
-      // to the live tier-2 read path). See CacheKeys.show.data.
-      return `shows:list:${filterHash}:v14`;
+      // :v15 bump: SongLight gained dateFirstPlayed (Setlist shape change).
+      return `shows:list:${filterHash}:v15`;
     },
 
     /** All show listing caches (for pattern deletion) */
@@ -43,15 +42,6 @@ export const CacheKeys = {
 
     /** Show + all-timer counts for a calendar day (On This Day home page widget) */
     onThisDayCounts: (monthDay: string) => `shows:on-this-day-counts:${monthDay}`,
-  },
-
-  /**
-   * Setlist cache keys
-   */
-  setlist: {
-    /** Complete setlist data with tracks and annotations. :v14 — tracks no
-     *  longer embed averageRating/ratingsCount (moved to live tier-2). */
-    data: (slug: string) => `setlist:${slug}:data:v14`,
   },
 
   /**
@@ -116,8 +106,10 @@ export const CacheKeys = {
    * Musician profile page cache keys
    */
   musicians: {
-    /** Full musician profile payload (appearances, songs played/written, performances). */
-    page: (slug: string) => `musician:${slug}:data:v4`,
+    /** Full musician profile payload (appearances, songs played/written,
+     *  performances). :v5 bump: SongLight gained dateFirstPlayed (Setlist
+     *  shape change; performances embed Setlist). */
+    page: (slug: string) => `musician:${slug}:data:v5`,
     /** Every musician profile cache (for pattern deletion on broad mutations). */
     allPages: () => "musician:*:data:*",
   },
@@ -140,10 +132,10 @@ export const CacheKeys = {
      * Pre-built SetlistList payload (setlists + external sources) for one
      * page of a user's attended shows. Paginated because the heaviest users
      * have 400+ attended shows and the un-paginated payload is large enough
-     * to be slow to deserialize/transport even from Redis. :v14 bump:
-     * setlists are SetlistLight (lean track songs; no lyrics/history text).
+     * to be slow to deserialize/transport even from Redis. :v15 bump:
+     * SongLight gained dateFirstPlayed (Setlist shape change).
      */
-    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}:v14`,
+    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}:v15`,
     /** All pages of a single user's attended-setlists caches (for per-user invalidation). */
     allAttendedSetlistsForUser: (userId: string) => `user:${userId}:attended-setlists:*`,
     /** All per-user attended-setlists caches (for pattern deletion on broad show mutations). */
@@ -168,9 +160,9 @@ export const CacheKeys = {
    */
   rockOperas: {
     /** Resource-page list payload: setlists + external sources for one rock
-     *  opera. :v12 bump: setlists are SetlistLight (lean track songs; no
-     *  lyrics/history text). */
-    performances: (slug: string) => `rock-operas:performances:${slug}:v12`,
+     *  opera. :v13 bump: SongLight gained dateFirstPlayed (Setlist
+     *  shape change). */
+    performances: (slug: string) => `rock-operas:performances:${slug}:v13`,
     /** Pattern for invalidating every performances cache (broad mutations). */
     allPerformances: () => "rock-operas:performances:*",
   },
@@ -179,8 +171,9 @@ export const CacheKeys = {
    * Home page cache keys
    */
   home: {
-    /** Recent setlists for home page (limit + sort direction) */
-    recentSetlists: (limit: number) => `home:recent-setlists:${limit}:v14`,
+    /** Recent setlists for home page (limit + sort direction). :v15 bump:
+     *  SongLight gained dateFirstPlayed (Setlist shape change). */
+    recentSetlists: (limit: number) => `home:recent-setlists:${limit}:v15`,
   },
 
   /**

--- a/packages/domain/src/models/setlist.ts
+++ b/packages/domain/src/models/setlist.ts
@@ -2,15 +2,21 @@ import type { Annotation } from "./annotation";
 import type { ShowLineupMember, TrackMusicianDelta } from "./musician";
 import type { RockOperaPerformanceAnnotation } from "./rock-opera";
 import type { Show } from "./show";
-import type { Track, TrackLight } from "./track";
+import type { TrackLight } from "./track";
 import type { Venue } from "./venue";
 
 export type Set = {
   label: string;
   sort: number;
-  tracks: Track[];
+  tracks: TrackLight[];
 };
 
+/**
+ * One show's setlist as every consumer reads it: tracks carry the lean
+ * SongLight (id/title/slug/kind/authorName/dateFirstPlayed), never the
+ * text-heavy song columns (lyrics, history, notes, tabs). This shape is
+ * what the redis-cached show page, list views, and MCP getters all serve.
+ */
 export type Setlist = {
   show: Show;
   venue: Venue;
@@ -38,43 +44,6 @@ export type Setlist = {
   /**
    * Per-track sit-in / sat-out deviations from the lineup, used to synthesize
    * performer footnotes. Populated only by single-show fetches.
-   */
-  trackMusicianDeltas: TrackMusicianDelta[];
-};
-
-export type SetLight = {
-  label: string;
-  sort: number;
-  tracks: TrackLight[];
-};
-
-export type SetlistLight = {
-  show: Show;
-  venue: Venue;
-  sets: SetLight[];
-  annotations: Annotation[];
-  averageSongGap: number | null;
-  medianSongGap: number | null;
-  /**
-   * Number of distinct catalog debuts in this show (tracks with `gap === null`,
-   * counting each song once even if played twice). Shown alongside the avg/median
-   * because debuts are excluded from those numbers but still signal rarity.
-   */
-  debutCount: number;
-  /**
-   * Rock opera annotations for this show. Populated only by single-show
-   * fetches (services.setlists.findByShowSlug); list-page composers leave
-   * this empty so list pages pay no lookup cost.
-   */
-  rockOperaPerformances: RockOperaPerformanceAnnotation[];
-  /**
-   * The show's default performer lineup. Populated only by single-show fetches;
-   * list-page composers leave this empty.
-   */
-  lineup: ShowLineupMember[];
-  /**
-   * Per-track sit-in / sat-out deviations from the lineup. Populated only by
-   * single-show fetches.
    */
   trackMusicianDeltas: TrackMusicianDelta[];
 };

--- a/packages/domain/src/models/track.ts
+++ b/packages/domain/src/models/track.ts
@@ -133,6 +133,9 @@ export const songLightSchema = z.object({
   // names the origin for covers/mashups.
   kind: z.enum(["original", "cover", "mashup", "improvisation"]).nullable().optional(),
   authorName: z.string().nullable().optional(),
+  // Carried for the show page's debut-year chart, which derives each song's
+  // debut year from its first-played date.
+  dateFirstPlayed: z.date().nullable().optional(),
 });
 
 export type SongLight = z.infer<typeof songLightSchema>;


### PR DESCRIPTION
Every setlist read now serves one lean payload: the show page, the show edit page, the MCP getters, and all list views share a single `Setlist` shape whose track songs carry only `id`/`title`/`slug`/`kind`/`authors`/`dateFirstPlayed`, never the text columns (lyrics, history, notes, tabs, featuredLyric, yearlyPlayData, longestGapsData). The `show:*:data` cache shrinks accordingly: the NYE '24 blob drops from ~105KB to 46KB. Nothing that reads these payloads used those columns.

With no heavy consumer left, the heavy path is deleted and the `Light` naming collapses:

- `SetlistLight` renames to `Setlist`; the old heavy `Setlist`/`Set` types, `HEAVY_SETLIST_INCLUDE`, and the heavy setlist mapper are gone. `findManyLight` becomes `findMany`, `findManyByShowIdsLight` becomes `findManyByShowIds`. The venue page (the last heavy caller) inherits the lean query and renders identically.
- `TrackLight`/`SongLight` keep their names: the full `Track`/`Song` types remain distinct and in use (admin track editors via `TRACK_FOOTNOTE_INCLUDE`, song pages, `/api/tracks`).
- `SongLight` gains an optional `dateFirstPlayed`; the show page's debut-year chart derives from it, and it was the only non-lean field any show-page consumer read.
- That's a `Setlist` shape change, so every key holding the shape bumps together: `show.data`, `shows.list`, `home.recentSetlists`, `users.attendedSetlists` to v15, `rockOperas.performances` to v13, `musicians.page` to v5.
- `SetlistService.findByShowId` deleted (no callers) and the `setlist:*:data` key removed (it was delete-only, never written).
- Adds `.claude/launch.json` so Claude Code's browser preview can start the dev server by name.

## Verification

- Show page SSR against the dev server renders the full setlist card, footnotes, highlights, debut-year chart, and JSON-LD; the cached v15 blob contains zero `lyrics` keys and carries `dateFirstPlayed`. The venue page renders its full card list from the lean query.
- MCP `get_setlists` for the same show diffed against prod (old code): payloads are byte-identical apart from row ordering on two relations that have no `orderBy` and are loaded through the same shared include constants in both paths, i.e. DB row order, not this change. Track ids, flags, completes, durations, and lineup all match, so sync-from-prod is unaffected.

## Reviewer note

`dateFirstPlayed` is optional-and-nullable rather than required: the DB column is nullable (never-played catalog songs), the value is a denormalized stat that lags the recompute (a just-debuted song is null until stats rebuild), and the optional key matches the adjacent `kind`/`authorName` pattern in `songLightSchema` while sparing every fixture that builds a `TrackLight`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
