### PR TITLE
Give the top-rated show list a stable tie order

### DIFF
--- a/packages/core/src/ratings/rater-weight-service.test.ts
+++ b/packages/core/src/ratings/rater-weight-service.test.ts
@@ -165,6 +165,45 @@ describe("RaterWeightService recompute settings", () => {
   });
 });
 
+describe("RaterWeightService.rankedShows", () => {
+  // Two shows with the same average_rating render best-first, so the score alone
+  // is a non-unique sort key. The simple path must carry a deterministic tiebreak
+  // into the SQL ORDER BY (ratings_count DESC, then the canonical show ordering).
+  test("simple mode orders by rating then a deterministic tiebreak", async () => {
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const db = { ratingSettings: { findFirst: vi.fn() }, $queryRaw: queryRaw } as never;
+    await new RaterWeightService(db).rankedShows("simple", 5);
+    const templateStrings: string[] = queryRaw.mock.calls[0][0];
+    expect(templateStrings.join("")).toContain("ORDER BY s.average_rating DESC, s.ratings_count DESC,");
+  });
+
+  // The calibrated path sorts in JS, so equal shrunk scores must resolve through
+  // an explicit comparator. Feeding the same rows in different input orders must
+  // yield one stable order: more-rated first, then newest-date first.
+  test("calibrated mode breaks equal scores by ratings_count then date (stable across input order)", async () => {
+    // Anchor 4 with raw == anchor makes shrinkToward return exactly 4 for every
+    // count, so all three shows tie on score and only the tiebreak decides order.
+    const rows = [
+      { id: "older-30", date: "2008-01-01", dayOrder: null, raw: 4, ratings: 30 },
+      { id: "fewer-20", date: "2005-01-01", dayOrder: null, raw: 4, ratings: 20 },
+      { id: "newer-30", date: "2010-01-01", dayOrder: null, raw: 4, ratings: 30 },
+    ];
+    const expected = ["newer-30", "older-30", "fewer-20"];
+
+    async function rank(inputOrder: typeof rows) {
+      const db = {
+        ratingSettings: { findFirst: vi.fn().mockResolvedValue({ showShrinkAnchor: 4 }) },
+        $queryRaw: vi.fn().mockResolvedValue(inputOrder),
+      } as never;
+      const ranked = await new RaterWeightService(db).rankedShows("calibrated", 5);
+      return ranked.map((s) => s.id);
+    }
+
+    expect(await rank(rows)).toEqual(expected);
+    expect(await rank([...rows].reverse())).toEqual(expected);
+  });
+});
+
 describe("RaterWeightService.recomputeRateable", () => {
   // A Marlon-era show rated 5 by a full-range credible rater (entropy 2 → full
   // weight) and 0.5 by a zero-entropy bomber.

--- a/packages/core/src/ratings/rater-weight-service.ts
+++ b/packages/core/src/ratings/rater-weight-service.ts
@@ -1,6 +1,7 @@
-import { drummerEraForDate, shrinkToward } from "@bip/domain";
+import { compareByShowDate, drummerEraForDate, shrinkToward } from "@bip/domain";
 import { Prisma } from "@prisma/client";
 import type { DbClient } from "../_shared/database/models";
+import { showOrderBySql } from "../_shared/show-ordering";
 import { aliasKey, mostRecentPerKey } from "./rater-aliases";
 import {
   bucketRatingValues,
@@ -327,24 +328,41 @@ export class RaterWeightService {
    * derives the year-picker counts from it, so the counts always match the list.
    */
   async rankedShows(mode: "simple" | "calibrated", minRatings: number): Promise<Array<{ id: string; date: string }>> {
+    // Tied scores must resolve to a stable order (they render best-first and the
+    // score alone is non-unique — e.g. two 85/18 shows both average 4.7222…).
+    // Tiebreak by ratings_count DESC (more-rated ranks higher among equals), then
+    // by the canonical show ordering DESC as a fully deterministic final key.
     if (mode === "simple") {
       return this.db.$queryRaw<Array<{ id: string; date: string }>>`
         SELECT s.id, s.date
         FROM shows s
         WHERE s.average_rating IS NOT NULL AND s.ratings_count >= ${minRatings}
-        ORDER BY s.average_rating DESC
+        ORDER BY s.average_rating DESC, s.ratings_count DESC, ${showOrderBySql("s", "DESC")}
       `;
     }
 
     const anchor = await this.shrinkAnchor();
-    const rows = await this.db.$queryRaw<Array<{ id: string; date: string; raw: number; ratings: number }>>`
-      SELECT s.id, s.date, s.weighted_rating AS raw, s.ratings_count AS ratings
+    const rows = await this.db.$queryRaw<
+      Array<{ id: string; date: string; dayOrder: number | null; raw: number; ratings: number }>
+    >`
+      SELECT s.id, s.date, s.day_order AS "dayOrder", s.weighted_rating AS raw, s.ratings_count AS ratings
       FROM shows s
       WHERE s.weighted_rating IS NOT NULL AND s.ratings_count >= ${minRatings}
     `;
     return rows
-      .map((r) => ({ id: r.id, date: r.date, score: shrinkToward(r.raw, anchor, r.ratings, SHRINK_K) }))
-      .sort((a, b) => b.score - a.score)
+      .map((r) => ({
+        id: r.id,
+        date: r.date,
+        dayOrder: r.dayOrder,
+        ratings: r.ratings,
+        score: shrinkToward(r.raw, anchor, r.ratings, SHRINK_K),
+      }))
+      .sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score;
+        if (b.ratings !== a.ratings) return b.ratings - a.ratings;
+        // DESC of the canonical ASC comparator, mirroring showOrderBySql(…, "DESC").
+        return -compareByShowDate({ show: a }, { show: b });
+      })
       .map(({ id, date }) => ({ id, date }));
   }
 


### PR DESCRIPTION
Shows with the same rating on `/shows/top-rated` now hold a fixed position instead of shuffling between page loads. Previously two equally-rated shows (e.g. 2001-09-08 and 2003-12-30, both exactly 4.7222…) had no tiebreaker, so Postgres/the JS sort returned them in arbitrary order that changed whenever the query re-planned.

Both ranking modes now break ties the same way, so each view is internally stable:
- **simple** (raw SQL): `ORDER BY average_rating DESC, ratings_count DESC, <canonical show ordering DESC>`
- **calibrated** (JS sort): score DESC, then `ratings_count` DESC, then the same canonical show ordering DESC

Tiebreak is `ratings_count DESC` first (a more-rated show ranks higher among equals), then date/`day_order`/`id` as a fully deterministic final key. Chronological ordering routes through the `show-ordering` helpers (`showOrderBySql` / `compareByShowDate`) per the repo convention, rather than a bare `date DESC`.

This is display-order determinism only: no change to the dedup rule, the calibrated shrink math, or the displayed average/count.

## Notes for the reviewer

The calibrated query now also selects `day_order` so the JS comparator has the same inputs the SQL path does, and the JS comparator negates the canonical ASC `compareByShowDate` to get DESC, mirroring `showOrderBySql(…, "DESC")` exactly (including the `id` final key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
