### PR TITLE
Add an opt-in Calibrated Track Rating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,9 @@ recompute-ratings:
 rating-validity-eval:
 	cd packages/core && doppler run -- bun run scripts/rating-validity-eval.ts
 
+track-rating-calibration-spike:
+	cd packages/core && doppler run -- bun run scripts/track-rating-calibration-spike.ts
+
 db-sync-missing-shows:
 	cd packages/core && doppler run -- bun run scripts/sync-missing-shows.ts $(if $(HELP),--help) $(if $(YEARS),--years=$(YEARS)) $(if $(DRY_RUN),--dry-run) $(if $(PRUNE_GHOST_SHOWS),--prune-ghost-shows) $(if $(NO_USERS),--no-users) $(if $(FULL_USERS),--full-users) $(if $(PRUNE_USERS),--prune-users)
 

--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -10,6 +10,7 @@ import { ShowDateLink } from "~/components/show-date-link";
 import { AllTimerCell, allTimerColumnMeta } from "~/components/track/all-timer-cell";
 import { DurationValue } from "~/components/track/duration-cell";
 import { NumberCell } from "~/components/ui/number-cell";
+import type { TrackRatingComparison } from "~/server/track-user-ratings";
 import { CombinedNotes } from "./combined-notes";
 import { DateVenueCell } from "./date-venue-cell";
 import { TrackRatingCell } from "./track-rating-cell";
@@ -42,26 +43,36 @@ export const gapSortingFn = makeGapSortingFn("gap");
 export const filteredGapSortingFn = makeGapSortingFn("filteredGap");
 
 /**
- * Sort comparator for the Rating column. Tracks with the same community
- * average resolve by vote count first (more votes = more confidence in the
- * average), then by show date, then by position so within-show repeats with
- * matching rating + vote count stay in setlist order relative to each other.
- *
- * Missing ratings collapse to -Infinity so unrated rows cluster at the
- * bottom on desc and the top on asc, matching the Gap column's treatment
- * of debuts/repeats.
+ * Sort comparator factory for the Rating column, parameterized by how a row's
+ * rating and vote count are resolved. Tracks with the same rating resolve by vote
+ * count first (more votes = more confidence), then by show date, then by position
+ * so within-show repeats with matching rating + count stay in setlist order.
+ * Missing ratings collapse to -Infinity so unrated rows cluster at the bottom on
+ * desc and the top on asc. The `ratingOf`/`countOf` seam lets the plain export and
+ * the calibrated-aware column share one comparator instead of two copies.
  */
-export function ratingSortingFn(a: Row<SongPagePerformance>, b: Row<SongPagePerformance>): number {
-  const aRating = a.original.rating ?? Number.NEGATIVE_INFINITY;
-  const bRating = b.original.rating ?? Number.NEGATIVE_INFINITY;
-  if (aRating !== bRating) return aRating - bRating;
-  const aVotes = a.original.ratingsCount ?? 0;
-  const bVotes = b.original.ratingsCount ?? 0;
-  if (aVotes !== bVotes) return aVotes - bVotes;
-  const dateCmp = compareByShowDate(a.original, b.original);
-  if (dateCmp !== 0) return dateCmp;
-  return (a.original.position ?? 0) - (b.original.position ?? 0);
+function makeRatingSortingFn(
+  ratingOf: (row: SongPagePerformance) => number | null,
+  countOf: (row: SongPagePerformance) => number | null,
+): (a: Row<SongPagePerformance>, b: Row<SongPagePerformance>) => number {
+  return (a, b) => {
+    const aRating = ratingOf(a.original) ?? Number.NEGATIVE_INFINITY;
+    const bRating = ratingOf(b.original) ?? Number.NEGATIVE_INFINITY;
+    if (aRating !== bRating) return aRating - bRating;
+    const aVotes = countOf(a.original) ?? 0;
+    const bVotes = countOf(b.original) ?? 0;
+    if (aVotes !== bVotes) return aVotes - bVotes;
+    const dateCmp = compareByShowDate(a.original, b.original);
+    if (dateCmp !== 0) return dateCmp;
+    return (a.original.position ?? 0) - (b.original.position ?? 0);
+  };
 }
+
+/** The plain-average Rating-column comparator (community `rating`/`ratingsCount`). */
+export const ratingSortingFn = makeRatingSortingFn(
+  (row) => row.rating ?? null,
+  (row) => row.ratingsCount ?? null,
+);
 
 /**
  * Adapt a SongPagePerformance row to the minimal Track-like shape the
@@ -194,6 +205,14 @@ interface PerformanceColumnOptions {
   hasNarrowingFilter?: boolean;
   userRatingMap: Map<string, number>;
   isAuthenticated: boolean;
+  /**
+   * The viewer's headline rating per track — the Calibrated Track Rating when they
+   * opted in, else the community average. Overrides the plain `row.rating` baked into
+   * the performance DTO for both display and sorting. Absent ⇒ the plain baked value.
+   */
+  displayRatingMap?: Map<string, { average: number; count: number }>;
+  /** Plain vs calibrated per track, present only for the author compare overlay. */
+  comparisonMap?: Map<string, TrackRatingComparison>;
 }
 
 function SortableHeader({
@@ -234,9 +253,22 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
     hasNarrowingFilter,
     userRatingMap,
     isAuthenticated,
+    displayRatingMap,
+    comparisonMap,
   } = options;
   const includeGapColumns = showGapColumns !== false;
   const columnHelper = createColumnHelper<SongPagePerformance>();
+
+  // The viewer's headline rating/count for a row: the live calibrated-or-plain map
+  // when loaded, falling back to the plain value baked into the DTO. Used by the
+  // rating column's accessor, sort, and cell so display and ordering never disagree.
+  const ratingOf = (row: SongPagePerformance): number | null =>
+    displayRatingMap?.get(row.trackId)?.average ?? row.rating ?? null;
+  const countOf = (row: SongPagePerformance): number | null =>
+    displayRatingMap?.get(row.trackId)?.count ?? row.ratingsCount ?? null;
+  // Same comparator as the plain export, but over the resolved values so a calibrated
+  // viewer sorts by the calibrated score.
+  const displayRatingSortingFn = makeRatingSortingFn(ratingOf, countOf);
   const columns: ColumnDef<SongPagePerformance, unknown>[] = [];
 
   // AllTimer column comes first so the flame anchors the leftmost slot
@@ -506,15 +538,15 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
         },
       },
     ) as ColumnDef<SongPagePerformance, unknown>,
-    columnHelper.accessor((row) => row.rating ?? 0, {
+    columnHelper.accessor((row) => ratingOf(row) ?? 0, {
       id: "rating",
       header: ({ column }) => <SortableHeader column={column} label="Rating" />,
       enableSorting: true,
       // Rating ties resolve to vote count (more votes = more confidence),
-      // then show date, then track position — same chain as gapSortingFn so
+      // then show date, then track position — same chain as ratingSortingFn so
       // identical-rating runs across multiple shows still read in a stable
       // order. Sort defaults to descending ("best first") via sortDescFirst.
-      sortingFn: ratingSortingFn,
+      sortingFn: displayRatingSortingFn,
       sortDescFirst: true,
       // Sized for the busiest badge form: "★ 5.00 · 999 | 4½" — community
       // average + 3-digit vote count + the viewer's own half-step rating
@@ -526,19 +558,16 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       // badge, so the column doesn't need a wider expanded state.
       meta: { fixedWidth: "8.25rem", mobileFixedWidth: "6.75rem" },
       cell: (info) => {
-        const rating = info.getValue();
-        const ratingsCount = info.row.original.ratingsCount;
-        const trackId = info.row.original.trackId;
-        const showSlug = info.row.original.show.slug;
-        const userRating = userRatingMap.get(trackId) ?? null;
+        const row = info.row.original;
         return (
           <TrackRatingCell
-            trackId={trackId}
-            showSlug={showSlug}
-            initialRating={rating || null}
-            ratingsCount={ratingsCount || null}
-            userRating={userRating}
+            trackId={row.trackId}
+            showSlug={row.show.slug}
+            initialRating={ratingOf(row)}
+            ratingsCount={countOf(row)}
+            userRating={userRatingMap.get(row.trackId) ?? null}
             isAuthenticated={isAuthenticated}
+            comparison={comparisonMap?.get(row.trackId)}
           />
         );
       },

--- a/apps/web/app/components/performance/performance-table.tsx
+++ b/apps/web/app/components/performance/performance-table.tsx
@@ -69,7 +69,7 @@ export function PerformanceTable({
   };
 
   const trackIds = useMemo(() => performances.map((performance) => performance.trackId), [performances]);
-  const { userRatingMap } = useTrackUserRatings(trackIds);
+  const { userRatingMap, displayRatingMap, comparisonMap } = useTrackUserRatings(trackIds);
 
   const columns = useMemo(
     () =>
@@ -81,6 +81,8 @@ export function PerformanceTable({
         hasNarrowingFilter,
         userRatingMap,
         isAuthenticated,
+        displayRatingMap,
+        comparisonMap,
       }),
     [
       showSongColumn,
@@ -90,6 +92,8 @@ export function PerformanceTable({
       hasNarrowingFilter,
       userRatingMap,
       isAuthenticated,
+      displayRatingMap,
+      comparisonMap,
     ],
   );
 

--- a/apps/web/app/components/performance/track-rating-cell.tsx
+++ b/apps/web/app/components/performance/track-rating-cell.tsx
@@ -1,10 +1,14 @@
 import { RatingBadgeButton } from "~/components/rating/rating-badge-button";
+import type { TrackRatingComparison } from "~/server/track-user-ratings";
 
 /**
- * Thin shim around `RatingBadgeButton` for the performance table cell
+ * Thin shim around `RatingBadgeButton` for the performance/setlist table cell
  * surface — picks the compact size variant. `skipRevalidation` is set so
  * editing inside a long virtualized table doesn't trigger a route
- * revalidation per submission.
+ * revalidation per submission. When a `comparison` is passed (the author
+ * compare/debug overlay), it renders a small "community → calibrated (Δ)" note
+ * under the badge — the one place that layout lives, shared by both table
+ * column factories.
  */
 export function TrackRatingCell({
   trackId,
@@ -13,6 +17,7 @@ export function TrackRatingCell({
   ratingsCount,
   userRating,
   isAuthenticated,
+  comparison,
 }: {
   trackId: string;
   showSlug: string;
@@ -20,8 +25,9 @@ export function TrackRatingCell({
   ratingsCount: number | null;
   userRating?: number | null;
   isAuthenticated: boolean;
+  comparison?: TrackRatingComparison;
 }) {
-  return (
+  const badge = (
     <RatingBadgeButton
       rateableId={trackId}
       rateableType="Track"
@@ -33,5 +39,20 @@ export function TrackRatingCell({
       size="compact"
       skipRevalidation
     />
+  );
+
+  if (!comparison) return badge;
+
+  return (
+    <div className="flex flex-col items-end gap-0.5">
+      {badge}
+      <span
+        className="text-[10px] leading-none text-content-text-tertiary tabular-nums"
+        title="community → calibrated (Δ)"
+      >
+        {comparison.plain.toFixed(2)}→{comparison.calibrated.toFixed(2)} ({comparison.delta >= 0 ? "+" : ""}
+        {comparison.delta.toFixed(2)})
+      </span>
+    </div>
   );
 }

--- a/apps/web/app/components/rating/rating-display-settings.test.tsx
+++ b/apps/web/app/components/rating/rating-display-settings.test.tsx
@@ -12,7 +12,13 @@ import { useFeatureFlags } from "~/hooks/use-feature-flags";
 // flagged toggles appear only when their feature flag is on, and flipping any
 // toggle persists immediately (no save button). Color coding ships to everyone,
 // so it renders unflagged and keeps the card alive for a typical user.
-const base = { showCalibratedRatings: null, showRatingComparisonDebug: null, colorCodeRatings: null };
+const base = {
+  showCalibratedRatings: null,
+  showRatingComparisonDebug: null,
+  trackCalibratedRatings: null,
+  trackRatingComparisonDebug: null,
+  colorCodeRatings: null,
+};
 
 function mockFlags(overrides: Partial<ReturnType<typeof useFeatureFlags>>) {
   vi.mocked(useFeatureFlags).mockReturnValue({
@@ -80,11 +86,33 @@ describe("RatingDisplaySettings", () => {
     expect((init.body as FormData).get("colorCodeRatings")).toBe("true");
   });
 
-  test("shows only the opt-in toggle when just toggle-visible is on", async () => {
+  test("shows only the opt-in toggles when just toggle-visible is on", async () => {
     mockFlags({ toggleVisible: true });
     await setupWithRouter(<RatingDisplaySettings {...base} />);
     expect(screen.getByText("Calibrated show rating")).toBeInTheDocument();
+    expect(screen.getByText("Calibrated track rating")).toBeInTheDocument();
     expect(screen.queryByText("Show Rating Comparison Overlay (debug)")).not.toBeInTheDocument();
+    expect(screen.queryByText("Track Rating Comparison Overlay (debug)")).not.toBeInTheDocument();
+  });
+
+  test("shows the track comparison overlay toggle only when compare-visible is on", async () => {
+    mockFlags({ toggleVisible: true, compareVisible: true });
+    await setupWithRouter(<RatingDisplaySettings {...base} />);
+    expect(screen.getByText("Track Rating Comparison Overlay (debug)")).toBeInTheDocument();
+  });
+
+  test("auto-saves the calibrated-track opt-in to /api/users on toggle", async () => {
+    mockFlags({ toggleVisible: true });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { user } = await setupWithRouter(<RatingDisplaySettings {...base} />);
+    await user.click(screen.getByLabelText("Use the calibrated track rating"));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/users");
+    expect((init.body as FormData).get("trackCalibratedRatings")).toBe("true");
   });
 
   test("shows the comparison overlay toggle when compare-visible is on", async () => {

--- a/apps/web/app/components/rating/rating-display-settings.tsx
+++ b/apps/web/app/components/rating/rating-display-settings.tsx
@@ -19,10 +19,14 @@ import { PREFERENCES_DEFAULT } from "~/hooks/use-preferences";
 export function RatingDisplaySettings({
   showCalibratedRatings,
   showRatingComparisonDebug,
+  trackCalibratedRatings,
+  trackRatingComparisonDebug,
   colorCodeRatings,
 }: {
   showCalibratedRatings: boolean | null;
   showRatingComparisonDebug: boolean | null;
+  trackCalibratedRatings: boolean | null;
+  trackRatingComparisonDebug: boolean | null;
   colorCodeRatings: boolean | null;
 }) {
   const { toggleVisible, compareVisible, defaultCalibrated } = useFeatureFlags();
@@ -68,6 +72,34 @@ export function RatingDisplaySettings({
             ariaLabel="Show rating comparison overlay"
             description="Show the community→calibrated score and rank delta on show cards and pages."
             initial={showRatingComparisonDebug ?? false}
+          />
+        )}
+
+        {toggleVisible && (
+          <PreferenceToggle
+            field="trackCalibratedRatings"
+            label="Calibrated track rating"
+            ariaLabel="Use the calibrated track rating"
+            description={
+              <>
+                Leans on raters who use the whole 0.5 to 5 star scale and discounts one-note fluffers, so tracks spread
+                out instead of all sitting near 5.{" "}
+                <Link to="/show-rating-algorithm" className="text-brand-primary hover:underline">
+                  How it works →
+                </Link>
+              </>
+            }
+            initial={trackCalibratedRatings ?? defaultCalibrated}
+          />
+        )}
+
+        {compareVisible && (
+          <PreferenceToggle
+            field="trackRatingComparisonDebug"
+            label="Track Rating Comparison Overlay (debug)"
+            ariaLabel="Track rating comparison overlay"
+            description="Show the community→calibrated track score and delta on setlist and performance rows."
+            initial={trackRatingComparisonDebug ?? false}
           />
         )}
       </CardContent>

--- a/apps/web/app/components/setlist/setlist-columns-personal.tsx
+++ b/apps/web/app/components/setlist/setlist-columns-personal.tsx
@@ -30,6 +30,7 @@ export function createPersonalSetlistColumns(
     averageRatingMap: ctx?.averageRatingMap ?? new Map(),
     userRatingMap: ctx?.userRatingMap ?? new Map(),
     isAuthenticated: ctx?.isAuthenticated ?? false,
+    comparisonMap: ctx?.comparisonMap,
   };
   return [
     ...createSetlistCommonColumns<PersonalSetlistTableRow>({ songLinkSearchParams: "attended=attended" }),

--- a/apps/web/app/components/setlist/setlist-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.tsx
@@ -33,6 +33,7 @@ export function createSetlistColumns(ctx?: Partial<SetlistRatingContext>): Colum
     averageRatingMap: ctx?.averageRatingMap ?? new Map(),
     userRatingMap: ctx?.userRatingMap ?? new Map(),
     isAuthenticated: ctx?.isAuthenticated ?? false,
+    comparisonMap: ctx?.comparisonMap,
   };
   return [
     ...createSetlistCommonColumns<SetlistTableRow>(),

--- a/apps/web/app/components/setlist/setlist-common-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-common-columns.tsx
@@ -6,6 +6,7 @@ import { AllTimerCell, allTimerColumnMeta } from "~/components/track/all-timer-c
 import { DurationValue } from "~/components/track/duration-cell";
 import { NumberCell } from "~/components/ui/number-cell";
 import { SortableHeader } from "~/components/ui/sortable-header";
+import type { TrackRatingComparison } from "~/server/track-user-ratings";
 import { GapCell, type GapCellState } from "./gap-cell";
 import { compareBySetThenPosition, countDistinctEncores, formatSetLabel } from "./set-label";
 import { TrackRatingOverlay } from "./track-rating-overlay";
@@ -27,17 +28,19 @@ function withSetPositionTiebreak<T extends TrackLight>(primary: (a: T, b: T) => 
 
 /**
  * Per-row inputs the rating column needs that the row itself doesn't carry:
- * the show slug (target of any rating mutation), the community average map and
- * the viewer's rating map (both resolved live from useTrackUserRatings at the
- * table level — community averages no longer ride in the structural setlist
- * blob), and the auth state. Identical between the catalog and personal column
- * factories.
+ * the show slug (target of any rating mutation), the viewer's headline rating map
+ * (the Calibrated Track Rating when they opted in, else the community average —
+ * both resolved live from useTrackUserRatings at the table level, since community
+ * averages no longer ride in the structural setlist blob), the viewer's own rating
+ * map, and the auth state. `comparisonMap` is present only for the author compare
+ * overlay. Identical between the catalog and personal column factories.
  */
 export interface SetlistRatingContext {
   showSlug: string;
   averageRatingMap: Map<string, { average: number; count: number }>;
   userRatingMap: Map<string, number>;
   isAuthenticated: boolean;
+  comparisonMap?: Map<string, TrackRatingComparison>;
 }
 
 /**
@@ -89,6 +92,7 @@ export function createRatingColumn<T extends TrackLight>(ctx: SetlistRatingConte
           ratingsCount={average?.count ?? null}
           userRating={ctx.userRatingMap.get(row.id) ?? null}
           isAuthenticated={ctx.isAuthenticated}
+          comparison={ctx.comparisonMap?.get(row.id)}
         />
       );
     },

--- a/apps/web/app/components/setlist/setlist-table-personal.tsx
+++ b/apps/web/app/components/setlist/setlist-table-personal.tsx
@@ -33,7 +33,7 @@ export function SetlistTablePersonal({ tracks, showSlug, showDate, onSummaryChan
   const { showSetlistTimes } = usePreferences();
   const isAuthenticated = !!user;
   const trackIds = useMemo(() => tracks.map((t) => t.id), [tracks]);
-  const { userRatingMap, averageRatingMap } = useTrackUserRatings(trackIds);
+  const { userRatingMap, displayRatingMap, comparisonMap } = useTrackUserRatings(trackIds);
 
   const setlistTracks = useMemo(
     () => tracks.map((t) => ({ id: t.id, songId: t.songId, set: t.set, position: t.position })),
@@ -56,10 +56,16 @@ export function SetlistTablePersonal({ tracks, showSlug, showDate, onSummaryChan
   const columns = useMemo(
     () =>
       applyTimePreference(
-        createPersonalSetlistColumns({ showSlug, averageRatingMap, userRatingMap, isAuthenticated }),
+        createPersonalSetlistColumns({
+          showSlug,
+          averageRatingMap: displayRatingMap,
+          userRatingMap,
+          isAuthenticated,
+          comparisonMap,
+        }),
         showSetlistTimes,
       ),
-    [showSlug, averageRatingMap, userRatingMap, isAuthenticated, showSetlistTimes],
+    [showSlug, displayRatingMap, userRatingMap, isAuthenticated, comparisonMap, showSetlistTimes],
   );
 
   // Hoist the summary up to the parent so it can render alongside the

--- a/apps/web/app/components/setlist/setlist-table.test.tsx
+++ b/apps/web/app/components/setlist/setlist-table.test.tsx
@@ -146,6 +146,8 @@ describe("SetlistTable", () => {
     vi.mocked(useTrackUserRatings).mockReturnValue({
       userRatingMap: new Map([["t-1", 5]]),
       averageRatingMap: new Map([["t-1", { average: 4.4, count: 22 }]]),
+      displayRatingMap: new Map([["t-1", { average: 4.4, count: 22 }]]),
+      comparisonMap: new Map(),
       isLoading: false,
     });
 

--- a/apps/web/app/components/setlist/setlist-table.tsx
+++ b/apps/web/app/components/setlist/setlist-table.tsx
@@ -39,7 +39,7 @@ export function SetlistTable({ tracks, showSlug, showDate }: SetlistTableProps) 
   const { showSetlistTimes } = usePreferences();
   const isAuthenticated = !!user;
   const trackIds = useMemo(() => tracks.map((t) => t.id), [tracks]);
-  const { userRatingMap, averageRatingMap } = useTrackUserRatings(trackIds);
+  const { userRatingMap, displayRatingMap, comparisonMap } = useTrackUserRatings(trackIds);
   const { data: songPlayDates, isLoading: isPlayDatesLoading } = useSongPlayDates();
 
   const rows: SetlistTableRow[] = useMemo(() => {
@@ -52,10 +52,16 @@ export function SetlistTable({ tracks, showSlug, showDate }: SetlistTableProps) 
   const columns = useMemo(
     () =>
       applyTimePreference(
-        createSetlistColumns({ showSlug, averageRatingMap, userRatingMap, isAuthenticated }),
+        createSetlistColumns({
+          showSlug,
+          averageRatingMap: displayRatingMap,
+          userRatingMap,
+          isAuthenticated,
+          comparisonMap,
+        }),
         showSetlistTimes,
       ),
-    [showSlug, averageRatingMap, userRatingMap, isAuthenticated, showSetlistTimes],
+    [showSlug, displayRatingMap, userRatingMap, isAuthenticated, comparisonMap, showSetlistTimes],
   );
   return (
     <DataTable

--- a/apps/web/app/components/settings/preference-toggle.tsx
+++ b/apps/web/app/components/settings/preference-toggle.tsx
@@ -9,6 +9,8 @@ import { Switch } from "~/components/ui/switch";
 export type PreferenceField =
   | "showCalibratedRatings"
   | "showRatingComparisonDebug"
+  | "trackCalibratedRatings"
+  | "trackRatingComparisonDebug"
   | "colorCodeRatings"
   | "showSetlistTimes";
 

--- a/apps/web/app/hooks/use-track-user-ratings.ts
+++ b/apps/web/app/hooks/use-track-user-ratings.ts
@@ -2,13 +2,20 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { batchedPostFetch } from "~/lib/batched-fetch";
 import { trackUserRatingsQueryKey } from "~/lib/query-keys";
-import type { TrackUserRatingsResponse } from "~/server/track-user-ratings";
+import type { TrackRatingComparison, TrackUserRatingsResponse } from "~/server/track-user-ratings";
 
 function mergeTrackUserRatings(results: TrackUserRatingsResponse[]): TrackUserRatingsResponse {
-  const merged: TrackUserRatingsResponse = { userRatings: {}, averageRatings: {} };
+  const merged: TrackUserRatingsResponse = {
+    userRatings: {},
+    averageRatings: {},
+    calibratedRatings: {},
+    comparisons: {},
+  };
   for (const result of results) {
     Object.assign(merged.userRatings, result.userRatings);
     Object.assign(merged.averageRatings, result.averageRatings);
+    Object.assign(merged.calibratedRatings, result.calibratedRatings);
+    Object.assign(merged.comparisons, result.comparisons);
   }
   return merged;
 }
@@ -52,5 +59,28 @@ export function useTrackUserRatings(trackIds: string[]) {
     return map;
   }, [data?.averageRatings]);
 
-  return { userRatingMap, averageRatingMap, isLoading };
+  // The headline map a viewer sees: the plain community average, overlaid with the
+  // calibrated score wherever the viewer opted in and it exists — same {average, count}
+  // shape either way, so rating components don't need to know which is which.
+  const displayRatingMap = useMemo(() => {
+    const map = new Map(averageRatingMap);
+    if (data?.calibratedRatings) {
+      for (const [trackId, value] of Object.entries(data.calibratedRatings)) {
+        map.set(trackId, { average: value.rating, count: value.count });
+      }
+    }
+    return map;
+  }, [averageRatingMap, data?.calibratedRatings]);
+
+  const comparisonMap = useMemo(() => {
+    const map = new Map<string, TrackRatingComparison>();
+    if (data?.comparisons) {
+      for (const [trackId, value] of Object.entries(data.comparisons)) {
+        map.set(trackId, value);
+      }
+    }
+    return map;
+  }, [data?.comparisons]);
+
+  return { userRatingMap, averageRatingMap, displayRatingMap, comparisonMap, isLoading };
 }

--- a/apps/web/app/routes/api/tracks/$trackId.tsx
+++ b/apps/web/app/routes/api/tracks/$trackId.tsx
@@ -3,6 +3,7 @@ import { protectedAction, publicLoader } from "~/lib/base-loaders";
 import { badRequest, methodNotAllowed } from "~/lib/errors";
 import { logger } from "~/lib/logger";
 import { services } from "~/server/services";
+import { resolveViewerRatingMode } from "~/server/viewer-rating";
 
 export const loader = publicLoader(async ({ params, context }) => {
   const { currentUser } = context;
@@ -29,14 +30,26 @@ export const loader = publicLoader(async ({ params, context }) => {
     }
   }
 
-  // Get the fresh average rating and count (already on track from DB)
-  const averageRating = track.averageRating || 0;
-  const ratingsCount = track.ratingsCount || 0;
+  // Headline rating + count AND the histogram both track the viewer's rating mode: a
+  // calibrated viewer sees the Calibrated Track Rating and the fluffer-dropped
+  // contributing distribution (so the overlay matches the setlist's inline cell);
+  // everyone else sees the plain community average + deduped distribution. Computed
+  // here (not denormalized) so it loads only when a track's overlay opens.
+  let averageRating = track.averageRating || 0;
+  let ratingsCount = track.ratingsCount || 0;
+  const { trackMode } = await resolveViewerRatingMode(context);
+  const calibrated = trackMode === "calibrated";
+  if (calibrated) {
+    const score = (await services.raterWeights.getCalibratedForTracks([trackId]))[trackId];
+    if (score) {
+      averageRating = score.rating;
+      ratingsCount = score.count;
+    }
+  }
 
-  // Rating distribution for the per-track histogram in the hover overlay.
-  // Computed here (not denormalized) so it loads only when a user opens a
-  // track's overlay, which is the only caller of this loader.
-  const distribution = await services.ratings.getRatingDistribution(trackId, "Track");
+  const distribution = calibrated
+    ? await services.raterWeights.getCalibratedTrackDistribution(trackId)
+    : await services.ratings.getRatingDistribution(trackId, "Track");
 
   return new Response(
     JSON.stringify({

--- a/apps/web/app/routes/api/users.tsx
+++ b/apps/web/app/routes/api/users.tsx
@@ -11,6 +11,8 @@ const updateUserSchema = z.object({
   // Toggles arrive as "true"/"false" strings; persistence is flag-gated below.
   showCalibratedRatings: z.enum(["true", "false"]).optional(),
   showRatingComparisonDebug: z.enum(["true", "false"]).optional(),
+  trackCalibratedRatings: z.enum(["true", "false"]).optional(),
+  trackRatingComparisonDebug: z.enum(["true", "false"]).optional(),
   colorCodeRatings: z.enum(["true", "false"]).optional(),
   showSetlistTimes: z.enum(["true", "false"]).optional(),
 });
@@ -76,6 +78,8 @@ export async function action({ request }: ActionFunctionArgs) {
       username?: string;
       showCalibratedRatings?: boolean;
       showRatingComparisonDebug?: boolean;
+      trackCalibratedRatings?: boolean;
+      trackRatingComparisonDebug?: boolean;
       colorCodeRatings?: boolean;
       showSetlistTimes?: boolean;
     } = {};
@@ -86,6 +90,12 @@ export async function action({ request }: ActionFunctionArgs) {
     }
     if (flags.compareVisible && validatedData.showRatingComparisonDebug !== undefined) {
       update.showRatingComparisonDebug = validatedData.showRatingComparisonDebug === "true";
+    }
+    if (flags.toggleVisible && validatedData.trackCalibratedRatings !== undefined) {
+      update.trackCalibratedRatings = validatedData.trackCalibratedRatings === "true";
+    }
+    if (flags.compareVisible && validatedData.trackRatingComparisonDebug !== undefined) {
+      update.trackRatingComparisonDebug = validatedData.trackRatingComparisonDebug === "true";
     }
     // Color coding and setlist times are available to everyone, so no flag
     // guards these.

--- a/apps/web/app/routes/show-rating-algorithm.tsx
+++ b/apps/web/app/routes/show-rating-algorithm.tsx
@@ -5,11 +5,11 @@ import { useSession } from "~/hooks/use-session";
 
 export function meta() {
   return [
-    { title: "How show ratings work | Biscuits Internet Project" },
+    { title: "How ratings work | Biscuits Internet Project" },
     {
       name: "description",
       content:
-        "How the Calibrated Show Rating works: entropy weighting, bias-centering, bad-faith exclusion, duplicate-account de-duplication, and count-shrinkage, and how it draws on (and differs from) the phish.net ratings research.",
+        "How the Calibrated Show Rating and Calibrated Track Rating work: entropy weighting, bias-centering, bad-faith exclusion, duplicate-account de-duplication, and count-shrinkage, and how they draw on (and differ from) the phish.net ratings research.",
     },
   ];
 }
@@ -32,7 +32,7 @@ function PostLink({ href, children }: { href: string; children: React.ReactNode 
 }
 
 /**
- * Public explainer for the Calibrated Show Rating. Always reachable by direct URL
+ * Public explainer for the Calibrated Show and Track Ratings. Always reachable by direct URL
  * (the `ratings.explainer-nav-link` flag gates only the nav link, not this page).
  * Written to be accurate enough to share with the phish.net ratings author whose
  * series it builds on. No loader; the only dynamic bit is the "profile settings"
@@ -49,7 +49,7 @@ export default function ShowRatingAlgorithm() {
   return (
     <div className="space-y-6 md:space-y-8">
       <div>
-        <h1 className="page-heading">HOW SHOW RATINGS WORK</h1>
+        <h1 className="page-heading">HOW RATINGS WORK</h1>
       </div>
 
       <div className="grid gap-6 md:gap-8">
@@ -57,15 +57,17 @@ export default function ShowRatingAlgorithm() {
           <CardContent className="p-6">
             <div className="prose prose-invert max-w-none space-y-4">
               <p className="text-content-text-secondary">
-                Every show has a <strong className="text-content-text-primary">community average</strong>, the plain
-                mean of fans' star ratings. It is simple and transparent, but a raw average is easy to skew: a handful
-                of people who rate everything 5 (or everything 0.5), or one person voting from several accounts, can
-                move a show more than they should.
+                Every show and every track has a{" "}
+                <strong className="text-content-text-primary">community average</strong>, the plain mean of fans' star
+                ratings. It is simple and transparent, but a raw average is easy to skew: a handful of people who rate
+                everything 5 (or everything 0.5), or one person voting from several accounts, can move the number more
+                than they should.
               </p>
               <p className="text-content-text-secondary">
-                The <strong className="text-content-text-primary">Calibrated Show Rating</strong> is an opt-in
-                alternative that tries to measure the same thing, how good the show was, while being much harder to
-                skew. Everyone sees the community average by default; you can switch on the Calibrated Show Rating in{" "}
+                The <strong className="text-content-text-primary">Calibrated Show Rating</strong> and the{" "}
+                <strong className="text-content-text-primary">Calibrated Track Rating</strong> are opt-in alternatives
+                that aim at the same thing, how good a show or track was, while being much harder to skew. Everyone sees
+                the community average by default; you can switch either on in{" "}
                 {settingsHref ? (
                   <Link to={settingsHref} className="text-brand-primary hover:underline">
                     your profile settings
@@ -73,7 +75,9 @@ export default function ShowRatingAlgorithm() {
                 ) : (
                   "your profile settings"
                 )}
-                .
+                . They share a core idea, giving more weight to raters who use the whole scale, but differ where shows
+                and tracks differ. This page explains what each does, then goes deeper on the show rating's design and
+                how we tested it.
               </p>
               <p className="text-content-text-secondary">
                 This work is directly inspired by Paul Jakus's four-part series on rating shows for phish.net:{" "}
@@ -90,7 +94,9 @@ export default function ShowRatingAlgorithm() {
 
         <Card variant="panel">
           <CardContent className="p-6">
-            <h2 className="text-2xl font-semibold text-content-text-primary mb-4">What the calibration does</h2>
+            <h2 className="text-2xl font-semibold text-content-text-primary mb-4">
+              What the Calibrated Show Rating does
+            </h2>
             <div className="space-y-5">
               <div>
                 <h3 className="text-lg font-medium text-content-text-primary mb-1">Weights raters by how they rate</h3>
@@ -142,6 +148,25 @@ export default function ShowRatingAlgorithm() {
                 </p>
               </div>
             </div>
+          </CardContent>
+        </Card>
+
+        <Card variant="panel">
+          <CardContent className="p-6">
+            <h2 className="text-2xl font-semibold text-content-text-primary mb-4">The Calibrated Track Rating</h2>
+            <p className="text-content-text-secondary text-sm mb-3">
+              Tracks have far fewer ratings than shows, from fewer raters, and those ratings skew high: most sit near 5
+              stars. The Calibrated Track Rating is a separate opt-in that gives more weight to raters who use the whole
+              0.5 to 5 star scale, which spreads the numbers out.
+            </p>
+            <p className="text-content-text-secondary text-sm">
+              It works by adjusting how much{" "}
+              <span className="text-content-text-primary">weight each rater&apos;s votes are given</span>, rather than
+              by removing raters. Someone who uses the full range is given more weight than someone who gives nearly
+              everything 5. Unlike the show rating, it also skips two steps that helped shows but not tracks in our
+              testing: it doesn&apos;t shift a rater&apos;s scores toward the crowd average, and it doesn&apos;t pull
+              thin tracks toward a global anchor.
+            </p>
           </CardContent>
         </Card>
 

--- a/apps/web/app/routes/songs/$slug.test.tsx
+++ b/apps/web/app/routes/songs/$slug.test.tsx
@@ -79,6 +79,15 @@ vi.mock("~/components/performance/performance-filter-controls", () => ({
 vi.mock("~/components/rating", () => ({
   RatingComponent: () => <div data-testid="RatingComponent" />,
 }));
+vi.mock("~/hooks/use-track-user-ratings", () => ({
+  useTrackUserRatings: () => ({
+    userRatingMap: new Map(),
+    averageRatingMap: new Map(),
+    displayRatingMap: new Map(),
+    comparisonMap: new Map(),
+    isLoading: false,
+  }),
+}));
 vi.mock("~/components/admin/admin-only", () => ({
   AdminOnly: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));

--- a/apps/web/app/routes/songs/$slug.tsx
+++ b/apps/web/app/routes/songs/$slug.tsx
@@ -20,6 +20,7 @@ import { StatBox } from "~/components/ui/stat-box";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { searchPerformance, usePerformancePageFilters } from "~/hooks/use-performance-page-filters";
 import { useSerializedLoaderData } from "~/hooks/use-serialized-loader-data";
+import { useTrackUserRatings } from "~/hooks/use-track-user-ratings";
 import { publicLoader } from "~/lib/base-loaders";
 import { formatVenueLocation } from "~/lib/format-venue";
 import { pickGapTier } from "~/lib/gap-tier";
@@ -209,6 +210,12 @@ export default function SongPage() {
 
   const hasAllTimers = useMemo(() => allPerformances.some((p) => p.allTimer), [allPerformances]);
   const filteredAllTimers = useMemo(() => filteredPerformances.filter((p) => p.allTimer), [filteredPerformances]);
+  // The featured all-timer cards (below) show a rating outside the performance
+  // table, so they need the same calibrated-or-plain headline the tables get.
+  // Keyed on the full performance set (matching the loader's prefetch) so it
+  // reuses the dehydrated cache instead of firing a separate request.
+  const allPerformanceTrackIds = useMemo(() => allPerformances.map((p) => p.trackId), [allPerformances]);
+  const { displayRatingMap: allTimerCardRatingMap } = useTrackUserRatings(allPerformanceTrackIds);
   // Jam Charts: all-timer OR any track with a curated note (non-empty).
   // Superset of all-timers; the tab only appears when the song has at
   // least one such performance.
@@ -432,7 +439,10 @@ export default function SongPage() {
                       >
                         <div className="flex items-start justify-between gap-3 mb-2">
                           <div className="text-lg font-medium text-content-text-primary">{p.show.date}</div>
-                          <RatingComponent rating={p.rating || null} ratingsCount={p.ratingsCount} />
+                          <RatingComponent
+                            rating={allTimerCardRatingMap.get(p.trackId)?.average ?? p.rating ?? null}
+                            ratingsCount={allTimerCardRatingMap.get(p.trackId)?.count ?? p.ratingsCount}
+                          />
                         </div>
                         <div className="space-y-2">
                           <div className="text-brand-secondary/90 font-medium text-base">{p.venue?.name}</div>

--- a/apps/web/app/routes/users/$username.tsx
+++ b/apps/web/app/routes/users/$username.tsx
@@ -513,6 +513,8 @@ export default function UserProfile() {
             <RatingDisplaySettings
               showCalibratedRatings={user.showCalibratedRatings}
               showRatingComparisonDebug={user.showRatingComparisonDebug}
+              trackCalibratedRatings={user.trackCalibratedRatings}
+              trackRatingComparisonDebug={user.trackRatingComparisonDebug}
               colorCodeRatings={user.colorCodeRatings}
             />
             <SetlistDisplaySettings showSetlistTimes={user.showSetlistTimes} />

--- a/apps/web/app/server/track-user-ratings.test.ts
+++ b/apps/web/app/server/track-user-ratings.test.ts
@@ -32,7 +32,7 @@ describe("computeTrackUserRatings", () => {
   // no performance/setlist rows (e.g. a venue with no tracked shows yet).
   test("returns empty response and makes no service calls when trackIds is empty", async () => {
     const result = await computeTrackUserRatings({ currentUser: undefined }, []);
-    expect(result).toEqual({ userRatings: {}, averageRatings: {} });
+    expect(result).toEqual({ userRatings: {}, averageRatings: {}, calibratedRatings: {}, comparisons: {} });
     expect(findManyByUserIdAndRateableIds).not.toHaveBeenCalled();
     expect(getAveragesForRateables).not.toHaveBeenCalled();
     expect(findByEmail).not.toHaveBeenCalled();

--- a/apps/web/app/server/track-user-ratings.ts
+++ b/apps/web/app/server/track-user-ratings.ts
@@ -1,6 +1,15 @@
 import type { PublicContext } from "~/lib/base-loaders";
 import { logger } from "~/lib/logger";
 import { services } from "~/server/services";
+import { resolveViewerRatingMode } from "~/server/viewer-rating";
+
+/** Plain vs Calibrated Track Rating side by side, for the author compare/debug overlay. */
+export interface TrackRatingComparison {
+  plain: number;
+  calibrated: number;
+  count: number;
+  delta: number;
+}
 
 export interface TrackUserRatingsResponse {
   /** The current user's own rating per track (absent when unrated/unauthenticated). */
@@ -12,6 +21,17 @@ export interface TrackUserRatingsResponse {
    * never staleness-busts the (long-lived) setlist blob.
    */
   averageRatings: Record<string, { average: number; count: number }>;
+  /**
+   * The Calibrated Track Rating + contributing count per track, populated only when
+   * the viewer opted into calibrated track ratings; absent means the plain community
+   * average is shown. The count is post-fluffer-exclusion.
+   */
+  calibratedRatings: Record<string, { rating: number; count: number }>;
+  /**
+   * Plain vs calibrated comparison per track, populated only for the author compare
+   * overlay (compare flag + pref); absent means no overlay.
+   */
+  comparisons: Record<string, TrackRatingComparison>;
 }
 
 /**
@@ -26,16 +46,40 @@ export async function computeTrackUserRatings(
   context: Pick<PublicContext, "currentUser">,
   trackIds: string[],
 ): Promise<TrackUserRatingsResponse> {
-  const response: TrackUserRatingsResponse = { userRatings: {}, averageRatings: {} };
+  const response: TrackUserRatingsResponse = {
+    userRatings: {},
+    averageRatings: {},
+    calibratedRatings: {},
+    comparisons: {},
+  };
 
   if (trackIds.length === 0) return response;
 
   try {
     response.averageRatings = await services.ratings.getAveragesForRateables(trackIds, "Track");
 
-    if (!context.currentUser) return response;
+    const { user, flags, trackMode } = await resolveViewerRatingMode(context);
+    const compareOn = flags.compareVisible && user?.trackRatingComparisonDebug === true;
 
-    const user = await services.users.findByEmail(context.currentUser.email);
+    if (trackMode === "calibrated" || compareOn) {
+      response.calibratedRatings = await services.raterWeights.getCalibratedForTracks(trackIds);
+    }
+    if (compareOn) {
+      for (const [trackId, calibrated] of Object.entries(response.calibratedRatings)) {
+        const plain = response.averageRatings[trackId]?.average;
+        if (plain == null) continue;
+        response.comparisons[trackId] = {
+          plain,
+          calibrated: calibrated.rating,
+          count: calibrated.count,
+          delta: calibrated.rating - plain,
+        };
+      }
+      // The compare overlay shows plain vs calibrated; the viewer isn't opted into the
+      // calibrated headline unless their own mode says so, so don't leak it as the display.
+      if (trackMode !== "calibrated") response.calibratedRatings = {};
+    }
+
     if (!user) return response;
 
     const ratings = await services.ratings.findManyByUserIdAndRateableIds(user.id, trackIds, "Track");

--- a/apps/web/app/server/viewer-rating.ts
+++ b/apps/web/app/server/viewer-rating.ts
@@ -9,14 +9,17 @@ type Viewer = Awaited<ReturnType<typeof services.users.findByEmail>>;
  * (needed for the saved calibrated pref and to target segment-gated flags by
  * username), read the feature flags for them, then decide simple vs calibrated.
  * Returns the user and flags too, since callers also need them (attendance/
- * ratings, the compare-overlay gate). Shared by show-user-data and Top Rated so
- * the segment-context and pref wiring can't drift between them.
+ * ratings, the compare-overlay gate). `mode` is the show mode; `trackMode` is the
+ * independent per-track opt-in (a separate pref, same flags). Shared by
+ * show-user-data, track-user-ratings and Top Rated so the segment-context and
+ * pref wiring can't drift between them.
  */
 export async function resolveViewerRatingMode(
   context: Pick<PublicContext, "currentUser">,
-): Promise<{ user: Viewer; flags: FeatureFlags; mode: RatingMode }> {
+): Promise<{ user: Viewer; flags: FeatureFlags; mode: RatingMode; trackMode: RatingMode }> {
   const user = context.currentUser ? await services.users.findByEmail(context.currentUser.email) : null;
   const flags = await getFeatureFlags(user ? { user: { id: user.id, username: user.username } } : undefined);
   const mode = resolveRatingMode(user?.showCalibratedRatings, flags);
-  return { user, flags, mode };
+  const trackMode = resolveRatingMode(user?.trackCalibratedRatings, flags);
+  return { user, flags, mode, trackMode };
 }

--- a/packages/core/scripts/track-rating-calibration-spike.test.ts
+++ b/packages/core/scripts/track-rating-calibration-spike.test.ts
@@ -1,0 +1,212 @@
+import { DRUMMER_ERAS } from "@bip/domain";
+import { describe, expect, test } from "vitest";
+import {
+  ceilingShare,
+  computeCalibratedTrackScores,
+  computeDiscriminatingScores,
+  computeVariantScores,
+  plainTrackAverages,
+  type SpikeRating,
+  skewness,
+  standardDeviation,
+} from "./track-rating-calibration-spike";
+
+/**
+ * Wiring tests for the spike's calibrated-track scoring: that it reuses production's
+ * dedup-free pure rule correctly (bad-faith exclusion drops a bucket, thin tracks
+ * shrink toward the anchor). The scoring math itself is covered in
+ * rater-weighting.test.ts; these prove the track wrapper threads it right.
+ */
+
+const ERA = DRUMMER_ERAS[0];
+
+/** One rater's votes over a spread of tracks, all in the same era. */
+function votes(userId: string, entries: Array<[track: string, value: number]>): SpikeRating[] {
+  return entries.map(([trackId, value]) => ({ userId, trackId, value, era: ERA }));
+}
+
+describe("computeCalibratedTrackScores", () => {
+  test("drops a one-note ceiling-fluffer bucket from a track's contributing count", () => {
+    // A fluffer: 6 straight 5.0s → entropy 0, mean 5 (>= 4.75), count >= 5 → excluded.
+    const fluffer = votes("fluffer", [
+      ["helicopters", 5],
+      ["basisforaday", 5],
+      ["confrontation", 5],
+      ["spaga", 5],
+      ["mrdon", 5],
+      ["shemrahboo", 5],
+    ]);
+    // A genuine wide-range rater who also rated "helicopters".
+    const honest = votes("honest", [
+      ["helicopters", 4],
+      ["basisforaday", 2],
+      ["confrontation", 5],
+      ["spaga", 1],
+      ["mrdon", 3],
+    ]);
+
+    const { scores } = computeCalibratedTrackScores([...fluffer, ...honest]);
+    // Both rated "helicopters", but the fluffer is excluded, so only 1 vote counts.
+    expect(scores.get("helicopters")?.count).toBe(1);
+  });
+
+  test("keeps both raters when neither trips the bad-faith gate", () => {
+    const wide = votes("wide", [
+      ["helicopters", 4],
+      ["basisforaday", 2],
+      ["confrontation", 5],
+      ["spaga", 1],
+      ["mrdon", 3],
+    ]);
+    const alsoWide = votes("alsowide", [
+      ["helicopters", 3],
+      ["basisforaday", 5],
+      ["confrontation", 2],
+      ["spaga", 4],
+      ["mrdon", 1],
+    ]);
+
+    const { scores } = computeCalibratedTrackScores([...wide, ...alsoWide]);
+    expect(scores.get("helicopters")?.count).toBe(2);
+  });
+
+  test("shrinks a thin track's extreme vote toward the anchor", () => {
+    // A broad field of mid-range tracks establishes an anchor well below 5, then one
+    // thin track gets a single 5.0. Its displayed score must land strictly between the
+    // anchor and 5 — the raw vote is pulled in because n=1 is unreliable.
+    const rater = votes("solo", [
+      ["helicopters", 3],
+      ["basisforaday", 3],
+      ["confrontation", 2.5],
+      ["spaga", 3.5],
+      ["mrdon", 3],
+      ["shemrahboo", 5],
+    ]);
+
+    const { scores, anchor } = computeCalibratedTrackScores(rater);
+    const thin = scores.get("shemrahboo");
+    expect(thin).toBeDefined();
+    expect(thin?.count).toBe(1);
+    expect(thin?.displayed).toBeGreaterThan(anchor);
+    expect(thin?.displayed).toBeLessThan(thin?.weighted ?? 5);
+  });
+});
+
+describe("computeDiscriminatingScores", () => {
+  test("follows the wide-range rater and drops the excluded fluffer, keeping the raw low score", () => {
+    // Fluffer: 6 straight 5.0s → entropy 0, mean 5 → excluded (weight 0).
+    const fluffer = votes("fluffer", [
+      ["helicopters", 5],
+      ["basisforaday", 5],
+      ["confrontation", 5],
+      ["spaga", 5],
+      ["mrdon", 5],
+      ["shemrahboo", 5],
+    ]);
+    // A wide-range rater who rated "helicopters" a genuine 0.5.
+    const wide = votes("wide", [
+      ["helicopters", 0.5],
+      ["basisforaday", 2],
+      ["confrontation", 5],
+      ["spaga", 1],
+      ["mrdon", 3.5],
+    ]);
+
+    const scores = computeDiscriminatingScores([...fluffer, ...wide], 3);
+    // Only the wide rater counts, and un-centered — so the low 0.5 survives intact.
+    expect(scores.get("helicopters")?.score).toBeCloseTo(0.5, 5);
+    expect(scores.get("helicopters")?.count).toBe(1);
+  });
+
+  test("a higher gamma pulls the score further toward the wider-range rater", () => {
+    // Two raters on one track: a narrow-range rater (low entropy) votes high, a
+    // wide-range rater votes low. Raising gamma should weight the wide rater more,
+    // pulling the blended score down.
+    const narrow = votes("narrow", [
+      ["helicopters", 5],
+      ["basisforaday", 4.5],
+      ["confrontation", 5],
+      ["spaga", 4.5],
+      ["mrdon", 5],
+    ]);
+    const wide = votes("wide", [
+      ["helicopters", 2],
+      ["basisforaday", 0.5],
+      ["confrontation", 5],
+      ["spaga", 1],
+      ["mrdon", 3.5],
+    ]);
+    const all = [...narrow, ...wide];
+    const low = computeDiscriminatingScores(all, 1).get("helicopters")?.score ?? 0;
+    const high = computeDiscriminatingScores(all, 4).get("helicopters")?.score ?? 0;
+    expect(high).toBeLessThan(low);
+  });
+});
+
+describe("computeVariantScores centering modes", () => {
+  // A harsh wide-range rater (personal mean well below the population) — only they rate "helicopters".
+  const harsh = votes("harsh", [
+    ["helicopters", 1],
+    ["basisforaday", 0.5],
+    ["confrontation", 2],
+    ["spaga", 1.5],
+    ["mrdon", 1],
+  ]);
+  // A generous wide-ish rater on other tracks, to pull the population mean above harsh's mean.
+  const generous = votes("generous", [
+    ["tela", 5],
+    ["crickets", 4.5],
+    ["kitchen", 5],
+    ["hotdog", 4],
+    ["shimmy", 5],
+  ]);
+
+  test("mean-centering lifts a harsh rater's low vote toward the population mean", () => {
+    const both = [...harsh, ...generous];
+    const none = computeVariantScores(both, { centering: "none", gamma: 1, shrinkK: 0 }).get("helicopters")?.score ?? 0;
+    const mean = computeVariantScores(both, { centering: "mean", gamma: 1, shrinkK: 0 }).get("helicopters")?.score ?? 0;
+    // Un-centered keeps the raw 1.0; mean-centering shifts it up (harsh's mean < population mean).
+    expect(none).toBeCloseTo(1, 5);
+    expect(mean).toBeGreaterThan(none);
+  });
+
+  test("shrinkK pulls a thin track toward the anchor; k0 leaves the raw score", () => {
+    const k0 = computeVariantScores(harsh, { centering: "none", gamma: 1, shrinkK: 0 }).get("helicopters");
+    const k3 = computeVariantScores(harsh, { centering: "none", gamma: 1, shrinkK: 3 }).get("helicopters");
+    expect(k0?.displayed).toBeCloseTo(k0?.score ?? 0, 5);
+    // With one vote, k=3 shrinks hard toward the anchor, away from the raw 1.0.
+    expect(k3?.displayed ?? 0).toBeGreaterThan(k0?.displayed ?? 0);
+  });
+});
+
+describe("distribution-shape stats", () => {
+  test("skewness is negative for a high-piled (fluffed) distribution", () => {
+    // Mass crushed near the 5.0 ceiling with a thin low tail → left-skewed → negative.
+    const fluffed = [5, 5, 5, 5, 5, 4.5, 4.5, 4, 1];
+    expect(skewness(fluffed)).toBeLessThan(0);
+  });
+
+  test("skewness is ~0 for a symmetric distribution", () => {
+    const symmetric = [1, 2, 3, 3, 3, 4, 5];
+    expect(Math.abs(skewness(symmetric))).toBeLessThan(0.1);
+  });
+
+  test("standardDeviation grows as a distribution spreads off a single point", () => {
+    expect(standardDeviation([3, 3, 3, 3])).toBe(0);
+    expect(standardDeviation([1, 2, 4, 5])).toBeGreaterThan(1);
+  });
+
+  test("ceilingShare counts the fraction at/above the threshold", () => {
+    expect(ceilingShare([5, 5, 4.5, 3, 1], 4.5)).toBeCloseTo(0.6, 5);
+  });
+});
+
+describe("plainTrackAverages", () => {
+  test("averages a track's votes and counts them", () => {
+    const ratings: SpikeRating[] = [
+      { userId: "a", trackId: "helicopters", value: 4, era: ERA },
+      { userId: "b", trackId: "helicopters", value: 2, era: ERA },
+    ];
+    expect(plainTrackAverages(ratings).get("helicopters")).toEqual({ average: 3, count: 2 });
+  });
+});

--- a/packages/core/scripts/track-rating-calibration-spike.ts
+++ b/packages/core/scripts/track-rating-calibration-spike.ts
@@ -1,0 +1,952 @@
+import { type DrummerEra, drummerEraForDate, shrinkToward } from "@bip/domain";
+import prisma from "../src/_shared/prisma/client";
+import { aliasKey, mostRecentPerKey } from "../src/ratings/rater-aliases";
+import { computeShowWeighted, type RaterScopeStat, type StatByUserEra } from "../src/ratings/rater-weight-service";
+import {
+  computeCleanedScopeStats,
+  ENTROPY_FULL_WEIGHT,
+  entropyWeight,
+  isExcludedBucket,
+  meanOf,
+  ratingEntropy,
+  type ScopedRating,
+  SHRINK_K,
+} from "../src/ratings/rater-weighting";
+
+/**
+ * Throwaway validation spike: would a calibrated (entropy-weighted, mean-centered,
+ * bomber-excluded, count-shrunk) TRACK rating be a better signal than the plain
+ * deduped average? Shows already have this; tracks don't. Before committing to the
+ * real build (new denormalized columns + engine changes + UI), this computes
+ * calibrated track scores in-memory — reusing the exact production scoring rule
+ * ({@link computeShowWeighted}) and the exported pure math — and reports whether
+ * calibration beats the plain average.
+ *
+ * Metrics:
+ *  1. Split-half reliability (headline, spans the WHOLE range): randomly split raters
+ *     into two disjoint halves, score each half independently, correlate across tracks.
+ *     The score that reproduces itself better from independent rater samples is the
+ *     more reliable signal — no ground-truth label needed. Reported for the raw
+ *     weighted score, the displayed (count-shrunk) score, and the plain average, over
+ *     the SAME track set each repeat so the comparison is fair.
+ *  2. Distribution shape (the de-fluffing test): spread/skew/ceiling-pile + histograms of
+ *     the plain vs calibrated score distributions — does calibration break the pile at 5.
+ *  3. All-timer / jam-chart discrimination (top-end): Spearman of each score against the
+ *     curated all-timer flag and jam-chart note. Mirrors `rating-validity-eval.ts`.
+ *  4. Rater similarity: who rates like the reference rater (entropy/mean/correlation) and
+ *     who the fluffers are.
+ *  5. The 0.5 spot-check: where a heavy rater's "nothing interesting" 0.5 votes land.
+ *  6. Variant sweep ({@link computeVariantScores}): the centering × gamma × shrink family,
+ *     each config judged on distribution shape vs split-half reliability.
+ *  7. All-fives show demo: real shows where a rater 5-starred every track, showing each
+ *     track's community average before (plain) vs after (discriminating / mean+shrink).
+ *
+ * Nothing is persisted and no schema changes: this only reads. Run:
+ *   `make track-rating-calibration-spike`
+ *   (env knobs: REPEATS, MIN_PER_HALF, MIN_RATINGS, MIN_DIST_RATINGS, MIN_SHARED, GAMMA, USER_EMAIL)
+ */
+
+export interface SpikeRating {
+  /** Canonical user id (duplicate accounts already collapsed). */
+  userId: string;
+  trackId: string;
+  value: number;
+  /** The drummer era of the track's show — the rater-stats scope axis. */
+  era: DrummerEra;
+}
+
+export interface TrackScore {
+  /** Raw (un-shrunk) entropy-weighted centered score. */
+  weighted: number;
+  /** Contributing raters after dedup + bad-faith exclusion. */
+  count: number;
+  /** `weighted` count-shrunk toward the track anchor — what a UI would show. */
+  displayed: number;
+}
+
+// ---------------------------------------------------------------------------
+// Stats helpers (tie-aware Spearman). Kept local: `rating-validity-eval.ts`
+// runs `main()` on import, so its copies can't be imported without side effects.
+// ---------------------------------------------------------------------------
+
+/** Average (tie-aware, 1-based) ranks of the values, for Spearman. */
+function ranks(values: number[]): number[] {
+  const order = values.map((value, index) => ({ value, index })).sort((a, b) => a.value - b.value);
+  const out = new Array<number>(values.length);
+  let i = 0;
+  while (i < order.length) {
+    let j = i;
+    while (j + 1 < order.length && order[j + 1].value === order[i].value) j += 1;
+    const tiedRank = (i + j) / 2 + 1;
+    for (let k = i; k <= j; k += 1) out[order[k].index] = tiedRank;
+    i = j + 1;
+  }
+  return out;
+}
+
+function pearson(xs: number[], ys: number[]): number {
+  const n = xs.length;
+  if (n === 0) return 0;
+  const meanX = xs.reduce((a, b) => a + b, 0) / n;
+  const meanY = ys.reduce((a, b) => a + b, 0) / n;
+  let cov = 0;
+  let varX = 0;
+  let varY = 0;
+  for (let i = 0; i < n; i += 1) {
+    const dx = xs[i] - meanX;
+    const dy = ys[i] - meanY;
+    cov += dx * dy;
+    varX += dx * dx;
+    varY += dy * dy;
+  }
+  return varX === 0 || varY === 0 ? 0 : cov / Math.sqrt(varX * varY);
+}
+
+const spearman = (xs: number[], ys: number[]): number => pearson(ranks(xs), ranks(ys));
+
+/** Population standard deviation (spread). */
+export function standardDeviation(values: number[]): number {
+  if (values.length === 0) return 0;
+  const mean = meanOf(values);
+  return Math.sqrt(values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / values.length);
+}
+
+/**
+ * Population skewness. Negative = a left tail with mass piled at the high end (the
+ * fluffed-to-5 shape); ~0 = symmetric; positive = piled low. Zero when there's no spread.
+ */
+export function skewness(values: number[]): number {
+  if (values.length === 0) return 0;
+  const mean = meanOf(values);
+  const sd = standardDeviation(values);
+  if (sd === 0) return 0;
+  return values.reduce((sum, value) => sum + ((value - mean) / sd) ** 3, 0) / values.length;
+}
+
+/** Share of values at/above `threshold` — the ceiling pile-up (fraction crushed near 5). */
+export function ceilingShare(values: number[], threshold: number): number {
+  if (values.length === 0) return 0;
+  return values.filter((value) => value >= threshold).length / values.length;
+}
+
+/**
+ * A fixed-bin text histogram of star scores (0.5-wide bins over [0.5, 5]), scaled so the
+ * tallest bin is `width` characters. Lets the plain and calibrated shapes be eyeballed
+ * side by side — is the mass a spike at the ceiling or a spread-out curve.
+ */
+export function textHistogram(values: number[], width = 40): string[] {
+  const bins = new Array(10).fill(0); // [0.5,1.0) … [5.0,5.0]
+  for (const value of values) {
+    const index = Math.min(9, Math.max(0, Math.floor((value - 0.5) / 0.5)));
+    bins[index] += 1;
+  }
+  const max = Math.max(1, ...bins);
+  return bins.map((count, index) => {
+    const low = (0.5 + index * 0.5).toFixed(1);
+    const bar = "█".repeat(Math.round((count / max) * width));
+    return `    ${low.padStart(4)}  ${bar} ${count}`;
+  });
+}
+
+/** Deterministic PRNG so split-half assignments are reproducible across runs. */
+function mulberry32(seed: number): () => number {
+  let a = seed;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure scoring (exported for the unit test — no DB access).
+// ---------------------------------------------------------------------------
+
+/**
+ * The calibrated score for every track in a set of ratings, reusing the exact
+ * production rule. Rater scope-stats are computed fresh from the given ratings (so a
+ * split-half subset gets stats from ONLY its half — no cross-half leakage), the
+ * population/anchor are derived empirically for tracks (the show constants are
+ * show-tuned and deliberately not reused for the baseline), and each track is scored
+ * by {@link computeShowWeighted}.
+ */
+export function computeCalibratedTrackScores(ratings: ReadonlyArray<SpikeRating>): {
+  scores: Map<string, TrackScore>;
+  populationMean: number;
+  anchor: number;
+} {
+  const populationMean = meanOf(ratings.map((rating) => rating.value));
+  const population = { mean: populationMean };
+
+  // Per-user cleaned scope stats (mean/entropy/count/isExcluded per era + GLOBAL).
+  const byUser = new Map<string, SpikeRating[]>();
+  for (const rating of ratings) {
+    const bucket = byUser.get(rating.userId) ?? [];
+    bucket.push(rating);
+    byUser.set(rating.userId, bucket);
+  }
+  const statLookup = new Map<string, RaterScopeStat>();
+  for (const [userId, userRatings] of byUser) {
+    const scoped = userRatings.map((rating): ScopedRating => ({ value: rating.value, era: rating.era, kind: "TRACK" }));
+    for (const [era, stats] of computeCleanedScopeStats(scoped)) {
+      statLookup.set(`${userId}:${era}`, {
+        mean: stats.mean,
+        entropy: stats.entropy,
+        count: stats.ratingsCount,
+        isExcluded: stats.isExcluded,
+      });
+    }
+  }
+  const statByUserEra: StatByUserEra = (userId, era) => statLookup.get(`${userId}:${era}`);
+
+  // Group ratings by track — the era is the track's show era, shared by all its votes.
+  const byTrack = new Map<string, { era: DrummerEra; votes: Array<{ userId: string; value: number }> }>();
+  for (const rating of ratings) {
+    const entry = byTrack.get(rating.trackId) ?? { era: rating.era, votes: [] };
+    entry.votes.push({ userId: rating.userId, value: rating.value });
+    byTrack.set(rating.trackId, entry);
+  }
+
+  const raw = new Map<string, { weighted: number; count: number }>();
+  for (const [trackId, { era, votes }] of byTrack) {
+    const { weightedRating, weightedRatingsCount } = computeShowWeighted(votes, era, statByUserEra, population);
+    if (weightedRating != null) raw.set(trackId, { weighted: weightedRating, count: weightedRatingsCount });
+  }
+
+  const anchor = meanOf([...raw.values()].map((score) => score.weighted)) || populationMean;
+  const scores = new Map<string, TrackScore>();
+  for (const [trackId, { weighted, count }] of raw) {
+    scores.set(trackId, { weighted, count, displayed: shrinkToward(weighted, anchor, count, SHRINK_K) });
+  }
+  return { scores, populationMean, anchor };
+}
+
+/** The plain deduped per-track average + count (today's track number). */
+export function plainTrackAverages(
+  ratings: ReadonlyArray<SpikeRating>,
+): Map<string, { average: number; count: number }> {
+  const byTrack = new Map<string, number[]>();
+  for (const rating of ratings) {
+    const bucket = byTrack.get(rating.trackId) ?? [];
+    bucket.push(rating.value);
+    byTrack.set(rating.trackId, bucket);
+  }
+  const out = new Map<string, { average: number; count: number }>();
+  for (const [trackId, values] of byTrack) out.set(trackId, { average: meanOf(values), count: values.length });
+  return out;
+}
+
+/**
+ * The "raters like me" variant: an entropy-POWER-weighted average of the RAW (un-centered)
+ * scores, no count-shrinkage, with pure fluffers dropped. Unlike the show scheme, it does
+ * not mean-center (so a discriminating rater's actual low scores survive instead of being
+ * shifted up toward the population) and it raises the entropy weight to `gamma` so
+ * high-entropy raters dominate rather than being merely un-penalized. `gamma = 1` is the
+ * soft show-style weight; higher `gamma` sharpens the preference for wide-range raters.
+ */
+
+/** How a rater's votes are re-based before averaging. */
+export type Centering =
+  | "none" // raw star value — a discriminating rater's real low scores survive.
+  | "mean" // value − raterMean + popMean — removes harsh/generous bias, keeps spread (the show move).
+  | "zscore"; // (value − raterMean)/raterSD → popMean/popSD — also rescales spread (tried + rejected for shows).
+
+export interface VariantOptions {
+  centering: Centering;
+  /** Entropy-weight exponent: higher favors wide-range raters harder (0 = uniform weight). */
+  gamma: number;
+  /** Count-shrinkage strength toward the anchor (0 = none, 3 = show default). */
+  shrinkK: number;
+}
+
+/** The score for one track under a variant: raw and (count-shrunk) displayed, plus contributing raters. */
+export interface VariantScore {
+  score: number;
+  displayed: number;
+  count: number;
+}
+
+/**
+ * The parametric "raters like me" family, spanning the axes we're comparing: how each
+ * rater is re-based (centering), how hard scale-users are favored (gamma), and how much
+ * thin tracks are pulled to the anchor (shrinkK). Fluffers (excluded buckets) get weight 0.
+ * The show scheme ≈ {mean, ~1, 3}; the pure discriminating variant = {none, 3, 0}.
+ */
+export function computeVariantScores(
+  ratings: ReadonlyArray<SpikeRating>,
+  options: VariantOptions,
+): Map<string, VariantScore> {
+  const { centering, gamma, shrinkK } = options;
+  const valuesByUser = new Map<string, number[]>();
+  for (const rating of ratings) {
+    const bucket = valuesByUser.get(rating.userId) ?? [];
+    bucket.push(rating.value);
+    valuesByUser.set(rating.userId, bucket);
+  }
+  const allValues = ratings.map((rating) => rating.value);
+  const popMean = meanOf(allValues);
+  const popSd = standardDeviation(allValues) || 1;
+
+  const profile = new Map<string, { weight: number; mean: number; sd: number }>();
+  for (const [userId, values] of valuesByUser) {
+    const entropy = ratingEntropy(values);
+    const excluded = isExcludedBucket({ mean: meanOf(values), entropy, ratingsCount: values.length });
+    profile.set(userId, {
+      weight: excluded ? 0 : entropyWeight(entropy, ENTROPY_FULL_WEIGHT) ** gamma,
+      mean: meanOf(values),
+      // Stabilize a thin rater's SD toward the population so a 2-vote rater can't post a huge z-score.
+      sd: shrinkToward(standardDeviation(values), popSd, values.length, 5),
+    });
+  }
+
+  const rebase = (value: number, p: { mean: number; sd: number }): number | null => {
+    if (centering === "mean") return value - p.mean + popMean;
+    if (centering === "zscore") return p.sd <= 0 ? null : ((value - p.mean) / p.sd) * popSd + popMean;
+    return value;
+  };
+
+  const byTrack = new Map<string, { sum: number; weight: number; count: number }>();
+  for (const rating of ratings) {
+    const p = profile.get(rating.userId);
+    if (!p || p.weight <= 0) continue;
+    const rebased = rebase(rating.value, p);
+    if (rebased == null) continue;
+    const entry = byTrack.get(rating.trackId) ?? { sum: 0, weight: 0, count: 0 };
+    entry.sum += rebased * p.weight;
+    entry.weight += p.weight;
+    entry.count += 1;
+    byTrack.set(rating.trackId, entry);
+  }
+
+  const raw = new Map<string, { score: number; count: number }>();
+  for (const [trackId, entry] of byTrack) {
+    if (entry.weight > 0) raw.set(trackId, { score: entry.sum / entry.weight, count: entry.count });
+  }
+  const anchor = meanOf([...raw.values()].map((entry) => entry.score)) || popMean;
+  const out = new Map<string, VariantScore>();
+  for (const [trackId, { score, count }] of raw) {
+    out.set(trackId, { score, displayed: shrinkToward(score, anchor, count, shrinkK), count });
+  }
+  return out;
+}
+
+/** The un-centered, un-shrunk discriminating score — {@link computeVariantScores} with `none`/k0. */
+export function computeDiscriminatingScores(
+  ratings: ReadonlyArray<SpikeRating>,
+  gamma: number,
+): Map<string, { score: number; count: number }> {
+  const scores = computeVariantScores(ratings, { centering: "none", gamma, shrinkK: 0 });
+  return new Map([...scores].map(([id, value]) => [id, { score: value.score, count: value.count }]));
+}
+
+/** Per-track rating count in a rating set (for split-half membership gating). */
+function countByTrack(ratings: ReadonlyArray<SpikeRating>): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const rating of ratings) counts.set(rating.trackId, (counts.get(rating.trackId) ?? 0) + 1);
+  return counts;
+}
+
+/**
+ * Generic split-half reliability for any per-track scoring function: over `repeats`
+ * random rater partitions, correlate the two halves' scores across tracks rated
+ * >= `minPerHalf` times in both halves AND scored in both. Used to compare arbitrary
+ * variants (plain, discriminating) on the same footing as the headline metric.
+ */
+export function splitHalfCorrelation(
+  ratings: ReadonlyArray<SpikeRating>,
+  repeats: number,
+  minPerHalf: number,
+  scoreFn: (subset: ReadonlyArray<SpikeRating>) => Map<string, number>,
+): { validRepeats: number; correlation: number } {
+  const users = [...new Set(ratings.map((rating) => rating.userId))];
+  let sum = 0;
+  let valid = 0;
+  for (let repeat = 0; repeat < repeats; repeat += 1) {
+    const random = mulberry32(repeat + 1);
+    const half = new Map<string, 0 | 1>();
+    for (const user of users) half.set(user, random() < 0.5 ? 0 : 1);
+    const a = ratings.filter((rating) => half.get(rating.userId) === 0);
+    const b = ratings.filter((rating) => half.get(rating.userId) === 1);
+    const countA = countByTrack(a);
+    const countB = countByTrack(b);
+    const scoreA = scoreFn(a);
+    const scoreB = scoreFn(b);
+    const tracks = [...countA.keys()].filter(
+      (id) =>
+        (countA.get(id) ?? 0) >= minPerHalf && (countB.get(id) ?? 0) >= minPerHalf && scoreA.has(id) && scoreB.has(id),
+    );
+    if (tracks.length < 3) continue;
+    sum += spearman(
+      tracks.map((id) => scoreA.get(id) ?? 0),
+      tracks.map((id) => scoreB.get(id) ?? 0),
+    );
+    valid += 1;
+  }
+  return { validRepeats: valid, correlation: valid ? sum / valid : 0 };
+}
+
+/**
+ * Split-half reliability: over `repeats` random rater partitions, correlate the two
+ * halves' scores across tracks rated >= `minPerHalf` times in BOTH halves. Higher =
+ * the score reproduces itself better from independent samples. Plain and calibrated
+ * are correlated over the identical track set each repeat so neither is advantaged.
+ */
+export function splitHalfReliability(ratings: ReadonlyArray<SpikeRating>, repeats: number, minPerHalf: number) {
+  const users = [...new Set(ratings.map((rating) => rating.userId))];
+  let displayedSum = 0;
+  let weightedSum = 0;
+  let plainSum = 0;
+  let trackSum = 0;
+  let validRepeats = 0;
+
+  for (let repeat = 0; repeat < repeats; repeat += 1) {
+    const random = mulberry32(repeat + 1);
+    const half = new Map<string, 0 | 1>();
+    for (const user of users) half.set(user, random() < 0.5 ? 0 : 1);
+    const a = ratings.filter((rating) => half.get(rating.userId) === 0);
+    const b = ratings.filter((rating) => half.get(rating.userId) === 1);
+
+    const aPlain = plainTrackAverages(a);
+    const bPlain = plainTrackAverages(b);
+    const aCalibrated = computeCalibratedTrackScores(a);
+    const bCalibrated = computeCalibratedTrackScores(b);
+
+    // Same membership for every metric: rated >= minPerHalf in both halves AND scored
+    // by calibration in both (a track can lose its calibrated score if all its raters
+    // in a half are excluded).
+    const tracks: string[] = [];
+    for (const [trackId, plainA] of aPlain) {
+      const plainB = bPlain.get(trackId);
+      if (!plainB || plainA.count < minPerHalf || plainB.count < minPerHalf) continue;
+      if (aCalibrated.scores.has(trackId) && bCalibrated.scores.has(trackId)) tracks.push(trackId);
+    }
+    if (tracks.length < 3) continue;
+
+    displayedSum += spearman(
+      tracks.map((id) => aCalibrated.scores.get(id)?.displayed ?? 0),
+      tracks.map((id) => bCalibrated.scores.get(id)?.displayed ?? 0),
+    );
+    weightedSum += spearman(
+      tracks.map((id) => aCalibrated.scores.get(id)?.weighted ?? 0),
+      tracks.map((id) => bCalibrated.scores.get(id)?.weighted ?? 0),
+    );
+    plainSum += spearman(
+      tracks.map((id) => aPlain.get(id)?.average ?? 0),
+      tracks.map((id) => bPlain.get(id)?.average ?? 0),
+    );
+    trackSum += tracks.length;
+    validRepeats += 1;
+  }
+
+  return {
+    validRepeats,
+    averageTracks: validRepeats ? trackSum / validRepeats : 0,
+    calibratedDisplayed: validRepeats ? displayedSum / validRepeats : 0,
+    calibratedWeighted: validRepeats ? weightedSum / validRepeats : 0,
+    plain: validRepeats ? plainSum / validRepeats : 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Data loading (mirrors RaterWeightService's private dedup + era tagging).
+// ---------------------------------------------------------------------------
+
+/**
+ * userId → canonical userId, collapsing duplicate accounts. A local mirror of
+ * `RaterWeightService.buildCanonicalUserMap` (private) reusing the shared
+ * {@link aliasKey} rule, so the spike dedupes exactly as production does.
+ */
+async function buildCanonicalUserMap(): Promise<Map<string, string>> {
+  const users = await prisma.user.findMany({
+    where: { username: { not: null } },
+    select: { id: true, username: true },
+  });
+  const counts = await prisma.rating.groupBy({ by: ["userId"], _count: { id: true } });
+  const ratingCount = new Map(counts.map((count) => [count.userId, count._count.id]));
+  const groups = new Map<string, Array<{ id: string; n: number }>>();
+  for (const user of users) {
+    if (!user.username) continue;
+    const key = aliasKey(user.username, user.id);
+    const group = groups.get(key) ?? [];
+    group.push({ id: user.id, n: ratingCount.get(user.id) ?? 0 });
+    groups.set(key, group);
+  }
+  const canonical = new Map<string, string>();
+  for (const group of groups.values()) {
+    const primary = group.reduce((best, member) => (member.n > best.n ? member : best)).id;
+    for (const member of group) canonical.set(member.id, primary);
+  }
+  return canonical;
+}
+
+/** All deduped TRACK ratings, era-tagged (tracks with an unknown show date are dropped). */
+async function loadTrackRatings(canonical: Map<string, string>): Promise<SpikeRating[]> {
+  const raw = await prisma.rating.findMany({
+    where: { rateableType: "Track" },
+    select: { userId: true, rateableId: true, value: true, createdAt: true },
+  });
+  if (raw.length === 0) return [];
+
+  // Remap to canonical user, then one most-recent vote per (person, track).
+  const deduped = mostRecentPerKey(
+    raw.map((rating) => ({ ...rating, userId: canonical.get(rating.userId) ?? rating.userId })),
+    (rating) => `${rating.userId}:${rating.rateableId}`,
+  );
+
+  const trackIds = [...new Set(deduped.map((rating) => rating.rateableId))];
+  const tracks = await prisma.track.findMany({
+    where: { id: { in: trackIds } },
+    select: { id: true, show: { select: { date: true } } },
+  });
+  const dateByTrack = new Map(tracks.map((track) => [track.id, track.show?.date ?? ""]));
+
+  const out: SpikeRating[] = [];
+  for (const rating of deduped) {
+    const date = dateByTrack.get(rating.rateableId);
+    if (!date) continue;
+    out.push({ userId: rating.userId, trackId: rating.rateableId, value: rating.value, era: drummerEraForDate(date) });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+async function discriminationReport(
+  ratings: SpikeRating[],
+  full: ReturnType<typeof computeCalibratedTrackScores>,
+  minRatings: number,
+): Promise<void> {
+  const plain = plainTrackAverages(ratings);
+  const qualified = [...plain.keys()].filter((id) => (plain.get(id)?.count ?? 0) >= minRatings);
+  const flagRows = await prisma.track.findMany({
+    where: { id: { in: qualified } },
+    select: { id: true, allTimer: true, note: true },
+  });
+  const flags = new Map(
+    flagRows.map((track) => [
+      track.id,
+      { allTimer: track.allTimer ? 1 : 0, jamChart: track.note && track.note.trim().length > 0 ? 1 : 0 },
+    ]),
+  );
+
+  const eligible = qualified.filter((id) => full.scores.has(id) && flags.has(id));
+  const calibrated = eligible.map((id) => full.scores.get(id)?.displayed ?? 0);
+  const simple = eligible.map((id) => plain.get(id)?.average ?? 0);
+  const allTimer = eligible.map((id) => flags.get(id)?.allTimer ?? 0);
+  const jamChart = eligible.map((id) => flags.get(id)?.jamChart ?? 0);
+  const allTimerCount = allTimer.reduce((a, b) => a + b, 0);
+  const jamChartCount = jamChart.reduce((a, b) => a + b, 0);
+
+  console.log(
+    `\nAll-timer / jam-chart discrimination — top-end sanity check (tracks with ratings_count >= ${minRatings})`,
+  );
+  console.log(
+    `  ${eligible.length} tracks · ${allTimerCount} all-timers · ${jamChartCount} jam-charted · Spearman, higher = separates the flagged jams better\n`,
+  );
+  const report = (label: string, truth: number[]): void => {
+    const calibratedCorrelation = spearman(calibrated, truth);
+    const simpleCorrelation = spearman(simple, truth);
+    const delta = calibratedCorrelation - simpleCorrelation;
+    const verdict = delta > 0.01 ? "✓ better" : delta < -0.01 ? "✗ worse" : "≈ tied";
+    console.log(
+      `  ${label.padEnd(20)} calibrated ${calibratedCorrelation.toFixed(4)} | plain ${simpleCorrelation.toFixed(4)} | Δ ${delta >= 0 ? "+" : ""}${delta.toFixed(4)}  ${verdict}`,
+    );
+  };
+  report("vs all-timer", allTimer);
+  report("vs jam-chart note", jamChart);
+}
+
+async function zeroPointFiveReport(
+  ratings: SpikeRating[],
+  full: ReturnType<typeof computeCalibratedTrackScores>,
+  canonical: Map<string, string>,
+  email: string,
+): Promise<void> {
+  const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
+  if (!user) {
+    console.log(`\n0.5 spot-check — skipped (no user for ${email})`);
+    return;
+  }
+  const canonicalId = canonical.get(user.id) ?? user.id;
+  const plain = plainTrackAverages(ratings);
+  const halfStar = ratings.filter((rating) => rating.userId === canonicalId && rating.value === 0.5);
+  const scored = halfStar
+    .map((rating) => ({
+      trackId: rating.trackId,
+      plain: plain.get(rating.trackId)?.average ?? 0,
+      count: plain.get(rating.trackId)?.count ?? 0,
+      displayed: full.scores.get(rating.trackId)?.displayed ?? null,
+    }))
+    .filter((row) => row.displayed != null) as Array<{
+    trackId: string;
+    plain: number;
+    count: number;
+    displayed: number;
+  }>;
+
+  console.log(`\n0.5 spot-check — where ${email}'s "nothing interesting" 0.5 votes land`);
+  if (scored.length === 0) {
+    console.log("  (no 0.5 track votes found)");
+    return;
+  }
+  const meanPlain = meanOf(scored.map((row) => row.plain));
+  const meanDisplayed = meanOf(scored.map((row) => row.displayed));
+  const washedUp = scored.filter((row) => row.displayed >= 3).length;
+  console.log(
+    `  ${scored.length} tracks · mean plain ${meanPlain.toFixed(2)} · mean calibrated ${meanDisplayed.toFixed(2)} · ${washedUp} (${((100 * washedUp) / scored.length).toFixed(0)}%) shown >= 3.0 by calibration`,
+  );
+
+  const titleRows = await prisma.track.findMany({
+    where: { id: { in: scored.map((row) => row.trackId) } },
+    select: { id: true, song: { select: { title: true } }, show: { select: { date: true } } },
+  });
+  const label = new Map(
+    titleRows.map((track) => [track.id, `${track.song?.title ?? "?"} — ${track.show?.date ?? "?"}`]),
+  );
+  const worst = [...scored].sort((a, b) => b.displayed - a.displayed).slice(0, 15);
+  console.log("\n  Most washed-up (highest calibrated despite your 0.5):");
+  for (const row of worst) {
+    console.log(
+      `    ${(label.get(row.trackId) ?? row.trackId).padEnd(40)} plain ${row.plain.toFixed(2)} (n=${row.count}) → calibrated ${row.displayed.toFixed(2)}`,
+    );
+  }
+}
+
+/**
+ * The distribution-shape comparison — the metric closest to the actual goal (stop
+ * fluffers pinning everything at 5). Over tracks rated >= `minRatings` times, contrasts
+ * the plain-average and calibrated-displayed score distributions: spread, skew, ceiling
+ * pile-up, and side-by-side histograms. A "better" (more discriminating) shape is more
+ * spread out, less left-skewed, and has less mass crushed at the top.
+ */
+function distributionReport(
+  ratings: SpikeRating[],
+  full: ReturnType<typeof computeCalibratedTrackScores>,
+  minRatings: number,
+): void {
+  const plain = plainTrackAverages(ratings);
+  const tracks = [...plain.keys()].filter((id) => (plain.get(id)?.count ?? 0) >= minRatings && full.scores.has(id));
+  const plainValues = tracks.map((id) => plain.get(id)?.average ?? 0);
+  const calibratedValues = tracks.map((id) => full.scores.get(id)?.displayed ?? 0);
+  const rawValues = tracks.map((id) => full.scores.get(id)?.weighted ?? 0);
+
+  console.log(
+    `\nDistribution shape — the de-fluffing test (${tracks.length} tracks with ratings_count >= ${minRatings})`,
+  );
+  const shape = (label: string, values: number[]): void => {
+    console.log(
+      `  ${label.padEnd(24)} mean ${meanOf(values).toFixed(2)} · sd ${standardDeviation(values).toFixed(3)} · skew ${skewness(values).toFixed(2)} · ${(100 * ceilingShare(values, 4.5)).toFixed(0)}% >= 4.5`,
+    );
+  };
+  shape("plain average", plainValues);
+  shape("calibrated (raw weighted)", rawValues);
+  shape("calibrated (displayed)", calibratedValues);
+  console.log("  Wider sd + skew nearer 0 + smaller >= 4.5 share = more discriminating, less ceiling-piled.");
+  console.log("  'raw weighted' isolates centering/exclusion; 'displayed' adds count-shrinkage toward the anchor.\n");
+  console.log("  plain average:");
+  for (const line of textHistogram(plainValues)) console.log(line);
+  console.log("  calibrated (raw weighted):");
+  for (const line of textHistogram(rawValues)) console.log(line);
+  console.log("  calibrated (displayed):");
+  for (const line of textHistogram(calibratedValues)) console.log(line);
+}
+
+/** One rater's style + how their ordering agrees with the reference rater's. */
+interface RaterProfile {
+  userId: string;
+  count: number;
+  mean: number;
+  entropy: number;
+  shared: number;
+  correlation: number;
+}
+
+/**
+ * Who rates like you, and who the fluffers are. Profiles every track rater by their range
+ * usage (entropy) and generosity (mean), and — over tracks you both rated — how well their
+ * ordering correlates with yours. High entropy + your correlation = kindred discriminators;
+ * high mean + low entropy = the fluffers calibration is meant to discount.
+ */
+async function raterSimilarityReport(
+  ratings: SpikeRating[],
+  canonical: Map<string, string>,
+  email: string,
+  minShared: number,
+): Promise<void> {
+  const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
+  if (!user) {
+    console.log(`\nRater similarity — skipped (no user for ${email})`);
+    return;
+  }
+  const meId = canonical.get(user.id) ?? user.id;
+
+  const valuesByUser = new Map<string, Map<string, number>>();
+  for (const rating of ratings) {
+    const byTrack = valuesByUser.get(rating.userId) ?? new Map<string, number>();
+    byTrack.set(rating.trackId, rating.value);
+    valuesByUser.set(rating.userId, byTrack);
+  }
+  const mine = valuesByUser.get(meId);
+  if (!mine) {
+    console.log(`\nRater similarity — skipped (${email} has no track ratings)`);
+    return;
+  }
+
+  const usernameRows = await prisma.user.findMany({
+    where: { id: { in: [...valuesByUser.keys()] } },
+    select: { id: true, username: true },
+  });
+  const nameById = new Map(usernameRows.map((row) => [row.id, row.username ?? row.id]));
+
+  const profiles: RaterProfile[] = [];
+  for (const [userId, byTrack] of valuesByUser) {
+    if (userId === meId) continue;
+    const values = [...byTrack.values()];
+    const sharedIds = [...byTrack.keys()].filter((id) => mine.has(id));
+    const correlation =
+      sharedIds.length >= minShared
+        ? pearson(
+            sharedIds.map((id) => mine.get(id) ?? 0),
+            sharedIds.map((id) => byTrack.get(id) ?? 0),
+          )
+        : Number.NaN;
+    profiles.push({
+      userId,
+      count: values.length,
+      mean: meanOf(values),
+      entropy: ratingEntropy(values),
+      shared: sharedIds.length,
+      correlation,
+    });
+  }
+
+  const myValues = [...mine.values()];
+  console.log(
+    `\nRater similarity — you (${email}): ${myValues.length} tracks · mean ${meanOf(myValues).toFixed(2)} · entropy ${ratingEntropy(myValues).toFixed(2)} bits`,
+  );
+  const row = (profile: RaterProfile): string =>
+    `    ${(nameById.get(profile.userId) ?? profile.userId).padEnd(22)} r ${Number.isNaN(profile.correlation) ? " n/a " : profile.correlation.toFixed(2).padStart(5)} · shared ${String(profile.shared).padStart(4)} · mean ${profile.mean.toFixed(2)} · entropy ${profile.entropy.toFixed(2)} · n ${profile.count}`;
+
+  const comparable = profiles.filter((profile) => !Number.isNaN(profile.correlation));
+  const closest = [...comparable].sort((a, b) => b.correlation - a.correlation).slice(0, 15);
+  console.log(`\n  Closest to you (Pearson over >= ${minShared} shared tracks, highest first):`);
+  for (const profile of closest) console.log(row(profile));
+
+  // Fluffers: generous AND one-note, among raters with enough volume to matter.
+  const fluffers = profiles
+    .filter((profile) => profile.count >= 50)
+    .sort((a, b) => b.mean - a.mean || a.entropy - b.entropy)
+    .slice(0, 12);
+  console.log("\n  Biggest fluffers (highest mean + lowest entropy, n >= 50) — what calibration discounts:");
+  for (const profile of fluffers) console.log(row(profile));
+}
+
+/**
+ * The variant sweep: the "combine the two" comparison. For each named config it reports
+ * the two axes that actually matter for the goal — distribution shape (does it spread off
+ * the 5-star ceiling) and split-half reliability (is that spread real signal or noise) —
+ * so the centering × gamma × shrink tradeoff is visible in one table. Self-alignment is
+ * deliberately gone: the goal is a discriminating score, not one tuned to agree with anyone.
+ */
+function variantSweepReport(
+  ratings: SpikeRating[],
+  options: { gamma: number; repeats: number; minPerHalf: number; minDistRatings: number },
+): void {
+  const { gamma, repeats, minPerHalf, minDistRatings } = options;
+  const plain = plainTrackAverages(ratings);
+  const distTracks = [...plain.keys()].filter((id) => (plain.get(id)?.count ?? 0) >= minDistRatings);
+
+  const configs: Array<{ label: string; options: VariantOptions }> = [
+    { label: "discriminating (none, γ" + gamma + ", k0)", options: { centering: "none", gamma, shrinkK: 0 } },
+    { label: `mean-center (mean, γ${gamma}, k0)`, options: { centering: "mean", gamma, shrinkK: 0 } },
+    { label: `z-score (zscore, γ${gamma}, k0)`, options: { centering: "zscore", gamma, shrinkK: 0 } },
+    { label: `mean + light shrink (mean, γ${gamma}, k1)`, options: { centering: "mean", gamma, shrinkK: 1 } },
+    { label: `mean, low γ1, k1`, options: { centering: "mean", gamma: 1, shrinkK: 1 } },
+  ];
+
+  console.log(
+    `\n=== Variant sweep — combining centering × gamma × shrink (${distTracks.length} tracks, ratings_count >= ${minDistRatings}) ===`,
+  );
+  console.log("  Goal: skew toward 0 + wider sd (discrimination) WHILE reliability stays high (the spread is real).\n");
+
+  const plainValues = distTracks.map((id) => plain.get(id)?.average ?? 0);
+  const plainReliability = splitHalfCorrelation(
+    ratings,
+    repeats,
+    minPerHalf,
+    (subset) => new Map([...plainTrackAverages(subset)].map(([id, value]) => [id, value.average])),
+  );
+  const shapeLine = (label: string, values: number[], reliability: number): void => {
+    console.log(
+      `  ${label.padEnd(34)} skew ${skewness(values).toFixed(2).padStart(5)} · sd ${standardDeviation(values).toFixed(3)} · ${String(Math.round(100 * ceilingShare(values, 4.5))).padStart(2)}% >= 4.5 · reliability ${reliability.toFixed(3)}`,
+    );
+  };
+  shapeLine("plain average", plainValues, plainReliability.correlation);
+  for (const { label, options: variant } of configs) {
+    const full = computeVariantScores(ratings, variant);
+    const values = distTracks.filter((id) => full.has(id)).map((id) => full.get(id)?.displayed ?? 0);
+    const reliability = splitHalfCorrelation(
+      ratings,
+      repeats,
+      minPerHalf,
+      (subset) => new Map([...computeVariantScores(subset, variant)].map(([id, value]) => [id, value.displayed])),
+    );
+    shapeLine(label, values, reliability.correlation);
+  }
+  console.log(
+    "  (Reference: plain reliability is the bar to beat; every point of discrimination tends to cost reliability.)",
+  );
+}
+
+/**
+ * The concrete demo: find shows where one or more raters gave EVERY track 5 stars, and show
+ * each track's community average before (plain) vs after (discriminating and mean+shrink
+ * variants). Makes the abstract distribution numbers tangible — you see the all-5 votes
+ * getting down-weighted track by track on a real setlist.
+ */
+async function allFivesShowDemo(
+  ratings: SpikeRating[],
+  gamma: number,
+  minTracks: number,
+  showLimit: number,
+): Promise<void> {
+  const trackIds = [...new Set(ratings.map((rating) => rating.trackId))];
+  const trackRows = await prisma.track.findMany({
+    where: { id: { in: trackIds } },
+    select: {
+      id: true,
+      showId: true,
+      set: true,
+      position: true,
+      song: { select: { title: true } },
+      show: { select: { date: true } },
+    },
+  });
+  const trackInfo = new Map(
+    trackRows.map((track) => [
+      track.id,
+      {
+        showId: track.showId,
+        date: track.show?.date ?? "?",
+        title: track.song?.title ?? "?",
+        set: track.set,
+        position: track.position,
+      },
+    ]),
+  );
+  const tracksByShow = new Map<string, string[]>();
+  for (const [id, info] of trackInfo) {
+    const bucket = tracksByShow.get(info.showId) ?? [];
+    bucket.push(id);
+    tracksByShow.set(info.showId, bucket);
+  }
+
+  // Count all-5 raters per show: a (user, show) where every one of their >= minTracks votes is 5.
+  const userShowValues = new Map<string, number[]>();
+  for (const rating of ratings) {
+    const info = trackInfo.get(rating.trackId);
+    if (!info) continue;
+    const key = `${rating.userId}|${info.showId}`;
+    const bucket = userShowValues.get(key) ?? [];
+    bucket.push(rating.value);
+    userShowValues.set(key, bucket);
+  }
+  const allFivesByShow = new Map<string, number>();
+  for (const [key, values] of userShowValues) {
+    if (values.length >= minTracks && values.every((value) => value === 5)) {
+      const showId = key.slice(key.indexOf("|") + 1);
+      allFivesByShow.set(showId, (allFivesByShow.get(showId) ?? 0) + 1);
+    }
+  }
+  const chosen = [...allFivesByShow.entries()].sort((a, b) => b[1] - a[1]).slice(0, showLimit);
+
+  const plain = plainTrackAverages(ratings);
+  const discriminating = computeVariantScores(ratings, { centering: "none", gamma, shrinkK: 0 });
+  const meanShrink = computeVariantScores(ratings, { centering: "mean", gamma, shrinkK: 1 });
+  const clamp = (value: number): number => Math.min(5, Math.max(0.5, value));
+
+  console.log(`\n=== Shows with all-5 raters — community average before vs after (γ${gamma}) ===`);
+  if (chosen.length === 0) {
+    console.log(`  (no shows had a rater giving 5★ to >= ${minTracks} tracks)`);
+    return;
+  }
+  for (const [showId, fluffers] of chosen) {
+    const showTracks = (tracksByShow.get(showId) ?? [])
+      .map((id) => ({ id, ...(trackInfo.get(id) as { date: string; title: string; set: string; position: number }) }))
+      .sort((a, b) => a.set.localeCompare(b.set) || a.position - b.position);
+    console.log(
+      `\n  ${showTracks[0]?.date ?? "?"} — ${fluffers} rater(s) gave every track 5★ · ${showTracks.length} tracks`,
+    );
+    console.log(`    ${"track".padEnd(32)} plain      discrim   mean+shrink`);
+    for (const track of showTracks) {
+      const p = plain.get(track.id);
+      if (!p) continue;
+      const d = discriminating.get(track.id)?.displayed;
+      const m = meanShrink.get(track.id)?.displayed;
+      console.log(
+        `    ${track.title.slice(0, 32).padEnd(32)} ${p.average.toFixed(2)} (n=${String(p.count).padStart(2)})  ${d == null ? "  --  " : clamp(d).toFixed(2).padStart(5)}     ${m == null ? "  --  " : clamp(m).toFixed(2).padStart(5)}`,
+      );
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const repeats = Number(process.env.REPEATS ?? 50);
+  const minPerHalf = Number(process.env.MIN_PER_HALF ?? 2);
+  const minRatings = Number(process.env.MIN_RATINGS ?? 10);
+  const minDistRatings = Number(process.env.MIN_DIST_RATINGS ?? 5);
+  const minShared = Number(process.env.MIN_SHARED ?? 20);
+  const gamma = Number(process.env.GAMMA ?? 3);
+  const email = process.env.USER_EMAIL ?? "evan@foo.net";
+
+  const canonical = await buildCanonicalUserMap();
+  const ratings = await loadTrackRatings(canonical);
+  const raters = new Set(ratings.map((rating) => rating.userId)).size;
+  const tracks = new Set(ratings.map((rating) => rating.trackId)).size;
+
+  const full = computeCalibratedTrackScores(ratings);
+
+  console.log("Track Rating Calibration — validation spike");
+  console.log(
+    `  ${ratings.length} deduped track ratings · ${tracks} tracks · ${raters} raters · ${full.scores.size} scored · population mean ${full.populationMean.toFixed(3)} · anchor ${full.anchor.toFixed(3)}`,
+  );
+
+  const reliability = splitHalfReliability(ratings, repeats, minPerHalf);
+  console.log(
+    `\nSplit-half reliability — headline, whole-range (${reliability.validRepeats}/${repeats} valid repeats · ~${reliability.averageTracks.toFixed(0)} tracks/repeat · >= ${minPerHalf} ratings per half)`,
+  );
+  console.log(
+    "  How well each score reproduces itself from an independent half of the raters (higher = more reliable):",
+  );
+  const line = (label: string, value: number, baseline: number): string => {
+    const delta = value - baseline;
+    const verdict = delta > 0.01 ? "✓ better" : delta < -0.01 ? "✗ worse" : "≈ tied";
+    return `  ${label.padEnd(28)} ${value.toFixed(4)}  (Δ vs plain ${delta >= 0 ? "+" : ""}${delta.toFixed(4)}  ${verdict})`;
+  };
+  console.log(`  ${"plain average".padEnd(28)} ${reliability.plain.toFixed(4)}`);
+  console.log(line("calibrated (displayed)", reliability.calibratedDisplayed, reliability.plain));
+  console.log(line("calibrated (raw weighted)", reliability.calibratedWeighted, reliability.plain));
+  console.log(
+    "  Note: 'displayed' is count-shrunk toward the anchor, which compresses thin tracks and can lift reliability on its own;\n  'raw weighted' isolates whether the entropy-centering itself (not just shrinkage) improves the signal.",
+  );
+
+  distributionReport(ratings, full, minDistRatings);
+  await discriminationReport(ratings, full, minRatings);
+  await raterSimilarityReport(ratings, canonical, email, minShared);
+  await zeroPointFiveReport(ratings, full, canonical, email);
+  variantSweepReport(ratings, { gamma, repeats, minPerHalf, minDistRatings });
+  await allFivesShowDemo(ratings, gamma, 5, 5);
+
+  await prisma.$disconnect();
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error("track-rating-calibration-spike failed:", error);
+    process.exit(1);
+  });
+}

--- a/packages/core/src/_shared/prisma/migrations/20260717000001_track_calibrated_rating/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260717000001_track_calibrated_rating/migration.sql
@@ -1,0 +1,8 @@
+-- Calibrated Track Rating: denormalized per-track discriminating score + its contributing
+-- rater count (recomputed in bulk by the ratings recompute, like shows.weighted_rating).
+-- Two new prefs let a viewer opt into the calibrated track score and the compare/debug overlay.
+ALTER TABLE "tracks" ADD COLUMN IF NOT EXISTS "discriminating_rating" double precision;
+ALTER TABLE "tracks" ADD COLUMN IF NOT EXISTS "discriminating_ratings_count" integer NOT NULL DEFAULT 0;
+
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "track_calibrated_rating" boolean;
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "track_rating_compare" boolean;

--- a/packages/core/src/_shared/prisma/schema.prisma
+++ b/packages/core/src/_shared/prisma/schema.prisma
@@ -616,6 +616,8 @@ model Track {
   nextTrackId     String?                  @map("next_track_id") @db.Uuid
   averageRating   Float?                   @default(0) @map("average_rating")
   ratingsCount    Int                      @default(0) @map("ratings_count")
+  discriminatingRating       Float?        @map("discriminating_rating")
+  discriminatingRatingsCount Int           @default(0) @map("discriminating_ratings_count")
   searchText      String?                  @map("search_text") @db.Text
   searchVector    Unsupported("tsvector")? @map("search_vector")
   gap                       Int?
@@ -765,6 +767,8 @@ model User {
   avatarFileUrl       String?      @map("avatar_file_url") @db.VarChar
   showCalibratedRatings     Boolean? @map("show_adjusted_rating")
   showRatingComparisonDebug Boolean? @map("show_rating_compare")
+  trackCalibratedRatings     Boolean? @map("track_calibrated_rating")
+  trackRatingComparisonDebug Boolean? @map("track_rating_compare")
   colorCodeRatings          Boolean? @map("color_code_ratings")
   showSetlistTimes          Boolean? @map("show_setlist_times")
   avatarFile          File?        @relation("UserAvatar", fields: [avatarFileId], references: [id], onDelete: SetNull, onUpdate: NoAction)

--- a/packages/core/src/ratings/rater-weight-service.test.ts
+++ b/packages/core/src/ratings/rater-weight-service.test.ts
@@ -1,5 +1,41 @@
 import { describe, expect, test, vi } from "vitest";
-import { RaterWeightService, rankShowComparisons } from "./rater-weight-service";
+import { computeTrackDiscriminating, RaterWeightService, rankShowComparisons } from "./rater-weight-service";
+
+describe("computeTrackDiscriminating", () => {
+  const wide = { mean: 3, entropy: 2, ratingsCount: 30 }; // full weight
+  const fluffer = { mean: 4.9, entropy: 0.3, ratingsCount: 20 }; // excluded → weight 0
+
+  test("weights by rater and drops excluded fluffers, keeping raw (un-centered) low scores", () => {
+    const stats = new Map([
+      ["wide", wide],
+      ["fluffer", fluffer],
+    ]);
+    const result = computeTrackDiscriminating(
+      [
+        { userId: "wide", value: 0.5 }, // a genuine low vote from a scale-user
+        { userId: "fluffer", value: 5 }, // dropped
+      ],
+      (userId) => stats.get(userId),
+      3,
+    );
+    // Only the wide rater counts, un-centered → the 0.5 survives intact.
+    expect(result.discriminatingRating).toBeCloseTo(0.5, 5);
+    expect(result.discriminatingRatingsCount).toBe(1);
+  });
+
+  test("returns null when every contributing rater is excluded or statless", () => {
+    const result = computeTrackDiscriminating(
+      [
+        { userId: "fluffer", value: 5 },
+        { userId: "unknown", value: 5 }, // no stats row → weight 0
+      ],
+      (userId) => (userId === "fluffer" ? fluffer : undefined),
+      3,
+    );
+    expect(result.discriminatingRating).toBeNull();
+    expect(result.discriminatingRatingsCount).toBe(0);
+  });
+});
 
 describe("rankShowComparisons", () => {
   // The 2001-09-01 overlay scenario: two single-vote 5.0 shows top the raw-average

--- a/packages/core/src/ratings/rater-weight-service.ts
+++ b/packages/core/src/ratings/rater-weight-service.ts
@@ -8,7 +8,9 @@ import {
   COLD_START_ENTROPY_K,
   COLD_START_RATER_K,
   computeCleanedScopeStats,
+  discriminatingRaterWeight,
   ENTROPY_FULL_WEIGHT,
+  entropyPowerWeightedAverage,
   entropyWeightedCenteredAverage,
   meanOf,
   POPULATION_SHOW_MEAN,
@@ -20,6 +22,7 @@ import {
   type ScopedRating,
   SHRINK_K,
   selectContributingRatings,
+  TRACK_DISCRIMINATING_GAMMA,
 } from "./rater-weighting";
 import type { RatingValueBucket } from "./rating-service";
 
@@ -122,7 +125,7 @@ export function rankShowComparisons(
 }
 
 /** One rater's GLOBAL-scope centering stats + their per-era bad-faith flag. */
-interface RaterScopeStat {
+export interface RaterScopeStat {
   mean: number;
   entropy: number;
   count: number;
@@ -131,7 +134,7 @@ interface RaterScopeStat {
 
 /** Look up a rater's stats for a given scope era (`"GLOBAL"` for centering, the show's
  * drummer era for exclusion); undefined for a statless (brand-new) rater. */
-type StatByUserEra = (userId: string, era: RaterEra) => RaterScopeStat | undefined;
+export type StatByUserEra = (userId: string, era: RaterEra) => RaterScopeStat | undefined;
 
 /**
  * Pure: a show's calibrated score from its deduped ratings, the raters' GLOBAL-scope
@@ -144,7 +147,7 @@ type StatByUserEra = (userId: string, era: RaterEra) => RaterScopeStat | undefin
  * mean + entropy are cold-start-shrunk by their rating count so a new/low-volume rater
  * still moves the score (a statless rater = pop-centered + full weight).
  */
-function computeShowWeighted(
+export function computeShowWeighted(
   ratings: ReadonlyArray<{ userId: string; value: number }>,
   showEra: RaterEra | null,
   statByUserEra: StatByUserEra,
@@ -171,6 +174,33 @@ function computeShowWeighted(
   return {
     weightedRating: result.contributingCount > 0 ? result.weightedAverage : null,
     weightedRatingsCount: result.contributingCount,
+  };
+}
+
+/** Look up a rater's GLOBAL-scope TRACK stats (entropy/mean/count) — the discriminating weight input. */
+type TrackStatByUser = (userId: string) => { mean: number; entropy: number; ratingsCount: number } | undefined;
+
+/**
+ * Pure: a track's Calibrated Track Rating from its deduped ratings and each rater's GLOBAL
+ * TRACK stats. Entropy^gamma weighted over RAW star values — no centering, no anchor-shrink
+ * (see {@link entropyPowerWeightedAverage}); one-note fluffers drop to weight 0. A statless
+ * rater (no track stats yet) also drops out. The single track-scoring rule, shared by the
+ * batch recompute and the incremental path so they can't diverge.
+ */
+export function computeTrackDiscriminating(
+  ratings: ReadonlyArray<{ userId: string; value: number }>,
+  statByUser: TrackStatByUser,
+  gamma: number,
+): { discriminatingRating: number | null; discriminatingRatingsCount: number } {
+  const result = entropyPowerWeightedAverage(
+    ratings.map((rating) => {
+      const stats = statByUser(rating.userId);
+      return { value: rating.value, weight: stats ? discriminatingRaterWeight(stats, gamma) : 0 };
+    }),
+  );
+  return {
+    discriminatingRating: result.contributingCount > 0 ? result.weightedAverage : null,
+    discriminatingRatingsCount: result.contributingCount,
   };
 }
 
@@ -293,6 +323,57 @@ export class RaterWeightService {
       };
     }
     return byId;
+  }
+
+  /**
+   * The Calibrated Track Rating + contributing count per track, keyed by track id. Read
+   * straight from the denormalized `tracks.discriminating_rating` — unlike shows there's no
+   * count-shrink or anchor (the track score deliberately keeps its raw spread). The count is
+   * the raters left after fluffer exclusion. Absent (unrated / all-excluded) ⇒ caller falls
+   * back to the canonical average + count.
+   */
+  async getCalibratedForTracks(trackIds: string[]): Promise<Record<string, { rating: number; count: number }>> {
+    if (trackIds.length === 0) return {};
+    const tracks = await this.db.track.findMany({
+      where: { id: { in: trackIds }, discriminatingRating: { not: null } },
+      select: { id: true, discriminatingRating: true, discriminatingRatingsCount: true },
+    });
+    const byId: Record<string, { rating: number; count: number }> = {};
+    for (const track of tracks) {
+      if (track.discriminatingRating == null) continue;
+      byId[track.id] = { rating: track.discriminatingRating, count: track.discriminatingRatingsCount };
+    }
+    return byId;
+  }
+
+  /**
+   * The calibrated histogram for one track: raw-star-value buckets of exactly the raters
+   * who feed the Calibrated Track Rating — those with a positive discriminating weight
+   * (fluffers and one-note zero-entropy raters dropped), by the track-global `rater_stats`
+   * bucket (tracks have no era scope). Bars stay raw star values; membership matches the
+   * score, so the bar total equals the displayed `discriminating_ratings_count`. Falls
+   * back to the full deduped set when no `rater_stats` exist or every rater drops out,
+   * matching the plain distribution the headline falls back to. Empty when unrated.
+   * Mirrors {@link getCalibratedDistribution} for shows.
+   */
+  async getCalibratedTrackDistribution(trackId: string): Promise<RatingValueBucket[]> {
+    const ratings = await this.loadCanonicalShowRatings("Track", trackId);
+    if (ratings.length === 0) return [];
+    const statRows = await this.db.raterStats.findMany({
+      where: { userId: { in: ratings.map((rating) => rating.userId) }, kind: "TRACK", era: "GLOBAL" },
+      select: { userId: true, mean: true, entropy: true, ratingsCount: true },
+    });
+    const contributing = new Set<string>();
+    for (const row of statRows) {
+      const weight = discriminatingRaterWeight(
+        { mean: row.mean, entropy: row.entropy, ratingsCount: row.ratingsCount },
+        TRACK_DISCRIMINATING_GAMMA,
+      );
+      if (weight > 0) contributing.add(row.userId);
+    }
+    const used = ratings.filter((rating) => contributing.has(rating.userId));
+    const active = used.length > 0 ? used : ratings;
+    return bucketRatingValues(active.map((rating) => rating.value));
   }
 
   /**
@@ -607,8 +688,36 @@ export class RaterWeightService {
   }
 
   /**
-   * Full rebuild: every person's per-kind scope stats (deduped) then every rated
-   * show's calibrated score. Run by the cron/script. Returns coverage counts.
+   * Chunked bulk write of computed scores into a denormalized (score, count) column pair,
+   * joining the values in as a VALUES table — one UPDATE per chunk instead of a per-row
+   * round-trip. Table and column names are hardcoded literals (via `Prisma.raw`), never
+   * user input. Shared by the show (`weighted_rating`) and track (`discriminating_rating`)
+   * recompute writes. Chunked to stay well under the bind-parameter limit.
+   */
+  private async writeDenormalizedScores(
+    table: "shows" | "tracks",
+    scoreColumn: string,
+    countColumn: string,
+    updates: ReadonlyArray<{ id: string; score: number | null; count: number }>,
+  ): Promise<void> {
+    const WRITE_CHUNK = 1000;
+    for (let i = 0; i < updates.length; i += WRITE_CHUNK) {
+      const rows = updates
+        .slice(i, i + WRITE_CHUNK)
+        .map((update) => Prisma.sql`(${update.id}::uuid, ${update.score}::double precision, ${update.count}::int)`);
+      await this.db.$executeRaw(Prisma.sql`
+        UPDATE ${Prisma.raw(table)} AS t
+        SET ${Prisma.raw(scoreColumn)} = v.score, ${Prisma.raw(countColumn)} = v.count
+        FROM (VALUES ${Prisma.join(rows)}) AS v(id, score, count)
+        WHERE t.id = v.id
+      `);
+    }
+  }
+
+  /**
+   * Full rebuild: every person's per-kind scope stats (deduped), then every rated show's
+   * calibrated score and every rated track's discriminating score. Run by the cron/script.
+   * Returns coverage counts.
    */
   async recomputeAll(): Promise<{ users: number; rateables: number }> {
     const rawRatings = await this.db.rating.findMany({
@@ -683,24 +792,55 @@ export class RaterWeightService {
       updates.push({ id: showId, ...computeShowWeighted(showRatings, era, statByUserEra, populationByKind.SHOW) });
     }
 
-    // One bulk UPDATE instead of ~1800 per-row round-trips: join the computed values
-    // in as a VALUES table. Chunked only to stay well under the parameter limit.
-    const WRITE_CHUNK = 1000;
-    for (let i = 0; i < updates.length; i += WRITE_CHUNK) {
-      const rows = updates
-        .slice(i, i + WRITE_CHUNK)
-        .map(
-          (update) =>
-            Prisma.sql`(${update.id}::uuid, ${update.weightedRating}::double precision, ${update.weightedRatingsCount}::int)`,
-        );
-      await this.db.$executeRaw`
-        UPDATE shows AS s
-        SET weighted_rating = v.weighted_rating, weighted_ratings_count = v.weighted_ratings_count
-        FROM (VALUES ${Prisma.join(rows)}) AS v(id, weighted_rating, weighted_ratings_count)
-        WHERE s.id = v.id
-      `;
-    }
+    // One bulk UPDATE instead of ~1800 per-row round-trips (see writeDenormalizedScores).
+    await this.writeDenormalizedScores(
+      "shows",
+      "weighted_rating",
+      "weighted_ratings_count",
+      updates.map((update) => ({ id: update.id, score: update.weightedRating, count: update.weightedRatingsCount })),
+    );
 
-    return { users: scopedByUser.size, rateables: updates.length };
+    // Calibrated Track Rating: entropy^gamma weighted, un-centered, un-shrunk. Weights come
+    // from each rater's GLOBAL-scope TRACK stats (just built above); excluded fluffers fall out.
+    const trackStatByUser = new Map<string, { mean: number; entropy: number; ratingsCount: number }>();
+    for (const record of allRecords) {
+      if (record.kind !== "TRACK" || record.era !== "GLOBAL") continue;
+      trackStatByUser.set(record.userId, {
+        mean: record.mean,
+        entropy: record.entropy,
+        ratingsCount: record.ratingsCount,
+      });
+    }
+    const ratingsByTrack = new Map<string, Array<{ userId: string; value: number }>>();
+    for (const rating of ratings) {
+      if (rating.rateableType !== "Track") continue;
+      const bucket = ratingsByTrack.get(rating.rateableId) ?? [];
+      bucket.push({ userId: rating.userId, value: rating.value });
+      ratingsByTrack.set(rating.rateableId, bucket);
+    }
+    const trackUpdates: Array<{ id: string; discriminatingRating: number | null; discriminatingRatingsCount: number }> =
+      [];
+    for (const [trackId, trackRatings] of ratingsByTrack) {
+      trackUpdates.push({
+        id: trackId,
+        ...computeTrackDiscriminating(
+          trackRatings,
+          (userId) => trackStatByUser.get(userId),
+          TRACK_DISCRIMINATING_GAMMA,
+        ),
+      });
+    }
+    await this.writeDenormalizedScores(
+      "tracks",
+      "discriminating_rating",
+      "discriminating_ratings_count",
+      trackUpdates.map((update) => ({
+        id: update.id,
+        score: update.discriminatingRating,
+        count: update.discriminatingRatingsCount,
+      })),
+    );
+
+    return { users: scopedByUser.size, rateables: updates.length + trackUpdates.length };
   }
 }

--- a/packages/core/src/ratings/rater-weighting.test.ts
+++ b/packages/core/src/ratings/rater-weighting.test.ts
@@ -3,6 +3,9 @@ import {
   bucketRatingValues,
   center,
   computeCleanedScopeStats,
+  discriminatingRaterWeight,
+  ENTROPY_FULL_WEIGHT,
+  entropyPowerWeightedAverage,
   entropyWeight,
   entropyWeightedCenteredAverage,
   isExcludedBucket,
@@ -116,6 +119,47 @@ describe("entropyWeightedCenteredAverage", () => {
 
   test("returns an empty result when every rater is weightless", () => {
     const result = entropyWeightedCenteredAverage([{ value: 5, userMean: 4, entropy: 0 }], { mean: 4 }, 2);
+    expect(result.contributingCount).toBe(0);
+    expect(result.weightedAverage).toBe(0);
+  });
+});
+
+// discriminatingRaterWeight — the calibrated TRACK rating's per-rater weight: a
+// sharpened entropy weight (favouring scale-users), zero for excluded fluffers.
+describe("discriminatingRaterWeight", () => {
+  test("excludes a one-note fluffer bucket entirely", () => {
+    expect(discriminatingRaterWeight({ entropy: 0.3, mean: 4.9, ratingsCount: 8 }, 3)).toBe(0);
+  });
+
+  test("gives a full-scale rater full weight regardless of gamma", () => {
+    // entropy >= ENTROPY_FULL_WEIGHT → entropyWeight 1 → 1^gamma = 1.
+    expect(discriminatingRaterWeight({ entropy: ENTROPY_FULL_WEIGHT, mean: 3, ratingsCount: 20 }, 3)).toBe(1);
+  });
+
+  test("a higher gamma shrinks a mid-entropy rater's weight (base < 1)", () => {
+    const stats = { entropy: 1, mean: 3, ratingsCount: 20 }; // entropyWeight = 0.5
+    const soft = discriminatingRaterWeight(stats, 1);
+    const sharp = discriminatingRaterWeight(stats, 3);
+    expect(soft).toBeCloseTo(0.5, 5);
+    expect(sharp).toBeLessThan(soft);
+  });
+});
+
+// entropyPowerWeightedAverage — the raw (un-centered, un-shrunk) weighted mean
+// behind the calibrated track score.
+describe("entropyPowerWeightedAverage", () => {
+  test("weights raw values and drops the weightless ones", () => {
+    const result = entropyPowerWeightedAverage([
+      { value: 5, weight: 1 },
+      { value: 1, weight: 1 },
+      { value: 5, weight: 0 }, // a fluffer, dropped
+    ]);
+    expect(result.contributingCount).toBe(2);
+    expect(result.weightedAverage).toBe(3);
+  });
+
+  test("returns an empty result when every rater is weightless", () => {
+    const result = entropyPowerWeightedAverage([{ value: 5, weight: 0 }]);
     expect(result.contributingCount).toBe(0);
     expect(result.weightedAverage).toBe(0);
   });

--- a/packages/core/src/ratings/rater-weighting.ts
+++ b/packages/core/src/ratings/rater-weighting.ts
@@ -192,6 +192,56 @@ export interface WeightedAverageResult {
   contributingCount: number;
 }
 
+/**
+ * Gamma for the Calibrated Track Rating's entropy weighting. Tracks pile at the 5-star
+ * ceiling far worse than shows (people only rate tracks they liked), so — unlike the show
+ * scheme — the track score is deliberately NOT mean-centered and NOT count-shrunk, and it
+ * leans HARDER on wide-range raters by raising the entropy weight to this power (shows use
+ * an effective power of 1). Higher favors scale-users more (more spread, less reliable); a
+ * spike over the full track corpus put the useful range at 2-6. Tunable; a change needs a
+ * recompute + a cache-key bump but no migration.
+ */
+export const TRACK_DISCRIMINATING_GAMMA = 3;
+
+/**
+ * One rater's confidence weight for the calibrated track score: their entropy weight raised
+ * to `gamma` (favouring raters who use the whole scale), or 0 for a one-note fluffer/bomber
+ * dropped by {@link isExcludedBucket}. The single "who counts, and how much" rule for tracks,
+ * shared by the score and any track histogram so they can't disagree.
+ */
+export function discriminatingRaterWeight(
+  stats: Pick<RaterStats, "entropy" | "mean" | "ratingsCount">,
+  gamma: number,
+): number {
+  if (isExcludedBucket(stats)) return 0;
+  return entropyWeight(stats.entropy, ENTROPY_FULL_WEIGHT) ** gamma;
+}
+
+/**
+ * A track's calibrated score: the entropy^gamma-weighted average of RAW star values — no
+ * mean-centering and no anchor-shrink, because tracks need their spread preserved rather
+ * than regressed toward a ceiling-inflated mean. Weightless (excluded) raters fall out.
+ * Clamped once at the end.
+ */
+export function entropyPowerWeightedAverage(
+  contributions: ReadonlyArray<{ value: number; weight: number }>,
+): WeightedAverageResult {
+  let valueSum = 0;
+  let weightSum = 0;
+  let contributingCount = 0;
+  for (const { value, weight } of contributions) {
+    if (weight <= 0) continue;
+    valueSum += value * weight;
+    weightSum += weight;
+    contributingCount += 1;
+  }
+  return {
+    weightedAverage: weightSum === 0 ? 0 : clampStar(valueSum / weightSum),
+    weightSum,
+    contributingCount,
+  };
+}
+
 /** entropy/mean/count for one bucket of a rater's ratings. */
 function statsOfRatings(ratings: ReadonlyArray<ScopedRating>): RaterStats {
   const values = ratings.map((rating) => rating.value);

--- a/packages/core/src/users/user-service.ts
+++ b/packages/core/src/users/user-service.ts
@@ -58,6 +58,8 @@ function mapUserToDomainEntity(dbUser: DbUser): User {
     updatedAt: dbUser.updatedAt,
     showCalibratedRatings: dbUser.showCalibratedRatings ?? null,
     showRatingComparisonDebug: dbUser.showRatingComparisonDebug ?? null,
+    trackCalibratedRatings: dbUser.trackCalibratedRatings ?? null,
+    trackRatingComparisonDebug: dbUser.trackRatingComparisonDebug ?? null,
     colorCodeRatings: dbUser.colorCodeRatings ?? null,
     showSetlistTimes: dbUser.showSetlistTimes ?? null,
   };

--- a/packages/domain/src/models/user.ts
+++ b/packages/domain/src/models/user.ts
@@ -11,6 +11,8 @@ export const userSchema = z.object({
   // Display prefs (tri-state: null = no explicit choice → app default).
   showCalibratedRatings: z.boolean().nullable(),
   showRatingComparisonDebug: z.boolean().nullable(),
+  trackCalibratedRatings: z.boolean().nullable(),
+  trackRatingComparisonDebug: z.boolean().nullable(),
   colorCodeRatings: z.boolean().nullable(),
   showSetlistTimes: z.boolean().nullable(),
 });


### PR DESCRIPTION
Fans can now switch on a **Calibrated Track Rating** from their profile
settings, a separate opt-in alongside the existing Calibrated Show Rating.
It gives more weight to raters who use the whole 0.5-to-5 star scale, so a
track's number leans on those raters rather than accounts that rate nearly
everything 5. Tracks spread out instead of piling near 5. Everyone still sees
the plain community average by default.

The calibrated number (and its histogram) shows everywhere a track rating
appears:

- setlist gap-chart tables
- the song performance tables (song, all-timers, jam-charts, on-this-day,
  musicians pages)
- the song-title hover popup and its distribution histogram
- the song-page featured all-timer cards

An author-only compare overlay (behind the existing `ratings.compare-visible`
flag) shows the plain → calibrated delta per track. The ratings explainer at
`/show-rating-algorithm` now covers both the show and track ratings.

## How it differs from the show rating

Same family (weight raters by how much of the scale they use, drop one-note
fluffers), but it deliberately skips the two show moves that backfire on tracks:
it does not mean-center a rater's scores toward the crowd average, and it does
not shrink thin tracks toward a global anchor. Tracks are ceiling-piled from a
smaller, higher-skewing pool, so both of those just push scores back up. The
main lever is weighting (`entropy^gamma`, gamma tunable), not exclusion.

## Notes for the reviewer

- New denormalized `tracks.discriminating_rating` + `discriminating_ratings_count`
  and two tri-state `User` prefs (`track_calibrated_rating`,
  `track_rating_compare`), via migration `20260717000001`. Scores are recomputed
  in `recomputeAll` (dirty-gated hourly cron + deploy), so a new track rating
  updates within the recompute window, not on the write.
- Display gating is client-side and per-viewer: `SongPagePerformance.rating`
  stays the plain baked value from the composer, and the calibrated value is
  overlaid in the rating components via `useTrackUserRatings` /
  `resolveViewerRatingMode`. Core and the page composer stay viewer-agnostic.
- The calibrated histogram (`getCalibratedTrackDistribution`) buckets exactly the
  raters with a positive discriminating weight, so the bar total equals the
  displayed calibrated count.
- `packages/core/scripts/track-rating-calibration-spike.ts` is the throwaway
  analysis behind the design (split-half reliability, distribution shape,
  gamma sweep); kept as the retuning tool, run via `make
  track-rating-calibration-spike`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
