### PR TITLE
Add a Relisten filter and collapse year-list cache keys

### DIFF
--- a/apps/web/app/components/show-filters-nav.test.tsx
+++ b/apps/web/app/components/show-filters-nav.test.tsx
@@ -13,13 +13,14 @@ function paramsOf(href: string) {
 describe("ShowFiltersNav", () => {
   // Every filter toggle renders regardless of which params are currently
   // active — users need to see the full menu to discover filters.
-  test("renders all four toggles", async () => {
+  test("renders all five toggles", async () => {
     await setupWithRouter(<ShowFiltersNav basePath="/shows/year/2024" currentURLParameters={new URLSearchParams()} />);
 
     expect(screen.getByRole("link", { name: /photos/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /nugs/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /youtube/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /archive/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /relisten/i })).toBeInTheDocument();
   });
 
   // First click on an empty filter advances to positive — the URL gains

--- a/apps/web/app/components/show-filters-nav.tsx
+++ b/apps/web/app/components/show-filters-nav.tsx
@@ -5,17 +5,18 @@ import { EXTERNAL_SOURCE_DOMAINS, faviconSrc } from "~/lib/favicon";
 import { parseTriState, TRI_STATE_NEXT, writeTriState } from "~/lib/tri-state-filter";
 
 /**
- * The URL param names for the four external-source filters. Order matches
- * the badge strip in SetlistCard so filter buttons and the per-row
- * indicators read the same way.
+ * The URL param names for the five media filters. Order matches the badge
+ * strip in SetlistCard so filter buttons and the per-row indicators read the
+ * same way.
  */
-const FILTER_KEYS = ["nugs", "youtube", "archive", "photos"] as const;
+const FILTER_KEYS = ["nugs", "youtube", "archive", "relisten", "photos"] as const;
 type FilterKey = (typeof FILTER_KEYS)[number];
 
 const FILTER_LABELS: Record<FilterKey, string> = {
   nugs: "Nugs",
   youtube: "YouTube",
   archive: "Archive",
+  relisten: "Relisten",
   photos: "Photos",
 };
 
@@ -24,6 +25,7 @@ const FILTER_FAVICON_DOMAINS: Record<FilterKey, string | null> = {
   nugs: EXTERNAL_SOURCE_DOMAINS.nugs,
   youtube: EXTERNAL_SOURCE_DOMAINS.youtube,
   archive: EXTERNAL_SOURCE_DOMAINS.archive,
+  relisten: EXTERNAL_SOURCE_DOMAINS.relisten,
   photos: null,
 };
 
@@ -46,7 +48,7 @@ export function ShowFiltersNav({ basePath, currentURLParameters }: ShowFiltersNa
       <h2 className="text-[10px] font-semibold text-content-text-tertiary uppercase tracking-wide mb-1.5 text-center">
         Filter by Media
       </h2>
-      <div className="grid grid-cols-4 sm:grid-cols-2 gap-1">
+      <div className="grid grid-cols-5 sm:grid-cols-3 gap-1">
         {FILTER_KEYS.map((key) => {
           const state = parseTriState(currentURLParameters.get(key));
           const next = new URLSearchParams(currentURLParameters);

--- a/apps/web/app/components/tri-state-filter-button.tsx
+++ b/apps/web/app/components/tri-state-filter-button.tsx
@@ -47,7 +47,9 @@ export function TriStateFilterButton({ state, label, icon, href }: TriStateFilte
       )}
     >
       <FilterIcon state={state}>{icon}</FilterIcon>
-      {label}
+      {/* Label hides below sm so the mobile strip fits all filters on one
+          icon-only row; the aria-label above keeps the name for assistive tech. */}
+      <span className="hidden sm:inline">{label}</span>
     </Link>
   );
 }

--- a/apps/web/app/lib/tri-state-filter.test.ts
+++ b/apps/web/app/lib/tri-state-filter.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, test } from "vitest";
-import { parseTriState, TRI_STATE_NEXT, writeTriState } from "~/lib/tri-state-filter";
+import { matchesTriState, parseTriState, TRI_STATE_NEXT, writeTriState } from "~/lib/tri-state-filter";
+
+describe("matchesTriState", () => {
+  // Positive keeps only items that have the thing.
+  test("positive keeps items with the attribute, drops those without", () => {
+    expect(matchesTriState("positive", true)).toBe(true);
+    expect(matchesTriState("positive", false)).toBe(false);
+  });
+
+  // Negative is the inverse — keeps only items that lack the thing.
+  test("negative keeps items without the attribute, drops those with", () => {
+    expect(matchesTriState("negative", false)).toBe(true);
+    expect(matchesTriState("negative", true)).toBe(false);
+  });
+
+  // Empty and undefined are both the no-filter state — everything passes.
+  test("empty and undefined keep everything", () => {
+    expect(matchesTriState("empty", true)).toBe(true);
+    expect(matchesTriState("empty", false)).toBe(true);
+    expect(matchesTriState(undefined, true)).toBe(true);
+    expect(matchesTriState(undefined, false)).toBe(true);
+  });
+});
 
 describe("parseTriState", () => {
   // Missing key in URLSearchParams.get() returns null — that's the empty state.

--- a/apps/web/app/lib/tri-state-filter.ts
+++ b/apps/web/app/lib/tri-state-filter.ts
@@ -53,6 +53,19 @@ export function triStateToBoolean(state: TriState): boolean | undefined {
   return state === "positive";
 }
 
+/**
+ * Keep-predicate for a single tri-state media/source filter: positive keeps
+ * items that HAVE the thing, negative keeps items that LACK it, empty keeps
+ * everything. The one place the positive/negative match lives so the DB-query
+ * filters, their in-memory equivalents (media counts, external sources), and
+ * the per-year counts helper can't drift apart.
+ */
+export function matchesTriState(state: TriState | undefined, has: boolean): boolean {
+  if (state === "positive") return has;
+  if (state === "negative") return !has;
+  return true;
+}
+
 /** True when at least one flag is in a non-empty state. */
 export function isAnyTriStateActive(flags: Record<string, TriState | undefined>): boolean {
   for (const key in flags) {

--- a/apps/web/app/routes/shows/year/$year.tsx
+++ b/apps/web/app/routes/shows/year/$year.tsx
@@ -19,9 +19,10 @@ import { logger } from "~/lib/logger";
 import { showUserDataQueryKey } from "~/lib/query-keys";
 import { createPrefetchClient, dehydrateAndClear } from "~/lib/query-prefetch";
 import { getShowsMeta } from "~/lib/seo";
-import { parseTriState, type TriState, triStateToBoolean } from "~/lib/tri-state-filter";
+import { parseTriState, type TriState } from "~/lib/tri-state-filter";
 import { cn } from "~/lib/utils";
 import { applyExternalSourceFilters } from "~/server/apply-external-source-filters";
+import { applyMediaCountFilters } from "~/server/apply-media-count-filters";
 import { services } from "~/server/services";
 import { computeShowCountsByYear } from "~/server/show-counts-by-year";
 import { computeShowExternalSources } from "~/server/show-external-sources";
@@ -34,7 +35,7 @@ interface LoaderData {
   externalSources: Record<string, ShowExternalSources>;
   showCountsByYear: Record<number, number>;
   monthCounts: Record<number, number>;
-  filters: { photos: TriState; youtube: TriState; nugs: TriState; archive: TriState };
+  filters: { photos: TriState; youtube: TriState; nugs: TriState; archive: TriState; relisten: TriState };
   dehydratedState: DehydratedState;
 }
 
@@ -81,6 +82,7 @@ export const loader = publicLoader(async ({ request, params, context }): Promise
     youtube: parseTriState(url.searchParams.get("youtube")),
     nugs: parseTriState(url.searchParams.get("nugs")),
     archive: parseTriState(url.searchParams.get("archive")),
+    relisten: parseTriState(url.searchParams.get("relisten")),
   };
   const emptyCounts: Record<number, number> = {};
 
@@ -115,35 +117,28 @@ export const loader = publicLoader(async ({ request, params, context }): Promise
     };
   }
 
-  // Cache year-based listings - these are stable and cacheable. Filter flags are part of the
-  // cache key so each combination is memoized independently.
+  // Cache one unfiltered set per (year, sort). All five media/source filters
+  // are applied in memory below, so the tri-state combinations share a single
+  // cached year blob instead of each caching a near-full-year payload.
   const currentYear = new Date().getFullYear();
   const sortDirection = yearInt === currentYear ? "desc" : "asc";
 
-  const yearCacheKey = CacheKeys.shows.list({
-    year: yearInt,
-    sort: sortDirection,
-    photos: filters.photos,
-    youtube: filters.youtube,
-  });
+  const yearCacheKey = CacheKeys.shows.list({ year: yearInt, sort: sortDirection });
 
   setlists = await services.cache.getOrSet(yearCacheKey, async () => {
     logger.info(`Loading shows from DB for year: ${yearInt}`);
     return await services.setlists.findMany({
-      filters: {
-        year: yearInt,
-        hasPhotos: triStateToBoolean(filters.photos),
-        hasYoutube: triStateToBoolean(filters.youtube),
-      },
+      filters: { year: yearInt },
       sort: [{ field: "date", direction: sortDirection }],
     });
   });
 
   const externalSources = await computeShowExternalSources(setlists.map((s) => s.show));
-  const filteredSetlists = applyExternalSourceFilters(setlists, externalSources, {
-    nugs: filters.nugs,
-    archive: filters.archive,
-  });
+  const filteredSetlists = applyExternalSourceFilters(
+    applyMediaCountFilters(setlists, { photos: filters.photos, youtube: filters.youtube }),
+    externalSources,
+    { nugs: filters.nugs, archive: filters.archive, relisten: filters.relisten },
+  );
 
   const showCountsByYear = await computeShowCountsByYear(filters);
 

--- a/apps/web/app/server/apply-external-source-filters.test.ts
+++ b/apps/web/app/server/apply-external-source-filters.test.ts
@@ -72,6 +72,32 @@ describe("applyExternalSourceFilters", () => {
     expect(result.map((s: { show: { id: string } }) => s.show.id)).toEqual(["basis"]);
   });
 
+  // Positive relisten keeps only shows with a relisten url.
+  test("relisten=positive keeps only shows with a relisten url", () => {
+    const setlists = [setlist("astronaut"), setlist("basis")];
+    const externalSources: Record<string, ShowExternalSources> = {
+      astronaut: sources({ relistenUrl: "https://relisten.net/db/2001" }),
+      basis: sources({}),
+    };
+
+    const result = applyExternalSourceFilters(setlists, externalSources, { relisten: "positive" });
+
+    expect(result.map((s: { show: { id: string } }) => s.show.id)).toEqual(["astronaut"]);
+  });
+
+  // Negative relisten keeps only shows without a relisten url.
+  test("relisten=negative keeps only shows without a relisten url", () => {
+    const setlists = [setlist("astronaut"), setlist("basis")];
+    const externalSources: Record<string, ShowExternalSources> = {
+      astronaut: sources({ relistenUrl: "https://relisten.net/db/2001" }),
+      basis: sources({}),
+    };
+
+    const result = applyExternalSourceFilters(setlists, externalSources, { relisten: "negative" });
+
+    expect(result.map((s: { show: { id: string } }) => s.show.id)).toEqual(["basis"]);
+  });
+
   // Positive archive — same shape as positive nugs but for archive.org links.
   test("archive=positive keeps only shows with an archive url", () => {
     const setlists = [setlist("astronaut"), setlist("basis")];

--- a/apps/web/app/server/apply-external-source-filters.ts
+++ b/apps/web/app/server/apply-external-source-filters.ts
@@ -1,24 +1,22 @@
 import type { Setlist } from "@bip/domain";
 import type { ShowExternalSources } from "~/components/setlist/show-external-badges";
-import type { TriState } from "~/lib/tri-state-filter";
+import { isAnyTriStateActive, matchesTriState, type TriState } from "~/lib/tri-state-filter";
 
 /**
  * Tri-state flags for the external-source filters that are NOT queryable in
- * Prisma (nugs/archive live in Redis catalogs). Photo and YouTube filters
- * live on the denormalized show counts and are applied in the DB query.
+ * Prisma (nugs/archive/relisten live in Redis catalogs). The photo/youtube
+ * counterpart lives on the denormalized show counts and is applied by
+ * applyMediaCountFilters.
  *
  * - "positive" → keep only setlists with the source
  * - "negative" → keep only setlists without the source
  * - "empty" / undefined → no filter
  */
-export interface ExternalSourceFilterFlags {
+export type ExternalSourceFilterFlags = {
   nugs?: TriState;
   archive?: TriState;
-}
-
-function isActive(state: TriState | undefined): boolean {
-  return state === "positive" || state === "negative";
-}
+  relisten?: TriState;
+};
 
 /**
  * Drop setlists whose resolved external sources don't match the active
@@ -31,17 +29,17 @@ export function applyExternalSourceFilters<T extends Pick<Setlist, "show">>(
   externalSources: Record<string, ShowExternalSources>,
   flags: ExternalSourceFilterFlags,
 ): T[] {
-  if (!isActive(flags.nugs) && !isActive(flags.archive)) return setlists;
+  if (!isAnyTriStateActive(flags)) return setlists;
 
   return setlists.filter((setlist) => {
     const sources = externalSources[setlist.show.id];
     const hasNugs = Boolean(sources?.nugsUrls?.length);
     const hasArchive = Boolean(sources?.archiveUrl);
-
-    if (flags.nugs === "positive" && !hasNugs) return false;
-    if (flags.nugs === "negative" && hasNugs) return false;
-    if (flags.archive === "positive" && !hasArchive) return false;
-    if (flags.archive === "negative" && hasArchive) return false;
-    return true;
+    const hasRelisten = Boolean(sources?.relistenUrl);
+    return (
+      matchesTriState(flags.nugs, hasNugs) &&
+      matchesTriState(flags.archive, hasArchive) &&
+      matchesTriState(flags.relisten, hasRelisten)
+    );
   });
 }

--- a/apps/web/app/server/apply-media-count-filters.test.ts
+++ b/apps/web/app/server/apply-media-count-filters.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "vitest";
+import { applyMediaCountFilters } from "./apply-media-count-filters";
+
+// Minimal setlist-like shape accepted by the helper — it only needs the
+// show's denormalized media counts. `as never` avoids building a full Setlist.
+function setlist(id: string, photos: number, youtube: number) {
+  return { show: { id, showPhotosCount: photos, showYoutubesCount: youtube } } as never;
+}
+
+function ids(setlists: { show: { id: string } }[]) {
+  return setlists.map((s) => s.show.id);
+}
+
+describe("applyMediaCountFilters", () => {
+  // No active flags → input passes through by reference. The year loader runs
+  // this on every request, so the no-op path must preserve reference equality.
+  test("returns setlists unchanged when no filters are active", () => {
+    const setlists = [setlist("astronaut", 0, 0), setlist("basis", 3, 0)];
+    expect(applyMediaCountFilters(setlists, {})).toBe(setlists);
+  });
+
+  // Explicit "empty" is the same as an absent flag.
+  test("treats empty tri-state as no filter", () => {
+    const setlists = [setlist("astronaut", 0, 0), setlist("basis", 3, 0)];
+    expect(applyMediaCountFilters(setlists, { photos: "empty", youtube: "empty" })).toBe(setlists);
+  });
+
+  // Positive photos keeps only shows with a nonzero photo count — the exact
+  // in-memory equivalent of the DB `showPhotosCount > 0` clause it replaces.
+  test("photos=positive keeps only shows with photos", () => {
+    const setlists = [setlist("astronaut", 0, 0), setlist("basis", 3, 0)];
+    expect(ids(applyMediaCountFilters(setlists, { photos: "positive" }))).toEqual(["basis"]);
+  });
+
+  // Negative photos is the DB `showPhotosCount === 0` clause.
+  test("photos=negative keeps only shows without photos", () => {
+    const setlists = [setlist("astronaut", 0, 0), setlist("basis", 3, 0)];
+    expect(ids(applyMediaCountFilters(setlists, { photos: "negative" }))).toEqual(["astronaut"]);
+  });
+
+  // Youtube mirrors photos against its own count column.
+  test("youtube=positive keeps only shows with youtube", () => {
+    const setlists = [setlist("astronaut", 0, 0), setlist("basis", 0, 2)];
+    expect(ids(applyMediaCountFilters(setlists, { youtube: "positive" }))).toEqual(["basis"]);
+  });
+
+  // Both flags AND together: a mixed positive/negative pair must intersect.
+  test("photos=positive + youtube=negative combine with AND", () => {
+    const setlists = [
+      setlist("crystal-ball", 4, 0), // photos yes, youtube no → keep
+      setlist("basis", 4, 1), // both → drop (has youtube)
+      setlist("munchkin", 0, 0), // neither → drop (no photos)
+      setlist("plan-b", 0, 3), // youtube only → drop (no photos)
+    ];
+    expect(ids(applyMediaCountFilters(setlists, { photos: "positive", youtube: "negative" }))).toEqual([
+      "crystal-ball",
+    ]);
+  });
+});

--- a/apps/web/app/server/apply-media-count-filters.ts
+++ b/apps/web/app/server/apply-media-count-filters.ts
@@ -1,0 +1,36 @@
+import type { Setlist } from "@bip/domain";
+import { isAnyTriStateActive, matchesTriState, type TriState } from "~/lib/tri-state-filter";
+
+/**
+ * Tri-state flags for the year-page media toggles that ride on a show's
+ * denormalized counts (showPhotosCount / showYoutubesCount).
+ *
+ * - "positive" → keep only shows WITH the media
+ * - "negative" → keep only shows WITHOUT the media
+ * - "empty" / undefined → no filter
+ */
+export type MediaCountFilterFlags = {
+  photos?: TriState;
+  youtube?: TriState;
+};
+
+/**
+ * Drop setlists whose show media counts don't match the active flags. The year
+ * page caches one unfiltered set per (year, sort) and narrows it here, so the
+ * nine photo/youtube tri-state combinations share a single cached year blob
+ * instead of each caching a near-full-year payload. Returns the input
+ * reference unchanged when no flag is active (preserves reference equality for
+ * the loader's every-request use), mirroring applyExternalSourceFilters.
+ */
+export function applyMediaCountFilters<T extends Pick<Setlist, "show">>(
+  setlists: T[],
+  flags: MediaCountFilterFlags,
+): T[] {
+  if (!isAnyTriStateActive(flags)) return setlists;
+
+  return setlists.filter(
+    (setlist) =>
+      matchesTriState(flags.photos, setlist.show.showPhotosCount > 0) &&
+      matchesTriState(flags.youtube, setlist.show.showYoutubesCount > 0),
+  );
+}

--- a/apps/web/app/server/show-counts-by-year.test.ts
+++ b/apps/web/app/server/show-counts-by-year.test.ts
@@ -5,12 +5,14 @@ import { computeShowCountsByYear } from "./show-counts-by-year";
 // per-test mocks so each assertion can shape both catalogs independently.
 const getReleaseUrlsByDate = vi.fn();
 const getPrimaryUrlsByDate = vi.fn();
+const getRelistenUrlsByDate = vi.fn();
 const getShowDatesWithFlags = vi.fn();
 
 vi.mock("~/server/services", () => ({
   services: {
     nugs: { getReleaseUrlsByDate: () => getReleaseUrlsByDate() },
     archiveDotOrg: { getPrimaryUrlsByDate: () => getPrimaryUrlsByDate() },
+    relisten: { getUrlsByDate: () => getRelistenUrlsByDate() },
     shows: { getShowDatesWithFlags: () => getShowDatesWithFlags() },
   },
 }));
@@ -20,6 +22,7 @@ describe("computeShowCountsByYear", () => {
     vi.clearAllMocks();
     getReleaseUrlsByDate.mockResolvedValue({});
     getPrimaryUrlsByDate.mockResolvedValue({});
+    getRelistenUrlsByDate.mockResolvedValue({});
     getShowDatesWithFlags.mockResolvedValue([]);
   });
 
@@ -97,6 +100,41 @@ describe("computeShowCountsByYear", () => {
 
     expect(getReleaseUrlsByDate).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ 2019: 1, 2023: 1 });
+  });
+
+  // Positive relisten intersects show dates with the relisten catalog, which
+  // keys a single url per date (unlike nugs' url array).
+  test("relisten=positive counts only shows present in the relisten catalog", async () => {
+    getShowDatesWithFlags.mockResolvedValue([
+      { date: "2001-03-17", hasPhotos: false, hasYoutube: false },
+      { date: "2009-08-10", hasPhotos: false, hasYoutube: false },
+      { date: "2023-06-15", hasPhotos: false, hasYoutube: false },
+    ]);
+    getRelistenUrlsByDate.mockResolvedValue({
+      "2001-03-17": "https://relisten.net/db/2001-03-17",
+      "2023-06-15": "https://relisten.net/db/2023-06-15",
+    });
+
+    const result = await computeShowCountsByYear({ relisten: "positive" });
+
+    expect(getRelistenUrlsByDate).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ 2001: 1, 2023: 1 });
+  });
+
+  // Negative relisten needs the catalog too — deciding "not in relisten"
+  // requires knowing which dates are in it.
+  test("relisten=negative counts only shows missing from the relisten catalog", async () => {
+    getShowDatesWithFlags.mockResolvedValue([
+      { date: "2001-03-17", hasPhotos: false, hasYoutube: false },
+      { date: "2009-08-10", hasPhotos: false, hasYoutube: false },
+    ]);
+    getRelistenUrlsByDate.mockResolvedValue({
+      "2001-03-17": "https://relisten.net/db/2001-03-17",
+    });
+
+    const result = await computeShowCountsByYear({ relisten: "negative" });
+
+    expect(result).toEqual({ 2009: 1 });
   });
 
   // Mixed positive + negative: the user's headline use case at the year-bucket

--- a/apps/web/app/server/show-counts-by-year.ts
+++ b/apps/web/app/server/show-counts-by-year.ts
@@ -1,4 +1,4 @@
-import type { TriState } from "~/lib/tri-state-filter";
+import { matchesTriState, type TriState } from "~/lib/tri-state-filter";
 import { services } from "~/server/services";
 
 /**
@@ -12,6 +12,7 @@ export interface ShowCountsFilterFlags {
   youtube?: TriState;
   nugs?: TriState;
   archive?: TriState;
+  relisten?: TriState;
 }
 
 function isActive(state: TriState | undefined): boolean {
@@ -22,36 +23,31 @@ function isActive(state: TriState | undefined): boolean {
  * Return the number of shows per year that satisfy every active filter. The
  * year page uses this to render counts beside each year in Filter-by-Year.
  *
- * One DB read (all show dates + denormalized flags) plus at most two Redis
- * reads (nugs/archive catalogs, each a full date-keyed map) — work is flat
- * regardless of how many years exist. Both positive and negative tri-state
+ * One DB read (all show dates + denormalized flags) plus at most three Redis
+ * reads (nugs/archive/relisten catalogs, each a full date-keyed map) — work is
+ * flat regardless of how many years exist. Both positive and negative tri-state
  * branches need the catalog: deciding "not in nugs" requires knowing which
  * dates are in nugs.
  */
 export async function computeShowCountsByYear(flags: ShowCountsFilterFlags): Promise<Record<number, number>> {
   const needsNugs = isActive(flags.nugs);
   const needsArchive = isActive(flags.archive);
+  const needsRelisten = isActive(flags.relisten);
 
-  const [showDates, nugsUrlsByDate, archiveUrlsByDate] = await Promise.all([
+  const [showDates, nugsUrlsByDate, archiveUrlsByDate, relistenUrlsByDate] = await Promise.all([
     services.shows.getShowDatesWithFlags(),
     needsNugs ? services.nugs.getReleaseUrlsByDate() : Promise.resolve<Record<string, string[]>>({}),
     needsArchive ? services.archiveDotOrg.getPrimaryUrlsByDate() : Promise.resolve<Record<string, string>>({}),
+    needsRelisten ? services.relisten.getUrlsByDate() : Promise.resolve<Record<string, string>>({}),
   ]);
 
   const counts: Record<number, number> = {};
   for (const show of showDates) {
-    if (flags.photos === "positive" && !show.hasPhotos) continue;
-    if (flags.photos === "negative" && show.hasPhotos) continue;
-    if (flags.youtube === "positive" && !show.hasYoutube) continue;
-    if (flags.youtube === "negative" && show.hasYoutube) continue;
-
-    const hasNugs = Boolean(nugsUrlsByDate[show.date]?.length);
-    if (flags.nugs === "positive" && !hasNugs) continue;
-    if (flags.nugs === "negative" && hasNugs) continue;
-
-    const hasArchive = Boolean(archiveUrlsByDate[show.date]);
-    if (flags.archive === "positive" && !hasArchive) continue;
-    if (flags.archive === "negative" && hasArchive) continue;
+    if (!matchesTriState(flags.photos, show.hasPhotos)) continue;
+    if (!matchesTriState(flags.youtube, show.hasYoutube)) continue;
+    if (!matchesTriState(flags.nugs, Boolean(nugsUrlsByDate[show.date]?.length))) continue;
+    if (!matchesTriState(flags.archive, Boolean(archiveUrlsByDate[show.date]))) continue;
+    if (!matchesTriState(flags.relisten, Boolean(relistenUrlsByDate[show.date]))) continue;
 
     const year = Number.parseInt(show.date.slice(0, 4), 10);
     counts[year] = (counts[year] ?? 0) + 1;


### PR DESCRIPTION
You can now filter the shows-by-year page by Relisten availability: the
Filter by Media bar gains a Relisten toggle alongside Nugs, YouTube,
Archive, and Photos, cycling include -> exclude -> off like the others,
and the year counts in Filter by Year reflect it. Relisten was already
resolved as a per-show badge; this wires it into the filter set.

The bar also relayouts for the fifth filter: three-wide on desktop
(previously two) so it grows sideways rather than taller, and a single
icon-only row on mobile so all five fit on one line (labels stay in the
aria-label for screen readers).

## Cache: collapse the year-list permutations

The `shows:list:*` cache family was the largest single consumer of the
Redis working set. Each `(year, sort, photos, youtube)` combination cached
its own near-full-year payload. The year loader now caches one unfiltered
set per `(year, sort)` and applies the photos/youtube filters in memory —
the same post-cache path nugs/archive (and now relisten) already use, off
the show's denormalized `showPhotosCount` / `showYoutubesCount`. Up to
nine tri-state combinations per year collapse to a single cached blob.

The cached value shape is unchanged (still `Setlist[]`), so this needs no
cache-key version bump; the old `...photos:...|youtube:...` keys become
orphans that age out via TTL and LRU.

The tri-state positive/negative match was inlined in three places after
this change, so it's extracted into one `matchesTriState` predicate that
the in-memory filters and the per-year counts helper share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
