### PR TITLE
Color-code rating values on a purple-to-green scale

### DIFF
--- a/apps/web/app/components/performance/track-rating-cell.test.tsx
+++ b/apps/web/app/components/performance/track-rating-cell.test.tsx
@@ -57,7 +57,7 @@ describe("TrackRatingCell", () => {
     );
 
     const button = container.querySelector("button");
-    expect(button?.className).toContain("border-amber-500");
+    expect(button).toHaveAttribute("data-rated", "true");
   });
 
   // When the user has NOT rated the track, the cell has a dashed border
@@ -164,7 +164,7 @@ describe("TrackRatingCell", () => {
 
     // Initially golden
     let button = container.querySelector("button");
-    expect(button?.className).toContain("border-amber-500");
+    expect(button).toHaveAttribute("data-rated", "true");
 
     rerender(
       <MemoryRouter>
@@ -180,10 +180,8 @@ describe("TrackRatingCell", () => {
     );
 
     // Should now be dashed (no user rating), not golden.
-    // Check for border-amber-500/50 (the active golden border class)
-    // not just border-amber-500 (which also matches hover:border-amber-500/30).
     button = container.querySelector("button");
     expect(button?.className).toContain("border-dashed");
-    expect(button?.className).not.toContain("bg-amber-500");
+    expect(button).toHaveAttribute("data-rated", "false");
   });
 });

--- a/apps/web/app/components/rating/rating-badge-button.test.tsx
+++ b/apps/web/app/components/rating/rating-badge-button.test.tsx
@@ -80,7 +80,7 @@ describe("RatingBadgeButton", () => {
     );
 
     const button = container.querySelector("button");
-    expect(button?.className).toContain("border-amber-500");
+    expect(button).toHaveAttribute("data-rated", "true");
   });
 
   test("shows dashed border when userRating is null", async () => {
@@ -187,7 +187,7 @@ describe("RatingBadgeButton", () => {
     );
 
     let button = container.querySelector("button");
-    expect(button?.className).toContain("border-amber-500");
+    expect(button).toHaveAttribute("data-rated", "true");
 
     rerender(
       <MemoryRouter>
@@ -205,7 +205,7 @@ describe("RatingBadgeButton", () => {
 
     button = container.querySelector("button");
     expect(button?.className).toContain("border-dashed");
-    expect(button?.className).not.toContain("bg-amber-500");
+    expect(button).toHaveAttribute("data-rated", "false");
   });
 
   // Size variant: "compact" is for table cells — uses py-1 and tighter
@@ -294,7 +294,7 @@ describe("RatingBadgeButton", () => {
   // the badge drops its amber chrome and the re-opened editor seeds with
   // an empty state — same local-capture path as a fresh submission, just
   // with a null value.
-  test("captures a cleared rating and drops the amber chrome", async () => {
+  test("captures a cleared rating and drops the gold edge", async () => {
     const user = userEvent.setup();
     const { container } = await setupWithRouter(
       <RatingBadgeButton
@@ -309,9 +309,9 @@ describe("RatingBadgeButton", () => {
       />,
     );
 
-    // Initial rated state — amber chrome.
+    // Initial rated state — gold edge.
     let button = container.querySelector("button") as HTMLButtonElement;
-    expect(button.className).toContain("bg-amber-500/10");
+    expect(button).toHaveAttribute("data-rated", "true");
 
     // Open the editor and fire the clear flow through StarRating's spy.
     await user.click(button);
@@ -321,9 +321,9 @@ describe("RatingBadgeButton", () => {
       lastProps.onAverageRatingChange(3.8, 4);
     });
 
-    // Editor collapsed; the badge re-renders without the amber chrome.
+    // Editor collapsed; the badge re-renders without the gold edge.
     button = container.querySelector("button") as HTMLButtonElement;
-    expect(button.className).not.toContain("bg-amber-500/10");
+    expect(button).toHaveAttribute("data-rated", "false");
     expect(button.className).toContain("border-dashed");
 
     // Re-opening seeds the editor with null, not the stale prop.

--- a/apps/web/app/components/rating/rating-badge-button.tsx
+++ b/apps/web/app/components/rating/rating-badge-button.tsx
@@ -7,6 +7,18 @@ import { cn } from "~/lib/utils";
 
 type RatingBadgeSize = "compact" | "regular";
 
+/**
+ * Chrome marking a badge the viewer has rated: a solid gold edge and outer
+ * glow. Deliberately no interior tint — the rating values are themselves
+ * color-coded, and a warm gold wash behind them both fights those hues and
+ * costs contrast (purple reads 5.19:1 over a 10% gold fill, 5.99:1 over the
+ * page). Shared by the collapsed badge and the popover that covers it, so the
+ * two can't drift apart. Assert on `data-rated` rather than these classes.
+ */
+const RATED_CHROME = "border border-rating-gold/50 shadow-[0_0_8px_hsl(var(--rating-gold)/0.2)]";
+/** Its counterpart: the dashed "not yet rated" affordance surface. */
+const UNRATED_CHROME = "glass-secondary border border-dashed border-glass-border";
+
 interface RatingBadgeButtonProps {
   rateableId: string;
   rateableType: "Show" | "Track";
@@ -108,9 +120,7 @@ export function RatingBadgeButton({
   const paddingClass =
     size === "compact" ? (localHasRated ? "px-1" : "px-2") : localHasRated ? "px-1.5 sm:px-2" : "px-2 sm:px-3";
 
-  const stateClass = localHasRated
-    ? "bg-amber-500/10 border border-amber-500/50 shadow-[0_0_8px_rgba(245,158,11,0.2)]"
-    : "glass-secondary border border-dashed border-glass-border hover:border-amber-500/30";
+  const stateClass = localHasRated ? RATED_CHROME : `${UNRATED_CHROME} hover:border-rating-gold/30`;
 
   // Badge is always the compact RatingComponent; tapping opens a Popover
   // with the 5-star picker (overlay rather than inline expansion). Same
@@ -120,6 +130,10 @@ export function RatingBadgeButton({
     <button
       type="button"
       onClick={(e) => e.stopPropagation()}
+      // Semantic hook for "the viewer has rated this", so callers and tests
+      // don't have to recognize the rated state by pattern-matching styling
+      // classes that are free to change.
+      data-rated={localHasRated}
       className={cn(
         layoutClass,
         paddingClass,
@@ -153,17 +167,16 @@ export function RatingBadgeButton({
          * its bottom edge sits over the badge, visually replacing the
          * collapsed star + count with the 5-star picker rather than
          * floating in empty space below. Styling mirrors the desktop
-         * inline-expanded state — amber tint + border + soft glow when
-         * the user has rated, glass / dashed-border when they haven't —
-         * so opening the picker reads as the same component, just
-         * floated on mobile.
+         * inline-expanded state — gold border + soft glow when the user
+         * has rated, glass / dashed-border when they haven't — so opening
+         * the picker reads as the same component, just floated on mobile.
          *
-         * The inline `background` style uses the raw `--popover` CSS
-         * variable directly because this Tailwind v4 theme registers
-         * `--color-*` tokens (used by Tailwind `bg-*` classes)
-         * separately from the older HSL-component `--popover` token
-         * shared with Radix — `bg-popover` / `bg-background` resolve to
-         * `transparent`. The amber tint layers on top via `bg-amber-500/10`.
+         * The inline `background` style names the page background directly
+         * rather than using a Tailwind `bg-*` class because this Tailwind v4
+         * theme registers `--color-*` tokens (used by Tailwind `bg-*` classes)
+         * separately from the older HSL-component `--background` token shared
+         * with Radix — `bg-popover` / `bg-background` resolve to
+         * `transparent`.
          */}
         <PopoverContent
           // Sized + colored to mirror the inline-expanded badge:
@@ -172,19 +185,16 @@ export function RatingBadgeButton({
           // least as tall as the underlying badge on desktop (~30px) so
           // it fully covers the badge with `align="center"` + `side="top"`.
           //
-          // Background is OPAQUE: rgb(33, 24, 11) = amber-500 (rgb 245,
-          // 158, 11) composited at 10% opacity over the dark page bg
-          // (--background ≈ rgb 9, 9, 11). Same visual color as the
-          // inline `bg-amber-500/10` reads against the row, without
-          // letting other cells show through.
+          // Background is OPAQUE so the cells underneath can't show through
+          // the picker; the badge itself is transparent to the row, so this
+          // matches it by naming the page background.
+          data-rated={localHasRated}
           className={cn(
             "w-auto rounded-md flex items-center gap-1 min-h-8",
             localHasRated ? "!p-1" : "!py-1 !px-2",
-            localHasRated
-              ? "border border-amber-500/50 shadow-[0_0_8px_rgba(245,158,11,0.2)]"
-              : "glass-secondary border border-dashed border-glass-border",
+            localHasRated ? RATED_CHROME : UNRATED_CHROME,
           )}
-          style={localHasRated ? { backgroundColor: "rgb(33, 24, 11)" } : undefined}
+          style={localHasRated ? { backgroundColor: "hsl(var(--background))" } : undefined}
           align="center"
           side="top"
           sideOffset={-32}

--- a/apps/web/app/components/rating/rating-display-settings.test.tsx
+++ b/apps/web/app/components/rating/rating-display-settings.test.tsx
@@ -1,17 +1,18 @@
-import { setup, setupWithRouter } from "@test/test-utils";
+import { setupWithRouter } from "@test/test-utils";
 import { screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
+import { PREFERENCES_DEFAULT } from "~/hooks/use-preferences";
 import { RatingDisplaySettings } from "./rating-display-settings";
 
 vi.mock("~/hooks/use-feature-flags", () => ({ useFeatureFlags: vi.fn() }));
 
 import { useFeatureFlags } from "~/hooks/use-feature-flags";
 
-// The card's whole point is conditional visibility plus auto-save: each toggle
-// appears only when its feature flag is on, the card hides when neither is, and
-// flipping a toggle persists immediately (no save button). v1 launches with only
-// the author flagged in, so a typical user must see nothing here.
-const base = { showCalibratedRatings: null, showRatingComparisonDebug: null };
+// The card's whole point is conditional visibility plus auto-save: the two
+// flagged toggles appear only when their feature flag is on, and flipping any
+// toggle persists immediately (no save button). Color coding ships to everyone,
+// so it renders unflagged and keeps the card alive for a typical user.
+const base = { showCalibratedRatings: null, showRatingComparisonDebug: null, colorCodeRatings: null };
 
 function mockFlags(overrides: Partial<ReturnType<typeof useFeatureFlags>>) {
   vi.mocked(useFeatureFlags).mockReturnValue({
@@ -30,10 +31,53 @@ afterEach(() => {
 });
 
 describe("RatingDisplaySettings", () => {
-  test("renders nothing when neither flag is enabled", async () => {
+  // Color coding is ungated, so the card has to survive a user with every flag
+  // off — the state nearly everyone is in.
+  test("still shows the color-coding toggle when no flag is enabled", async () => {
     mockFlags({});
-    const { container } = await setup(<RatingDisplaySettings {...base} />);
-    expect(container).toBeEmptyDOMElement();
+    await setupWithRouter(<RatingDisplaySettings {...base} />);
+    expect(screen.getByText("Color-code rating values")).toBeInTheDocument();
+    expect(screen.queryByText("Calibrated show rating")).not.toBeInTheDocument();
+    expect(screen.queryByText("Show Rating Comparison Overlay (debug)")).not.toBeInTheDocument();
+  });
+
+  // The switch has to show the app default for a viewer who never chose, or it
+  // claims a state the badges aren't actually in. Asserted against the constant
+  // so flipping the default doesn't need a test edit.
+  test("shows the app default when the viewer has never chosen", async () => {
+    mockFlags({});
+    await setupWithRouter(<RatingDisplaySettings {...base} />);
+    expect(screen.getByLabelText("Color-code rating values")).toHaveAttribute(
+      "aria-checked",
+      String(PREFERENCES_DEFAULT.colorCodeRatings),
+    );
+  });
+
+  test("reflects an explicit color-coding opt-in", async () => {
+    mockFlags({});
+    await setupWithRouter(<RatingDisplaySettings {...base} colorCodeRatings={true} />);
+    expect(screen.getByLabelText("Color-code rating values")).toHaveAttribute("aria-checked", "true");
+  });
+
+  test("reflects an explicit color-coding opt-out", async () => {
+    mockFlags({});
+    await setupWithRouter(<RatingDisplaySettings {...base} colorCodeRatings={false} />);
+    expect(screen.getByLabelText("Color-code rating values")).toHaveAttribute("aria-checked", "false");
+  });
+
+  test("auto-saves the color-coding opt-in with no flag enabled", async () => {
+    mockFlags({});
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { user } = await setupWithRouter(<RatingDisplaySettings {...base} />);
+    await user.click(screen.getByLabelText("Color-code rating values"));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/users");
+    expect(init.method).toBe("POST");
+    expect((init.body as FormData).get("colorCodeRatings")).toBe("true");
   });
 
   test("shows only the opt-in toggle when just toggle-visible is on", async () => {
@@ -65,15 +109,25 @@ describe("RatingDisplaySettings", () => {
     expect((init.body as FormData).get("showCalibratedRatings")).toBe("true");
   });
 
-  test("reverts the toggle when the save fails", async () => {
+  // Holds the response open so the optimistic flip is observable on its own.
+  // Asserting only the end state can't tell a revert apart from a toggle that
+  // never moved, since both land back where they started.
+  test("flips optimistically, then reverts when the save fails", async () => {
     mockFlags({ toggleVisible: true });
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    let settle: () => void = () => {};
+    const pending = new Promise<{ ok: boolean }>((resolve) => {
+      settle = () => resolve({ ok: false });
+    });
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(pending));
 
-    const { user } = await setupWithRouter(<RatingDisplaySettings {...base} />);
+    const { user } = await setupWithRouter(<RatingDisplaySettings {...base} showCalibratedRatings={true} />);
     const toggle = screen.getByLabelText("Use the calibrated show rating");
-    expect(toggle).toHaveAttribute("aria-checked", "false");
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+
     await user.click(toggle);
-    // Optimistic flip reverts once the failed response resolves (async, so wait).
-    await waitFor(() => expect(toggle).toHaveAttribute("aria-checked", "false"));
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    settle();
+    await waitFor(() => expect(toggle).toHaveAttribute("aria-checked", "true"));
   });
 });

--- a/apps/web/app/components/rating/rating-display-settings.tsx
+++ b/apps/web/app/components/rating/rating-display-settings.tsx
@@ -4,14 +4,16 @@ import { toast } from "sonner";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Switch } from "~/components/ui/switch";
 import { useFeatureFlags } from "~/hooks/use-feature-flags";
+import { PREFERENCES_DEFAULT } from "~/hooks/use-preferences";
 
 /**
- * Rating-display preferences for the viewer's own profile. The calibrated-rating
- * opt-in renders only when `ratings.toggle-visible` makes it available to this
- * user; the author comparison overlay only when `ratings.compare-visible` does;
- * the whole card hides when neither is on. Each toggle auto-saves on change
- * (optimistic, reverting on failure) to /api/users, which re-checks the flags
- * before persisting, with no separate save step.
+ * Rating-display preferences for the viewer's own profile. Color coding is
+ * available to everyone, so it always renders; the calibrated-rating opt-in
+ * renders only when `ratings.toggle-visible` makes it available to this user,
+ * and the author comparison overlay only when `ratings.compare-visible` does.
+ * Each toggle auto-saves on change (optimistic, reverting on failure) to
+ * /api/users, which re-checks the flags before persisting, with no separate
+ * save step.
  *
  * Takes only the viewer's saved preferences as props; the gating feature flags are
  * read from `useFeatureFlags()` so it's clear at this use site that flags drive
@@ -20,21 +22,22 @@ import { useFeatureFlags } from "~/hooks/use-feature-flags";
 export function RatingDisplaySettings({
   showCalibratedRatings,
   showRatingComparisonDebug,
+  colorCodeRatings,
 }: {
   showCalibratedRatings: boolean | null;
   showRatingComparisonDebug: boolean | null;
+  colorCodeRatings: boolean | null;
 }) {
   const { toggleVisible, compareVisible, defaultCalibrated } = useFeatureFlags();
   // Each switch reflects the user's explicit choice, falling back to the app
   // default when they've never set one (a null pref resolves to the default).
   const [calibrated, setCalibrated] = useState(showCalibratedRatings ?? defaultCalibrated);
   const [compare, setCompare] = useState(showRatingComparisonDebug ?? false);
+  const [colorCoded, setColorCoded] = useState(colorCodeRatings ?? PREFERENCES_DEFAULT.colorCodeRatings);
   const [savingField, setSavingField] = useState<string | null>(null);
 
-  if (!toggleVisible && !compareVisible) return null;
-
   async function save(
-    field: "showCalibratedRatings" | "showRatingComparisonDebug",
+    field: "showCalibratedRatings" | "showRatingComparisonDebug" | "colorCodeRatings",
     value: boolean,
     apply: (v: boolean) => void,
   ) {
@@ -60,6 +63,22 @@ export function RatingDisplaySettings({
         <CardTitle className="text-content-text-primary">Rating display</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <div className="text-content-text-primary font-medium">Color-code rating values</div>
+            <p className="text-sm text-content-text-tertiary">
+              Tint rating numbers from purple to green so you can spot strong and weak scores, and see where you differ
+              from the crowd, without reading them.
+            </p>
+          </div>
+          <Switch
+            checked={colorCoded}
+            disabled={savingField === "colorCodeRatings"}
+            onCheckedChange={(v) => save("colorCodeRatings", v, setColorCoded)}
+            aria-label="Color-code rating values"
+          />
+        </div>
+
         {toggleVisible && (
           <div className="flex items-start justify-between gap-4">
             <div className="space-y-1">

--- a/apps/web/app/components/rating/rating-distribution-chart.test.tsx
+++ b/apps/web/app/components/rating/rating-distribution-chart.test.tsx
@@ -2,7 +2,10 @@ import type { RatingValueBucket } from "@bip/core";
 import { setup } from "@test/test-utils";
 import { screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
-import { RatingDistributionChart, RatingHistogramTooltip } from "./rating-distribution-chart";
+import { PreferencesProvider } from "~/hooks/use-preferences";
+import { CHART_COLORS } from "~/lib/chart-colors";
+import { RATING_COLOR_GREEN, RATING_COLOR_NEUTRAL, RATING_COLOR_PURPLE } from "~/lib/rating-colors";
+import { RatingAxisTick, RatingDistributionChart, RatingHistogramTooltip } from "./rating-distribution-chart";
 
 // Recharts ResponsiveContainer measures parent layout via ResizeObserver,
 // which jsdom doesn't implement. Stub it to a fixed-size div so the chart
@@ -43,6 +46,53 @@ describe("RatingDistributionChart", () => {
   test("uses the singular when exactly one rating", async () => {
     await setup(<RatingDistributionChart buckets={[{ value: 5, count: 1 }]} />);
     expect(screen.getByText("1 rating")).toBeInTheDocument();
+  });
+});
+
+// Recharts injects x/y/payload into the element passed as `tick`, and jsdom
+// won't render the axis, so drive the tick directly with the props recharts
+// would supply. `payload.index` is the row index into RATING_BUCKETS; the
+// label recharts hands over is the already-formatted glyph.
+describe("RatingAxisTick", () => {
+  const renderTick = (index: number, label: string, colorCodeRatings: boolean | null = true) =>
+    setup(
+      <PreferencesProvider colorCodeRatings={colorCodeRatings}>
+        <svg role="img" aria-label="axis">
+          <RatingAxisTick x={10} y={20} fontSize={12} payload={{ value: label, index }} />
+        </svg>
+      </PreferencesProvider>,
+    );
+
+  // The axis doubles as the scale's legend: each tick renders in the color that
+  // rating's value renders in everywhere else.
+  test("tints each tick with its own bucket's color", async () => {
+    const low = await renderTick(0, "½");
+    expect(low.container.querySelector("text")).toHaveAttribute("fill", RATING_COLOR_PURPLE);
+    low.unmount();
+
+    const mid = await renderTick(6, "3½");
+    expect(mid.container.querySelector("text")).toHaveAttribute("fill", RATING_COLOR_NEUTRAL);
+    mid.unmount();
+
+    const high = await renderTick(9, "5");
+    expect(high.container.querySelector("text")).toHaveAttribute("fill", RATING_COLOR_GREEN);
+  });
+
+  test("still renders the label recharts supplies", async () => {
+    const { container } = await renderTick(6, "3½");
+    expect(container.querySelector("text")?.textContent).toBe("3½");
+  });
+
+  // The preference has to reach the axis too, or it only half applies. Both the
+  // explicit opt-out and the unset default must leave the axis plain.
+  test("falls back to the plain axis color when the viewer opts out", async () => {
+    const { container } = await renderTick(9, "5", false);
+    expect(container.querySelector("text")).toHaveAttribute("fill", CHART_COLORS.axis);
+  });
+
+  test("falls back to the plain axis color by default", async () => {
+    const { container } = await renderTick(9, "5", null);
+    expect(container.querySelector("text")).toHaveAttribute("fill", CHART_COLORS.axis);
   });
 });
 

--- a/apps/web/app/components/rating/rating-distribution-chart.tsx
+++ b/apps/web/app/components/rating/rating-distribution-chart.tsx
@@ -1,8 +1,10 @@
 import type { RatingValueBucket } from "@bip/core";
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { ChartTooltipCard } from "~/components/ui/chart-tooltip";
+import { usePreferences } from "~/hooks/use-preferences";
 import { CHART_BAR_CURSOR, CHART_COLORS } from "~/lib/chart-colors";
-import { ALL_YEARS_SERIES, buildHistogramData, histogramYAxisConfig } from "~/lib/rating-charts";
+import { ALL_YEARS_SERIES, buildHistogramData, histogramYAxisConfig, RATING_BUCKETS } from "~/lib/rating-charts";
+import { ratingColor } from "~/lib/rating-colors";
 
 interface RatingDistributionChartProps {
   buckets: RatingValueBucket[];
@@ -60,7 +62,12 @@ export function RatingDistributionChart({
         <ResponsiveContainer width="100%" height="100%">
           <BarChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }} barCategoryGap="12%">
             <CartesianGrid strokeDasharray="3 3" stroke={CHART_COLORS.grid} opacity={0.3} />
-            <XAxis dataKey="label" stroke={CHART_COLORS.axis} fontSize={compact ? 10 : 12} />
+            <XAxis
+              dataKey="label"
+              stroke={CHART_COLORS.axis}
+              fontSize={compact ? 10 : 12}
+              tick={<RatingAxisTick fontSize={compact ? 10 : 12} />}
+            />
             <YAxis
               stroke={CHART_COLORS.axis}
               fontSize={compact ? 10 : 12}
@@ -87,6 +94,35 @@ export function RatingDistributionChart({
         </ResponsiveContainer>
       </div>
     </div>
+  );
+}
+
+interface RatingAxisTickProps {
+  /** Injected by recharts when this element is passed as `tick`. */
+  x?: number;
+  y?: number;
+  payload?: { value?: string | number; index?: number };
+  fontSize?: number;
+}
+
+/**
+ * X-axis tick that renders each star value in the color that value carries
+ * everywhere else, so the axis doubles as a legend for the rating color scale
+ * without spending any layout on one.
+ *
+ * Recovers the numeric rating from `payload.index` rather than the tick label,
+ * because the axis is keyed on the formatted glyph ("3½") and the color is a
+ * function of the number. The histogram always renders all of RATING_BUCKETS,
+ * zero-filled, so row index and bucket index line up.
+ */
+export function RatingAxisTick({ x, y, payload, fontSize }: RatingAxisTickProps) {
+  const { colorCodeRatings } = usePreferences();
+  const value = payload?.index === undefined ? undefined : RATING_BUCKETS[payload.index];
+  const fill = colorCodeRatings && value !== undefined ? ratingColor(value) : CHART_COLORS.axis;
+  return (
+    <text x={x} y={y} dy={10} textAnchor="middle" fontSize={fontSize} fill={fill}>
+      {payload?.value}
+    </text>
   );
 }
 

--- a/apps/web/app/components/rating/rating.test.tsx
+++ b/apps/web/app/components/rating/rating.test.tsx
@@ -1,7 +1,17 @@
 import { setup } from "@test/test-utils";
 import { screen } from "@testing-library/react";
+import type { ReactElement } from "react";
 import { describe, expect, test } from "vitest";
+import { PreferencesProvider } from "~/hooks/use-preferences";
+import { RATING_COLOR_GREEN, RATING_COLOR_PURPLE, ratingColor } from "~/lib/rating-colors";
 import { RatingComponent } from "./rating";
+
+/**
+ * Mounts under an explicit opt-in. Color coding ships off, so a bare `setup`
+ * renders uncolored and every coloring assertion has to opt in first.
+ */
+const withColorCoding = (ui: ReactElement) =>
+  setup(<PreferencesProvider colorCodeRatings={true}>{ui}</PreferencesProvider>);
 
 describe("RatingComponent", () => {
   // Baseline: an average rating + ratingsCount renders the star, the
@@ -64,5 +74,57 @@ describe("RatingComponent", () => {
     await setup(<RatingComponent rating={4.32} ratingsCount={12} userRating={0.5} />);
     expect(screen.getByTestId("user-rating-value")).toHaveTextContent("½");
     expect(screen.getByTestId("user-rating-value").textContent).not.toMatch(/0/);
+  });
+
+  // The whole point of the color scale: a strong show and a weak one must be
+  // tellable apart without reading the digits.
+  test("colors the average by where it falls on the scale", async () => {
+    const { unmount } = await withColorCoding(<RatingComponent rating={5} ratingsCount={12} />);
+    expect(screen.getByText("5.00")).toHaveStyle({ color: RATING_COLOR_GREEN });
+    unmount();
+
+    await withColorCoding(<RatingComponent rating={0.5} ratingsCount={12} />);
+    expect(screen.getByText("0.50")).toHaveStyle({ color: RATING_COLOR_PURPLE });
+  });
+
+  // The second half of the point: two differently-colored numbers in one badge
+  // is what tells a viewer they disagree with the crowd.
+  test("colors the viewer's own rating independently of the average", async () => {
+    await withColorCoding(<RatingComponent rating={4.62} ratingsCount={12} userRating={0.5} />);
+
+    expect(screen.getByText("4.62")).toHaveStyle({ color: ratingColor(4.62) });
+    expect(screen.getByTestId("user-rating-value")).toHaveStyle({ color: RATING_COLOR_PURPLE });
+  });
+
+  // Color coding ships off, so the untouched badge must look exactly as it did
+  // before the scale existed.
+  test("leaves both values uncolored by default", async () => {
+    await setup(<RatingComponent rating={5} ratingsCount={12} userRating={2} />);
+
+    expect(screen.getByText("5.00").style.color).toBe("");
+    expect(screen.getByTestId("user-rating-value").style.color).toBe("");
+  });
+
+  test("leaves both values uncolored when the viewer opts out", async () => {
+    await setup(
+      <PreferencesProvider colorCodeRatings={false}>
+        <RatingComponent rating={5} ratingsCount={12} userRating={2} />
+      </PreferencesProvider>,
+    );
+
+    expect(screen.getByText("5.00").style.color).toBe("");
+    expect(screen.getByTestId("user-rating-value").style.color).toBe("");
+  });
+
+  // The gold star is Don's, and it means "rating" regardless of the score —
+  // the scale colors the digits only. Checked with coloring on, since that's
+  // the only state where the star could be dragged along with the values.
+  test("leaves the star gold at both ends of the scale", async () => {
+    const { container, unmount } = await withColorCoding(<RatingComponent rating={5} ratingsCount={12} />);
+    expect(container.querySelector(".text-rating-gold")).toBeInTheDocument();
+    unmount();
+
+    const low = await withColorCoding(<RatingComponent rating={0.5} ratingsCount={12} />);
+    expect(low.container.querySelector(".text-rating-gold")).toBeInTheDocument();
   });
 });

--- a/apps/web/app/components/rating/rating.tsx
+++ b/apps/web/app/components/rating/rating.tsx
@@ -1,4 +1,6 @@
 import { Star } from "lucide-react";
+import { usePreferences } from "~/hooks/use-preferences";
+import { ratingColor } from "~/lib/rating-colors";
 
 interface RatingProps {
   rating: number | null;
@@ -23,7 +25,39 @@ export function formatHalfStep(value: number): string {
   return String(whole);
 }
 
+/**
+ * Inline style that puts a rating value on the purple-to-green scale, or
+ * nothing when the viewer has opted out. A style rather than a class because
+ * the color is a continuous function of the value.
+ */
+function ratingColorStyle(value: number, enabled: boolean): { color: string } | undefined {
+  return enabled ? { color: ratingColor(value) } : undefined;
+}
+
+/**
+ * Gold star followed by a rating value on the color scale. `label` carries the
+ * formatted text because callers format differently (a community average wants
+ * 2 decimals, a personal score wants the ½ glyph) while the color always comes
+ * from the underlying number.
+ */
+export function StarValue({ value, label }: { value: number; label: string }) {
+  const { colorCodeRatings } = usePreferences();
+  return (
+    <span className="inline-flex items-center whitespace-nowrap">
+      <Star className="h-3 w-3 sm:h-4 sm:w-4 shrink-0 text-rating-gold mr-0.5 sm:mr-1" />
+      <span
+        className="font-medium text-xs sm:text-sm text-content-text-primary"
+        style={ratingColorStyle(value, colorCodeRatings)}
+      >
+        {label}
+      </span>
+    </span>
+  );
+}
+
 export const RatingComponent = ({ rating, ratingsCount, userRating }: RatingProps) => {
+  const { colorCodeRatings } = usePreferences();
+
   if (!rating) return <div className="text-xs sm:text-sm text-content-text-secondary">Rate</div>;
   const hasUserRating = typeof userRating === "number" && userRating > 0;
   // Tighter inter-element gaps when the user has rated — the row is
@@ -32,10 +66,7 @@ export const RatingComponent = ({ rating, ratingsCount, userRating }: RatingProp
   const outerGap = hasUserRating ? "gap-1" : "gap-1 sm:gap-1.5";
   return (
     <div className={`flex items-center ${outerGap}`}>
-      <div className="flex items-center">
-        <Star className="h-3 w-3 sm:h-4 sm:w-4 text-rating-gold mr-0.5 sm:mr-1" />
-        <span className="font-medium text-xs sm:text-sm text-content-text-primary">{rating.toFixed(2)}</span>
-      </div>
+      <StarValue value={rating} label={rating.toFixed(2)} />
       {ratingsCount &&
         ratingsCount > 0 &&
         (hasUserRating ? (
@@ -65,6 +96,7 @@ export const RatingComponent = ({ rating, ratingsCount, userRating }: RatingProp
             // as its integer; the slot is wide enough for "5½" while still
             // centering "5".
             className="font-medium text-[10px] sm:text-xs text-content-text-primary inline-block min-w-[2ch] text-center whitespace-nowrap"
+            style={ratingColorStyle(userRating, colorCodeRatings)}
           >
             {formatHalfStep(userRating)}
           </span>

--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -303,7 +303,7 @@ describe("SetlistCard", () => {
   // in the Rating | number | null resolver inside SetlistCard would slip
   // through — the RatingBadgeButton itself is rated tested in isolation,
   // but the resolver lives here.
-  test("rating badge shows amber border when userRating is a bare number", async () => {
+  test("rating badge shows the gold rated border when userRating is a bare number", async () => {
     vi.mocked(useSession).mockReturnValue({
       user: { id: "user-1" } as never,
       supabase: null as never,
@@ -314,12 +314,12 @@ describe("SetlistCard", () => {
     );
     const buttons = container.querySelectorAll("button");
     // The rating badge is the trailing rated-styled button in the header.
-    const ratingButton = Array.from(buttons).find((btn) => btn.className.includes("bg-amber-500/10"));
+    const ratingButton = Array.from(buttons).find((btn) => btn.dataset.rated === "true");
     expect(ratingButton).toBeDefined();
-    expect(ratingButton?.className).toContain("border-amber-500");
+    expect(ratingButton).toHaveAttribute("data-rated", "true");
   });
 
-  test("rating badge shows amber border when userRating is a Rating object", async () => {
+  test("rating badge shows the gold rated border when userRating is a Rating object", async () => {
     vi.mocked(useSession).mockReturnValue({
       user: { id: "user-1" } as never,
       supabase: null as never,
@@ -338,9 +338,9 @@ describe("SetlistCard", () => {
       <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={ratingObj} showRating={null} />,
     );
     const buttons = container.querySelectorAll("button");
-    const ratingButton = Array.from(buttons).find((btn) => btn.className.includes("bg-amber-500/10"));
+    const ratingButton = Array.from(buttons).find((btn) => btn.dataset.rated === "true");
     expect(ratingButton).toBeDefined();
-    expect(ratingButton?.className).toContain("border-amber-500");
+    expect(ratingButton).toHaveAttribute("data-rated", "true");
   });
 
   // The dashed (unrated) state is the default when the viewer is logged in
@@ -356,9 +356,10 @@ describe("SetlistCard", () => {
       <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={null} />,
     );
     const buttons = container.querySelectorAll("button");
-    const dashedButton = Array.from(buttons).find((btn) => btn.className.includes("border-dashed"));
-    expect(dashedButton).toBeDefined();
-    expect(dashedButton?.className).not.toContain("bg-amber-500/10");
+    const ratingButton = Array.from(buttons).find((btn) => btn.dataset.rated !== undefined);
+    expect(ratingButton).toBeDefined();
+    expect(ratingButton).toHaveAttribute("data-rated", "false");
+    expect(ratingButton?.className).toContain("border-dashed");
   });
 
   // Clicking "gap chart" swaps to the table view. Existence of the

--- a/apps/web/app/components/setlist/setlist-highlights.test.tsx
+++ b/apps/web/app/components/setlist/setlist-highlights.test.tsx
@@ -225,9 +225,9 @@ describe("SetlistHighlights (compressed)", () => {
   });
 
   // Each row carries the corresponding flame icon. All-timer rows get the
-  // orange flame; jam-chart rows (note only) get the off-white flame so
+  // orange flame; jam-chart rows (note only) get the gold flame so
   // the two categories are visually distinct in the same list.
-  test("orange flame on all-timer rows, off-white flame on jam-chart rows", async () => {
+  test("orange flame on all-timer rows, gold flame on jam-chart rows", async () => {
     const setlist = makeSetlist([
       {
         label: "S1",
@@ -244,8 +244,8 @@ describe("SetlistHighlights (compressed)", () => {
     expect(basisRow).not.toBeNull();
     const aceeFlame = within(aceeRow as HTMLElement).getByLabelText("All-timer");
     const basisFlame = within(basisRow as HTMLElement).getByLabelText("Jam chart");
-    expect(aceeFlame.getAttribute("class") ?? "").toMatch(/text-orange-500/);
-    expect(basisFlame.getAttribute("class") ?? "").toMatch(/text-content-text-primary/);
+    expect(aceeFlame.getAttribute("class") ?? "").toMatch(/text-flame-all-timer/);
+    expect(basisFlame.getAttribute("class") ?? "").toMatch(/text-flame-jam/);
   });
 
   // Tracks render in canonical show order (set bucket → position within

--- a/apps/web/app/components/track/sortable-track-item.test.tsx
+++ b/apps/web/app/components/track/sortable-track-item.test.tsx
@@ -111,8 +111,7 @@ describe("SortableTrackItem", () => {
       <SortableTrackItem track={makeTrack({ allTimer: true })} onEdit={vi.fn()} onDelete={vi.fn()} />,
     );
 
-    // Flame icon has text-orange-500. Assert one is present.
-    const flames = container.querySelectorAll("svg.text-orange-500");
+    const flames = container.querySelectorAll("svg.text-flame-all-timer");
     expect(flames.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -121,7 +120,7 @@ describe("SortableTrackItem", () => {
       <SortableTrackItem track={makeTrack({ allTimer: false })} onEdit={vi.fn()} onDelete={vi.fn()} />,
     );
 
-    expect(container.querySelector("svg.text-orange-500")).toBeNull();
+    expect(container.querySelector("svg.text-flame-all-timer")).toBeNull();
   });
 
   // Segue marker (">") renders inline next to the title when present.

--- a/apps/web/app/components/track/track-icon.test.tsx
+++ b/apps/web/app/components/track/track-icon.test.tsx
@@ -22,16 +22,17 @@ describe("TrackIcon", () => {
   test("renders an orange flame when allTimer is true", () => {
     render(<TrackIcon track={{ allTimer: true, note: null }} />);
     const flame = screen.getByLabelText("All-timer");
-    expect(flame.getAttribute("class") ?? "").toMatch(/text-orange-500/);
+    expect(flame.getAttribute("class") ?? "").toMatch(/text-flame-all-timer/);
   });
 
-  // Jam-chart (note only) gets the off-white flame so it reads as a
-  // quieter signal next to the orange all-timer flame on the same list.
-  test("renders an off-white flame when only note is set", () => {
+  // Jam-chart (note only) gets the gold flame. Color is the only thing telling
+  // the two markers apart, so each carries its own token rather than inheriting
+  // from the caller — the two are close in hue and easy to conflate otherwise.
+  test("renders a gold flame when only note is set", () => {
     render(<TrackIcon track={{ allTimer: false, note: "Big Type II Spaga." }} />);
     const flame = screen.getByLabelText("Jam chart");
-    expect(flame.getAttribute("class") ?? "").toMatch(/text-content-text-primary/);
-    expect(flame.getAttribute("class") ?? "").not.toMatch(/text-orange-500/);
+    expect(flame.getAttribute("class") ?? "").toMatch(/text-flame-jam/);
+    expect(flame.getAttribute("class") ?? "").not.toMatch(/text-flame-all-timer/);
   });
 
   // When both flags are set, orange (all-timer) wins — it's the stronger
@@ -40,7 +41,7 @@ describe("TrackIcon", () => {
   test("orange flame wins when both allTimer and note are set", () => {
     render(<TrackIcon track={{ allTimer: true, note: "Story of the World > Crickets." }} />);
     const flame = screen.getByLabelText("All-timer");
-    expect(flame.getAttribute("class") ?? "").toMatch(/text-orange-500/);
+    expect(flame.getAttribute("class") ?? "").toMatch(/text-flame-all-timer/);
   });
 
   // Allow callers to pin a custom size — the same component is used in

--- a/apps/web/app/components/track/track-icon.tsx
+++ b/apps/web/app/components/track/track-icon.tsx
@@ -19,7 +19,7 @@ interface TrackIconProps {
 
 /**
  * Visual marker for noteworthy tracks. Renders the orange flame when the
- * track is an all-timer, the off-white flame when it carries a curated
+ * track is an all-timer, the gold flame when it carries a curated
  * jam-chart note but isn't an all-timer, and nothing otherwise. The
  * surrounding hover/click affordance for showing the note text is
  * provided by the caller (e.g. AllTimerCell wraps the flame in a
@@ -32,7 +32,7 @@ export function TrackIcon({ track, iconClassName, className }: TrackIconProps) {
 
   if (!allTimer && !note) return null;
 
-  const colorClass = allTimer ? "text-orange-500" : "text-content-text-primary";
+  const colorClass = allTimer ? "text-flame-all-timer" : "text-flame-jam";
   const sizeClass = iconClassName ?? "h-4 w-4";
   const label = allTimer ? "All-timer" : "Jam chart";
   return (

--- a/apps/web/app/hooks/use-preferences.test.tsx
+++ b/apps/web/app/hooks/use-preferences.test.tsx
@@ -1,0 +1,57 @@
+import { setup } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { PREFERENCES_DEFAULT, PreferencesProvider, usePreferences } from "./use-preferences";
+
+function Harness() {
+  return <div data-testid="color">{String(usePreferences().colorCodeRatings)}</div>;
+}
+
+describe("usePreferences", () => {
+  // Rating values render from nearly every page, including inside the error
+  // boundary and in component tests that mount no provider. The no-provider
+  // case has to resolve the same way "never chose" does, rather than diverging
+  // from what the app actually ships.
+  test("falls back to the app default with no provider mounted", async () => {
+    await setup(<Harness />);
+    expect(screen.getByTestId("color").textContent).toBe(String(PREFERENCES_DEFAULT.colorCodeRatings));
+  });
+
+  // `null` is the stored tri-state for "never chose", which must resolve to the
+  // app default rather than read as an explicit choice either way. Asserted
+  // against the constant so flipping the default doesn't need a test edit.
+  test("resolves an unset preference to the app default", async () => {
+    await setup(
+      <PreferencesProvider colorCodeRatings={null}>
+        <Harness />
+      </PreferencesProvider>,
+    );
+    expect(screen.getByTestId("color").textContent).toBe(String(PREFERENCES_DEFAULT.colorCodeRatings));
+  });
+
+  // Both explicit choices must survive a change to the default, which is the
+  // whole reason the stored value is tri-state.
+  test("honors an explicit opt-out", async () => {
+    await setup(
+      <PreferencesProvider colorCodeRatings={false}>
+        <Harness />
+      </PreferencesProvider>,
+    );
+    expect(screen.getByTestId("color").textContent).toBe("false");
+  });
+
+  test("honors an explicit opt-in", async () => {
+    await setup(
+      <PreferencesProvider colorCodeRatings={true}>
+        <Harness />
+      </PreferencesProvider>,
+    );
+    expect(screen.getByTestId("color").textContent).toBe("true");
+  });
+
+  // Pins the shipped default itself. Color coding stays opt-in until the rating
+  // work it belongs to is opened up, so a stray flip should fail loudly here.
+  test("ships with color coding off", () => {
+    expect(PREFERENCES_DEFAULT.colorCodeRatings).toBe(false);
+  });
+});

--- a/apps/web/app/hooks/use-preferences.tsx
+++ b/apps/web/app/hooks/use-preferences.tsx
@@ -1,0 +1,57 @@
+import { createContext, useContext, useMemo } from "react";
+
+export type Preferences = {
+  colorCodeRatings: boolean;
+};
+
+/**
+ * App defaults, used wherever the viewer expressed no choice (a stored `null`)
+ * and wherever the provider is absent (the error boundary, or a component
+ * mounted outside the route tree in tests). A preference the viewer never set
+ * behaves the same in both cases.
+ *
+ * Color coding is off until the rating work it belongs to is opened up more
+ * broadly. Flipping this constant switches it on for everyone who hasn't made
+ * an explicit choice, and leaves explicit choices on either side intact — which
+ * is why the stored preference stays tri-state rather than defaulting in the
+ * database.
+ */
+export const PREFERENCES_DEFAULT: Preferences = {
+  colorCodeRatings: false,
+};
+
+const PreferencesContext = createContext<Preferences>(PREFERENCES_DEFAULT);
+
+/**
+ * Seeds the viewer's display preferences from the root loader. Context rather
+ * than `useRouteLoaderData` at the point of use because these are read by leaf
+ * components (rating values) rendered from nearly every page: a context has a
+ * usable default outside a data router, so component tests don't each have to
+ * stub the router or mock the hook.
+ *
+ * Takes the stored tri-state (`null` = never chose) and resolves the default
+ * here, so the fallback lives in exactly one place.
+ */
+export function PreferencesProvider({
+  colorCodeRatings,
+  children,
+}: {
+  colorCodeRatings: boolean | null | undefined;
+  children: React.ReactNode;
+}) {
+  const value = useMemo<Preferences>(
+    () => ({ colorCodeRatings: colorCodeRatings ?? PREFERENCES_DEFAULT.colorCodeRatings }),
+    [colorCodeRatings],
+  );
+  return <PreferencesContext.Provider value={value}>{children}</PreferencesContext.Provider>;
+}
+
+/**
+ * Reads the viewer's display preferences at the point of use
+ * (`usePreferences().colorCodeRatings`) instead of having the value threaded
+ * down as a prop through every rating call site. SSR-seeded, so the first paint
+ * already has the right values.
+ */
+export function usePreferences(): Preferences {
+  return useContext(PreferencesContext);
+}

--- a/apps/web/app/lib/rating-colors.test.ts
+++ b/apps/web/app/lib/rating-colors.test.ts
@@ -1,0 +1,120 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  RATING_COLOR_GREEN,
+  RATING_COLOR_NEUTRAL,
+  RATING_COLOR_PURPLE,
+  RATING_COLOR_TOKENS,
+  ratingColor,
+} from "./rating-colors";
+
+describe("ratingColor", () => {
+  test("renders the pivot in the neutral text color", () => {
+    expect(ratingColor(3.5)).toBe(RATING_COLOR_NEUTRAL);
+  });
+
+  test("renders a perfect rating in full brand green", () => {
+    expect(ratingColor(5)).toBe(RATING_COLOR_GREEN);
+  });
+
+  test("renders the bottom of the scale in full brand purple", () => {
+    expect(ratingColor(0.5)).toBe(RATING_COLOR_PURPLE);
+  });
+
+  test("clamps beyond the ramp ends rather than overshooting", () => {
+    expect(ratingColor(5.4)).toBe(RATING_COLOR_GREEN);
+    expect(ratingColor(0.2)).toBe(RATING_COLOR_PURPLE);
+  });
+
+  // The two sides reach their end at different distances (0.5 and 5.0 are not
+  // equidistant from the 3.5 pivot), so each midpoint is checked against its
+  // own span rather than a shared one.
+  test("blends halfway between neutral and each end at that side's midpoint", () => {
+    expect(ratingColor(4.25)).toBe(mixHex(RATING_COLOR_NEUTRAL, RATING_COLOR_GREEN, 0.5));
+    expect(ratingColor(2)).toBe(mixHex(RATING_COLOR_NEUTRAL, RATING_COLOR_PURPLE, 0.5));
+  });
+
+  // The reason the ramp reaches all the way to 0.5: a symmetric span clamped
+  // everything at or below 2.0 to one flat purple, which erased the difference
+  // between a ½ and a 2 wherever a low rating actually appears.
+  test("gives every half-step on the scale a distinct color", () => {
+    const buckets = [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5];
+    const colors = buckets.map(ratingColor);
+    expect(new Set(colors).size).toBe(buckets.length);
+  });
+
+  test("moves monotonically away from neutral as the rating climbs", () => {
+    const greens = [3.5, 4, 4.5, 5].map((v) => channels(ratingColor(v)));
+    for (let i = 1; i < greens.length; i++) {
+      // Brand green is the only endpoint with less red than neutral, so red
+      // falling on every step proves the blend advances rather than plateaus.
+      expect(greens[i][0]).toBeLessThan(greens[i - 1][0]);
+    }
+  });
+});
+
+// The ramp can't read its endpoints from CSS (it interpolates between them, so
+// it needs numeric channels), so the hex literals restate three design tokens.
+// This is the guard on that duplication: retuning a token without updating the
+// ramp fails here instead of silently leaving rating values on the old color —
+// the same drift that left the badge chrome on amber-500 after the rating-gold
+// token replaced it.
+describe("ramp endpoints vs. the design tokens they mirror", () => {
+  // Read off disk rather than imported: vitest stubs CSS imports, so both
+  // `../styles.css` and `?raw` resolve to an empty string here and every
+  // assertion below would pass against nothing.
+  const stylesheet = readFileSync(resolve(process.cwd(), "app/styles.css"), "utf-8");
+
+  test("reads the real stylesheet", () => {
+    expect(stylesheet).toContain("@theme");
+  });
+
+  for (const [token, expected] of Object.entries(RATING_COLOR_TOKENS)) {
+    test(`${token} still equals ${expected}`, () => {
+      const match = stylesheet.match(new RegExp(`${token}:\\s*hsl\\(([\\d.]+)\\s+([\\d.]+)%\\s+([\\d.]+)%\\)`));
+      expect(match, `${token} not found as an hsl() value in styles.css`).not.toBeNull();
+      const [, hue, saturation, lightness] = match as RegExpMatchArray;
+      expect(hslToHex(Number(hue), Number(saturation), Number(lightness))).toBe(expected);
+    });
+  }
+});
+
+function hslToHex(hue: number, saturationPercent: number, lightnessPercent: number): string {
+  const saturation = saturationPercent / 100;
+  const lightness = lightnessPercent / 100;
+  const chroma = (1 - Math.abs(2 * lightness - 1)) * saturation;
+  const second = chroma * (1 - Math.abs(((hue / 60) % 2) - 1));
+  const lightest = lightness - chroma / 2;
+  const [red, green, blue] =
+    hue < 60
+      ? [chroma, second, 0]
+      : hue < 120
+        ? [second, chroma, 0]
+        : hue < 180
+          ? [0, chroma, second]
+          : hue < 240
+            ? [0, second, chroma]
+            : hue < 300
+              ? [second, 0, chroma]
+              : [chroma, 0, second];
+  return `#${[red, green, blue]
+    .map((channel) =>
+      Math.round((channel + lightest) * 255)
+        .toString(16)
+        .padStart(2, "0"),
+    )
+    .join("")}`;
+}
+
+function channels(hex: string): [number, number, number] {
+  const n = Number.parseInt(hex.slice(1), 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function mixHex(from: string, to: string, t: number): string {
+  const a = channels(from);
+  const b = channels(to);
+  const mixed = a.map((channel, i) => Math.round(channel + (b[i] - channel) * t));
+  return `#${mixed.map((c) => c.toString(16).padStart(2, "0")).join("")}`;
+}

--- a/apps/web/app/lib/rating-colors.ts
+++ b/apps/web/app/lib/rating-colors.ts
@@ -1,0 +1,63 @@
+/**
+ * Maps a rating to the color its digits render in, so a viewer can tell a
+ * strong show from a weak one, and their own score from the crowd's, without
+ * reading the numbers. The value is dynamic, so it can't be a Tailwind
+ * className — like `chart-colors.ts`, this file holds literal hex equivalents
+ * of design tokens and is the single source of truth for the ramp.
+ *
+ * Deliberately anchored to the nominal 0.5-5 scale rather than to the observed
+ * distribution (show averages cluster around a 4.00 median). A fixed ramp is
+ * legible without knowing the stats, and leaving a 4 visibly short of green
+ * reflects what a 4 actually means.
+ */
+
+/**
+ * Ramp endpoints, as literal hex equivalents of the design tokens named below.
+ * They're duplicated from `styles.css` rather than read from it because the
+ * ramp interpolates *between* them: that needs numeric channels, which a CSS
+ * custom property can't give a pure function at module scope. `rating-colors.test.ts`
+ * pins each one to its token, so a retuned token fails the build instead of
+ * silently leaving the ramp on the old color.
+ */
+export const RATING_COLOR_PURPLE = "#ac6ef7"; // --color-brand-primary
+export const RATING_COLOR_NEUTRAL = "#bcbcc2"; // --color-content-text-secondary
+export const RATING_COLOR_GREEN = "#30e87d"; // --color-brand-tertiary
+
+/** The token each endpoint mirrors, as the drift test reads them from styles.css. */
+export const RATING_COLOR_TOKENS = {
+  "--color-brand-primary": RATING_COLOR_PURPLE,
+  "--color-content-text-secondary": RATING_COLOR_NEUTRAL,
+  "--color-brand-tertiary": RATING_COLOR_GREEN,
+} as const;
+
+/** Ratings at or above this read as better than typical, below as worse. */
+export const RATING_COLOR_PIVOT = 3.5;
+/**
+ * Distance from the pivot at which each end is fully reached: 0.5 and 5.0, the
+ * ends of the rating scale itself. The two differ because the pivot isn't the
+ * midpoint of the scale, so a symmetric span would have to clamp one side and
+ * render every rating below it in the same flat color. Covering the whole scale
+ * costs an uneven rate instead (green deepens faster per star than purple),
+ * which is the better trade: no rating is ever indistinguishable from another.
+ */
+export const RATING_COLOR_SPAN_LOW = RATING_COLOR_PIVOT - 0.5;
+export const RATING_COLOR_SPAN_HIGH = 5 - RATING_COLOR_PIVOT;
+
+export function ratingColor(value: number): string {
+  const above = value >= RATING_COLOR_PIVOT;
+  const span = above ? RATING_COLOR_SPAN_HIGH : RATING_COLOR_SPAN_LOW;
+  const distance = Math.min(Math.abs(value - RATING_COLOR_PIVOT) / span, 1);
+  return mix(RATING_COLOR_NEUTRAL, above ? RATING_COLOR_GREEN : RATING_COLOR_PURPLE, distance);
+}
+
+function mix(from: string, to: string, amount: number): string {
+  const a = channels(from);
+  const b = channels(to);
+  const mixed = a.map((channel, i) => Math.round(channel + (b[i] - channel) * amount));
+  return `#${mixed.map((channel) => channel.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function channels(hex: string): [number, number, number] {
+  const packed = Number.parseInt(hex.slice(1), 16);
+  return [(packed >> 16) & 255, (packed >> 8) & 255, packed & 255];
+}

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -20,13 +20,24 @@ import { HeaderLayout } from "~/components/layout/header-layout";
 import { SearchProvider } from "~/components/search/search-provider";
 import { SupabaseProvider } from "~/context/supabase-provider";
 import { GlobalSearchProvider } from "~/hooks/use-global-search";
+import { PreferencesProvider } from "~/hooks/use-preferences";
 import { mergeDehydratedStates } from "~/lib/query-prefetch";
 import type { SessionUser } from "~/lib/session-user";
 import { toSessionUser } from "~/lib/session-user";
 import { QueryProvider } from "~/providers/query-provider";
 import { env } from "~/server/env";
 import { getRequestUser } from "~/server/request-user";
+import { services } from "~/server/services";
 import stylesheet from "./styles.css?url";
+
+export type RootPreferences = {
+  /**
+   * Tri-state, as stored: `null` means the viewer never chose, which
+   * `usePreferences()` resolves to the app default. Kept unresolved here so
+   * the default lives in exactly one place.
+   */
+  colorCodeRatings: boolean | null;
+};
 
 export type RootData = {
   env: ClientSideEnv;
@@ -37,6 +48,12 @@ export type RootData = {
    * individual flag values threaded down as props.
    */
   featureFlags: FeatureFlags;
+  /**
+   * Display preferences resolved once for the whole app so leaf components
+   * can read them via `usePreferences()` instead of having the values threaded
+   * through every intermediate component as props.
+   */
+  preferences: RootPreferences;
 };
 
 export type ClientSideEnv = {
@@ -68,10 +85,18 @@ export async function loader({ request }: Route.LoaderArgs): Promise<RootData> {
     sessionUser?.username ? { user: { username: sessionUser.username } } : undefined,
   );
 
+  // Display preferences live on the user row, so unlike the flags above this
+  // needs a lookup. Signed-out visitors skip it entirely and fall through to
+  // the defaults in `usePreferences()`.
+  const viewer = sessionUser?.email ? await services.users.findByEmail(sessionUser.email) : null;
+
   return {
     env: clientEnv,
     sessionUser,
     featureFlags,
+    preferences: {
+      colorCodeRatings: viewer?.colorCodeRatings ?? null,
+    },
   };
 }
 
@@ -101,11 +126,13 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <SupabaseProvider env={env}>
           <QueryProvider>
             <HydrationBoundary state={dehydratedState}>
-              <GlobalSearchProvider>
-                <SearchProvider>
-                  <HeaderLayout>{children}</HeaderLayout>
-                </SearchProvider>
-              </GlobalSearchProvider>
+              <PreferencesProvider colorCodeRatings={data?.preferences?.colorCodeRatings}>
+                <GlobalSearchProvider>
+                  <SearchProvider>
+                    <HeaderLayout>{children}</HeaderLayout>
+                  </SearchProvider>
+                </GlobalSearchProvider>
+              </PreferencesProvider>
             </HydrationBoundary>
           </QueryProvider>
         </SupabaseProvider>

--- a/apps/web/app/routes/api/users.tsx
+++ b/apps/web/app/routes/api/users.tsx
@@ -11,6 +11,7 @@ const updateUserSchema = z.object({
   // Toggles arrive as "true"/"false" strings; persistence is flag-gated below.
   showCalibratedRatings: z.enum(["true", "false"]).optional(),
   showRatingComparisonDebug: z.enum(["true", "false"]).optional(),
+  colorCodeRatings: z.enum(["true", "false"]).optional(),
 });
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -70,7 +71,12 @@ export async function action({ request }: ActionFunctionArgs) {
     // Build the update explicitly: persist a rating pref only if the matching flag
     // makes that toggle visible for this user (so an ineligible user can't set it via
     // a crafted POST), and coerce the "true"/"false" strings to booleans.
-    const update: { username?: string; showCalibratedRatings?: boolean; showRatingComparisonDebug?: boolean } = {};
+    const update: {
+      username?: string;
+      showCalibratedRatings?: boolean;
+      showRatingComparisonDebug?: boolean;
+      colorCodeRatings?: boolean;
+    } = {};
     if (validatedData.username) update.username = validatedData.username;
     const flags = await getFeatureFlags({ user: { id: localUser.id, username: localUser.username } });
     if (flags.toggleVisible && validatedData.showCalibratedRatings !== undefined) {
@@ -78,6 +84,10 @@ export async function action({ request }: ActionFunctionArgs) {
     }
     if (flags.compareVisible && validatedData.showRatingComparisonDebug !== undefined) {
       update.showRatingComparisonDebug = validatedData.showRatingComparisonDebug === "true";
+    }
+    // Color coding is available to everyone, so no flag guards this one.
+    if (validatedData.colorCodeRatings !== undefined) {
+      update.colorCodeRatings = validatedData.colorCodeRatings === "true";
     }
 
     const updatedUser = await services.users.update(localUser.id, update);

--- a/apps/web/app/routes/on-this-day.$monthDay.tsx
+++ b/apps/web/app/routes/on-this-day.$monthDay.tsx
@@ -179,7 +179,7 @@ export default function OnThisDay() {
         <div className="space-y-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
-              <Flame className="h-6 w-6 text-content-text-secondary" />
+              <Flame className="h-6 w-6 text-flame-jam" />
               <h2 className="text-2xl font-bold text-content-text-primary">Jam Charts</h2>
             </div>
             <Link

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -366,13 +366,13 @@ export default function SongPage() {
           </TabsTrigger>
           {hasJamCharts && (
             <TabsTrigger value="jam-charts">
-              <Flame className="h-4 w-4" />
+              <Flame className="h-4 w-4 text-flame-jam" />
               Jam Charts
             </TabsTrigger>
           )}
           {hasAllTimers && (
             <TabsTrigger value="all-timers">
-              <Flame className="h-4 w-4 text-orange-500" />
+              <Flame className="h-4 w-4 text-flame-all-timer" />
               All-Timers
             </TabsTrigger>
           )}

--- a/apps/web/app/routes/songs/_layout.tsx
+++ b/apps/web/app/routes/songs/_layout.tsx
@@ -17,8 +17,8 @@ const TABS: Tab[] = [
   { label: "All Songs", path: "/songs", icon: ListMusic },
   { label: "Last 10 Shows", path: "/songs/recent", icon: Clock },
   { label: "This Year", path: "/songs/this-year", icon: Calendar },
-  { label: "Jam Charts", path: "/songs/jam-charts", icon: Flame },
-  { label: "All-Timers", path: "/songs/all-timers", icon: Flame, iconClassName: "text-orange-500" },
+  { label: "Jam Charts", path: "/songs/jam-charts", icon: Flame, iconClassName: "text-flame-jam" },
+  { label: "All-Timers", path: "/songs/all-timers", icon: Flame, iconClassName: "text-flame-all-timer" },
   { label: "Histories", path: "/songs/histories", icon: History },
 ];
 

--- a/apps/web/app/routes/users/$username.tsx
+++ b/apps/web/app/routes/users/$username.tsx
@@ -4,7 +4,7 @@ import { CalendarDays, Edit, MessageSquare, Star, Users } from "lucide-react";
 import { useState } from "react";
 import type { LoaderFunctionArgs, MetaFunction } from "react-router-dom";
 import { Link, useNavigate } from "react-router-dom";
-import { formatHalfStep } from "~/components/rating/rating";
+import { formatHalfStep, StarValue } from "~/components/rating/rating";
 import { RatingCharts } from "~/components/rating/rating-charts";
 import { RatingDisplaySettings } from "~/components/rating/rating-display-settings";
 import { formatSetLabel } from "~/components/setlist/set-label";
@@ -416,6 +416,7 @@ export default function UserProfile() {
         <RatingDisplaySettings
           showCalibratedRatings={user.showCalibratedRatings}
           showRatingComparisonDebug={user.showRatingComparisonDebug}
+          colorCodeRatings={user.colorCodeRatings}
         />
       )}
 
@@ -769,15 +770,6 @@ function ModifiedDate({ createdAt }: { createdAt: Date | string }) {
   );
 }
 
-function StarValue({ value }: { value: number }) {
-  return (
-    <span className="inline-flex items-center gap-1 whitespace-nowrap">
-      <Star className="h-3 w-3 sm:h-4 sm:w-4 text-rating-gold" />
-      <span className="font-medium text-xs sm:text-sm text-content-text-primary">{formatHalfStep(value)}</span>
-    </span>
-  );
-}
-
 // Show date cell with venue line below on sm+ viewports. Uses plain media
 // queries (not the @container/datecell variant in ShowDate) so the column
 // width and the date-format swap don't fight each other inside a table
@@ -846,7 +838,7 @@ function ShowRatingsTable({ rows, sort, direction, onSort }: ShowRatingsTablePro
                   <DateVenueLink date={row.show.date} slug={row.show.slug} venueLine={venueLine} />
                 </td>
                 <td className={tableCellClass}>
-                  <StarValue value={row.value} />
+                  <StarValue value={row.value} label={formatHalfStep(row.value)} />
                 </td>
                 <td className={`${tableCellClass} text-content-text-tertiary whitespace-nowrap`}>
                   <ModifiedDate createdAt={row.createdAt} />
@@ -916,7 +908,7 @@ function TrackRatingsTable({ rows, sort, direction, onSort }: TrackRatingsTableP
                 </Link>
               </td>
               <td className={tableCellClass}>
-                <StarValue value={row.value} />
+                <StarValue value={row.value} label={formatHalfStep(row.value)} />
               </td>
               <td className={`${tableCellClass} text-content-text-tertiary whitespace-nowrap`}>
                 <ModifiedDate createdAt={row.createdAt} />

--- a/apps/web/app/styles.css
+++ b/apps/web/app/styles.css
@@ -56,6 +56,14 @@
 
   /* Rating Colors */
   --color-rating-gold: hsl(38 95% 62%);
+
+  /* Track marker flames. Color is the only thing distinguishing a jam chart
+     from an all-timer, and these two are close in hue (38 vs 25), so they read
+     as a warm family rather than as opposites: legible apart side by side, but
+     near-identical under red-green color blindness. If that distinction ever
+     needs to carry more weight, separate the hues rather than the lightness. */
+  --color-flame-jam: var(--color-rating-gold);
+  --color-flame-all-timer: hsl(24.6 95% 53.1%);
 }
 
 /* Radix Popover/Select sets `body[data-scroll-locked]` and adds a

--- a/packages/core/scripts/sync-missing-shows.test.ts
+++ b/packages/core/scripts/sync-missing-shows.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import type { RatingService } from "../src/ratings/rating-service";
 import {
+  attendanceBindingKey,
   buildRockOperaAssignmentDiff,
   buildSetlistReconciliation,
   buildShowCreateInput,
@@ -28,6 +29,7 @@ import {
   parseYearsArg,
   planShowRenames,
   planVenueOrphans,
+  ratingBindingKey,
   resolveCompletionLinks,
   STUB_USER_PASSWORD_DIGEST,
   showNeedsUpdate,
@@ -4035,5 +4037,32 @@ describe("syncUserActivity — blog posts", () => {
     expect(state.files).toHaveLength(1);
     expect(state.files[0]).toMatchObject({ id: "file-existing", variants: { public: "new.jpg" } });
     expect(state.blogPostToFiles).toHaveLength(1);
+  });
+});
+
+// The binding keys flatten user + rateable into one Map key, so the separator is
+// load-bearing: if it could occur inside a component, two distinct tuples would
+// collide and the id-binding reconcile would silently mis-pair rows. NUL is the
+// one character a uuid or rateableType can't contain. Written as a \u0000 escape
+// so the source stays plain text rather than reading as binary to grep.
+describe("ratingBindingKey / attendanceBindingKey", () => {
+  test("joins components with a NUL separator", () => {
+    expect(ratingBindingKey("u1", "r1", "Show")).toBe(`u1\u0000r1\u0000Show`);
+    expect(attendanceBindingKey("u1", "s1")).toBe(`u1\u0000s1`);
+  });
+
+  // The collision the separator exists to prevent: concatenated bare, ("ab","c")
+  // and ("a","bc") would both flatten to "abc".
+  test("does not collide when a boundary shifts between components", () => {
+    expect(attendanceBindingKey("ab", "c")).not.toBe(attendanceBindingKey("a", "bc"));
+    expect(ratingBindingKey("ab", "c", "Show")).not.toBe(ratingBindingKey("a", "bc", "Show"));
+  });
+
+  test("distinguishes rateable types for the same user and rateable", () => {
+    expect(ratingBindingKey("u1", "r1", "Show")).not.toBe(ratingBindingKey("u1", "r1", "Track"));
+  });
+
+  test("returns an equal key for an equal tuple, so repeat lookups hit one Map entry", () => {
+    expect(ratingBindingKey("u1", "r1", "Show")).toBe(ratingBindingKey("u1", "r1", "Show"));
   });
 });

--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -276,6 +276,7 @@ export interface McpSyncUser {
   // Rating-display opt-in prefs, mirrored from prod so adoption can be inspected locally.
   showCalibratedRatings: boolean | null;
   showRatingComparisonDebug: boolean | null;
+  colorCodeRatings: boolean | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -1413,16 +1414,17 @@ async function mcpBulkChunked<TItem, TRow>(
 
 // Compound-key strings mirroring the rating / attendance unique constraints
 // (ratings_user_id_rateable_id_rateable_type_unique,
-// attendances_user_id_show_id_unique). The space separator can't appear in a
-// uuid or rateableType, so distinct tuples never collide. Detects id↔content
-// divergence
-// between local and prod — see findSquatterIds.
+// attendances_user_id_show_id_unique). The NUL separator can't appear in a
+// uuid or rateableType, so distinct tuples never collide. It's written as a
+// \u0000 escape rather than a literal byte, which would make tools classify
+// this whole file as binary and cause plain grep to skip it silently.
+// Detects id↔content divergence between local and prod, see findSquatterIds.
 export function ratingBindingKey(userId: string, rateableId: string, rateableType: string): string {
-  return `${userId} ${rateableId} ${rateableType}`;
+  return `${userId}\u0000${rateableId}\u0000${rateableType}`;
 }
 
 export function attendanceBindingKey(userId: string, showId: string): string {
-  return `${userId} ${showId}`;
+  return `${userId}\u0000${showId}`;
 }
 
 /**
@@ -1699,6 +1701,7 @@ export async function syncUserActivity(
               avatarFileUrl: u.avatarFileUrl,
               showCalibratedRatings: u.showCalibratedRatings,
               showRatingComparisonDebug: u.showRatingComparisonDebug,
+              colorCodeRatings: u.colorCodeRatings,
               updatedAt: new Date(u.updatedAt),
             },
           });
@@ -1715,6 +1718,7 @@ export async function syncUserActivity(
               avatarFileUrl: u.avatarFileUrl,
               showCalibratedRatings: u.showCalibratedRatings,
               showRatingComparisonDebug: u.showRatingComparisonDebug,
+              colorCodeRatings: u.colorCodeRatings,
               updatedAt: new Date(u.updatedAt),
             },
           });
@@ -1730,6 +1734,7 @@ export async function syncUserActivity(
               avatarFileUrl: u.avatarFileUrl,
               showCalibratedRatings: u.showCalibratedRatings,
               showRatingComparisonDebug: u.showRatingComparisonDebug,
+              colorCodeRatings: u.colorCodeRatings,
               createdAt: new Date(u.createdAt),
               updatedAt: new Date(u.updatedAt),
             },

--- a/packages/core/src/_shared/prisma/migrations/20260716000000_color_code_ratings/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260716000000_color_code_ratings/migration.sql
@@ -1,0 +1,5 @@
+-- Viewer preference for coloring rating values on a purple-to-green scale.
+-- Nullable with no default: NULL means the viewer never chose, which the app
+-- resolves to on. That keeps "never chose" distinguishable from "opted in",
+-- matching show_adjusted_rating / show_rating_compare.
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "color_code_ratings" BOOLEAN;

--- a/packages/core/src/_shared/prisma/schema.prisma
+++ b/packages/core/src/_shared/prisma/schema.prisma
@@ -765,6 +765,7 @@ model User {
   avatarFileUrl       String?      @map("avatar_file_url") @db.VarChar
   showCalibratedRatings     Boolean? @map("show_adjusted_rating")
   showRatingComparisonDebug Boolean? @map("show_rating_compare")
+  colorCodeRatings          Boolean? @map("color_code_ratings")
   avatarFile          File?        @relation("UserAvatar", fields: [avatarFileId], references: [id], onDelete: SetNull, onUpdate: NoAction)
   attendances         Attendance[]
   blogPosts           BlogPost[]

--- a/packages/core/src/users/user-service.test.ts
+++ b/packages/core/src/users/user-service.test.ts
@@ -168,6 +168,7 @@ describe("UserService.listForSync", () => {
       avatarFileUrl: true,
       showCalibratedRatings: true,
       showRatingComparisonDebug: true,
+      colorCodeRatings: true,
       createdAt: true,
       updatedAt: true,
     });

--- a/packages/core/src/users/user-service.ts
+++ b/packages/core/src/users/user-service.ts
@@ -58,6 +58,7 @@ function mapUserToDomainEntity(dbUser: DbUser): User {
     updatedAt: dbUser.updatedAt,
     showCalibratedRatings: dbUser.showCalibratedRatings ?? null,
     showRatingComparisonDebug: dbUser.showRatingComparisonDebug ?? null,
+    colorCodeRatings: dbUser.colorCodeRatings ?? null,
   };
 }
 
@@ -437,6 +438,7 @@ export class UserService {
       // Rating-display opt-in prefs, mirrored to local so prod adoption can be inspected.
       showCalibratedRatings: boolean | null;
       showRatingComparisonDebug: boolean | null;
+      colorCodeRatings: boolean | null;
       createdAt: Date;
       updatedAt: Date;
     }>
@@ -461,6 +463,7 @@ export class UserService {
         avatarFileUrl: true,
         showCalibratedRatings: true,
         showRatingComparisonDebug: true,
+        colorCodeRatings: true,
         createdAt: true,
         updatedAt: true,
       },

--- a/packages/domain/src/models/user.ts
+++ b/packages/domain/src/models/user.ts
@@ -11,6 +11,7 @@ export const userSchema = z.object({
   // Rating-display prefs (tri-state: null = no explicit choice → app default).
   showCalibratedRatings: z.boolean().nullable(),
   showRatingComparisonDebug: z.boolean().nullable(),
+  colorCodeRatings: z.boolean().nullable(),
 });
 
 export const userMinimalSchema = userSchema


### PR DESCRIPTION
## Color-code rating values

Rating numbers now carry a color. Brand purple means weak, neutral means
typical, brand green means strong, centered on 3.50. The community average and
your own score sit on the same scale, so two different colors in one badge tell
you at a glance that you disagree with the crowd, without reading either digit.
A show page's rating distribution chart tints its x-axis with the same ramp, so
the axis doubles as the scale's legend at no cost in layout.

**This ships off.** Each viewer turns it on under "Rating display" on their
profile. There is no feature flag: to turn it on for everyone, flip
`PREFERENCES_DEFAULT.colorCodeRatings` in `use-preferences.tsx`. That switches
it on for everyone who never touched the toggle and leaves explicit choices on
either side intact, which is why the stored column is tri-state rather than
carrying a database default.

### The scale

| Rating | Color | Token |
| --- | --- | --- |
| 0.50 | `#ac6ef7` | `--color-brand-primary` |
| 3.50 | `#bcbcc2` | `--color-content-text-secondary` |
| 5.00 | `#30e87d` | `--color-brand-tertiary` |

Every endpoint is an existing token; no new palette entries.

### Also in here

- **One gold.** The star used the `rating-gold` token while the badge chrome
  used a hardcoded `amber-500` plus a magic `rgb(33, 24, 11)`, left behind by
  an incomplete design-token migration in 2025-07. Both now derive from
  `rating-gold`.
- **Flame colors are tokens.** `--color-flame-jam` (gold) and
  `--color-flame-all-timer` (orange). The jam flame had drifted to three
  different colors across four call sites.
- **`StarValue` is one component.** The profile page had its own copy of the
  star-plus-value markup.
- **`data-rated` on the rating badge**, so tests assert the state instead of
  pattern-matching styling classes.
- **A `sync-missing-shows.ts` fix** unrelated to ratings: the file embedded raw
  NUL bytes as key separators, so tools classified it as binary and a plain
  `grep` silently skipped all 4,400 lines. They are now written as a unicode
  escape sequence instead, which is the identical string at runtime.

### Notes for the reviewer

**The ramp is anchored to the nominal scale, not the observed one.** Show
averages cluster tightly (p25 3.58, median 4.00, p75 4.31), so a
distribution-anchored ramp would discriminate better but would only be readable
if you already knew that 4.00 is the median. A fixed scale explains itself, and
leaving a 4 visibly short of green reflects what a 4 actually means.

**The two sides reach their ends at different rates.** 3.50 is not the midpoint
of 0.50 to 5, so green deepens twice as fast per star as purple. The
alternative was a symmetric span, which clamped everything at or below 2.0 to
one flat purple and made four of the ten axis ticks identical. Covering the
whole scale was the better trade.

**The badge has no interior tint.** The rated state is carried by the gold
border and glow alone. A gold wash behind color-coded numbers both fights those
hues and costs contrast (purple reads 5.19:1 over a 10% gold fill vs 5.99:1
over the page).

**A test pins the ramp's hex literals to the tokens they mirror.** The ramp
interpolates between endpoints, which needs numeric channels a CSS variable
cannot give a pure function, so the hexes are duplicated from `styles.css`.
`rating-colors.test.ts` reads the real stylesheet and fails if a token is
retuned without the ramp following. That guard is the thing whose absence let
`amber-500` drift from `rating-gold` in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
