### PR TITLE
Order setlist instruments and annotations deterministically

### DIFF
--- a/packages/core/src/setlists/setlist-service.test.ts
+++ b/packages/core/src/setlists/setlist-service.test.ts
@@ -359,6 +359,36 @@ describe("SetlistService.findMany", () => {
   });
 });
 
+describe("deterministic relation ordering", () => {
+  // Instrument bridges and annotations have no curated position column, so an
+  // include without orderBy returns DB insertion order, which differs between
+  // prod and a local restore, destabilizing cached blobs and MCP sync diffs.
+  // Every setlist query must order instruments by slug (unique) and
+  // annotations by entry time (createdAt, id tiebreak).
+  test("orders lineup and track-performer instruments by instrument slug", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never, makeRockOperaStub());
+
+    await service.findMany({ filters: { year: 2024 } });
+
+    const call = db.show.findMany.mock.calls[0][0];
+    expect(call.include.showMusicians.include.instruments.orderBy).toEqual({ instrument: { slug: "asc" } });
+    expect(call.include.tracks.select.trackMusicians.include.instruments.orderBy).toEqual({
+      instrument: { slug: "asc" },
+    });
+  });
+
+  test("orders track annotations by createdAt with id tiebreak", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never, makeRockOperaStub());
+
+    await service.findManyByShowIds(["show-1"]);
+
+    const call = db.show.findMany.mock.calls[0][0];
+    expect(call.include.tracks.select.annotations.orderBy).toEqual([{ createdAt: "asc" }, { id: "asc" }]);
+  });
+});
+
 describe("SetlistService.findManyByShowIds", () => {
   // The light by-ids query backs cached list payloads (attended-setlists,
   // rock-opera performances). Its whole reason to exist is that the song

--- a/packages/core/src/setlists/setlist-service.ts
+++ b/packages/core/src/setlists/setlist-service.ts
@@ -21,6 +21,7 @@ import {
   type TrackMusicianDelta,
   type Venue,
 } from "@bip/domain";
+import type { Prisma } from "@prisma/client";
 import type {
   DbAnnotation,
   DbClient,
@@ -654,13 +655,18 @@ function mapSetlistToDomainEntity(
 // instruments played. Loaded on list queries too (not just single-show fetches)
 // so the synthesized "with <guest> on <instrument>" footnotes render in setlist
 // listings, matching the free-text annotations they replaced.
-// The musician (with default instrument) + played instruments for one lineup
-// row. Shared so ShowService.getLineup loads exactly what
-// mapShowMusicianToLineupMember reads, keeping the edit page's read-only
-// lineup identical to the show page's.
+// The musician (with default instrument) + played instruments for one
+// performer row: a show lineup member or a per-track sit-in/sat-out delta,
+// which load the identical shape. Shared so ShowService.getLineup loads
+// exactly what mapShowMusicianToLineupMember reads, keeping the edit page's
+// read-only lineup identical to the show page's. Instruments order by slug
+// (unique): the bridge tables have no position column, so an unordered
+// include returns DB insertion order, which differs between environments
+// (prod vs. a local restore) and destabilizes cached payloads and MCP sync
+// diffs.
 export const LINEUP_MEMBER_INCLUDE = {
   musician: { include: { defaultInstrument: true } },
-  instruments: { include: { instrument: true } },
+  instruments: { include: { instrument: true }, orderBy: { instrument: { slug: "asc" } } },
 } as const;
 
 const SINGLE_SHOW_PERFORMER_INCLUDE = {
@@ -671,12 +677,14 @@ const SINGLE_SHOW_PERFORMER_INCLUDE = {
 
 export const TRACK_PERFORMER_INCLUDE = {
   trackMusicians: {
-    include: {
-      musician: { include: { defaultInstrument: true } },
-      instruments: { include: { instrument: true } },
-    },
+    include: LINEUP_MEMBER_INCLUDE,
   },
 } as const;
+
+// Annotations have no curated order column and the footnote list renders them
+// in array order, so entry order (createdAt, id as a same-timestamp tiebreak)
+// keeps footnote numbering deterministic across environments.
+export const ANNOTATION_ORDER_BY: Prisma.AnnotationOrderByWithRelationInput[] = [{ createdAt: "asc" }, { id: "asc" }];
 
 // Structured flags plus both ends of the cross-show completion link. A track
 // that is the *later* one completing an earlier version owns a `completionsAsLater`
@@ -760,7 +768,7 @@ const SETLIST_INCLUDE = {
           ...SONG_AUTHORS_SETLIST_INCLUDE,
         },
       },
-      annotations: true,
+      annotations: { orderBy: ANNOTATION_ORDER_BY },
     },
   },
   venue: true,

--- a/packages/core/src/tracks/track-service.ts
+++ b/packages/core/src/tracks/track-service.ts
@@ -13,6 +13,7 @@ import { buildIncludeClause, buildOrderByClause, buildWhereClause } from "../_sh
 import type { QueryOptions } from "../_shared/database/types";
 import { slugify } from "../_shared/utils/slugify";
 import {
+  ANNOTATION_ORDER_BY,
   mapTrackMusicianToDelta,
   mapTrackToDomainEntity as mapTrackRowToFootnoteDomain,
   TRACK_FOOTNOTE_INCLUDE,
@@ -164,7 +165,7 @@ export class TrackService {
     const result = await this.db.track.findUnique({
       where: { id },
       include: {
-        annotations: true,
+        annotations: { orderBy: ANNOTATION_ORDER_BY },
         song: true,
       },
     });
@@ -327,7 +328,7 @@ export class TrackService {
       orderBy: [{ position: "asc" }],
       include: {
         song: true,
-        annotations: true,
+        annotations: { orderBy: ANNOTATION_ORDER_BY },
       },
     });
 


### PR DESCRIPTION
Lineup instrument lists and annotation footnotes now render in the same
order everywhere: instruments by slug, annotations by entry time
(createdAt, id tiebreak). Previously both relations loaded with no
orderBy, so the order was DB insertion order and differed between prod
and a local restore, which showed up as spurious churn when diffing MCP
get_setlists payloads against prod.

Annotations have no curated order column and the footnote list renders
them in array order, so entry order preserves what footnote numbering
historically showed. Instrument display already sorts by name in-memory,
so that ordering only affects payload/sync stability, not the UI.

No cache key bump: the payload shape is unchanged, only array order, so
cached blobs age out with their TTL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
