### PR TITLE
Quiet the show row so the rating leads

### DIFF
--- a/apps/web/app/components/performance/track-rating-cell.test.tsx
+++ b/apps/web/app/components/performance/track-rating-cell.test.tsx
@@ -62,7 +62,7 @@ describe("TrackRatingCell", () => {
 
   // When the user has NOT rated the track, the cell has a dashed border
   // (no golden highlight).
-  test("shows dashed border when userRating is null", async () => {
+  test("marks itself unrated when userRating is null", async () => {
     const { container } = await setupWithRouter(
       <TrackRatingCell
         trackId="t1"
@@ -75,7 +75,7 @@ describe("TrackRatingCell", () => {
     );
 
     const button = container.querySelector("button");
-    expect(button?.className).toContain("border-dashed");
+    expect(button).toHaveAttribute("data-rated", "false");
   });
 
   // When React reuses a TrackRatingCell component at the same DOM position
@@ -150,7 +150,7 @@ describe("TrackRatingCell", () => {
 
   // When the component is reused at the same DOM position, the golden
   // border state must track the new userRating prop, not the old one.
-  test("updates golden border state when userRating prop changes", async () => {
+  test("updates its rated state when the userRating prop changes", async () => {
     const { container, rerender } = await setupWithRouter(
       <TrackRatingCell
         trackId="t1"
@@ -179,9 +179,8 @@ describe("TrackRatingCell", () => {
       </MemoryRouter>,
     );
 
-    // Should now be dashed (no user rating), not golden.
+    // Should now read as unrated (no user rating).
     button = container.querySelector("button");
-    expect(button?.className).toContain("border-dashed");
     expect(button).toHaveAttribute("data-rated", "false");
   });
 });

--- a/apps/web/app/components/rating/rating-badge-button.test.tsx
+++ b/apps/web/app/components/rating/rating-badge-button.test.tsx
@@ -64,9 +64,10 @@ describe("RatingBadgeButton", () => {
     expect(screen.getByText("Rate")).toBeInTheDocument();
   });
 
-  // Visual rated/unrated state: amber border + bg when the user has rated,
-  // dashed glass border otherwise. Same contract for both size variants.
-  test("shows amber border when userRating is provided", async () => {
+  // Rated/unrated is carried by data-rated and by the viewer's own score
+  // rendering to the right of the divider — not by chrome. Same contract for
+  // both size variants.
+  test("marks itself rated when userRating is provided", async () => {
     const { container } = await setupWithRouter(
       <RatingBadgeButton
         rateableId="t1"
@@ -83,7 +84,7 @@ describe("RatingBadgeButton", () => {
     expect(button).toHaveAttribute("data-rated", "true");
   });
 
-  test("shows dashed border when userRating is null", async () => {
+  test("marks itself unrated when userRating is null", async () => {
     const { container } = await setupWithRouter(
       <RatingBadgeButton
         rateableId="t1"
@@ -97,7 +98,7 @@ describe("RatingBadgeButton", () => {
     );
 
     const button = container.querySelector("button");
-    expect(button?.className).toContain("border-dashed");
+    expect(button).toHaveAttribute("data-rated", "false");
   });
 
   // Component must track new props when React reuses the same DOM position
@@ -173,7 +174,7 @@ describe("RatingBadgeButton", () => {
 
   // The amber/dashed state must follow the latest userRating prop, not a
   // cached value from a prior row at the same DOM position.
-  test("updates amber/dashed state when userRating prop changes", async () => {
+  test("updates its rated state when the userRating prop changes", async () => {
     const { container, rerender } = await setupWithRouter(
       <RatingBadgeButton
         rateableId="t1"
@@ -204,7 +205,6 @@ describe("RatingBadgeButton", () => {
     );
 
     button = container.querySelector("button");
-    expect(button?.className).toContain("border-dashed");
     expect(button).toHaveAttribute("data-rated", "false");
   });
 
@@ -294,7 +294,7 @@ describe("RatingBadgeButton", () => {
   // the badge drops its amber chrome and the re-opened editor seeds with
   // an empty state — same local-capture path as a fresh submission, just
   // with a null value.
-  test("captures a cleared rating and drops the gold edge", async () => {
+  test("captures a cleared rating and returns to the unrated state", async () => {
     const user = userEvent.setup();
     const { container } = await setupWithRouter(
       <RatingBadgeButton
@@ -309,7 +309,7 @@ describe("RatingBadgeButton", () => {
       />,
     );
 
-    // Initial rated state — gold edge.
+    // Initial rated state.
     let button = container.querySelector("button") as HTMLButtonElement;
     expect(button).toHaveAttribute("data-rated", "true");
 
@@ -321,10 +321,9 @@ describe("RatingBadgeButton", () => {
       lastProps.onAverageRatingChange(3.8, 4);
     });
 
-    // Editor collapsed; the badge re-renders without the gold edge.
+    // Editor collapsed; the badge re-renders as unrated.
     button = container.querySelector("button") as HTMLButtonElement;
     expect(button).toHaveAttribute("data-rated", "false");
-    expect(button.className).toContain("border-dashed");
 
     // Re-opening seeds the editor with null, not the stale prop.
     await user.click(button);

--- a/apps/web/app/components/rating/rating-badge-button.tsx
+++ b/apps/web/app/components/rating/rating-badge-button.tsx
@@ -3,21 +3,41 @@ import { RatingComponent } from "~/components/rating/rating";
 import { LoginPromptPopover } from "~/components/ui/login-prompt-popover";
 import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
 import { StarRating } from "~/components/ui/star-rating";
+import { usePreferences } from "~/hooks/use-preferences";
+import { ROW_CHIP_HOVER } from "~/lib/interaction-styles";
 import { cn } from "~/lib/utils";
 
 type RatingBadgeSize = "compact" | "regular";
 
 /**
- * Chrome marking a badge the viewer has rated: a solid gold edge and outer
- * glow. Deliberately no interior tint — the rating values are themselves
- * color-coded, and a warm gold wash behind them both fights those hues and
- * costs contrast (purple reads 5.19:1 over a 10% gold fill, 5.99:1 over the
- * page). Shared by the collapsed badge and the popover that covers it, so the
- * two can't drift apart. Assert on `data-rated` rather than these classes.
+ * The badge's surface when the color scale is off. Note `glass-secondary` sets
+ * `border` with `!important`, which defeats any border utility OR inline border
+ * style placed alongside it — the chrome options here are alternatives for that
+ * reason, never combined.
  */
-const RATED_CHROME = "border border-rating-gold/50 shadow-[0_0_8px_hsl(var(--rating-gold)/0.2)]";
-/** Its counterpart: the dashed "not yet rated" affordance surface. */
-const UNRATED_CHROME = "glass-secondary border border-dashed border-glass-border";
+const BADGE_CHROME = "glass-secondary";
+
+/**
+ * The gold edge marking a badge the viewer has rated, worn only when the color
+ * scale is off — with the scale on, the tinted score says it already and the
+ * badge wears a neutral hairline instead (see `SCALE_CHROME`).
+ *
+ * Assert on `data-rated`, never on these classes.
+ */
+const RATED_GOLD_CHROME =
+  "border border-rating-gold/50 shadow-[0_0_8px_hsl(var(--rating-gold)/0.2)] hover:border-rating-gold/80 hover:bg-rating-gold/10";
+
+/**
+ * The badge edge worn when the scale is on: a neutral hairline that gives the
+ * badge a shape without spending a color. The score and star are already tinted,
+ * so anything colored here is a third voice saying what they say — and gold
+ * specifically then competes with the tint rather than framing it.
+ *
+ * Deliberately not `glass-secondary`: that sets `border` with `!important` and
+ * would silently eat this.
+ */
+const SCALE_CHROME =
+  "border border-content-text-secondary/28 hover:border-content-text-secondary/60 hover:bg-content-text-secondary/10";
 
 interface RatingBadgeButtonProps {
   rateableId: string;
@@ -77,6 +97,7 @@ export function RatingBadgeButton({
   const [localUserRating, setLocalUserRating] = useState<number | null>(userRating ?? null);
   const animationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const localHasRated = localUserRating != null;
+  const { colorCodeRatings } = usePreferences();
 
   // Sync display + rated state when props change. Handles two cases:
   // (1) async data arriving after first render (e.g. useTrackUserRatings
@@ -113,14 +134,25 @@ export function RatingBadgeButton({
   const layoutClass =
     size === "compact"
       ? "inline-flex items-center justify-center gap-1 py-1 rounded-md"
-      : "flex items-center justify-center gap-1 h-6 sm:h-8 rounded-md transition-all";
+      : "flex items-center justify-center gap-1 h-6 sm:h-8 rounded-md";
 
   // Padding tightens when the personal score renders to compensate for the
   // busier row (divider + extra value).
   const paddingClass =
     size === "compact" ? (localHasRated ? "px-1" : "px-2") : localHasRated ? "px-1.5 sm:px-2" : "px-2 sm:px-3";
 
-  const stateClass = localHasRated ? RATED_CHROME : `${UNRATED_CHROME} hover:border-rating-gold/30`;
+  // Three surfaces, never layered — see BADGE_CHROME for why they can't be.
+  // Scale on: a neutral hairline, since the score carries the color. Scale off:
+  // gold once rated, glass until then.
+  const stateClass = colorCodeRatings ? SCALE_CHROME : localHasRated ? RATED_GOLD_CHROME : BADGE_CHROME;
+
+  // The picker has to be opaque or the rows under it read through. Only
+  // `glass-secondary` brings its own fill (plus a backdrop blur); the gold and
+  // scale chromes are border-only, so those cases need the page color spelled
+  // out. The badge itself stays transparent to its row either way.
+  const popoverStyle: React.CSSProperties = {
+    ...(stateClass === BADGE_CHROME ? {} : { backgroundColor: "hsl(var(--background))" }),
+  };
 
   // Badge is always the compact RatingComponent; tapping opens a Popover
   // with the 5-star picker (overlay rather than inline expansion). Same
@@ -137,7 +169,7 @@ export function RatingBadgeButton({
       className={cn(
         layoutClass,
         paddingClass,
-        "origin-center hover:brightness-110 cursor-pointer",
+        ROW_CHIP_HOVER,
         stateClass,
         isAnimating && "animate-[avg-rating-update_0.5s_ease-out]",
       )}
@@ -166,35 +198,23 @@ export function RatingBadgeButton({
          * `side="top"` + negative sideOffset positions the popover so
          * its bottom edge sits over the badge, visually replacing the
          * collapsed star + count with the 5-star picker rather than
-         * floating in empty space below. Styling mirrors the desktop
-         * inline-expanded state — gold border + soft glow when the user
-         * has rated, glass / dashed-border when they haven't — so opening
-         * the picker reads as the same component, just floated on mobile.
-         *
-         * The inline `background` style names the page background directly
-         * rather than using a Tailwind `bg-*` class because this Tailwind v4
-         * theme registers `--color-*` tokens (used by Tailwind `bg-*` classes)
-         * separately from the older HSL-component `--background` token shared
-         * with Radix — `bg-popover` / `bg-background` resolve to
-         * `transparent`.
+         * floating in empty space below. Wears the same chrome as the badge
+         * it covers, so opening the picker reads as the same component just
+         * floated on mobile — and `glass-secondary`'s backdrop blur keeps the
+         * rows beneath from reading through the picker.
          */}
         <PopoverContent
-          // Sized + colored to mirror the inline-expanded badge:
-          // same py-1 + px padding, same border + glow as the rated
-          // state. `min-h-8` + `sideOffset={-32}` makes the popover at
-          // least as tall as the underlying badge on desktop (~30px) so
-          // it fully covers the badge with `align="center"` + `side="top"`.
-          //
-          // Background is OPAQUE so the cells underneath can't show through
-          // the picker; the badge itself is transparent to the row, so this
-          // matches it by naming the page background.
+          // `min-h-8` + `sideOffset={-32}` makes the popover at least as tall
+          // as the underlying badge on desktop (~30px) so it fully covers the
+          // badge with `align="center"` + `side="top"`. Padding still tracks
+          // the rated state because that changes the badge's width underneath.
           data-rated={localHasRated}
           className={cn(
             "w-auto rounded-md flex items-center gap-1 min-h-8",
             localHasRated ? "!p-1" : "!py-1 !px-2",
-            localHasRated ? RATED_CHROME : UNRATED_CHROME,
+            stateClass,
           )}
-          style={localHasRated ? { backgroundColor: "hsl(var(--background))" } : undefined}
+          style={popoverStyle}
           align="center"
           side="top"
           sideOffset={-32}

--- a/apps/web/app/components/rating/rating.tsx
+++ b/apps/web/app/components/rating/rating.tsx
@@ -35,20 +35,23 @@ function ratingColorStyle(value: number, enabled: boolean): { color: string } | 
 }
 
 /**
- * Gold star followed by a rating value on the color scale. `label` carries the
+ * Star followed by a rating value on the color scale. `label` carries the
  * formatted text because callers format differently (a community average wants
  * 2 decimals, a personal score wants the ½ glyph) while the color always comes
  * from the underlying number.
+ *
+ * The star takes the value's color alongside it when the scale is on, so the
+ * badge reads as one tinted unit rather than a gold mark competing with a
+ * colored number. With the scale off it falls back to gold, which is then the
+ * badge's only color.
  */
 export function StarValue({ value, label }: { value: number; label: string }) {
   const { colorCodeRatings } = usePreferences();
+  const tint = ratingColorStyle(value, colorCodeRatings);
   return (
     <span className="inline-flex items-center whitespace-nowrap">
-      <Star className="h-3 w-3 sm:h-4 sm:w-4 shrink-0 text-rating-gold mr-0.5 sm:mr-1" />
-      <span
-        className="font-medium text-xs sm:text-sm text-content-text-primary"
-        style={ratingColorStyle(value, colorCodeRatings)}
-      >
+      <Star className="h-3 w-3 sm:h-4 sm:w-4 shrink-0 text-rating-gold mr-0.5 sm:mr-1" style={tint} />
+      <span className="font-medium text-xs sm:text-sm text-content-text-primary" style={tint}>
         {label}
       </span>
     </span>

--- a/apps/web/app/components/setlist/anniversary-badge.test.tsx
+++ b/apps/web/app/components/setlist/anniversary-badge.test.tsx
@@ -50,12 +50,12 @@ describe("AnniversaryBadge", () => {
   });
 
   // Uses amber-400 text color
-  test("applies amber-400 color", async () => {
+  test("shares the rating star's gold", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-14"));
     const { container } = await setupWithRouter(<AnniversaryBadge showDate="2021-04-14" />);
     const badge = container.firstChild as HTMLElement;
-    expect(badge.className).toContain("text-amber-400");
+    expect(badge.className).toContain("text-rating-gold");
     vi.useRealTimers();
   });
 

--- a/apps/web/app/components/setlist/anniversary-badge.tsx
+++ b/apps/web/app/components/setlist/anniversary-badge.tsx
@@ -27,7 +27,10 @@ export function AnniversaryBadge({ showDate }: AnniversaryBadgeProps) {
   const tier = getTier(years);
   const Icon = anniversaryIcons[tier];
   return (
-    <span className="flex items-center gap-1 text-sm font-medium text-amber-400">
+    // Shares the rating star's gold rather than carrying its own near-identical
+    // amber: the two sit inches apart in a setlist row, and two golds that
+    // almost match read as an accident rather than as an accent.
+    <span className="flex items-center gap-1 text-sm font-medium text-rating-gold">
       <Icon className="h-4 w-4" />
       {years}
       {getOrdinalSuffix(years)} Anniversary

--- a/apps/web/app/components/setlist/setlist-card.test.tsx
+++ b/apps/web/app/components/setlist/setlist-card.test.tsx
@@ -2,10 +2,12 @@ import type { Setlist } from "@bip/domain";
 import { expectMockedShallowComponent, mockShallowComponent, setupWithRouter } from "@test/test-utils";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 // Mock hooks used internally by SetlistCard
 import { useSession } from "~/hooks/use-session";
+import { useAttendanceMutation } from "~/hooks/use-show-user-data";
 
 vi.mock("~/hooks/use-session", () => ({
   useSession: vi.fn(() => ({ user: null, supabase: null, loading: false })),
@@ -126,6 +128,9 @@ describe("SetlistCard", () => {
       supabase: null as never,
       loading: false,
     } as never);
+    // Same reasoning for the attendance mutation: the attendance tests swap in
+    // per-test mutate spies, so restore the inert default for everyone else.
+    vi.mocked(useAttendanceMutation).mockReturnValue({ mutate: vi.fn(), isPending: false } as never);
   });
 
   // Passes the show date to AnniversaryBadge so it can decide whether to render
@@ -343,10 +348,10 @@ describe("SetlistCard", () => {
     expect(ratingButton).toHaveAttribute("data-rated", "true");
   });
 
-  // The dashed (unrated) state is the default when the viewer is logged in
-  // but hasn't rated the show. Pinned because the resolver short-circuits on
-  // null and the rated-state derivation must follow.
-  test("rating badge shows dashed border when userRating is null and viewer is logged in", async () => {
+  // Unrated is the default when the viewer is logged in but hasn't rated the
+  // show. Pinned because the resolver short-circuits on null and the
+  // rated-state derivation must follow.
+  test("rating badge is unrated when userRating is null and viewer is logged in", async () => {
     vi.mocked(useSession).mockReturnValue({
       user: { id: "user-1" } as never,
       supabase: null as never,
@@ -359,7 +364,175 @@ describe("SetlistCard", () => {
     const ratingButton = Array.from(buttons).find((btn) => btn.dataset.rated !== undefined);
     expect(ratingButton).toBeDefined();
     expect(ratingButton).toHaveAttribute("data-rated", "false");
-    expect(ratingButton?.className).toContain("border-dashed");
+  });
+
+  // Attendance button. The whole feature lives in SetlistCard (unlike rating,
+  // which is extracted into RatingBadgeButton and tested there), so the
+  // attended/unattended rendering, the optimistic toggle, and the revert-on-
+  // error path are only covered here. Assert on `data-attended` rather than the
+  // chrome classes, which are free to change.
+  describe("attendance button", () => {
+    function mockLoggedIn() {
+      vi.mocked(useSession).mockReturnValue({
+        user: { id: "user-1" } as never,
+        supabase: null as never,
+        loading: false,
+      } as never);
+    }
+
+    function makeAttendance() {
+      return { id: "attendance-1", showId: "show-1", userId: "user-1" } as never;
+    }
+
+    const getAttendanceButton = () => screen.getByRole("button", { name: /saw it/i });
+
+    // Marking attendance is a logged-in-only affordance; logged-out viewers
+    // get no button at all rather than one that prompts to sign in.
+    test("is not rendered for a logged-out viewer", async () => {
+      await setupWithRouter(
+        <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={null} />,
+      );
+      expect(screen.queryByRole("button", { name: /saw it/i })).not.toBeInTheDocument();
+    });
+
+    // The trailing "?" is the affordance: "Saw it?" asks, "Saw it" confirms.
+    test("renders the unattended prompt when the viewer has not marked the show", async () => {
+      mockLoggedIn();
+      await setupWithRouter(
+        <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={null} />,
+      );
+      const button = getAttendanceButton();
+      expect(button).toHaveAttribute("data-attended", "false");
+      expect(button).toHaveTextContent("Saw it?");
+    });
+
+    test("renders the attended state when userAttendance is present", async () => {
+      mockLoggedIn();
+      await setupWithRouter(
+        <SetlistCard setlist={makeSetlist()} userAttendance={makeAttendance()} userRating={null} showRating={null} />,
+      );
+      const button = getAttendanceButton();
+      expect(button).toHaveAttribute("data-attended", "true");
+      expect(button).toHaveTextContent("Saw it");
+      expect(button).not.toHaveTextContent("Saw it?");
+    });
+
+    // The button flips before the server answers. `mutate` here never invokes
+    // its callbacks, so a button that only updated in onSuccess would fail.
+    test("flips to attended optimistically before the mutation resolves", async () => {
+      mockLoggedIn();
+      const mutate = vi.fn();
+      vi.mocked(useAttendanceMutation).mockReturnValue({ mutate, isPending: false } as never);
+      const { user } = await setupWithRouter(
+        <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={null} />,
+      );
+
+      await user.click(getAttendanceButton());
+
+      expect(getAttendanceButton()).toHaveAttribute("data-attended", "true");
+      // currentAttendance must be the value captured BEFORE the optimistic
+      // update, or the mutation would toggle the wrong direction.
+      expect(mutate).toHaveBeenCalledWith({ showId: "show-1", currentAttendance: null }, expect.anything());
+    });
+
+    // Un-marking passes the existing attendance through so the server knows
+    // which row to delete.
+    test("clicking an attended show unmarks it and passes the current attendance", async () => {
+      mockLoggedIn();
+      const mutate = vi.fn();
+      vi.mocked(useAttendanceMutation).mockReturnValue({ mutate, isPending: false } as never);
+      const attendance = makeAttendance();
+      const { user } = await setupWithRouter(
+        <SetlistCard setlist={makeSetlist()} userAttendance={attendance} userRating={null} showRating={null} />,
+      );
+
+      await user.click(getAttendanceButton());
+
+      expect(getAttendanceButton()).toHaveAttribute("data-attended", "false");
+      expect(mutate).toHaveBeenCalledWith({ showId: "show-1", currentAttendance: attendance }, expect.anything());
+    });
+
+    // A failed toggle must not leave the button lying about attendance.
+    test("reverts to unattended when the mutation fails", async () => {
+      mockLoggedIn();
+      const mutate = vi.fn((_variables, callbacks) => callbacks.onError(new Error("network")));
+      vi.mocked(useAttendanceMutation).mockReturnValue({ mutate, isPending: false } as never);
+      const { user } = await setupWithRouter(
+        <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={null} />,
+      );
+
+      await user.click(getAttendanceButton());
+
+      expect(getAttendanceButton()).toHaveAttribute("data-attended", "false");
+    });
+
+    // Reverting an un-mark restores the original attendance rather than
+    // clearing it — the failure case the captured `previousAttendance` exists for.
+    test("reverts to attended when un-marking fails", async () => {
+      mockLoggedIn();
+      const mutate = vi.fn((_variables, callbacks) => callbacks.onError(new Error("network")));
+      vi.mocked(useAttendanceMutation).mockReturnValue({ mutate, isPending: false } as never);
+      const { user } = await setupWithRouter(
+        <SetlistCard setlist={makeSetlist()} userAttendance={makeAttendance()} userRating={null} showRating={null} />,
+      );
+
+      await user.click(getAttendanceButton());
+
+      expect(getAttendanceButton()).toHaveAttribute("data-attended", "true");
+    });
+
+    // The server's answer wins over the optimistic guess.
+    test("settles on the attendance returned by a successful mutation", async () => {
+      mockLoggedIn();
+      const serverAttendance = { id: "attendance-server", showId: "show-1", userId: "user-1" } as never;
+      const mutate = vi.fn((_variables, callbacks) =>
+        callbacks.onSuccess({ attendance: serverAttendance, isAttending: true }),
+      );
+      vi.mocked(useAttendanceMutation).mockReturnValue({ mutate, isPending: false } as never);
+      const { user } = await setupWithRouter(
+        <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={null} />,
+      );
+
+      await user.click(getAttendanceButton());
+
+      expect(getAttendanceButton()).toHaveAttribute("data-attended", "true");
+    });
+
+    // A toggle already in flight must not fire a second mutation. The button is
+    // disabled while pending AND toggleAttendance early-returns; this pins the
+    // user-facing contract rather than either mechanism.
+    test("ignores clicks while a toggle is already pending", async () => {
+      mockLoggedIn();
+      const mutate = vi.fn();
+      vi.mocked(useAttendanceMutation).mockReturnValue({ mutate, isPending: true } as never);
+      const { user } = await setupWithRouter(
+        <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={null} />,
+      );
+
+      await user.click(getAttendanceButton());
+
+      expect(mutate).not.toHaveBeenCalled();
+    });
+
+    // Attendance is mirrored into local state, so a prop arriving later (the
+    // route's user-data query resolving after first paint) must still land.
+    test("picks up attendance arriving from props after mount", async () => {
+      mockLoggedIn();
+      const { rerender } = await setupWithRouter(
+        <SetlistCard setlist={makeSetlist()} userAttendance={null} userRating={null} showRating={null} />,
+      );
+      expect(getAttendanceButton()).toHaveAttribute("data-attended", "false");
+
+      // rerender replaces the whole tree, so the router wrapper that
+      // setupWithRouter added must be repeated here.
+      rerender(
+        <MemoryRouter>
+          <SetlistCard setlist={makeSetlist()} userAttendance={makeAttendance()} userRating={null} showRating={null} />
+        </MemoryRouter>,
+      );
+
+      expect(getAttendanceButton()).toHaveAttribute("data-attended", "true");
+    });
   });
 
   // Clicking "gap chart" swaps to the table view. Existence of the

--- a/apps/web/app/components/setlist/setlist-card.tsx
+++ b/apps/web/app/components/setlist/setlist-card.tsx
@@ -12,6 +12,7 @@ import { Card, CardContent, CardHeader } from "~/components/ui/card";
 import { useSession } from "~/hooks/use-session";
 import { useAttendanceMutation } from "~/hooks/use-show-user-data";
 import { formatVenueLocation } from "~/lib/format-venue";
+import { ROW_CHIP_HOVER } from "~/lib/interaction-styles";
 import { deriveShowLineupNotes } from "~/lib/lineup-notes";
 import { cn } from "~/lib/utils";
 import { AnniversaryBadge } from "./anniversary-badge";
@@ -23,6 +24,43 @@ import { SetlistViewControl, type SetlistViewSummary } from "./setlist-view-cont
 import { ShowExternalBadges, type ShowExternalSources } from "./show-external-badges";
 
 export type SetlistView = "setlist" | "gap-chart" | "personal";
+
+/**
+ * Chrome for a show the viewer marked attended: a green fill, edge and glow.
+ *
+ * The fill earns its place beyond looks — `ROW_CHIP_HOVER` brightens and
+ * saturates, and both are filters, so without a background they have almost
+ * nothing to act on and the hover reads as broken.
+ *
+ * Every green here resolves from `green-500`: fill and border via Tailwind's
+ * `--color-green-500`, the glow via the bare `--green-500`. The glow used to
+ * hardcode stock Tailwind green, which never matched the border it sat on.
+ */
+const ATTENDED_CHROME =
+  "bg-green-500/10 border border-green-500/50 shadow-[0_0_8px_hsl(var(--green-500)/0.2)] hover:bg-green-500/20 hover:border-green-500/80";
+
+/**
+ * Chrome for a show not yet marked attended: the same frosted surface
+ * `glass-secondary` paints, but reached through the raw tokens instead of that
+ * class, so hover can answer in green the way the attended state does.
+ *
+ * `glass-secondary` sets `background-color` AND `border` with `!important`,
+ * which silently defeats any hover utility beside it — this button carried a
+ * `hover:border-green-500/30` that has never once rendered. Naming the same
+ * tokens directly reproduces the surface exactly while leaving hover free.
+ *
+ * The border is solid rather than dashed on purpose: the class list here used
+ * to say `border-dashed`, but `glass-secondary`'s `!important` overrode it, so
+ * solid is what has always shipped and what people recognise.
+ */
+const UNATTENDED_CHROME = [
+  "bg-[var(--glass-bg-secondary)] border border-[var(--glass-border)]",
+  // The blur token is a whole filter function, not a length, so it can't feed
+  // Tailwind's `backdrop-blur-[…]`; set the property directly to avoid
+  // restating 12px here.
+  "[backdrop-filter:var(--backdrop-blur)]",
+  "hover:bg-green-500/10 hover:border-green-500/50",
+].join(" ");
 
 interface SetlistCardProps {
   setlist: Setlist;
@@ -192,6 +230,45 @@ function SetlistCardComponent({
     );
   };
 
+  // Sits on the header's first line, beside the show date, rather than next to
+  // the rating badge. Attendance and rating are different questions, and putting
+  // them shoulder to shoulder made the row a contest between two bordered chips —
+  // worst on a profile, where every show is attended. Here the badge owns the
+  // right edge alone.
+  const attendanceButton = (
+    <button
+      type="button"
+      onClick={toggleAttendance}
+      disabled={attendanceMutation.isPending}
+      // Semantic hook for "the viewer marked this show attended", so tests don't
+      // have to recognize the state by pattern-matching styling classes that are
+      // free to change. Mirrors `data-rated` on the rating badge.
+      data-attended={isAttending}
+      className={cn(
+        "flex items-center justify-center gap-1 px-2 h-6 sm:px-3 sm:h-8 rounded-md",
+        "shrink-0 whitespace-nowrap",
+        ROW_CHIP_HOVER,
+        isAttending ? ATTENDED_CHROME : UNATTENDED_CHROME,
+        isAttendanceAnimating && "animate-[avg-rating-update_0.5s_ease-out]",
+        attendanceMutation.isPending && "opacity-50",
+      )}
+    >
+      <Check
+        className={cn("h-3.5 w-3.5 sm:h-4 sm:w-4", isAttending ? "text-green-500" : "text-content-text-tertiary")}
+      />
+      {/*
+       * The label stays neutral in both states. It was the single heaviest
+       * element in the row — brightest colour and most ink — which put a fact
+       * the green check already states above the rating it sits beside. Green
+       * now lives only on the check and the chrome, which also leaves the
+       * button speaking one green rather than two.
+       */}
+      <span className="text-sm font-medium hidden sm:inline text-content-text-tertiary">
+        {isAttending ? "Saw it" : "Saw it?"}
+      </span>
+    </button>
+  );
+
   return (
     <Card className="relative overflow-hidden">
       <CardHeader
@@ -218,10 +295,29 @@ function SetlistCardComponent({
             <div className="flex items-center gap-2 text-lg md:text-2xl font-medium">
               <Link
                 to={setlist.show.slug ? `/shows/${setlist.show.slug}` : `/shows`}
-                className="text-brand-primary hover:text-brand-secondary transition-colors"
+                // Reserve a column wide enough for the longest date this renders
+                // (`12/30/2025` — the header has no @container/datecell, so it's
+                // always the full M/D/YYYY), so the attendance button beside it
+                // lands on the same vertical line in every row instead of sliding
+                // with the date's length.
+                //
+                // `ch` rather than a px/rem value: this text renders in the
+                // system font stack, so its metrics differ per platform, and it
+                // scales text-lg → text-2xl at the md breakpoint. A fixed length
+                // would need re-measuring on every OS and duplicating per
+                // breakpoint; `ch` is defined against the font actually in use,
+                // so one value covers both. 9ch clears the widest date with a few
+                // px to spare at both sizes.
+                //
+                // `min-w`, not `w`: an unexpectedly wide date pushes the row out
+                // rather than overflowing. And not a container query — ShowDate
+                // documents that `container-type: inline-size` collapses it and
+                // breaks the date character-by-character.
+                className="text-brand-primary hover:text-brand-secondary transition-colors shrink-0 min-w-[9ch]"
               >
                 <ShowDate date={setlist.show.date} />
               </Link>
+              {user && attendanceButton}
               <AnniversaryBadge showDate={setlist.show.date} />
               {notForStats && (
                 <Badge
@@ -239,66 +335,18 @@ function SetlistCardComponent({
             </div>
           </div>
           <div className="flex flex-col items-end gap-2">
-            {user && (
-              <div className="flex items-center gap-2">
-                {/* Attendance badge - clickable to toggle */}
-                <button
-                  type="button"
-                  onClick={toggleAttendance}
-                  disabled={attendanceMutation.isPending}
-                  className={cn(
-                    "flex items-center justify-center gap-1 px-2 h-6 sm:px-3 sm:h-8 rounded-md transition-all",
-                    "shrink-0 whitespace-nowrap",
-                    "hover:brightness-110 cursor-pointer",
-                    isAttending
-                      ? "bg-green-500/10 border border-green-500/50 shadow-[0_0_8px_rgba(34,197,94,0.2)]"
-                      : "glass-secondary border border-dashed border-glass-border hover:border-green-500/30",
-                    isAttendanceAnimating && "animate-[avg-rating-update_0.5s_ease-out]",
-                    attendanceMutation.isPending && "opacity-50",
-                  )}
-                >
-                  <Check
-                    className={cn(
-                      "h-3.5 w-3.5 sm:h-4 sm:w-4",
-                      isAttending ? "text-green-500" : "text-content-text-tertiary",
-                    )}
-                  />
-                  <span
-                    className={cn(
-                      "text-sm font-medium hidden sm:inline",
-                      isAttending ? "text-green-400" : "text-content-text-secondary",
-                    )}
-                  >
-                    {isAttending ? "Saw it" : "Saw it?"}
-                  </span>
-                </button>
-
-                <RatingBadgeButton
-                  rateableId={setlist.show.id}
-                  rateableType="Show"
-                  showSlug={setlist.show.slug}
-                  initialRating={displayedRating}
-                  ratingsCount={displayedCount}
-                  userRating={resolvedUserRating}
-                  isAuthenticated
-                />
-                {summaryEl}
-              </div>
-            )}
-            {!user && (
-              <div className="flex items-center gap-2">
-                <RatingBadgeButton
-                  rateableId={setlist.show.id}
-                  rateableType="Show"
-                  showSlug={setlist.show.slug}
-                  initialRating={displayedRating}
-                  ratingsCount={displayedCount}
-                  userRating={null}
-                  isAuthenticated={false}
-                />
-                {summaryEl}
-              </div>
-            )}
+            <div className="flex items-center gap-2">
+              <RatingBadgeButton
+                rateableId={setlist.show.id}
+                rateableType="Show"
+                showSlug={setlist.show.slug}
+                initialRating={displayedRating}
+                ratingsCount={displayedCount}
+                userRating={user ? resolvedUserRating : null}
+                isAuthenticated={!!user}
+              />
+              {summaryEl}
+            </div>
             <div className="pr-2 sm:pr-3">
               <ShowExternalBadges
                 sources={externalSources ?? {}}

--- a/apps/web/app/components/setlist/show-external-badges.tsx
+++ b/apps/web/app/components/setlist/show-external-badges.tsx
@@ -1,6 +1,12 @@
 import { Camera } from "lucide-react";
 import { Link } from "react-router-dom";
-import { EXTERNAL_FAVICON_LINK_CLASS, EXTERNAL_SOURCE_DOMAINS, faviconSrc } from "~/lib/favicon";
+import {
+  EXTERNAL_FAVICON_IMG_CLASS,
+  EXTERNAL_FAVICON_LINK_CLASS,
+  EXTERNAL_SOURCE_DOMAINS,
+  faviconBoost,
+  faviconSrc,
+} from "~/lib/favicon";
 import { cn } from "~/lib/utils";
 
 /**
@@ -42,9 +48,10 @@ interface ShowExternalBadgesProps {
 interface FaviconLinkProps {
   /** Bare host (e.g. "nugs.net") used to resolve the favicon. */
   domain: string;
-  /** Fully-qualified link target. Undefined collapses the badge to nothing so
-   *  callers can pass the raw optional URL without a surrounding `&&` gate. */
-  href: string | undefined;
+  /** Fully-qualified link target. Null or undefined collapses the badge to
+   *  nothing so callers can pass a raw optional URL, from either a loader
+   *  (nullable) or an optional prop, without a surrounding `&&` gate. */
+  href: string | null | undefined;
   /** Hover tooltip and screen-reader label. */
   label: string;
 }
@@ -62,15 +69,22 @@ interface PhotosBadgeProps {
 const BADGE_ICON_CLASS = "h-5 w-5 shrink-0";
 
 /**
- * A single favicon-as-link inside the badge strip. Owns its own absence —
- * returns null when the URL isn't available so the parent strip can pass
- * optional URLs in directly without per-field `&&` gates.
+ * A single favicon-as-link. Owns its own absence — returns null when the URL
+ * isn't available so callers can pass optional URLs in directly without
+ * per-field `&&` gates. Exported because the same affordance appears outside
+ * the badge strip (resource pages), and the per-domain brightness tuning it
+ * carries has to stay identical everywhere a service logo is shown.
  */
-function FaviconLink({ domain, href, label }: FaviconLinkProps) {
+export function FaviconLink({ domain, href, label }: FaviconLinkProps) {
   if (!href) return null;
   return (
     <a href={href} target="_blank" rel="noopener noreferrer" title={label} className={EXTERNAL_FAVICON_LINK_CLASS}>
-      <img src={faviconSrc(domain)} alt={label} className={BADGE_ICON_CLASS} />
+      <img
+        src={faviconSrc(domain)}
+        alt={label}
+        className={cn(BADGE_ICON_CLASS, EXTERNAL_FAVICON_IMG_CLASS)}
+        style={faviconBoost(domain)}
+      />
     </a>
   );
 }
@@ -78,11 +92,24 @@ function FaviconLink({ domain, href, label }: FaviconLinkProps) {
 /**
  * Camera icon + count, linking to the show's #photos anchor. Owns its own
  * absence so the parent can pass raw optional values without `&&` gates.
+ *
+ * Carries an explicit muted color because it's the one badge drawn as a stroked
+ * icon rather than a favicon image: the strip's desaturation only reaches the
+ * images, so left on the default text color this would read as the boldest
+ * thing in a row of greys.
+ *
+ * Tuned a step brighter than the favicons' tinted fill rather than matched to
+ * it. An outline covers far fewer pixels than a filled tile, so at an equal
+ * value it reads lighter — the extra step buys equal presence, not equal color.
  */
 function PhotosBadge({ href, count }: PhotosBadgeProps) {
   if (!href || !count || count <= 0) return null;
   return (
-    <Link to={href} title={`${count} photos`} className={cn(EXTERNAL_FAVICON_LINK_CLASS, "gap-1")}>
+    <Link
+      to={href}
+      title={`${count} photos`}
+      className={cn(EXTERNAL_FAVICON_LINK_CLASS, "gap-1 text-content-text-secondary")}
+    >
       <Camera className={BADGE_ICON_CLASS} />
       {/* Count crowds the icon strip on mobile; show it from `sm` up. */}
       <span className="hidden sm:inline text-sm">{count}</span>

--- a/apps/web/app/components/ui/star-rating.tsx
+++ b/apps/web/app/components/ui/star-rating.tsx
@@ -4,7 +4,9 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { useRevalidator } from "react-router-dom";
 import { toast } from "sonner";
+import { usePreferences } from "~/hooks/use-preferences";
 import { useSession } from "~/hooks/use-session";
+import { ratingColor } from "~/lib/rating-colors";
 import { cn } from "~/lib/utils";
 import type { ShowUserDataResponse } from "~/server/show-user-data";
 
@@ -40,6 +42,7 @@ export function StarRating({
   const [hoveredRating, setHoveredRating] = useState<number | null>(null);
   const [isAnimating, setIsAnimating] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { colorCodeRatings } = usePreferences();
   const [rating, setRating] = useState<RatingResponse | null>(
     initialRating !== undefined ? { userRating: initialRating, averageRating: null } : null,
   );
@@ -322,6 +325,7 @@ export function StarRating({
             <StarIcon
               filled={filled}
               half={half}
+              color={starColor(half ? star - 0.5 : star, colorCodeRatings)}
               isAnimating={isAnimating && (filled || half)}
               delay={animationDelay}
             />
@@ -332,21 +336,36 @@ export function StarRating({
   );
 }
 
+/**
+ * Fill color for the star at `value`. With the scale on, each star wears the
+ * color that rating would render in, so the row reads purple → neutral → green
+ * as it fills and the picker previews the scale instead of just measuring it.
+ * With the scale off, every star is the usual gold.
+ */
+function starColor(value: number, colorCodeRatings: boolean): string {
+  return colorCodeRatings ? ratingColor(value) : "hsl(var(--rating-gold))";
+}
+
 const StarIcon = ({
   filled,
   half,
+  color,
   isAnimating,
   delay,
 }: {
   filled: boolean;
   half?: boolean;
+  color: string;
   isAnimating?: boolean;
   delay?: number;
 }) => (
   <div className="relative">
-    {/* Empty star (background) */}
+    {/* Unearned star, sitting under the fill. Dim rather than a mid grey: the
+        fill's colour passes through near-neutral at the middle of the scale, and
+        against the old grey a filled 3.5 read at 1.36:1 — indistinguishable from
+        an empty one. */}
     <svg
-      className={cn("w-4 h-4", filled || half ? "text-content-text-tertiary" : "text-content-text-tertiary")}
+      className="w-4 h-4 text-rating-dim"
       aria-hidden="true"
       xmlns="http://www.w3.org/2000/svg"
       fill="currentColor"
@@ -369,7 +388,7 @@ const StarIcon = ({
           className={cn("w-4 h-4", isAnimating && "animate-star-glow")}
           style={{
             animationDelay: delay ? `${delay}ms` : undefined,
-            color: "hsl(var(--rating-gold))",
+            color,
           }}
           aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"

--- a/apps/web/app/lib/favicon.ts
+++ b/apps/web/app/lib/favicon.ts
@@ -35,6 +35,69 @@ export const EXTERNAL_SOURCE_DOMAINS = {
  * an external source renders as a clickable icon (setlist badge strip,
  * resource-page performance rows). Centralized so the hover treatment stays
  * identical across surfaces.
+ *
+ * Icons render desaturated and dimmed at rest, and return to full brand color
+ * on hover. Each row already carries the show date, the rating, and up to five
+ * of these; letting nugs purple, YouTube red and Relisten blue all shout at
+ * rest left no colors free to mean anything. Muted, they read as one group of
+ * "where to hear this" links, and the row's remaining color belongs to the
+ * rating.
+ *
+ * The dimming sits on the link rather than on the icon so it reaches every
+ * badge shape alike: the favicon `img`s, the photos badge's Lucide `svg` and
+ * its count. Only the desaturation is image-scoped, since the icons drawn as
+ * SVG take their color from `currentColor` and have none to lose.
+ *
+ * Each image reads its own correction from `--favicon-boost` (see
+ * `faviconBoost`), and `group-hover` drops the whole filter so the brand color
+ * returns intact.
+ *
+ * Hover grows and lights the icon but does not move it: these sit inline with
+ * the rating and attendance buttons, which lift in place, and an icon that also
+ * slid upward read as a different kind of control. The glow is the brand purple
+ * rather than a hardcoded one, so it tracks the palette.
  */
 export const EXTERNAL_FAVICON_LINK_CLASS =
-  "inline-flex items-center transition-transform hover:scale-110 hover:-translate-y-0.5 hover:drop-shadow-[0_0_6px_rgba(167,139,250,0.55)]";
+  "group inline-flex items-center opacity-75 transition-[transform,opacity,filter] hover:opacity-100 hover:scale-110 hover:drop-shadow-[0_0_6px_hsl(var(--brand-primary)/0.55)]";
+
+/**
+ * Applied to each favicon `img`. Desaturates, then multiplies by that domain's
+ * `--favicon-boost` so every logo lands at a comparable weight.
+ */
+export const EXTERNAL_FAVICON_IMG_CLASS =
+  "[filter:grayscale(1)_brightness(var(--favicon-boost,1))] transition-[filter] group-hover:[filter:none]";
+
+/**
+ * Per-domain brightness correction, applied after desaturation.
+ *
+ * `grayscale()` collapses a pixel to its luminance, which is weighted heavily
+ * toward green (0.72G vs 0.21R and 0.07B). Brands built on red or purple carry
+ * almost no green, so they crush far darker than a blue or cyan logo does at
+ * the same apparent vividness — nugs and YouTube came out visibly duller than
+ * Relisten from the identical filter. These multipliers put them back on terms.
+ *
+ * Relisten is the baseline at 1. Values are tuned against each icon's p90
+ * luminance — the brightness of its *ink* rather than its mean, which for a
+ * logo drawn as light-on-dark (archive.org) is dragged down by a background the
+ * eye doesn't read. Ceilings matter as much as floors: YouTube stays well under
+ * full correction because its play triangle is white against the button, and
+ * over-brightening merges the two and dissolves the logo.
+ *
+ * archive.org is deliberately absent. Its field is near-black and its ink is
+ * already clipped white, so multiplying moves neither — brightness cannot make
+ * it louder, and opacity is the only lever that would.
+ */
+const FAVICON_BOOST: Record<string, number> = {
+  [EXTERNAL_SOURCE_DOMAINS.nugs]: 1.95,
+  [EXTERNAL_SOURCE_DOMAINS.youtube]: 1.6,
+};
+
+/**
+ * Inline style carrying a domain's correction to `EXTERNAL_FAVICON_IMG_CLASS`.
+ * A custom property rather than a plain `filter` because the hover state has to
+ * stay in CSS, and an inline filter would win over it.
+ */
+export function faviconBoost(domain: string): React.CSSProperties {
+  const boost = FAVICON_BOOST[domain];
+  return boost ? ({ "--favicon-boost": boost } as React.CSSProperties) : {};
+}

--- a/apps/web/app/lib/interaction-styles.ts
+++ b/apps/web/app/lib/interaction-styles.ts
@@ -1,0 +1,20 @@
+/**
+ * Hover treatment for the paired chips in a show row — the rating badge and the
+ * attendance button. One constant because the two sit shoulder to shoulder and
+ * have to answer a pointer the same way; as separate strings they drifted apart
+ * the moment either was touched.
+ *
+ * Grow and saturate rather than a fill or an edge, because those are the only
+ * things every state can show. Both buttons have states painted by
+ * `glass-secondary`, whose `!important` background and border silently defeat
+ * any `hover:bg-*` or `hover:border-*` beside them — a transform and a filter
+ * are immune. Each chrome adds its own fill and edge on top where its state
+ * allows, and those are the parts that carry the color.
+ *
+ * Saturate, not just brightness: these sit inline with the external-source
+ * favicons, which return from grey to full color on hover
+ * (`EXTERNAL_FAVICON_LINK_CLASS`). Brightening alone read as a different, weaker
+ * kind of response next to that.
+ */
+export const ROW_CHIP_HOVER =
+  "origin-center transition-all cursor-pointer hover:scale-105 hover:brightness-110 hover:saturate-150";

--- a/apps/web/app/routes/resources/chemical-warfare-brigade.tsx
+++ b/apps/web/app/routes/resources/chemical-warfare-brigade.tsx
@@ -1,10 +1,11 @@
 import type React from "react";
 import { Link } from "react-router-dom";
 import { SetlistList } from "~/components/setlist/setlist-list";
+import { FaviconLink } from "~/components/setlist/show-external-badges";
 import { Card, CardHeader } from "~/components/ui/card";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
 import { publicLoader } from "~/lib/base-loaders";
-import { EXTERNAL_FAVICON_LINK_CLASS, EXTERNAL_SOURCE_DOMAINS, faviconSrc } from "~/lib/favicon";
+import { EXTERNAL_SOURCE_DOMAINS } from "~/lib/favicon";
 import { formatVenueLocation } from "~/lib/format-venue";
 import { ROCK_OPERA_SLUG, rockOperaPath } from "~/lib/rock-operas";
 import { slugifyAnchor } from "~/lib/utils";
@@ -765,36 +766,16 @@ const ChemicalWarfareBrigade: React.FC = () => {
                       </div>
                       {(perf.archiveUrl || perf.relistenUrl) && (
                         <div className="flex items-center gap-2 pr-2 sm:pr-3">
-                          {perf.archiveUrl && (
-                            <a
-                              href={perf.archiveUrl}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              title="Available on archive.org"
-                              className={EXTERNAL_FAVICON_LINK_CLASS}
-                            >
-                              <img
-                                src={faviconSrc(EXTERNAL_SOURCE_DOMAINS.archive)}
-                                alt="Available on archive.org"
-                                className="h-5 w-5 shrink-0"
-                              />
-                            </a>
-                          )}
-                          {perf.relistenUrl && (
-                            <a
-                              href={perf.relistenUrl}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              title="Available on Relisten"
-                              className={EXTERNAL_FAVICON_LINK_CLASS}
-                            >
-                              <img
-                                src={faviconSrc(EXTERNAL_SOURCE_DOMAINS.relisten)}
-                                alt="Available on Relisten"
-                                className="h-5 w-5 shrink-0"
-                              />
-                            </a>
-                          )}
+                          <FaviconLink
+                            domain={EXTERNAL_SOURCE_DOMAINS.archive}
+                            href={perf.archiveUrl}
+                            label="Available on archive.org"
+                          />
+                          <FaviconLink
+                            domain={EXTERNAL_SOURCE_DOMAINS.relisten}
+                            href={perf.relistenUrl}
+                            label="Available on Relisten"
+                          />
                         </div>
                       )}
                     </div>

--- a/apps/web/app/styles.css
+++ b/apps/web/app/styles.css
@@ -56,6 +56,10 @@
 
   /* Rating Colors */
   --color-rating-gold: hsl(38 95% 62%);
+  /* Unearned stars in the picker. Dark enough that a filled star still reads as
+     filled at the middle of the colour scale, where its tint is a near-neutral
+     grey — against the old tertiary grey that was only 1.36:1. */
+  --color-rating-dim: hsl(240 5% 35%);
 
   /* Track marker flames. Color is the only thing distinguishing a jam chart
      from an all-timer, and these two are close in hue (38 vs 25), so they read
@@ -180,7 +184,6 @@ html body[data-scroll-locked] {
     --info: 205 100% 70%; /* Info blue */
     --info-bg: 205 50% 12%; /* Info background */
     --rating-gold: 38 95% 62%; /* Star ratings - yellowy orange */
-    --rating-dim: 240 5% 35%; /* Inactive ratings */
 
     /* Chart & Data Visualization - Purple Primary, Green Secondary */
     --chart-primary: 263 85% 60%; /* Purple primary chart */


### PR DESCRIPTION
## Quiet the show row so the rating leads

A show row was spending colour on everything except the thing you came for. The
brightest element was the words "Saw it" — a fact the green check beside it
already states — and below that, up to five brand logos in red, purple and blue.
The rating average, the actual data, was the dimmest thing in the row.

This rebalances it:

- **"Saw it" moves up beside the show date**, on a column wide enough for the
  longest date, so every button lands on the same vertical line instead of
  sliding with the date's length. The venue keeps its own line. The rating badge
  now owns the right edge alone.
- **The attendance label goes neutral.** The green check still says attended, and
  the word still changes from "Saw it?" to "Saw it".
- **External-source favicons render desaturated and dimmed**, returning to full
  brand colour on hover.
- **The anniversary badge shares the rating star's gold.**

Measured on `/users/evan`, where every row is attended, the label carried more
visual weight on its own (luminance × ink ≈ 201) than the entire rating badge
combined (≈ 122). Borders and glows scored 9 and 1 — they were never the problem.

### Hover

Both chips now grow, brighten and saturate together (`ROW_CHIP_HOVER`), and each
adds its own colour on top. The favicons grow and light up in place rather than
sliding upward, so a row reads as one family of controls.

Two of these hovers had never worked. The attendance button's
`hover:border-green-500/30` and the rating badge's `hover:border-rating-gold/30`
were both defeated by `glass-secondary`, which sets `border` with `!important`.
The unattended button now reaches the same tokens directly instead of through
that class, which reproduces the surface exactly and leaves hover free to answer
in green.

### With the colour scale on

Off by default; opt in under Rating display on your profile.

- The star takes its score's colour and the badge wears a neutral hairline.
  Gold next to a tinted number was a second voice saying the same thing.
- **The star picker fills as a gradient** — purple → neutral → green — so the
  scale previews itself while you choose, rather than only reporting afterwards.

### Fixes that stand on their own

- **A filled star at 3.5 was invisible.** It sat at 1.36:1 against an empty star.
  Empty stars now use `--rating-dim`, a token that has been defined and unused
  since it was written, taking that to 3.90:1. This was already true of the gold
  star before any of this work — gold vs an empty star was 1.45:1.
- **The favicon hover glow** was hardcoded to stock Tailwind violet-400 rather
  than the brand purple. The token version also has a light-mode value, which the
  literal never could.
- **`FaviconLink` is one component.** The resources page had its own copy of the
  markup, which would have silently missed the muting.

### Notes for the reviewer

**The attendance-glow work from a background task is bundled here.** It ran in
this working tree rather than an isolated worktree. It fixed the glow to resolve
from `--green-500` instead of a hardcoded stock green that never matched its own
border — correct, and about 46% brighter as a result. It also removed the
button's fill; that is restored, because the hover is a filter and had nothing to
act on without a background.

**Favicon brightness is tuned per domain** (nugs ×1.95, YouTube ×1.6). Grayscale
collapses a pixel to luminance, which is ~72% green-weighted, so red and purple
logos crush far darker than blue at the same apparent vividness. Values are set
against each icon's p90 luminance — its ink rather than its mean, which for a
light-on-dark logo like archive.org is dragged down by a background the eye does
not read. YouTube stays under full correction on purpose: its play triangle is
white against the button, and over-brightening merges the two.

**archive.org has no correction and cannot have one.** Its field is near-black
and its ink is already clipped white, so multiplying moves neither.

**The date column is sized in `ch`, not px.** That text renders in the system
font stack, so its metrics differ per platform, and it scales at the `md`
breakpoint. A fixed length would need re-measuring per OS and duplicating per
breakpoint.

**Known rough edge:** full purple against a dim star is 2.22:1, below the 3:1
WCAG wants for non-text UI. Darkening the dim further starts making empty stars
vanish against the near-black popover, which they only clear at 2.58:1. Hue does
work luminance does not here, but a half-star will read less clearly than a five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
