### PR TITLE
Let viewers turn off setlist times

### DIFF
--- a/apps/web/app/components/rating/rating-display-settings.tsx
+++ b/apps/web/app/components/rating/rating-display-settings.tsx
@@ -1,8 +1,6 @@
-import { useState } from "react";
 import { Link } from "react-router-dom";
-import { toast } from "sonner";
+import { PreferenceToggle } from "~/components/settings/preference-toggle";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
-import { Switch } from "~/components/ui/switch";
 import { useFeatureFlags } from "~/hooks/use-feature-flags";
 import { PREFERENCES_DEFAULT } from "~/hooks/use-preferences";
 
@@ -11,9 +9,8 @@ import { PREFERENCES_DEFAULT } from "~/hooks/use-preferences";
  * available to everyone, so it always renders; the calibrated-rating opt-in
  * renders only when `ratings.toggle-visible` makes it available to this user,
  * and the author comparison overlay only when `ratings.compare-visible` does.
- * Each toggle auto-saves on change (optimistic, reverting on failure) to
- * /api/users, which re-checks the flags before persisting, with no separate
- * save step.
+ * Each toggle auto-saves on change to /api/users, which re-checks the flags
+ * before persisting.
  *
  * Takes only the viewer's saved preferences as props; the gating feature flags are
  * read from `useFeatureFlags()` so it's clear at this use site that flags drive
@@ -29,33 +26,6 @@ export function RatingDisplaySettings({
   colorCodeRatings: boolean | null;
 }) {
   const { toggleVisible, compareVisible, defaultCalibrated } = useFeatureFlags();
-  // Each switch reflects the user's explicit choice, falling back to the app
-  // default when they've never set one (a null pref resolves to the default).
-  const [calibrated, setCalibrated] = useState(showCalibratedRatings ?? defaultCalibrated);
-  const [compare, setCompare] = useState(showRatingComparisonDebug ?? false);
-  const [colorCoded, setColorCoded] = useState(colorCodeRatings ?? PREFERENCES_DEFAULT.colorCodeRatings);
-  const [savingField, setSavingField] = useState<string | null>(null);
-
-  async function save(
-    field: "showCalibratedRatings" | "showRatingComparisonDebug" | "colorCodeRatings",
-    value: boolean,
-    apply: (v: boolean) => void,
-  ) {
-    apply(value); // optimistic
-    setSavingField(field);
-    try {
-      const body = new FormData();
-      body.set(field, String(value));
-      const response = await fetch("/api/users", { method: "POST", body });
-      if (!response.ok) throw new Error("save failed");
-      toast.success("Rating settings saved");
-    } catch {
-      apply(!value); // revert
-      toast.error("Couldn't save rating settings");
-    } finally {
-      setSavingField(null);
-    }
-  }
 
   return (
     <Card>
@@ -63,58 +33,42 @@ export function RatingDisplaySettings({
         <CardTitle className="text-content-text-primary">Rating display</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1">
-            <div className="text-content-text-primary font-medium">Color-code rating values</div>
-            <p className="text-sm text-content-text-tertiary">
-              Tint rating numbers from purple to green so you can spot strong and weak scores, and see where you differ
-              from the crowd, without reading them.
-            </p>
-          </div>
-          <Switch
-            checked={colorCoded}
-            disabled={savingField === "colorCodeRatings"}
-            onCheckedChange={(v) => save("colorCodeRatings", v, setColorCoded)}
-            aria-label="Color-code rating values"
-          />
-        </div>
+        {/* Each switch reflects the user's explicit choice, falling back to the
+            app default when they've never set one (a null pref resolves to the
+            default). The calibrated toggle's default is flag-driven. */}
+        <PreferenceToggle
+          field="colorCodeRatings"
+          label="Color-code rating values"
+          description="Tint rating numbers from purple to green so you can spot strong and weak scores, and see where you differ from the crowd, without reading them."
+          initial={colorCodeRatings ?? PREFERENCES_DEFAULT.colorCodeRatings}
+        />
 
         {toggleVisible && (
-          <div className="flex items-start justify-between gap-4">
-            <div className="space-y-1">
-              <div className="text-content-text-primary font-medium">Calibrated show rating</div>
-              <p className="text-sm text-content-text-tertiary">
+          <PreferenceToggle
+            field="showCalibratedRatings"
+            label="Calibrated show rating"
+            ariaLabel="Use the calibrated show rating"
+            description={
+              <>
                 Weights raters by how much of the 0.5 to 5 star scale they use, corrects for generous and harsh graders,
                 and counts each person once.{" "}
                 <Link to="/show-rating-algorithm" className="text-brand-primary hover:underline">
                   How it works →
                 </Link>
-              </p>
-            </div>
-            <Switch
-              checked={calibrated}
-              disabled={savingField === "showCalibratedRatings"}
-              onCheckedChange={(v) => save("showCalibratedRatings", v, setCalibrated)}
-              aria-label="Use the calibrated show rating"
-            />
-          </div>
+              </>
+            }
+            initial={showCalibratedRatings ?? defaultCalibrated}
+          />
         )}
 
         {compareVisible && (
-          <div className="flex items-start justify-between gap-4">
-            <div className="space-y-1">
-              <div className="text-content-text-primary font-medium">Show Rating Comparison Overlay (debug)</div>
-              <p className="text-sm text-content-text-tertiary">
-                Show the community→calibrated score and rank delta on show cards and pages.
-              </p>
-            </div>
-            <Switch
-              checked={compare}
-              disabled={savingField === "showRatingComparisonDebug"}
-              onCheckedChange={(v) => save("showRatingComparisonDebug", v, setCompare)}
-              aria-label="Show rating comparison overlay"
-            />
-          </div>
+          <PreferenceToggle
+            field="showRatingComparisonDebug"
+            label="Show Rating Comparison Overlay (debug)"
+            ariaLabel="Show rating comparison overlay"
+            description="Show the community→calibrated score and rank delta on show cards and pages."
+            initial={showRatingComparisonDebug ?? false}
+          />
         )}
       </CardContent>
     </Card>

--- a/apps/web/app/components/rating/rating-distribution-chart.test.tsx
+++ b/apps/web/app/components/rating/rating-distribution-chart.test.tsx
@@ -56,7 +56,7 @@ describe("RatingDistributionChart", () => {
 describe("RatingAxisTick", () => {
   const renderTick = (index: number, label: string, colorCodeRatings: boolean | null = true) =>
     setup(
-      <PreferencesProvider colorCodeRatings={colorCodeRatings}>
+      <PreferencesProvider colorCodeRatings={colorCodeRatings} showSetlistTimes={null}>
         <svg role="img" aria-label="axis">
           <RatingAxisTick x={10} y={20} fontSize={12} payload={{ value: label, index }} />
         </svg>

--- a/apps/web/app/components/rating/rating.test.tsx
+++ b/apps/web/app/components/rating/rating.test.tsx
@@ -11,7 +11,11 @@ import { RatingComponent } from "./rating";
  * renders uncolored and every coloring assertion has to opt in first.
  */
 const withColorCoding = (ui: ReactElement) =>
-  setup(<PreferencesProvider colorCodeRatings={true}>{ui}</PreferencesProvider>);
+  setup(
+    <PreferencesProvider colorCodeRatings={true} showSetlistTimes={null}>
+      {ui}
+    </PreferencesProvider>,
+  );
 
 describe("RatingComponent", () => {
   // Baseline: an average rating + ratingsCount renders the star, the
@@ -107,7 +111,7 @@ describe("RatingComponent", () => {
 
   test("leaves both values uncolored when the viewer opts out", async () => {
     await setup(
-      <PreferencesProvider colorCodeRatings={false}>
+      <PreferencesProvider colorCodeRatings={false} showSetlistTimes={null}>
         <RatingComponent rating={5} ratingsCount={12} userRating={2} />
       </PreferencesProvider>,
     );

--- a/apps/web/app/components/setlist/setlist-common-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-common-columns.tsx
@@ -281,6 +281,21 @@ export function createGapColumn<T extends TrackLight>(opts: {
   ) as ColumnDef<T, unknown>;
 }
 
+const DURATION_COLUMN_ID = "duration";
+
+/**
+ * Drops the Time column for a viewer who turned setlist times off. Applied by
+ * the table components rather than the column factories so the factories stay
+ * a pure description of the view, and so both gap-chart tables honor the
+ * preference the same way.
+ */
+export function applyTimePreference<T>(
+  columns: ColumnDef<T, unknown>[],
+  showSetlistTimes: boolean,
+): ColumnDef<T, unknown>[] {
+  return showSetlistTimes ? columns : columns.filter((column) => column.id !== DURATION_COLUMN_ID);
+}
+
 /**
  * "Time" column for the gap-chart views: each track's duration, with
  * archive-sourced values shown as estimates. Reused by both the catalog and
@@ -291,7 +306,7 @@ export function createGapColumn<T extends TrackLight>(opts: {
 export function createDurationColumn<T extends TrackLight>(): ColumnDef<T, unknown> {
   const columnHelper = createColumnHelper<T>();
   return columnHelper.accessor((row) => row.duration ?? Number.NEGATIVE_INFINITY, {
-    id: "duration",
+    id: DURATION_COLUMN_ID,
     header: ({ column }) => <SortableHeader column={column} label="Time" />,
     // Wide enough for the h:mm:ss form ("1:04:18"). Hidden on mobile — the
     // gap-chart already runs out of width there.

--- a/apps/web/app/components/setlist/setlist-display-settings.test.tsx
+++ b/apps/web/app/components/setlist/setlist-display-settings.test.tsx
@@ -1,0 +1,62 @@
+import { setupWithRouter } from "@test/test-utils";
+import { screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { PREFERENCES_DEFAULT } from "~/hooks/use-preferences";
+import { SetlistDisplaySettings } from "./setlist-display-settings";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("SetlistDisplaySettings", () => {
+  // The switch has to show the app default for a viewer who never chose, or it
+  // claims a state the setlist isn't actually in. Asserted against the constant
+  // so flipping the default doesn't need a test edit.
+  test("shows the app default when the viewer has never chosen", async () => {
+    await setupWithRouter(<SetlistDisplaySettings showSetlistTimes={null} />);
+    expect(screen.getByLabelText("Show set times")).toHaveAttribute(
+      "aria-checked",
+      String(PREFERENCES_DEFAULT.showSetlistTimes),
+    );
+  });
+
+  test("reflects an explicit opt-out", async () => {
+    await setupWithRouter(<SetlistDisplaySettings showSetlistTimes={false} />);
+    expect(screen.getByLabelText("Show set times")).toHaveAttribute("aria-checked", "false");
+  });
+
+  test("auto-saves the opt-out to /api/users immediately on toggle (no save button)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { user } = await setupWithRouter(<SetlistDisplaySettings showSetlistTimes={null} />);
+    await user.click(screen.getByLabelText("Show set times"));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/users");
+    expect(init.method).toBe("POST");
+    expect((init.body as FormData).get("showSetlistTimes")).toBe("false");
+  });
+
+  // Holds the response open so the optimistic flip is observable on its own.
+  // Asserting only the end state can't tell a revert apart from a toggle that
+  // never moved, since both land back where they started.
+  test("flips optimistically, then reverts when the save fails", async () => {
+    let settle: () => void = () => {};
+    const pending = new Promise<{ ok: boolean }>((resolve) => {
+      settle = () => resolve({ ok: false });
+    });
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(pending));
+
+    const { user } = await setupWithRouter(<SetlistDisplaySettings showSetlistTimes={true} />);
+    const toggle = screen.getByLabelText("Show set times");
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    settle();
+    await waitFor(() => expect(toggle).toHaveAttribute("aria-checked", "true"));
+  });
+});

--- a/apps/web/app/components/setlist/setlist-display-settings.tsx
+++ b/apps/web/app/components/setlist/setlist-display-settings.tsx
@@ -1,0 +1,26 @@
+import { PreferenceToggle } from "~/components/settings/preference-toggle";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { PREFERENCES_DEFAULT } from "~/hooks/use-preferences";
+
+/**
+ * Setlist-display preferences for the viewer's own profile. Times are on for
+ * everyone who hasn't said otherwise, so this card exists for the people who
+ * want the setlist to read as a plain list of songs.
+ */
+export function SetlistDisplaySettings({ showSetlistTimes }: { showSetlistTimes: boolean | null }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-content-text-primary">Setlist display</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <PreferenceToggle
+          field="showSetlistTimes"
+          label="Show set times"
+          description="Show how long each set and the full show ran, plus the per-track Time column in the gap chart."
+          initial={showSetlistTimes ?? PREFERENCES_DEFAULT.showSetlistTimes}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/app/components/setlist/setlist-flow.test.tsx
+++ b/apps/web/app/components/setlist/setlist-flow.test.tsx
@@ -13,6 +13,7 @@ vi.mock("~/components/track/noteworthy-marker", () => ({
   NoteworthyMarker: () => null,
 }));
 
+import { PreferencesProvider } from "~/hooks/use-preferences";
 import { SetlistFlow } from "./setlist-flow";
 
 function durTrack(
@@ -159,6 +160,41 @@ describe("SetlistFlow", () => {
     );
     expect(screen.queryByText("Total")).not.toBeInTheDocument();
     expect(screen.queryByText(/Partial/)).not.toBeInTheDocument();
+  });
+
+  // Opting out has to clear every time on the setlist — the per-set headings,
+  // the Total, and the partial-timing note that only exists to caveat them —
+  // while leaving the songs and set labels alone.
+  test("drops every time for a viewer who turned setlist times off", async () => {
+    await setupWithRouter(
+      <PreferencesProvider colorCodeRatings={null} showSetlistTimes={false}>
+        <SetlistFlow
+          setlist={flowSetlist([
+            {
+              label: "S1",
+              tracks: [durTrack("a", "Helicopters", 522, "S1", 1), durTrack("b", "Spaga", null, "S1", 2)],
+            },
+            { label: "S2", tracks: [durTrack("c", "Basis for a Day", 410, "S2", 1)] },
+          ])}
+        />
+      </PreferencesProvider>,
+    );
+    expect(screen.queryByText("8:42")).not.toBeInTheDocument();
+    expect(screen.queryByText("Total")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Partial/)).not.toBeInTheDocument();
+    expect(screen.getByText("Set 1")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Helicopters" })).toBeInTheDocument();
+  });
+
+  // The rest of the suite renders with no provider; this pins that the shipped
+  // default (and an explicit opt-in) actually keeps the times.
+  test("keeps the times for a viewer who never chose", async () => {
+    await setupWithRouter(
+      <PreferencesProvider colorCodeRatings={null} showSetlistTimes={null}>
+        <SetlistFlow setlist={flowSetlist([{ label: "S1", tracks: [durTrack("a", "Helicopters", 522, "S1", 1)] }])} />
+      </PreferencesProvider>,
+    );
+    expect(screen.getByText("8:42")).toBeInTheDocument();
   });
 
   // A lone encore reads "Encore" (no number).

--- a/apps/web/app/components/setlist/setlist-flow.tsx
+++ b/apps/web/app/components/setlist/setlist-flow.tsx
@@ -2,6 +2,7 @@ import type { Setlist } from "@bip/domain";
 import { formatDuration } from "@bip/domain";
 import { Link } from "react-router-dom";
 import { NoteworthyMarker } from "~/components/track/noteworthy-marker";
+import { usePreferences } from "~/hooks/use-preferences";
 import { cn } from "~/lib/utils";
 import { buildShowFootnotes } from "./footnotes";
 import { countSetlistEncores } from "./set-label";
@@ -14,8 +15,12 @@ import { TrackRatingOverlay } from "./track-rating-overlay";
  * annotations. Extracted from SetlistCard so this (the bulk of the card body)
  * can be rendered and tested on its own, apart from the rating/attendance/
  * view-toggle machinery around it.
+ *
+ * Running times are the viewer's `showSetlistTimes` preference; opting out
+ * leaves the setlist as a plain list of songs, footnotes and all.
  */
 export function SetlistFlow({ setlist }: { setlist: Setlist }) {
+  const { showSetlistTimes } = usePreferences();
   const allTracks = setlist.sets.flatMap((set) => set.tracks);
   const { trackFootnoteIndices, orderedFootnotes } = buildShowFootnotes(setlist);
 
@@ -39,7 +44,7 @@ export function SetlistFlow({ setlist }: { setlist: Setlist }) {
                 <span className="text-base font-medium text-content-text-tertiary">
                   {formatSetHeading(set.label, encoresInSet, isSoleRegularSet)}
                 </span>
-                {setDuration.known > 0 && (
+                {showSetlistTimes && setDuration.known > 0 && (
                   <span
                     className="text-sm text-content-text-tertiary tabular-nums"
                     title={
@@ -92,7 +97,7 @@ export function SetlistFlow({ setlist }: { setlist: Setlist }) {
         })}
       </div>
 
-      {showDuration.known > 0 && !isSoleSet && (
+      {showSetlistTimes && showDuration.known > 0 && !isSoleSet && (
         <div className="mt-4 text-sm text-content-text-secondary">
           <span className="font-medium text-content-text-tertiary">Total</span>{" "}
           <span className="tabular-nums">
@@ -101,7 +106,7 @@ export function SetlistFlow({ setlist }: { setlist: Setlist }) {
           </span>
         </div>
       )}
-      {showDuration.known > 0 && showDuration.missing > 0 && (
+      {showSetlistTimes && showDuration.known > 0 && showDuration.missing > 0 && (
         <div className={cn(isSoleSet ? "mt-4" : "mt-1", "text-xs text-content-text-tertiary")}>
           * Partial: {showDuration.missing} track{showDuration.missing > 1 ? "s" : ""} not yet timed
         </div>

--- a/apps/web/app/components/setlist/setlist-table-personal.tsx
+++ b/apps/web/app/components/setlist/setlist-table-personal.tsx
@@ -2,10 +2,12 @@ import { average, median, type TrackLight } from "@bip/domain";
 import { useEffect, useMemo } from "react";
 import { DataTable } from "~/components/ui/data-table";
 import { usePersonalSongHistory } from "~/hooks/use-personal-song-history";
+import { usePreferences } from "~/hooks/use-preferences";
 import { useSession } from "~/hooks/use-session";
 import { useTrackUserRatings } from "~/hooks/use-track-user-ratings";
 import { computePersonalRow, eligiblePersonalGaps, type PersonalSetlistRow } from "~/lib/personal-setlist-columns";
 import { createPersonalSetlistColumns, type PersonalSetlistTableRow } from "./setlist-columns-personal";
+import { applyTimePreference } from "./setlist-common-columns";
 
 interface SetlistTablePersonalProps {
   tracks: TrackLight[];
@@ -28,6 +30,7 @@ interface SetlistTablePersonalProps {
 export function SetlistTablePersonal({ tracks, showSlug, showDate, onSummaryChange }: SetlistTablePersonalProps) {
   const { data, isLoading } = usePersonalSongHistory();
   const { user } = useSession();
+  const { showSetlistTimes } = usePreferences();
   const isAuthenticated = !!user;
   const trackIds = useMemo(() => tracks.map((t) => t.id), [tracks]);
   const { userRatingMap, averageRatingMap } = useTrackUserRatings(trackIds);
@@ -51,8 +54,12 @@ export function SetlistTablePersonal({ tracks, showSlug, showDate, onSummaryChan
   }, [tracks, data, setlistTracks, showDate]);
 
   const columns = useMemo(
-    () => createPersonalSetlistColumns({ showSlug, averageRatingMap, userRatingMap, isAuthenticated }),
-    [showSlug, averageRatingMap, userRatingMap, isAuthenticated],
+    () =>
+      applyTimePreference(
+        createPersonalSetlistColumns({ showSlug, averageRatingMap, userRatingMap, isAuthenticated }),
+        showSetlistTimes,
+      ),
+    [showSlug, averageRatingMap, userRatingMap, isAuthenticated, showSetlistTimes],
   );
 
   // Hoist the summary up to the parent so it can render alongside the

--- a/apps/web/app/components/setlist/setlist-table.test.tsx
+++ b/apps/web/app/components/setlist/setlist-table.test.tsx
@@ -25,6 +25,7 @@ vi.mock("~/components/performance/track-rating-cell", () => ({
   TrackRatingCell: (props: object) => mockShallowComponent("TrackRatingCell", props),
 }));
 
+const { PreferencesProvider } = await import("~/hooks/use-preferences");
 const { useSession } = await import("~/hooks/use-session");
 const { useTrackUserRatings } = await import("~/hooks/use-track-user-ratings");
 const { useSongPlayDates } = await import("~/hooks/use-song-play-dates");
@@ -213,5 +214,51 @@ describe("SetlistTable", () => {
     const cells = screen.getAllByRole("cell");
     expect(cells[7].textContent).toBe("3");
     expect(cells[16].textContent).toBe("0");
+  });
+
+  // The gap chart is the only other place a setlist shows times, so the
+  // preference has to reach it too — otherwise a viewer who turned times off
+  // still meets them one toggle away.
+  test("drops the Time column for a viewer who turned setlist times off", async () => {
+    await setupWithRouter(
+      <PreferencesProvider colorCodeRatings={null} showSetlistTimes={false}>
+        <SetlistTable
+          showSlug="2024-07-19-camden"
+          showDate="2024-07-19"
+          tracks={[
+            makeTrack({
+              songId: "a",
+              position: 1,
+              duration: 522,
+              song: { id: "a", title: "Above the Waves", slug: "above-the-waves" },
+            }),
+          ]}
+        />
+      </PreferencesProvider>,
+    );
+    expect(screen.queryByRole("columnheader", { name: /Time/ })).not.toBeInTheDocument();
+    expect(screen.queryByText("8:42")).not.toBeInTheDocument();
+    // The rest of the chart is untouched.
+    expect(screen.getByRole("link", { name: "Above the Waves" })).toBeInTheDocument();
+  });
+
+  test("keeps the Time column for a viewer who never chose", async () => {
+    await setupWithRouter(
+      <PreferencesProvider colorCodeRatings={null} showSetlistTimes={null}>
+        <SetlistTable
+          showSlug="2024-07-19-camden"
+          showDate="2024-07-19"
+          tracks={[
+            makeTrack({
+              songId: "a",
+              position: 1,
+              duration: 522,
+              song: { id: "a", title: "Above the Waves", slug: "above-the-waves" },
+            }),
+          ]}
+        />
+      </PreferencesProvider>,
+    );
+    expect(screen.getByText("8:42")).toBeInTheDocument();
   });
 });

--- a/apps/web/app/components/setlist/setlist-table.tsx
+++ b/apps/web/app/components/setlist/setlist-table.tsx
@@ -1,10 +1,12 @@
 import { countSortedBefore, type TrackLight } from "@bip/domain";
 import { useMemo } from "react";
 import { DataTable } from "~/components/ui/data-table";
+import { usePreferences } from "~/hooks/use-preferences";
 import { useSession } from "~/hooks/use-session";
 import { useSongPlayDates } from "~/hooks/use-song-play-dates";
 import { useTrackUserRatings } from "~/hooks/use-track-user-ratings";
 import { createSetlistColumns, type SetlistTableRow } from "./setlist-columns";
+import { applyTimePreference } from "./setlist-common-columns";
 
 interface SetlistTableProps {
   tracks: TrackLight[];
@@ -34,6 +36,7 @@ interface SetlistTableProps {
  */
 export function SetlistTable({ tracks, showSlug, showDate }: SetlistTableProps) {
   const { user } = useSession();
+  const { showSetlistTimes } = usePreferences();
   const isAuthenticated = !!user;
   const trackIds = useMemo(() => tracks.map((t) => t.id), [tracks]);
   const { userRatingMap, averageRatingMap } = useTrackUserRatings(trackIds);
@@ -47,8 +50,12 @@ export function SetlistTable({ tracks, showSlug, showDate }: SetlistTableProps) 
   }, [tracks, songPlayDates, isPlayDatesLoading, showDate]);
 
   const columns = useMemo(
-    () => createSetlistColumns({ showSlug, averageRatingMap, userRatingMap, isAuthenticated }),
-    [showSlug, averageRatingMap, userRatingMap, isAuthenticated],
+    () =>
+      applyTimePreference(
+        createSetlistColumns({ showSlug, averageRatingMap, userRatingMap, isAuthenticated }),
+        showSetlistTimes,
+      ),
+    [showSlug, averageRatingMap, userRatingMap, isAuthenticated, showSetlistTimes],
   );
   return (
     <DataTable

--- a/apps/web/app/components/settings/preference-toggle.tsx
+++ b/apps/web/app/components/settings/preference-toggle.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { Switch } from "~/components/ui/switch";
+
+/**
+ * The display preferences a viewer can set on their own profile. Mirrors the
+ * fields `/api/users` accepts, so a typo can't reach the wire.
+ */
+export type PreferenceField =
+  | "showCalibratedRatings"
+  | "showRatingComparisonDebug"
+  | "colorCodeRatings"
+  | "showSetlistTimes";
+
+/**
+ * One labelled preference switch that persists itself. Every settings card is
+ * built from these, so the whole app shares one auto-save behavior (optimistic
+ * flip, revert plus a toast on failure, disabled while in flight) and one row
+ * layout, with no separate save step anywhere.
+ *
+ * Takes the resolved boolean rather than the stored tri-state: resolving `null`
+ * to the app default belongs to the caller, which is the only place that knows
+ * which default applies.
+ */
+export function PreferenceToggle({
+  field,
+  label,
+  ariaLabel,
+  description,
+  initial,
+}: {
+  field: PreferenceField;
+  label: string;
+  /** Accessible name, when the visible label reads as a noun rather than an action. */
+  ariaLabel?: string;
+  description: React.ReactNode;
+  initial: boolean;
+}) {
+  const [checked, setChecked] = useState(initial);
+  const [isSaving, setIsSaving] = useState(false);
+
+  async function save(value: boolean) {
+    setChecked(value); // optimistic
+    setIsSaving(true);
+    try {
+      const body = new FormData();
+      body.set(field, String(value));
+      const response = await fetch("/api/users", { method: "POST", body });
+      if (!response.ok) throw new Error("save failed");
+      toast.success("Settings saved");
+    } catch {
+      setChecked(!value); // revert
+      toast.error("Couldn't save settings");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div className="space-y-1">
+        <div className="text-content-text-primary font-medium">{label}</div>
+        <p className="text-sm text-content-text-tertiary">{description}</p>
+      </div>
+      <Switch checked={checked} disabled={isSaving} onCheckedChange={save} aria-label={ariaLabel ?? label} />
+    </div>
+  );
+}

--- a/apps/web/app/hooks/use-preferences.test.tsx
+++ b/apps/web/app/hooks/use-preferences.test.tsx
@@ -4,7 +4,13 @@ import { describe, expect, test } from "vitest";
 import { PREFERENCES_DEFAULT, PreferencesProvider, usePreferences } from "./use-preferences";
 
 function Harness() {
-  return <div data-testid="color">{String(usePreferences().colorCodeRatings)}</div>;
+  const { colorCodeRatings, showSetlistTimes } = usePreferences();
+  return (
+    <>
+      <div data-testid="color">{String(colorCodeRatings)}</div>
+      <div data-testid="times">{String(showSetlistTimes)}</div>
+    </>
+  );
 }
 
 describe("usePreferences", () => {
@@ -22,7 +28,7 @@ describe("usePreferences", () => {
   // against the constant so flipping the default doesn't need a test edit.
   test("resolves an unset preference to the app default", async () => {
     await setup(
-      <PreferencesProvider colorCodeRatings={null}>
+      <PreferencesProvider showSetlistTimes={null} colorCodeRatings={null}>
         <Harness />
       </PreferencesProvider>,
     );
@@ -33,7 +39,7 @@ describe("usePreferences", () => {
   // whole reason the stored value is tri-state.
   test("honors an explicit opt-out", async () => {
     await setup(
-      <PreferencesProvider colorCodeRatings={false}>
+      <PreferencesProvider showSetlistTimes={null} colorCodeRatings={false}>
         <Harness />
       </PreferencesProvider>,
     );
@@ -42,7 +48,7 @@ describe("usePreferences", () => {
 
   test("honors an explicit opt-in", async () => {
     await setup(
-      <PreferencesProvider colorCodeRatings={true}>
+      <PreferencesProvider showSetlistTimes={null} colorCodeRatings={true}>
         <Harness />
       </PreferencesProvider>,
     );
@@ -53,5 +59,29 @@ describe("usePreferences", () => {
   // work it belongs to is opened up, so a stray flip should fail loudly here.
   test("ships with color coding off", () => {
     expect(PREFERENCES_DEFAULT.colorCodeRatings).toBe(false);
+  });
+
+  // Setlist times are what the setlist has always shown, so the default has to
+  // stay on: only a viewer who asks for a cleaner setlist loses them.
+  test("ships with setlist times on", () => {
+    expect(PREFERENCES_DEFAULT.showSetlistTimes).toBe(true);
+  });
+
+  test("resolves an unset setlist-times preference to the app default", async () => {
+    await setup(
+      <PreferencesProvider colorCodeRatings={null} showSetlistTimes={null}>
+        <Harness />
+      </PreferencesProvider>,
+    );
+    expect(screen.getByTestId("times").textContent).toBe(String(PREFERENCES_DEFAULT.showSetlistTimes));
+  });
+
+  test("honors an explicit setlist-times opt-out", async () => {
+    await setup(
+      <PreferencesProvider colorCodeRatings={null} showSetlistTimes={false}>
+        <Harness />
+      </PreferencesProvider>,
+    );
+    expect(screen.getByTestId("times").textContent).toBe("false");
   });
 });

--- a/apps/web/app/hooks/use-preferences.tsx
+++ b/apps/web/app/hooks/use-preferences.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useMemo } from "react";
 
 export type Preferences = {
   colorCodeRatings: boolean;
+  showSetlistTimes: boolean;
 };
 
 /**
@@ -11,13 +12,15 @@ export type Preferences = {
  * behaves the same in both cases.
  *
  * Color coding is off until the rating work it belongs to is opened up more
- * broadly. Flipping this constant switches it on for everyone who hasn't made
- * an explicit choice, and leaves explicit choices on either side intact — which
- * is why the stored preference stays tri-state rather than defaulting in the
- * database.
+ * broadly. Setlist times are on, matching how the setlist has always rendered:
+ * only a viewer who asks for a cleaner setlist loses them. Flipping either
+ * constant moves everyone who hasn't made an explicit choice, and leaves
+ * explicit choices on either side intact — which is why the stored preferences
+ * stay tri-state rather than defaulting in the database.
  */
 export const PREFERENCES_DEFAULT: Preferences = {
   colorCodeRatings: false,
+  showSetlistTimes: true,
 };
 
 const PreferencesContext = createContext<Preferences>(PREFERENCES_DEFAULT);
@@ -34,14 +37,19 @@ const PreferencesContext = createContext<Preferences>(PREFERENCES_DEFAULT);
  */
 export function PreferencesProvider({
   colorCodeRatings,
+  showSetlistTimes,
   children,
 }: {
   colorCodeRatings: boolean | null | undefined;
+  showSetlistTimes: boolean | null | undefined;
   children: React.ReactNode;
 }) {
   const value = useMemo<Preferences>(
-    () => ({ colorCodeRatings: colorCodeRatings ?? PREFERENCES_DEFAULT.colorCodeRatings }),
-    [colorCodeRatings],
+    () => ({
+      colorCodeRatings: colorCodeRatings ?? PREFERENCES_DEFAULT.colorCodeRatings,
+      showSetlistTimes: showSetlistTimes ?? PREFERENCES_DEFAULT.showSetlistTimes,
+    }),
+    [colorCodeRatings, showSetlistTimes],
   );
   return <PreferencesContext.Provider value={value}>{children}</PreferencesContext.Provider>;
 }

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -37,6 +37,7 @@ export type RootPreferences = {
    * the default lives in exactly one place.
    */
   colorCodeRatings: boolean | null;
+  showSetlistTimes: boolean | null;
 };
 
 export type RootData = {
@@ -96,6 +97,7 @@ export async function loader({ request }: Route.LoaderArgs): Promise<RootData> {
     featureFlags,
     preferences: {
       colorCodeRatings: viewer?.colorCodeRatings ?? null,
+      showSetlistTimes: viewer?.showSetlistTimes ?? null,
     },
   };
 }
@@ -126,7 +128,10 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <SupabaseProvider env={env}>
           <QueryProvider>
             <HydrationBoundary state={dehydratedState}>
-              <PreferencesProvider colorCodeRatings={data?.preferences?.colorCodeRatings}>
+              <PreferencesProvider
+                colorCodeRatings={data?.preferences?.colorCodeRatings}
+                showSetlistTimes={data?.preferences?.showSetlistTimes}
+              >
                 <GlobalSearchProvider>
                   <SearchProvider>
                     <HeaderLayout>{children}</HeaderLayout>

--- a/apps/web/app/routes/api/users.tsx
+++ b/apps/web/app/routes/api/users.tsx
@@ -12,6 +12,7 @@ const updateUserSchema = z.object({
   showCalibratedRatings: z.enum(["true", "false"]).optional(),
   showRatingComparisonDebug: z.enum(["true", "false"]).optional(),
   colorCodeRatings: z.enum(["true", "false"]).optional(),
+  showSetlistTimes: z.enum(["true", "false"]).optional(),
 });
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -68,14 +69,15 @@ export async function action({ request }: ActionFunctionArgs) {
       }
     }
 
-    // Build the update explicitly: persist a rating pref only if the matching flag
-    // makes that toggle visible for this user (so an ineligible user can't set it via
-    // a crafted POST), and coerce the "true"/"false" strings to booleans.
+    // Build the update explicitly: persist a flag-gated pref only if the matching
+    // flag makes that toggle visible for this user (so an ineligible user can't set
+    // it via a crafted POST), and coerce the "true"/"false" strings to booleans.
     const update: {
       username?: string;
       showCalibratedRatings?: boolean;
       showRatingComparisonDebug?: boolean;
       colorCodeRatings?: boolean;
+      showSetlistTimes?: boolean;
     } = {};
     if (validatedData.username) update.username = validatedData.username;
     const flags = await getFeatureFlags({ user: { id: localUser.id, username: localUser.username } });
@@ -85,9 +87,13 @@ export async function action({ request }: ActionFunctionArgs) {
     if (flags.compareVisible && validatedData.showRatingComparisonDebug !== undefined) {
       update.showRatingComparisonDebug = validatedData.showRatingComparisonDebug === "true";
     }
-    // Color coding is available to everyone, so no flag guards this one.
+    // Color coding and setlist times are available to everyone, so no flag
+    // guards these.
     if (validatedData.colorCodeRatings !== undefined) {
       update.colorCodeRatings = validatedData.colorCodeRatings === "true";
+    }
+    if (validatedData.showSetlistTimes !== undefined) {
+      update.showSetlistTimes = validatedData.showSetlistTimes === "true";
     }
 
     const updatedUser = await services.users.update(localUser.id, update);

--- a/apps/web/app/routes/users/$username.tsx
+++ b/apps/web/app/routes/users/$username.tsx
@@ -8,6 +8,7 @@ import { formatHalfStep, StarValue } from "~/components/rating/rating";
 import { RatingCharts } from "~/components/rating/rating-charts";
 import { RatingDisplaySettings } from "~/components/rating/rating-display-settings";
 import { formatSetLabel } from "~/components/setlist/set-label";
+import { SetlistDisplaySettings } from "~/components/setlist/setlist-display-settings";
 import { SetlistList } from "~/components/setlist/setlist-list";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
 import { Badge } from "~/components/ui/badge";
@@ -410,14 +411,17 @@ export default function UserProfile() {
         </CardContent>
       </Card>
 
-      {/* Rating-display preferences — only on your own profile, and only when a
-          feature flag makes a toggle available (the component self-hides otherwise). */}
+      {/* Display preferences — only on your own profile. Individual rating
+          toggles self-hide behind their feature flags. */}
       {isOwnProfile && (
-        <RatingDisplaySettings
-          showCalibratedRatings={user.showCalibratedRatings}
-          showRatingComparisonDebug={user.showRatingComparisonDebug}
-          colorCodeRatings={user.colorCodeRatings}
-        />
+        <>
+          <RatingDisplaySettings
+            showCalibratedRatings={user.showCalibratedRatings}
+            showRatingComparisonDebug={user.showRatingComparisonDebug}
+            colorCodeRatings={user.colorCodeRatings}
+          />
+          <SetlistDisplaySettings showSetlistTimes={user.showSetlistTimes} />
+        </>
       )}
 
       {/* Content Tabs — mobile shows a <select> dropdown (sm:hidden), sm+

--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -273,10 +273,13 @@ export interface McpSyncUser {
   username: string | null;
   avatarFileId: string | null;
   avatarFileUrl: string | null;
-  // Rating-display opt-in prefs, mirrored from prod so adoption can be inspected locally.
+  // Display prefs, mirrored from prod so adoption can be inspected locally.
   showCalibratedRatings: boolean | null;
   showRatingComparisonDebug: boolean | null;
   colorCodeRatings: boolean | null;
+  // Optional until the setlist-times deploy lands on prod: an older prod omits
+  // it, and the sync then leaves the local value alone rather than clearing it.
+  showSetlistTimes?: boolean | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -1702,6 +1705,7 @@ export async function syncUserActivity(
               showCalibratedRatings: u.showCalibratedRatings,
               showRatingComparisonDebug: u.showRatingComparisonDebug,
               colorCodeRatings: u.colorCodeRatings,
+              showSetlistTimes: u.showSetlistTimes,
               updatedAt: new Date(u.updatedAt),
             },
           });
@@ -1719,6 +1723,7 @@ export async function syncUserActivity(
               showCalibratedRatings: u.showCalibratedRatings,
               showRatingComparisonDebug: u.showRatingComparisonDebug,
               colorCodeRatings: u.colorCodeRatings,
+              showSetlistTimes: u.showSetlistTimes,
               updatedAt: new Date(u.updatedAt),
             },
           });
@@ -1735,6 +1740,7 @@ export async function syncUserActivity(
               showCalibratedRatings: u.showCalibratedRatings,
               showRatingComparisonDebug: u.showRatingComparisonDebug,
               colorCodeRatings: u.colorCodeRatings,
+              showSetlistTimes: u.showSetlistTimes,
               createdAt: new Date(u.createdAt),
               updatedAt: new Date(u.updatedAt),
             },

--- a/packages/core/src/_shared/prisma/migrations/20260717000000_show_setlist_times/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260717000000_show_setlist_times/migration.sql
@@ -1,0 +1,5 @@
+-- Viewer preference for showing track and set times in the setlist view.
+-- Nullable with no default: NULL means the viewer never chose, which the app
+-- resolves to on. That keeps "never chose" distinguishable from "opted in",
+-- matching show_adjusted_rating / show_rating_compare / color_code_ratings.
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "show_setlist_times" BOOLEAN;

--- a/packages/core/src/_shared/prisma/schema.prisma
+++ b/packages/core/src/_shared/prisma/schema.prisma
@@ -766,6 +766,7 @@ model User {
   showCalibratedRatings     Boolean? @map("show_adjusted_rating")
   showRatingComparisonDebug Boolean? @map("show_rating_compare")
   colorCodeRatings          Boolean? @map("color_code_ratings")
+  showSetlistTimes          Boolean? @map("show_setlist_times")
   avatarFile          File?        @relation("UserAvatar", fields: [avatarFileId], references: [id], onDelete: SetNull, onUpdate: NoAction)
   attendances         Attendance[]
   blogPosts           BlogPost[]

--- a/packages/core/src/users/user-service.test.ts
+++ b/packages/core/src/users/user-service.test.ts
@@ -169,6 +169,7 @@ describe("UserService.listForSync", () => {
       showCalibratedRatings: true,
       showRatingComparisonDebug: true,
       colorCodeRatings: true,
+      showSetlistTimes: true,
       createdAt: true,
       updatedAt: true,
     });

--- a/packages/core/src/users/user-service.ts
+++ b/packages/core/src/users/user-service.ts
@@ -59,6 +59,7 @@ function mapUserToDomainEntity(dbUser: DbUser): User {
     showCalibratedRatings: dbUser.showCalibratedRatings ?? null,
     showRatingComparisonDebug: dbUser.showRatingComparisonDebug ?? null,
     colorCodeRatings: dbUser.colorCodeRatings ?? null,
+    showSetlistTimes: dbUser.showSetlistTimes ?? null,
   };
 }
 
@@ -435,10 +436,11 @@ export class UserService {
       username: string | null;
       avatarFileId: string | null;
       avatarFileUrl: string | null;
-      // Rating-display opt-in prefs, mirrored to local so prod adoption can be inspected.
+      // Display prefs, mirrored to local so prod adoption can be inspected.
       showCalibratedRatings: boolean | null;
       showRatingComparisonDebug: boolean | null;
       colorCodeRatings: boolean | null;
+      showSetlistTimes: boolean | null;
       createdAt: Date;
       updatedAt: Date;
     }>
@@ -464,6 +466,7 @@ export class UserService {
         showCalibratedRatings: true,
         showRatingComparisonDebug: true,
         colorCodeRatings: true,
+        showSetlistTimes: true,
         createdAt: true,
         updatedAt: true,
       },

--- a/packages/domain/src/models/user.ts
+++ b/packages/domain/src/models/user.ts
@@ -8,10 +8,11 @@ export const userSchema = z.object({
   username: z.string(),
   avatarFileId: z.string().uuid().nullable(),
   avatarUrl: z.string().url().nullable(),
-  // Rating-display prefs (tri-state: null = no explicit choice → app default).
+  // Display prefs (tri-state: null = no explicit choice → app default).
   showCalibratedRatings: z.boolean().nullable(),
   showRatingComparisonDebug: z.boolean().nullable(),
   colorCodeRatings: z.boolean().nullable(),
+  showSetlistTimes: z.boolean().nullable(),
 });
 
 export const userMinimalSchema = userSchema


### PR DESCRIPTION
Your profile now has a **Setlist display** card with a **Show set times** toggle. Turn it off and the setlist reads as a plain list of songs: the per-set times, the show Total, and the "Partial: N tracks not yet timed" note all disappear, as does the Time column in the gap chart and personal gap chart. Songs, set labels, and footnotes are untouched. The toggle saves itself, no save button.

Times stay on for everyone who hasn't touched the toggle, so nothing changes for existing viewers.

## Notes for the reviewer

The preference is stored tri-state (`users.show_setlist_times` is nullable, `NULL` = never chose), matching the existing rating prefs. That keeps "never chose" distinguishable from "opted in", so the app default can move later without overwriting anyone's explicit choice.

Two things worth a look:

- **The PII-allowlist test in `user-service.test.ts` changed.** It asserts the exact `select` shape of the sync export and exists to make any widening deliberate; `show_setlist_times` now rides along with the rating prefs so prod adoption can be inspected locally. `McpSyncUser` types it optional, unlike the deployed rating prefs, because a prod that predates this deploy omits the field entirely: optional means the sync leaves the local value alone rather than clearing it.
- **`RatingDisplaySettings` was refactored onto the new shared `PreferenceToggle`**, which owns the switch row and the optimistic save/revert. Behavior is unchanged except the toast copy is now generic ("Settings saved" rather than "Rating settings saved").

🤖 Generated with [Claude Code](https://claude.com/claude-code)