### PR TITLE
Credit mashups to the members who wrote them

### DIFF
--- a/apps/web/app/lib/seo.test.ts
+++ b/apps/web/app/lib/seo.test.ts
@@ -1,6 +1,6 @@
-import type { Setlist, Venue } from "@bip/domain";
+import type { Setlist, Song, Venue } from "@bip/domain";
 import { describe, expect, it } from "vitest";
-import { getShowMeta, getVenueMeta } from "./seo";
+import { getShowMeta, getSongMeta, getVenueMeta } from "./seo";
 
 /**
  * Page titles/descriptions are built from the venue location. International
@@ -10,6 +10,11 @@ import { getShowMeta, getVenueMeta } from "./seo";
 function titleContent(meta: Array<Record<string, unknown>>): string {
   const tag = meta.find((m) => m.title !== undefined);
   return String(tag?.title ?? "");
+}
+
+function descriptionContent(meta: Array<Record<string, unknown>>): string {
+  const tag = meta.find((m) => m.name === "description");
+  return String(tag?.content ?? "");
 }
 
 const harpa = {
@@ -41,5 +46,37 @@ describe("getShowMeta", () => {
     const title = titleContent(getShowMeta(setlist));
     expect(title).toContain("Reykjavik, Iceland");
     expect(title).not.toContain("null");
+  });
+});
+
+function song(overrides: Partial<Song>): Song {
+  return {
+    id: "s1",
+    title: "Caves of the East x Something About Us",
+    slug: "caves-of-the-east-x-something-about-us",
+    timesPlayed: 1,
+    ...overrides,
+  } as unknown as Song;
+}
+
+/**
+ * The by-line names whoever actually wrote the song. Attributing every song to
+ * the band put "Dancing Queen by The Disco Biscuits" in the tab title and the
+ * search snippet for covers and mashups alike.
+ */
+describe("getSongMeta", () => {
+  it("credits the song's authors rather than the band", () => {
+    const meta = getSongMeta(song({ authorName: "Marc Brownstein, Daft Punk" }));
+    expect(titleContent(meta)).toContain("by Marc Brownstein, Daft Punk");
+    expect(descriptionContent(meta)).toContain("by Marc Brownstein, Daft Punk");
+  });
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["empty", ""],
+  ])("falls back to the band when a song's authorName is %s", (_label, authorName) => {
+    const title = titleContent(getSongMeta(song({ title: "Simulations", authorName })));
+    expect(title).toContain("Simulations by The Disco Biscuits");
   });
 });

--- a/apps/web/app/lib/seo.ts
+++ b/apps/web/app/lib/seo.ts
@@ -177,9 +177,12 @@ export function getSongsMeta() {
 
 // Generate meta tags for a song detail page
 export function getSongMeta(song: Song & { timesPlayed?: number; debutDate?: string }) {
-  const title = `${song.title} by ${SEO_CONFIG.bandName} | ${SEO_CONFIG.siteName}`;
+  // Covers and mashups are written by someone other than the band, so credit the
+  // song's own authors. Falls back to the band for songs with none recorded.
+  const byLine = song.authorName || SEO_CONFIG.bandName;
+  const title = `${song.title} by ${byLine} | ${SEO_CONFIG.siteName}`;
   const debutYear = song.debutDate ? new Date(song.debutDate).getFullYear() : "";
-  const description = `View performance history, lyrics, tabs, and statistics for "${song.title}" by ${SEO_CONFIG.bandName}.${song.timesPlayed ? ` Played ${song.timesPlayed} times` : ""}${debutYear ? ` since ${debutYear}` : ""}.`;
+  const description = `View performance history, lyrics, tabs, and statistics for "${song.title}" by ${byLine}.${song.timesPlayed ? ` Played ${song.timesPlayed} times` : ""}${debutYear ? ` since ${debutYear}` : ""}.`;
   const url = `${SEO_CONFIG.url}/songs/${song.slug}`;
 
   const keywords = [

--- a/packages/core/src/_shared/prisma/migrations/20260715000000_fix_mashup_metadata/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260715000000_fix_mashup_metadata/migration.sql
@@ -1,0 +1,94 @@
+-- Correct the metadata on the mashups that credit the generic band author
+-- ("The Disco Biscuits") instead of the member who wrote the Biscuits-side
+-- component. A mashup's authors are the concatenation of its component songs'
+-- author lists, in the order the components appear in the title, deduped; each
+-- component contributes its credit verbatim, so a component crediting a member
+-- yields that member and a component crediting the band yields the band.
+--
+-- Everything matches by slug and author name. Row ids are assigned per
+-- environment and differ between the local prod-restore and prod, and an
+-- id-keyed WHERE that misses fails SILENTLY (0 rows, no error) — the bug that
+-- made 20260604000000_song_kind deploy "successfully" but wrong.
+
+-- 1. Ensure every author exists so a from-scratch replay can't miss a join.
+INSERT INTO "authors" ("name", "slug", "created_at", "updated_at")
+SELECT v.name, v.slug, now(), now()
+FROM (VALUES
+    ('Marc Brownstein', 'marc-brownstein'),
+    ('Aron Magner', 'aron-magner'),
+    ('Jon Gutwillig', 'jon-gutwillig'),
+    ('Joey Friedman', 'joey-friedman'),
+    ('Dean Turnley', 'dean-turnley'),
+    ('Daft Punk', 'daft-punk'),
+    ('The Disco Biscuits', 'the-disco-biscuits')
+) AS v(name, slug)
+WHERE NOT EXISTS (SELECT 1 FROM "authors" a WHERE a."name" = v.name);
+
+-- 2. "Caves of the East x Something About Us" was filed as a cover and entered
+-- with minor words capitalized. Title-case matches its component song ("Caves of
+-- the East") and the rules in 20260413225404_fix_song_title_casing. The slug is
+-- already correct and stays untouched so existing links keep working.
+-- 20260715000001 refreshes this song's search_text, which the trigger cannot do
+-- on a rename.
+UPDATE "songs"
+SET "kind" = 'mashup',
+    "title" = 'Caves of the East x Something About Us',
+    "updated_at" = now()
+WHERE "slug" = 'caves-of-the-east-x-something-about-us';
+
+-- 3. "Falling 303" sits at a slug that misspells an unrelated mashup, so
+-- /songs/falling-303 404s while /songs/dino-bany-x-b-o-t-a serves the song. The
+-- title guard prevents renaming the wrong row; the NOT EXISTS guard keeps a
+-- replay off the unique slug index.
+UPDATE "songs"
+SET "slug" = 'falling-303',
+    "updated_at" = now()
+WHERE "slug" = 'dino-bany-x-b-o-t-a'
+  AND "title" = 'Falling 303'
+  AND NOT EXISTS (SELECT 1 FROM "songs" other WHERE other."slug" = 'falling-303');
+
+-- 4. Replace the author set for each mashup that credited the band in place of
+-- the component's writer.
+DELETE FROM "song_authors"
+WHERE "song_id" IN (
+    SELECT "id" FROM "songs" WHERE "slug" IN (
+        'caves-of-the-east-x-something-about-us',
+        'konkrete-x-floodlights',
+        'actin-tough-x-neck-romancer',
+        'tourists-rocket-ship-x-on-time'
+    )
+);
+
+INSERT INTO "song_authors" ("song_id", "author_id", "position", "created_at", "updated_at")
+SELECT s."id", a."id", m.pos, now(), now()
+FROM (VALUES
+    -- Caves of the East (Marc Brownstein) x Something About Us (Daft Punk)
+    ('caves-of-the-east-x-something-about-us', 'Marc Brownstein', 0),
+    ('caves-of-the-east-x-something-about-us', 'Daft Punk', 1),
+    -- Konkrete (Jon Gutwillig) x Floodlights (Marc Brownstein)
+    ('konkrete-x-floodlights', 'Jon Gutwillig', 0),
+    ('konkrete-x-floodlights', 'Marc Brownstein', 1),
+    -- Actin' Tough (Dean Turnley) x Neck Romancer (Aron Magner)
+    ('actin-tough-x-neck-romancer', 'Dean Turnley', 0),
+    ('actin-tough-x-neck-romancer', 'Aron Magner', 1),
+    -- Tourists (Rocket Ship) (Aron Magner, Joey Friedman, Jon Gutwillig) x On Time (The Disco Biscuits)
+    ('tourists-rocket-ship-x-on-time', 'Aron Magner', 0),
+    ('tourists-rocket-ship-x-on-time', 'Joey Friedman', 1),
+    ('tourists-rocket-ship-x-on-time', 'Jon Gutwillig', 2),
+    ('tourists-rocket-ship-x-on-time', 'The Disco Biscuits', 3)
+) AS m(song_slug, author_name, pos)
+JOIN "songs" s ON s."slug" = m.song_slug
+JOIN LATERAL (SELECT "id" FROM "authors" WHERE "name" = m.author_name ORDER BY "created_at" LIMIT 1) a ON true;
+
+-- 5. Refresh the caches that bake in song kind, title, and authors. The deploy's
+-- recompute-pending run calls invalidateSongCaches() + invalidateShowListings(),
+-- busting songs:index:full, songs:filtered:*, and the per-show show:*:data:*
+-- payloads (24h TTL) that carry the kind-derived debut footnote. HAVING (not
+-- WHERE ... NOT EXISTS) so this inserts zero rows, not a NULL row, when a request
+-- for the earliest date already exists.
+INSERT INTO "stats_recompute_requests" ("id", "since_date")
+SELECT gen_random_uuid(), MIN("date")::date
+FROM "shows"
+WHERE "date" IS NOT NULL
+HAVING MIN("date") IS NOT NULL
+   AND MIN("date")::date NOT IN (SELECT "since_date" FROM "stats_recompute_requests" WHERE "since_date" IS NOT NULL);

--- a/packages/core/src/_shared/prisma/migrations/20260715000001_fix_song_search_text_on_title_change/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260715000001_fix_song_search_text_on_title_change/migration.sql
@@ -1,0 +1,30 @@
+-- Keep songs.search_text in step with the title when a song is renamed.
+--
+-- update_song_search_fields is a BEFORE INSERT OR UPDATE trigger, but it built
+-- its value with build_song_search_text(NEW.id), which re-SELECTs the title from
+-- the songs table. During a BEFORE UPDATE the table still holds the pre-update
+-- row, so a rename wrote the OLD title into search_text and the song stayed
+-- unsearchable under its new name until some later UPDATE happened to re-fire
+-- the trigger. Renaming "Caves Of The East x Something About Us" to its correct
+-- casing left search_text on the old string; "Thank You for Being a Friend"
+-- carries the same staleness from an earlier retitle.
+--
+-- NEW.title is the incoming value, so read it directly. build_song_search_text
+-- keeps its id-based signature for backfills, where the row is committed and the
+-- re-read is correct.
+CREATE OR REPLACE FUNCTION update_song_search_fields()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.search_text := COALESCE(NEW.title, '');
+  NEW.search_vector := to_tsvector('english', NEW.search_text);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Repair the rows the old trigger left behind. The corrected trigger recomputes
+-- both columns from NEW.title, so this re-states the same values it derives.
+UPDATE "songs"
+SET "search_text" = "title",
+    "search_vector" = to_tsvector('english', COALESCE("title", '')),
+    "updated_at" = now()
+WHERE "search_text" IS DISTINCT FROM "title";


### PR DESCRIPTION
Mashups now credit the people who actually wrote them. **Caves of the East x Something About Us** was filed as a cover by The Disco Biscuits; it is now a mashup by Marc Brownstein and Daft Punk, with its title cased to match its component song. Three older mashups had the same generic band credit and now name their writers:

| mashup | was | now |
| --- | --- | --- |
| Caves of the East x Something About Us | The Disco Biscuits, Daft Punk | Marc Brownstein, Daft Punk |
| Konkrete x Floodlights | The Disco Biscuits | Jon Gutwillig, Marc Brownstein |
| Actin' Tough x Neck Romancer | The Disco Biscuits, Dean Turnley | Dean Turnley, Aron Magner |
| Tourists (Rocket Ship) x On Time | The Disco Biscuits | Aron Magner, Joey Friedman, Jon Gutwillig, The Disco Biscuits |

**Falling 303** is reachable at `/songs/falling-303`. It had been sitting at `dino-bany-x-b-o-t-a`, a misspelling of an unrelated mashup, so its own URL 404'd while a typo served the song.

Song pages now credit their own authors in the tab title and search snippet. A cover reads "Dancing Queen by ABBA" instead of "Dancing Queen by The Disco Biscuits"; songs with no authors recorded still fall back to the band.

The audit covered all 13 mashups and every song added this year. The nine mashups not listed above were already correct, as were the other new songs from 2026-07-09 (Positive, More You Know) and that show's annotations.

## Notes for the reviewer

**The rule.** A mashup's authors are its component songs' author lists concatenated in title order, deduped, each component contributing its credit verbatim. That is what the nine correct mashups already do, so this brings the outliers in line rather than inventing a convention. It is why Tourists x On Time mixes three members with the band: `tourists-rocket-ship` credits the members, `on-time` credits the band.

**The search trigger.** `20260715000001` is here because the first migration exposed a live bug. `update_song_search_fields` is a BEFORE INSERT OR UPDATE trigger that built its value with `build_song_search_text(NEW.id)`, which re-SELECTs the row from `songs`. A BEFORE trigger sees the pre-update row, so renaming a song wrote the OLD title into `search_text` and left it unsearchable under its new name. It now reads `NEW.title` directly; `build_song_search_text` keeps its id-based signature for backfills, where the row is committed and the re-read is correct. The migration also repairs the rows the old trigger stranded (this song, plus "Thank You for Being a Friend" from an earlier retitle).

The venues, shows, and tracks triggers share this defect and are NOT fixed here: 801 venues are stale, 760 of them with an empty `search_text`, which makes them unfindable by exact name. Their `build_*` functions read joined tables, so `NEW.*` alone will not serve and each needs its own shape. Tracked separately.

**Ordering.** `20260715000000` runs under the old trigger and strands `search_text`; `20260715000001` then fixes the function and backfills with a broad `WHERE search_text IS DISTINCT FROM title`, which catches it. That holds on a from-scratch prod deploy, not just incrementally on top of this DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
