### PR TITLE
Rename ratings explainer and add a color-code preview

### DIFF
--- a/apps/web/app/components/layout/footer.tsx
+++ b/apps/web/app/components/layout/footer.tsx
@@ -2,6 +2,7 @@ import { Heart, Mail, Sparkles } from "lucide-react";
 import { Link } from "react-router-dom";
 import { ContactDialog } from "~/components/contact/contact-dialog";
 import { useFeatureFlags } from "~/hooks/use-feature-flags";
+import { CALIBRATED_RATING_ALGORITHM_PATH } from "~/lib/route-paths";
 
 export function Footer() {
   const currentYear = new Date().getFullYear();
@@ -39,7 +40,7 @@ export function Footer() {
           </Link>
           {explainerNavLink && (
             <Link
-              to="/show-rating-algorithm"
+              to={CALIBRATED_RATING_ALGORITHM_PATH}
               className="text-content-text-secondary hover:text-content-text-primary transition-colors duration-200"
             >
               Ratings

--- a/apps/web/app/components/rating/rating-badge-button.tsx
+++ b/apps/web/app/components/rating/rating-badge-button.tsx
@@ -7,7 +7,7 @@ import { usePreferences } from "~/hooks/use-preferences";
 import { ROW_CHIP_HOVER } from "~/lib/interaction-styles";
 import { cn } from "~/lib/utils";
 
-type RatingBadgeSize = "compact" | "regular";
+export type RatingBadgeSize = "compact" | "regular";
 
 /**
  * The badge's surface when the color scale is off. Note `glass-secondary` sets
@@ -38,6 +38,31 @@ const RATED_GOLD_CHROME =
  */
 const SCALE_CHROME =
   "border border-content-text-secondary/28 hover:border-content-text-secondary/60 hover:bg-content-text-secondary/10";
+
+/**
+ * Layout + padding for the badge chip, by size and whether the viewer has
+ * rated (a rated badge tightens padding to fit the divider + personal value).
+ * Exported so the rating-display settings preview renders the same chip shape
+ * without the button, popover, and click behavior.
+ */
+export function ratingBadgeLayoutClass(size: RatingBadgeSize, hasRated: boolean): string {
+  const layout =
+    size === "compact"
+      ? "inline-flex items-center justify-center gap-1 py-1 rounded-md"
+      : "flex items-center justify-center gap-1 h-6 sm:h-8 rounded-md";
+  const padding = size === "compact" ? (hasRated ? "px-1" : "px-2") : hasRated ? "px-1.5 sm:px-2" : "px-2 sm:px-3";
+  return cn(layout, padding);
+}
+
+/**
+ * The badge's edge, one of three never-layered surfaces (see `BADGE_CHROME`).
+ * Scale on: a neutral hairline, since the tinted score carries the color. Scale
+ * off: gold once rated, glass until then. `colorEnabled` is passed in rather
+ * than read from preferences so the settings preview can force each column.
+ */
+export function ratingBadgeStateClass(colorEnabled: boolean, hasRated: boolean): string {
+  return colorEnabled ? SCALE_CHROME : hasRated ? RATED_GOLD_CHROME : BADGE_CHROME;
+}
 
 interface RatingBadgeButtonProps {
   rateableId: string;
@@ -128,23 +153,7 @@ export function RatingBadgeButton({
     onAverageRatingChange?.(average, count);
   };
 
-  // Size variants pick layout + height classes. `compact` is inline-flex
-  // so the table cell can hug the content width; `regular` uses flex with
-  // explicit height to align next to neighbor buttons (Saw it?, etc.).
-  const layoutClass =
-    size === "compact"
-      ? "inline-flex items-center justify-center gap-1 py-1 rounded-md"
-      : "flex items-center justify-center gap-1 h-6 sm:h-8 rounded-md";
-
-  // Padding tightens when the personal score renders to compensate for the
-  // busier row (divider + extra value).
-  const paddingClass =
-    size === "compact" ? (localHasRated ? "px-1" : "px-2") : localHasRated ? "px-1.5 sm:px-2" : "px-2 sm:px-3";
-
-  // Three surfaces, never layered — see BADGE_CHROME for why they can't be.
-  // Scale on: a neutral hairline, since the score carries the color. Scale off:
-  // gold once rated, glass until then.
-  const stateClass = colorCodeRatings ? SCALE_CHROME : localHasRated ? RATED_GOLD_CHROME : BADGE_CHROME;
+  const stateClass = ratingBadgeStateClass(colorCodeRatings, localHasRated);
 
   // The picker has to be opaque or the rows under it read through. Only
   // `glass-secondary` brings its own fill (plus a backdrop blur); the gold and
@@ -167,8 +176,7 @@ export function RatingBadgeButton({
       // classes that are free to change.
       data-rated={localHasRated}
       className={cn(
-        layoutClass,
-        paddingClass,
+        ratingBadgeLayoutClass(size, localHasRated),
         ROW_CHIP_HOVER,
         stateClass,
         isAnimating && "animate-[avg-rating-update_0.5s_ease-out]",

--- a/apps/web/app/components/rating/rating-display-settings.tsx
+++ b/apps/web/app/components/rating/rating-display-settings.tsx
@@ -1,8 +1,63 @@
+import { Fragment } from "react";
 import { Link } from "react-router-dom";
+import { RatingComponent } from "~/components/rating/rating";
+import { ratingBadgeLayoutClass, ratingBadgeStateClass } from "~/components/rating/rating-badge-button";
 import { PreferenceToggle } from "~/components/settings/preference-toggle";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { useFeatureFlags } from "~/hooks/use-feature-flags";
 import { PREFERENCES_DEFAULT } from "~/hooks/use-preferences";
+import { CALIBRATED_RATING_ALGORITHM_PATH } from "~/lib/route-paths";
+import { cn } from "~/lib/utils";
+
+/**
+ * Live before/after for the color-code toggle: the same three ratings rendered
+ * in the real rating badge with the scale off and on, so the effect is shown
+ * rather than described. Each row pairs a crowd average with a personal score,
+ * and the pairs are picked to land in different parts of the purple-to-green
+ * ramp: agreement up high, a small gap near the middle, and a wide gap where the
+ * crowd panned a show the viewer loved. `colorCode` is forced per column so the
+ * preview ignores the viewer's own setting.
+ */
+const COLOR_CODE_PREVIEW_ROWS = [
+  { caption: "You agree", crowd: 4.7, you: 5 },
+  { caption: "Small gap", crowd: 3.1, you: 2.5 },
+  { caption: "Big gap", crowd: 1.8, you: 4.5 },
+];
+
+function PreviewBadge({ crowd, you, colorCode }: { crowd: number; you: number; colorCode: boolean }) {
+  return (
+    <div
+      className={cn(
+        ratingBadgeLayoutClass("regular", true),
+        ratingBadgeStateClass(colorCode, true),
+        "justify-self-center",
+      )}
+    >
+      <RatingComponent rating={crowd} userRating={you} colorCode={colorCode} />
+    </div>
+  );
+}
+
+function ColorCodeExample() {
+  return (
+    <div className="flex justify-center">
+      <Card variant="panel" className="w-fit p-4">
+        <div className="grid grid-cols-[auto_auto_auto] items-center gap-x-4 gap-y-2.5">
+          <span />
+          <span className="justify-self-center text-content-text-tertiary text-[11px]">Example off</span>
+          <span className="justify-self-center text-content-text-tertiary text-[11px]">Example on</span>
+          {COLOR_CODE_PREVIEW_ROWS.map((row) => (
+            <Fragment key={row.caption}>
+              <span className="text-content-text-secondary text-xs">{row.caption}</span>
+              <PreviewBadge crowd={row.crowd} you={row.you} colorCode={false} />
+              <PreviewBadge crowd={row.crowd} you={row.you} colorCode={true} />
+            </Fragment>
+          ))}
+        </div>
+      </Card>
+    </div>
+  );
+}
 
 /**
  * Rating-display preferences for the viewer's own profile. Color coding is
@@ -40,13 +95,6 @@ export function RatingDisplaySettings({
         {/* Each switch reflects the user's explicit choice, falling back to the
             app default when they've never set one (a null pref resolves to the
             default). The calibrated toggle's default is flag-driven. */}
-        <PreferenceToggle
-          field="colorCodeRatings"
-          label="Color-code rating values"
-          description="Tint rating numbers from purple to green so you can spot strong and weak scores, and see where you differ from the crowd, without reading them."
-          initial={colorCodeRatings ?? PREFERENCES_DEFAULT.colorCodeRatings}
-        />
-
         {toggleVisible && (
           <PreferenceToggle
             field="showCalibratedRatings"
@@ -56,7 +104,7 @@ export function RatingDisplaySettings({
               <>
                 Weights raters by how much of the 0.5 to 5 star scale they use, corrects for generous and harsh graders,
                 and counts each person once.{" "}
-                <Link to="/show-rating-algorithm" className="text-brand-primary hover:underline">
+                <Link to={CALIBRATED_RATING_ALGORITHM_PATH} className="text-brand-primary hover:underline">
                   How it works →
                 </Link>
               </>
@@ -82,9 +130,9 @@ export function RatingDisplaySettings({
             ariaLabel="Use the calibrated track rating"
             description={
               <>
-                Leans on raters who use the whole 0.5 to 5 star scale and discounts one-note fluffers, so tracks spread
-                out instead of all sitting near 5.{" "}
-                <Link to="/show-rating-algorithm" className="text-brand-primary hover:underline">
+                Weights raters by how much of the 0.5 to 5 star scale they use, so tracks spread out instead of all
+                sitting near 5.{" "}
+                <Link to={CALIBRATED_RATING_ALGORITHM_PATH} className="text-brand-primary hover:underline">
                   How it works →
                 </Link>
               </>
@@ -102,6 +150,19 @@ export function RatingDisplaySettings({
             initial={trackRatingComparisonDebug ?? false}
           />
         )}
+
+        {/* Available to everyone, so it sits last, after the opt-in calibrated
+            settings. Carries a live before/after preview since the tint is
+            easier to show than to describe. */}
+        <div className="space-y-3">
+          <PreferenceToggle
+            field="colorCodeRatings"
+            label="Color-code rating values"
+            description="Tint rating numbers from purple to green so you can spot strong and weak scores, and see where you differ from the crowd, without reading them."
+            initial={colorCodeRatings ?? PREFERENCES_DEFAULT.colorCodeRatings}
+          />
+          <ColorCodeExample />
+        </div>
       </CardContent>
     </Card>
   );

--- a/apps/web/app/components/rating/rating.test.tsx
+++ b/apps/web/app/components/rating/rating.test.tsx
@@ -109,6 +109,26 @@ describe("RatingComponent", () => {
     expect(screen.getByTestId("user-rating-value").style.color).toBe("");
   });
 
+  // The `colorCode` override wins over the saved preference so the settings
+  // preview can force the scale on. Here the preference is off (bare setup).
+  test("colors values when colorCode={true} overrides a disabled preference", async () => {
+    await setup(<RatingComponent rating={1.8} userRating={4.5} colorCode={true} />);
+    expect(screen.getByText("1.80")).toHaveStyle({ color: ratingColor(1.8) });
+    expect(screen.getByTestId("user-rating-value")).toHaveStyle({ color: ratingColor(4.5) });
+  });
+
+  // The other direction: the preview's "off" column forces the scale off even
+  // when the viewer has color coding on.
+  test("leaves values uncolored when colorCode={false} overrides an enabled preference", async () => {
+    await setup(
+      <PreferencesProvider colorCodeRatings={true} showSetlistTimes={null}>
+        <RatingComponent rating={1.8} userRating={4.5} colorCode={false} />
+      </PreferencesProvider>,
+    );
+    expect(screen.getByText("1.80").style.color).toBe("");
+    expect(screen.getByTestId("user-rating-value").style.color).toBe("");
+  });
+
   test("leaves both values uncolored when the viewer opts out", async () => {
     await setup(
       <PreferencesProvider colorCodeRatings={false} showSetlistTimes={null}>

--- a/apps/web/app/components/rating/rating.tsx
+++ b/apps/web/app/components/rating/rating.tsx
@@ -12,6 +12,13 @@ interface RatingProps {
    * treated as "not rated" — the divider and slot don't render.
    */
   userRating?: number | null;
+  /**
+   * Forces the color scale on (`true`) or off (`false`) regardless of the
+   * viewer's saved preference. Only the settings preview sets it, to show the
+   * same rating both ways; leave it undefined everywhere else so the viewer's
+   * own preference decides.
+   */
+  colorCode?: boolean;
 }
 
 /**
@@ -45,9 +52,9 @@ function ratingColorStyle(value: number, enabled: boolean): { color: string } | 
  * colored number. With the scale off it falls back to gold, which is then the
  * badge's only color.
  */
-export function StarValue({ value, label }: { value: number; label: string }) {
+export function StarValue({ value, label, colorCode }: { value: number; label: string; colorCode?: boolean }) {
   const { colorCodeRatings } = usePreferences();
-  const tint = ratingColorStyle(value, colorCodeRatings);
+  const tint = ratingColorStyle(value, colorCode ?? colorCodeRatings);
   return (
     <span className="inline-flex items-center whitespace-nowrap">
       <Star className="h-3 w-3 sm:h-4 sm:w-4 shrink-0 text-rating-gold mr-0.5 sm:mr-1" style={tint} />
@@ -58,8 +65,9 @@ export function StarValue({ value, label }: { value: number; label: string }) {
   );
 }
 
-export const RatingComponent = ({ rating, ratingsCount, userRating }: RatingProps) => {
+export const RatingComponent = ({ rating, ratingsCount, userRating, colorCode }: RatingProps) => {
   const { colorCodeRatings } = usePreferences();
+  const colorEnabled = colorCode ?? colorCodeRatings;
 
   if (!rating) return <div className="text-xs sm:text-sm text-content-text-secondary">Rate</div>;
   const hasUserRating = typeof userRating === "number" && userRating > 0;
@@ -69,7 +77,7 @@ export const RatingComponent = ({ rating, ratingsCount, userRating }: RatingProp
   const outerGap = hasUserRating ? "gap-1" : "gap-1 sm:gap-1.5";
   return (
     <div className={`flex items-center ${outerGap}`}>
-      <StarValue value={rating} label={rating.toFixed(2)} />
+      <StarValue value={rating} label={rating.toFixed(2)} colorCode={colorCode} />
       {ratingsCount &&
         ratingsCount > 0 &&
         (hasUserRating ? (
@@ -99,7 +107,7 @@ export const RatingComponent = ({ rating, ratingsCount, userRating }: RatingProp
             // as its integer; the slot is wide enough for "5½" while still
             // centering "5".
             className="font-medium text-[10px] sm:text-xs text-content-text-primary inline-block min-w-[2ch] text-center whitespace-nowrap"
-            style={ratingColorStyle(userRating, colorCodeRatings)}
+            style={ratingColorStyle(userRating, colorEnabled)}
           >
             {formatHalfStep(userRating)}
           </span>

--- a/apps/web/app/lib/route-paths.ts
+++ b/apps/web/app/lib/route-paths.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared absolute route paths, so links and the router config reference the
+ * same string instead of each hardcoding it. Add a path here once it's used in
+ * more than one place. Keep these free of server imports — `routes.ts` and
+ * client components both import this module.
+ */
+
+export const CALIBRATED_RATING_ALGORITHM_PATH = "/calibrated-rating-algorithm";

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -1,5 +1,6 @@
 import type { RouteConfig } from "@react-router/dev/routes";
 import { index, layout, prefix, route } from "@react-router/dev/routes";
+import { CALIBRATED_RATING_ALGORITHM_PATH } from "./lib/route-paths";
 
 export default [
   // Root index route
@@ -10,7 +11,7 @@ export default [
 
   // Legal and info pages
   route("about", "routes/about.tsx"),
-  route("show-rating-algorithm", "routes/show-rating-algorithm.tsx"),
+  route(CALIBRATED_RATING_ALGORITHM_PATH.slice(1), "routes/calibrated-rating-algorithm.tsx"),
   route("terms", "routes/terms.tsx"),
   route("privacy", "routes/privacy.tsx"),
   route("community", "routes/community.tsx"),

--- a/apps/web/app/routes/calibrated-rating-algorithm.test.tsx
+++ b/apps/web/app/routes/calibrated-rating-algorithm.test.tsx
@@ -1,7 +1,7 @@
 import { setupWithRouter } from "@test/test-utils";
 import { screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
-import ShowRatingAlgorithm from "./show-rating-algorithm";
+import CalibratedRatingAlgorithm from "./calibrated-rating-algorithm";
 
 vi.mock("~/hooks/use-feature-flags", () => ({ useFeatureFlags: vi.fn() }));
 vi.mock("~/hooks/use-session", () => ({ useSession: vi.fn() }));
@@ -35,18 +35,18 @@ function mockUser(username: string | null) {
   });
 }
 
-describe("ShowRatingAlgorithm", () => {
+describe("CalibratedRatingAlgorithm", () => {
   test("links 'your profile settings' to the viewer's profile when the toggle is available", async () => {
     mockFlags(true);
     mockUser("tractorbeam");
-    await setupWithRouter(<ShowRatingAlgorithm />);
+    await setupWithRouter(<CalibratedRatingAlgorithm />);
     expect(screen.getByRole("link", { name: "your profile settings" })).toHaveAttribute("href", "/users/tractorbeam");
   });
 
   test("leaves 'your profile settings' as plain text when the toggle flag is off", async () => {
     mockFlags(false);
     mockUser("tractorbeam");
-    await setupWithRouter(<ShowRatingAlgorithm />);
+    await setupWithRouter(<CalibratedRatingAlgorithm />);
     expect(screen.queryByRole("link", { name: "your profile settings" })).not.toBeInTheDocument();
     expect(screen.getByText(/your profile settings/)).toBeInTheDocument();
   });
@@ -54,7 +54,7 @@ describe("ShowRatingAlgorithm", () => {
   test("leaves 'your profile settings' as plain text for a signed-out visitor", async () => {
     mockFlags(true);
     mockUser(null);
-    await setupWithRouter(<ShowRatingAlgorithm />);
+    await setupWithRouter(<CalibratedRatingAlgorithm />);
     expect(screen.queryByRole("link", { name: "your profile settings" })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/routes/calibrated-rating-algorithm.tsx
+++ b/apps/web/app/routes/calibrated-rating-algorithm.tsx
@@ -5,7 +5,7 @@ import { useSession } from "~/hooks/use-session";
 
 export function meta() {
   return [
-    { title: "How ratings work | Biscuits Internet Project" },
+    { title: "How Calibrated Ratings Work | Biscuits Internet Project" },
     {
       name: "description",
       content:
@@ -39,7 +39,7 @@ function PostLink({ href, children }: { href: string; children: React.ReactNode 
  * link, shown when the `ratings.toggle-visible` flag makes the opt-in available to
  * this signed-in viewer.
  */
-export default function ShowRatingAlgorithm() {
+export default function CalibratedRatingAlgorithm() {
   const { toggleVisible } = useFeatureFlags();
   const { user } = useSession();
   // Link straight to the viewer's profile (where the opt-in toggle lives) only
@@ -49,7 +49,7 @@ export default function ShowRatingAlgorithm() {
   return (
     <div className="space-y-6 md:space-y-8">
       <div>
-        <h1 className="page-heading">HOW RATINGS WORK</h1>
+        <h1 className="page-heading">HOW CALIBRATED RATINGS WORK</h1>
       </div>
 
       <div className="grid gap-6 md:gap-8">


### PR DESCRIPTION
The ratings explainer now lives at `/calibrated-rating-algorithm` and is titled
"How Calibrated Ratings Work". The old `/show-rating-algorithm` URL is gone.

On your own profile's Settings tab, the "Color-code rating values" toggle now
carries a live before/after preview: the real rating badge shown with the color
scale off and on, across three crowd-vs-you pairs: you agree (both high), a
small gap, and a wide gap where the crowd panned a show you loved. It moved
below the calibrated show/track settings, since color coding is available to
everyone.

The calibrated track-rating description was also reworded to reuse the show
rating's opening clause, so the two read consistently.

## Notes for the reviewer

- The shared route path is a single constant in `app/lib/route-paths.ts`. The
  router config strips the leading slash (`route()` wants the segment) so the
  config and the `<Link to>` sites can't drift.
- The preview reuses the real `RatingComponent` (new optional `colorCode` prop
  that overrides the viewer's saved preference per column) and the real badge
  chrome (extracted from `RatingBadgeButton` into `ratingBadgeLayoutClass` /
  `ratingBadgeStateClass`), so the demo can't drift from production rendering.
  Because it's the real badge, the "off" column also shows the gold rated
  border and "on" shows the neutral hairline, faithful to production, so both
  the border and the number tint differ between columns.
- `/show-rating-algorithm` now 404s; no redirect was added. Say the word if the
  old URL was shared externally and should redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
