### PR TITLE
Link the ratings explainer to the reader's profile settings

### DIFF
--- a/apps/web/app/routes/show-rating-algorithm.test.tsx
+++ b/apps/web/app/routes/show-rating-algorithm.test.tsx
@@ -1,0 +1,60 @@
+import { setupWithRouter } from "@test/test-utils";
+import { screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import ShowRatingAlgorithm from "./show-rating-algorithm";
+
+vi.mock("~/hooks/use-feature-flags", () => ({ useFeatureFlags: vi.fn() }));
+vi.mock("~/hooks/use-session", () => ({ useSession: vi.fn() }));
+
+import { useFeatureFlags } from "~/hooks/use-feature-flags";
+import { useSession } from "~/hooks/use-session";
+
+// The explainer is static except for one branch: the "your profile settings"
+// phrase becomes a link to the viewer's own profile (where the opt-in toggle
+// lives) only when the toggle-visible flag is on AND we know their username.
+// Otherwise it must stay plain text so nobody is pointed at a setting they
+// can't reach.
+function mockFlags(toggleVisible: boolean) {
+  vi.mocked(useFeatureFlags).mockReturnValue({
+    calibratedEnabled: true,
+    toggleVisible,
+    compareVisible: false,
+    defaultCalibrated: false,
+    explainerNavLink: false,
+    recomputeEnabled: false,
+  });
+}
+
+function mockUser(username: string | null) {
+  vi.mocked(useSession).mockReturnValue({
+    user:
+      username === null
+        ? null
+        : { id: "u1", email: "e@x.co", username, avatarUrl: null, internalUserId: "iu1", isAdmin: false },
+    supabase: null,
+  });
+}
+
+describe("ShowRatingAlgorithm", () => {
+  test("links 'your profile settings' to the viewer's profile when the toggle is available", async () => {
+    mockFlags(true);
+    mockUser("tractorbeam");
+    await setupWithRouter(<ShowRatingAlgorithm />);
+    expect(screen.getByRole("link", { name: "your profile settings" })).toHaveAttribute("href", "/users/tractorbeam");
+  });
+
+  test("leaves 'your profile settings' as plain text when the toggle flag is off", async () => {
+    mockFlags(false);
+    mockUser("tractorbeam");
+    await setupWithRouter(<ShowRatingAlgorithm />);
+    expect(screen.queryByRole("link", { name: "your profile settings" })).not.toBeInTheDocument();
+    expect(screen.getByText(/your profile settings/)).toBeInTheDocument();
+  });
+
+  test("leaves 'your profile settings' as plain text for a signed-out visitor", async () => {
+    mockFlags(true);
+    mockUser(null);
+    await setupWithRouter(<ShowRatingAlgorithm />);
+    expect(screen.queryByRole("link", { name: "your profile settings" })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/routes/show-rating-algorithm.tsx
+++ b/apps/web/app/routes/show-rating-algorithm.tsx
@@ -1,4 +1,7 @@
+import { Link } from "react-router-dom";
 import { Card, CardContent } from "~/components/ui/card";
+import { useFeatureFlags } from "~/hooks/use-feature-flags";
+import { useSession } from "~/hooks/use-session";
 
 export function meta() {
   return [
@@ -32,9 +35,17 @@ function PostLink({ href, children }: { href: string; children: React.ReactNode 
  * Public explainer for the Calibrated Show Rating. Always reachable by direct URL
  * (the `ratings.explainer-nav-link` flag gates only the nav link, not this page).
  * Written to be accurate enough to share with the phish.net ratings author whose
- * series it builds on. Static content, no loader.
+ * series it builds on. No loader; the only dynamic bit is the "profile settings"
+ * link, shown when the `ratings.toggle-visible` flag makes the opt-in available to
+ * this signed-in viewer.
  */
 export default function ShowRatingAlgorithm() {
+  const { toggleVisible } = useFeatureFlags();
+  const { user } = useSession();
+  // Link straight to the viewer's profile (where the opt-in toggle lives) only
+  // when they can actually enable it: the flag is on and we know their username.
+  const settingsHref = toggleVisible && user?.username ? `/users/${user.username}` : null;
+
   return (
     <div className="space-y-6 md:space-y-8">
       <div>
@@ -54,8 +65,15 @@ export default function ShowRatingAlgorithm() {
               <p className="text-content-text-secondary">
                 The <strong className="text-content-text-primary">Calibrated Show Rating</strong> is an opt-in
                 alternative that tries to measure the same thing, how good the show was, while being much harder to
-                skew. Everyone sees the community average by default; you can switch on the Calibrated Show Rating in
-                your profile settings.
+                skew. Everyone sees the community average by default; you can switch on the Calibrated Show Rating in{" "}
+                {settingsHref ? (
+                  <Link to={settingsHref} className="text-brand-primary hover:underline">
+                    your profile settings
+                  </Link>
+                ) : (
+                  "your profile settings"
+                )}
+                .
               </p>
               <p className="text-content-text-secondary">
                 This work is directly inspired by Paul Jakus's four-part series on rating shows for phish.net:{" "}


### PR DESCRIPTION
On the "How show ratings work" page, the phrase "your profile settings" now links straight to the reader's own profile (`/users/<username>`), where the Calibrated Show Rating toggle lives, so a reader can go turn the rating on for themselves in one click.

The link renders only when the reader is signed in **and** the `ratings.toggle-visible` flag makes the opt-in available to them. Signed-out visitors, and signed-in users without the flag, see the phrase as plain text (there's no setting for them to reach, and the link targets their own profile, which requires knowing who they are).

The page stays loader-free: it reads the flag via `useFeatureFlags()` and the viewer via `useSession()`, both already SSR-seeded from the root loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
