### PR TITLE
Mirror Calibrated Track Rating prefs through MCP user sync

### DIFF
--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -276,6 +276,8 @@ export interface McpSyncUser {
   // Display prefs, mirrored from prod so adoption can be inspected locally.
   showCalibratedRatings: boolean | null;
   showRatingComparisonDebug: boolean | null;
+  trackCalibratedRatings: boolean | null;
+  trackRatingComparisonDebug: boolean | null;
   colorCodeRatings: boolean | null;
   // Optional until the setlist-times deploy lands on prod: an older prod omits
   // it, and the sync then leaves the local value alone rather than clearing it.
@@ -1704,6 +1706,8 @@ export async function syncUserActivity(
               avatarFileUrl: u.avatarFileUrl,
               showCalibratedRatings: u.showCalibratedRatings,
               showRatingComparisonDebug: u.showRatingComparisonDebug,
+              trackCalibratedRatings: u.trackCalibratedRatings,
+              trackRatingComparisonDebug: u.trackRatingComparisonDebug,
               colorCodeRatings: u.colorCodeRatings,
               showSetlistTimes: u.showSetlistTimes,
               updatedAt: new Date(u.updatedAt),
@@ -1722,6 +1726,8 @@ export async function syncUserActivity(
               avatarFileUrl: u.avatarFileUrl,
               showCalibratedRatings: u.showCalibratedRatings,
               showRatingComparisonDebug: u.showRatingComparisonDebug,
+              trackCalibratedRatings: u.trackCalibratedRatings,
+              trackRatingComparisonDebug: u.trackRatingComparisonDebug,
               colorCodeRatings: u.colorCodeRatings,
               showSetlistTimes: u.showSetlistTimes,
               updatedAt: new Date(u.updatedAt),
@@ -1739,6 +1745,8 @@ export async function syncUserActivity(
               avatarFileUrl: u.avatarFileUrl,
               showCalibratedRatings: u.showCalibratedRatings,
               showRatingComparisonDebug: u.showRatingComparisonDebug,
+              trackCalibratedRatings: u.trackCalibratedRatings,
+              trackRatingComparisonDebug: u.trackRatingComparisonDebug,
               colorCodeRatings: u.colorCodeRatings,
               showSetlistTimes: u.showSetlistTimes,
               createdAt: new Date(u.createdAt),

--- a/packages/core/src/users/user-service.test.ts
+++ b/packages/core/src/users/user-service.test.ts
@@ -168,6 +168,8 @@ describe("UserService.listForSync", () => {
       avatarFileUrl: true,
       showCalibratedRatings: true,
       showRatingComparisonDebug: true,
+      trackCalibratedRatings: true,
+      trackRatingComparisonDebug: true,
       colorCodeRatings: true,
       showSetlistTimes: true,
       createdAt: true,

--- a/packages/core/src/users/user-service.ts
+++ b/packages/core/src/users/user-service.ts
@@ -441,6 +441,8 @@ export class UserService {
       // Display prefs, mirrored to local so prod adoption can be inspected.
       showCalibratedRatings: boolean | null;
       showRatingComparisonDebug: boolean | null;
+      trackCalibratedRatings: boolean | null;
+      trackRatingComparisonDebug: boolean | null;
       colorCodeRatings: boolean | null;
       showSetlistTimes: boolean | null;
       createdAt: Date;
@@ -467,6 +469,8 @@ export class UserService {
         avatarFileUrl: true,
         showCalibratedRatings: true,
         showRatingComparisonDebug: true,
+        trackCalibratedRatings: true,
+        trackRatingComparisonDebug: true,
         colorCodeRatings: true,
         showSetlistTimes: true,
         createdAt: true,


### PR DESCRIPTION
No user-facing change. This is internal dev/adoption tooling: the two Calibrated Track Rating prefs added in #222 now flow prod→local through the MCP user sync, so prod adoption can be inspected locally the same way the show-rating prefs already are.

`trackCalibratedRatings` and `trackRatingComparisonDebug` are added everywhere the two `show*` prefs already appear in the sync path:

- `UserService.listForSync`: `select` and its return type
- `McpSyncUser` interface in `sync-missing-shows.ts`
- the three user upsert blocks (update-by-id, update-by-username, create)

No migration or schema change; the columns already exist end to end from #222. The upserts are field-scoped (they only write the columns they name), so this adds the two prefs without touching anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)