### PR TITLE
Use a neutral test identity in tests

### DIFF
--- a/apps/web/app/lib/session-user.test.ts
+++ b/apps/web/app/lib/session-user.test.ts
@@ -5,7 +5,7 @@ import { toSessionUser } from "./session-user";
 function makeSupabaseUser(overrides: Partial<User> = {}): User {
   return {
     id: "auth-1",
-    email: "evan@foo.net",
+    email: "test-user@example.com",
     app_metadata: {},
     user_metadata: {},
     aud: "authenticated",
@@ -21,15 +21,15 @@ describe("toSessionUser", () => {
   test("projects the supabase user to the client-safe shape", () => {
     const result = toSessionUser(
       makeSupabaseUser({
-        user_metadata: { username: "evan", internal_user_id: "local-1" },
+        user_metadata: { username: "test-user", internal_user_id: "local-1" },
         app_metadata: { isAdmin: true, provider: "email" },
       }),
     );
 
     expect(result).toEqual({
       id: "auth-1",
-      email: "evan@foo.net",
-      username: "evan",
+      email: "test-user@example.com",
+      username: "test-user",
       avatarUrl: null,
       internalUserId: "local-1",
       isAdmin: true,
@@ -72,9 +72,9 @@ describe("toSessionUser", () => {
   // ensureUserSynced fires) still gets a well-formed shape; the
   // client-side sync fills the id in later.
   test("returns null internalUserId when metadata lacks it", () => {
-    const result = toSessionUser(makeSupabaseUser({ user_metadata: { username: "evan" } }));
+    const result = toSessionUser(makeSupabaseUser({ user_metadata: { username: "test-user" } }));
     expect(result.internalUserId).toBeNull();
-    expect(result.username).toBe("evan");
+    expect(result.username).toBe("test-user");
   });
 
   // Supabase types `email` as optional. The helper coerces missing

--- a/apps/web/app/routes/users/$username.test.tsx
+++ b/apps/web/app/routes/users/$username.test.tsx
@@ -26,8 +26,8 @@ vi.mock("~/hooks/use-feature-flags", () => ({
 const baseLoaderData = {
   user: {
     id: "u1",
-    email: "evan@foo.net",
-    username: "evan",
+    email: "test-user@example.com",
+    username: "test-user",
     avatarUrl: null,
     createdAt: new Date("2020-01-01T00:00:00Z"),
   },
@@ -130,7 +130,7 @@ const trackRatingRow = {
   },
 };
 
-function renderProfile(initialEntry = "/users/evan") {
+function renderProfile(initialEntry = "/users/test-user") {
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
       <UserProfile />
@@ -171,7 +171,7 @@ describe("UserProfile", () => {
   test("Settings tab holds the display-preference cards on your own profile", () => {
     vi.mocked(useSerializedLoaderData).mockReturnValue({ ...baseLoaderData, activeTab: "settings" });
 
-    renderProfile("/users/evan?tab=settings");
+    renderProfile("/users/test-user?tab=settings");
 
     expect(screen.getByText(/rating display/i)).toBeInTheDocument();
     expect(screen.getByText(/setlist display/i)).toBeInTheDocument();
@@ -213,7 +213,7 @@ describe("UserProfile", () => {
       activeTab: "track-ratings",
     });
 
-    renderProfile("/users/evan?tab=track-ratings");
+    renderProfile("/users/test-user?tab=track-ratings");
 
     const trackTab = screen.getByRole("tab", { name: /song version ratings/i });
     expect(trackTab.getAttribute("data-state")).toBe("active");
@@ -331,7 +331,7 @@ describe("UserProfile", () => {
       ratingsPagination: { page: 1, pageSize: 100, totalPages: 18, total: 1739 },
     });
 
-    renderProfile("/users/evan?tab=show-ratings");
+    renderProfile("/users/test-user?tab=show-ratings");
     // Charts is the default view, so pagination isn't shown until the user
     // switches to the table.
     expect(screen.queryByText(/Showing 1 to 100 of 1739 results/)).not.toBeInTheDocument();
@@ -351,7 +351,7 @@ describe("UserProfile", () => {
       ratingsPagination: { page: 2, pageSize: 100, totalPages: 78, total: 7784 },
     });
 
-    renderProfile("/users/evan?tab=track-ratings");
+    renderProfile("/users/test-user?tab=track-ratings");
     fireEvent.click(screen.getByRole("button", { name: /^table$/i }));
     expect(screen.getAllByText(/Showing 101 to 200 of 7784 results/)).toHaveLength(2);
   });
@@ -367,7 +367,7 @@ describe("UserProfile", () => {
       ratingsPagination: { page: 1, pageSize: 100, totalPages: 1, total: 1 },
     });
 
-    renderProfile("/users/evan?tab=show-ratings&view=table");
+    renderProfile("/users/test-user?tab=show-ratings&view=table");
 
     expect(screen.getByRole("table")).toBeInTheDocument();
     expect(screen.queryByTestId("RatingCharts")).not.toBeInTheDocument();
@@ -382,7 +382,7 @@ describe("UserProfile", () => {
       ratingsPagination: { page: 1, pageSize: 100, totalPages: 1, total: 1 },
     });
 
-    renderProfile("/users/evan?tab=show-ratings");
+    renderProfile("/users/test-user?tab=show-ratings");
 
     expect(screen.getByTestId("RatingCharts")).toBeInTheDocument();
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
@@ -399,7 +399,7 @@ describe("UserProfile", () => {
       ratingsPagination: { page: 1, pageSize: 100, totalPages: 1, total: 5 },
     });
 
-    renderProfile("/users/evan?tab=show-ratings");
+    renderProfile("/users/test-user?tab=show-ratings");
     fireEvent.click(screen.getByRole("button", { name: /^table$/i }));
     expect(screen.queryByRole("button", { name: /next/i })).not.toBeInTheDocument();
   });
@@ -477,14 +477,16 @@ describe("shouldRevalidate", () => {
   // Toggling Charts/Table changes only `view`, which the loader ignores — so
   // it must not refetch the (heavy) ratings query.
   test("skips revalidation when only the view sub-tab changes", () => {
-    expect(run("/users/evan?tab=show-ratings", "/users/evan?tab=show-ratings&view=table")).toBe(false);
+    expect(run("/users/test-user?tab=show-ratings", "/users/test-user?tab=show-ratings&view=table")).toBe(false);
   });
 
   // A tab / page / sort / dir change is loader-relevant and must revalidate.
   test("revalidates when a loader-relevant param changes", () => {
-    expect(run("/users/evan?tab=show-ratings", "/users/evan?tab=track-ratings")).toBe(true);
-    expect(run("/users/evan?tab=show-ratings&page=1", "/users/evan?tab=show-ratings&page=2")).toBe(true);
-    expect(run("/users/evan?tab=show-ratings&sort=date", "/users/evan?tab=show-ratings&sort=rating")).toBe(true);
-    expect(run("/users/evan?tab=show-ratings&dir=desc", "/users/evan?tab=show-ratings&dir=asc")).toBe(true);
+    expect(run("/users/test-user?tab=show-ratings", "/users/test-user?tab=track-ratings")).toBe(true);
+    expect(run("/users/test-user?tab=show-ratings&page=1", "/users/test-user?tab=show-ratings&page=2")).toBe(true);
+    expect(run("/users/test-user?tab=show-ratings&sort=date", "/users/test-user?tab=show-ratings&sort=rating")).toBe(
+      true,
+    );
+    expect(run("/users/test-user?tab=show-ratings&dir=desc", "/users/test-user?tab=show-ratings&dir=asc")).toBe(true);
   });
 });

--- a/apps/web/app/server/request-user.test.ts
+++ b/apps/web/app/server/request-user.test.ts
@@ -26,7 +26,7 @@ describe("getRequestUser", () => {
   // must dedupe to one upstream auth call so we don't pay the Supabase
   // round-trip twice per page.
   test("dedupes concurrent calls that share a cookie header", async () => {
-    const user = { id: "u1", email: "evan@foo.net" } as User;
+    const user = { id: "u1", email: "test-user@example.com" } as User;
     supabaseGetUser.mockResolvedValue({ data: { user }, error: null });
 
     const reqA = makeRequest();
@@ -42,7 +42,7 @@ describe("getRequestUser", () => {
   // the old in-flight entry — entries evict on settle so the next
   // request's auth state is fetched fresh.
   test("re-fetches after the first call has resolved", async () => {
-    const user = { id: "u1", email: "evan@foo.net" } as User;
+    const user = { id: "u1", email: "test-user@example.com" } as User;
     supabaseGetUser.mockResolvedValue({ data: { user }, error: null });
 
     await getRequestUser(makeRequest());

--- a/apps/web/app/server/show-user-data.test.ts
+++ b/apps/web/app/server/show-user-data.test.ts
@@ -112,9 +112,10 @@ describe("computeShowUserData", () => {
     getAveragesForRateables.mockResolvedValue({});
     findByEmail.mockResolvedValue(null);
 
-    const result = await computeShowUserData({ currentUser: { id: "auth-1", email: "evan@foo.net", isAdmin: false } }, [
-      "show-1",
-    ]);
+    const result = await computeShowUserData(
+      { currentUser: { id: "auth-1", email: "test-user@example.com", isAdmin: false } },
+      ["show-1"],
+    );
 
     expect(result.attendances["show-1"]).toBeNull();
     expect(result.userRatings["show-1"]).toBeNull();
@@ -130,17 +131,17 @@ describe("computeShowUserData", () => {
       "show-1": { average: 4.0, count: 5 },
       "show-2": { average: 3.0, count: 2 },
     });
-    findByEmail.mockResolvedValue({ id: "user-1", email: "evan@foo.net" });
+    findByEmail.mockResolvedValue({ id: "user-1", email: "test-user@example.com" });
     const attendance1 = { id: "att-1", showId: "show-1", userId: "user-1" } as Attendance;
     findManyByUserIdAndShowIds.mockResolvedValue([attendance1]);
     findManyByUserIdAndRateableIds.mockResolvedValue([
       { rateableId: "show-2", rateableType: "Show", value: 5, userId: "user-1" },
     ]);
 
-    const result = await computeShowUserData({ currentUser: { id: "auth-1", email: "evan@foo.net", isAdmin: false } }, [
-      "show-1",
-      "show-2",
-    ]);
+    const result = await computeShowUserData(
+      { currentUser: { id: "auth-1", email: "test-user@example.com", isAdmin: false } },
+      ["show-1", "show-2"],
+    );
 
     expect(result.attendances["show-1"]).toBe(attendance1);
     expect(result.attendances["show-2"]).toBeNull();
@@ -154,13 +155,14 @@ describe("computeShowUserData", () => {
   // calibrated-score or rank-comparison queries — those are the expensive parts.
   test("skips calibrated + rank queries in simple mode", async () => {
     getAveragesForRateables.mockResolvedValue({});
-    findByEmail.mockResolvedValue({ id: "user-1", email: "evan@foo.net", showCalibratedRatings: null });
+    findByEmail.mockResolvedValue({ id: "user-1", email: "test-user@example.com", showCalibratedRatings: null });
     findManyByUserIdAndShowIds.mockResolvedValue([]);
     findManyByUserIdAndRateableIds.mockResolvedValue([]);
 
-    const result = await computeShowUserData({ currentUser: { id: "a", email: "evan@foo.net", isAdmin: false } }, [
-      "show-1",
-    ]);
+    const result = await computeShowUserData(
+      { currentUser: { id: "a", email: "test-user@example.com", isAdmin: false } },
+      ["show-1"],
+    );
 
     expect(getDisplayedForShows).not.toHaveBeenCalled();
     expect(getShowRankComparisons).not.toHaveBeenCalled();
@@ -173,7 +175,7 @@ describe("computeShowUserData", () => {
     getAveragesForRateables.mockResolvedValue({});
     findByEmail.mockResolvedValue({
       id: "user-1",
-      email: "evan@foo.net",
+      email: "test-user@example.com",
       showCalibratedRatings: true,
       showRatingComparisonDebug: true,
     });
@@ -188,9 +190,10 @@ describe("computeShowUserData", () => {
     };
     getShowRankComparisons.mockResolvedValue({ "show-1": rank });
 
-    const result = await computeShowUserData({ currentUser: { id: "a", email: "evan@foo.net", isAdmin: false } }, [
-      "show-1",
-    ]);
+    const result = await computeShowUserData(
+      { currentUser: { id: "a", email: "test-user@example.com", isAdmin: false } },
+      ["show-1"],
+    );
 
     expect(result.displayedRatings["show-1"]).toEqual({ rating: 4.2, count: 18 });
     expect(result.rankComparisons["show-1"]).toEqual(rank);

--- a/apps/web/app/server/track-user-ratings.test.ts
+++ b/apps/web/app/server/track-user-ratings.test.ts
@@ -57,7 +57,7 @@ describe("computeTrackUserRatings", () => {
     getAveragesForRateables.mockResolvedValue({ t1: { average: 3, count: 2 } });
     findByEmail.mockResolvedValue(null);
     const result = await computeTrackUserRatings(
-      { currentUser: { id: "auth-1", email: "evan@foo.net", isAdmin: false } },
+      { currentUser: { id: "auth-1", email: "test-user@example.com", isAdmin: false } },
       ["t1"],
     );
     expect(result.averageRatings).toEqual({ t1: { average: 3, count: 2 } });
@@ -73,14 +73,14 @@ describe("computeTrackUserRatings", () => {
       t1: { average: 5, count: 8 },
       t3: { average: 4, count: 4 },
     });
-    findByEmail.mockResolvedValue({ id: "user-1", email: "evan@foo.net" });
+    findByEmail.mockResolvedValue({ id: "user-1", email: "test-user@example.com" });
     findManyByUserIdAndRateableIds.mockResolvedValue([
       { rateableId: "t1", rateableType: "Track", value: 5, userId: "user-1" },
       { rateableId: "t3", rateableType: "Track", value: 3, userId: "user-1" },
     ]);
 
     const result = await computeTrackUserRatings(
-      { currentUser: { id: "auth-1", email: "evan@foo.net", isAdmin: false } },
+      { currentUser: { id: "auth-1", email: "test-user@example.com", isAdmin: false } },
       ["t1", "t2", "t3"],
     );
 

--- a/packages/core/scripts/sync-missing-shows.test.ts
+++ b/packages/core/scripts/sync-missing-shows.test.ts
@@ -3674,7 +3674,7 @@ describe("syncUserActivity — avatarFileId FK safety", () => {
 
 describe("syncUserActivity — username-keyed user upsert", () => {
   // When a prod user's id doesn't match locally but their username does
-  // (e.g. local was seeded from a dump that gave evan a different id), the
+  // (e.g. local was seeded from a dump that gave test-user a different id), the
   // sync must update the local row in place — NOT create a second row that
   // would hit users_username_unique — and must remap ratings/attendances
   // owned by the prod id onto the local id so they attach to the right
@@ -3684,10 +3684,10 @@ describe("syncUserActivity — username-keyed user upsert", () => {
       users: [
         {
           // Local id, kept stable across the sync (PKs aren't rewritten).
-          id: "local-evan-id",
-          email: "stub-local-evan-id@local.invalid",
+          id: "local-test-user-id",
+          email: "stub-local-test-user-id@local.invalid",
           passwordDigest: "STUB",
-          username: "evan",
+          username: "test-user",
           avatarFileId: null,
           avatarFileUrl: null,
           createdAt: new Date("2020-01-01T00:00:00Z"),
@@ -3701,11 +3701,11 @@ describe("syncUserActivity — username-keyed user upsert", () => {
         {
           users: [
             {
-              // Prod's id for "evan" differs from local.
-              id: "prod-evan-id",
-              username: "evan",
+              // Prod's id for "test-user" differs from local.
+              id: "prod-test-user-id",
+              username: "test-user",
               avatarFileId: null,
-              avatarFileUrl: "https://cdn.example/evan.jpg",
+              avatarFileUrl: "https://cdn.example/test-user.jpg",
               createdAt: "2020-01-01T00:00:00Z",
               updatedAt: "2024-08-12T00:00:00Z",
             },
@@ -3718,7 +3718,7 @@ describe("syncUserActivity — username-keyed user upsert", () => {
           ratings: [
             {
               id: "r-1",
-              userId: "prod-evan-id",
+              userId: "prod-test-user-id",
               value: 5,
               rateableType: "Show",
               rateableId: "show-1",
@@ -3746,11 +3746,11 @@ describe("syncUserActivity — username-keyed user upsert", () => {
     // Only one user row — no users_username_unique violation; local id
     // stays stable; the prod-side update (new avatar URL) lands.
     expect(state.users).toHaveLength(1);
-    expect(state.users[0].id).toBe("local-evan-id");
-    expect(state.users[0].avatarFileUrl).toBe("https://cdn.example/evan.jpg");
-    // Rating's userId was remapped from prod-evan-id to local-evan-id.
+    expect(state.users[0].id).toBe("local-test-user-id");
+    expect(state.users[0].avatarFileUrl).toBe("https://cdn.example/test-user.jpg");
+    // Rating's userId was remapped from prod-test-user-id to local-test-user-id.
     expect(state.ratings).toHaveLength(1);
-    expect(state.ratings[0].userId).toBe("local-evan-id");
+    expect(state.ratings[0].userId).toBe("local-test-user-id");
   });
 });
 

--- a/packages/core/scripts/track-rating-calibration-spike.ts
+++ b/packages/core/scripts/track-rating-calibration-spike.ts
@@ -761,7 +761,7 @@ function variantSweepReport(
   const distTracks = [...plain.keys()].filter((id) => (plain.get(id)?.count ?? 0) >= minDistRatings);
 
   const configs: Array<{ label: string; options: VariantOptions }> = [
-    { label: "discriminating (none, γ" + gamma + ", k0)", options: { centering: "none", gamma, shrinkK: 0 } },
+    { label: `discriminating (none, γ${gamma}, k0)`, options: { centering: "none", gamma, shrinkK: 0 } },
     { label: `mean-center (mean, γ${gamma}, k0)`, options: { centering: "mean", gamma, shrinkK: 0 } },
     { label: `z-score (zscore, γ${gamma}, k0)`, options: { centering: "zscore", gamma, shrinkK: 0 } },
     { label: `mean + light shrink (mean, γ${gamma}, k1)`, options: { centering: "mean", gamma, shrinkK: 1 } },


### PR DESCRIPTION
Test fixtures now use a neutral `test-user` / `test-user@example.com` identity
instead of a personal name and email address.

The lone remaining `evan` reference is in `quonfig.test.ts`, which asserts the
real feature-flag config gates the debug overlay to the author username. That's
production config under test, not placeholder data, so it stays.

Also converts a string concatenation to a template literal in
`track-rating-calibration-spike.ts` to clear a Biome lint hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
