### PR TITLE
Collapse one rater's alias accounts into a single vote

### DIFF
--- a/packages/core/src/_shared/prisma/migrations/20260719000000_force_ratings_recompute_after_alias_merge/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260719000000_force_ratings_recompute_after_alias_merge/migration.sql
@@ -1,0 +1,13 @@
+-- One-time force of the ratings recompute so the expanded duplicate-account merge
+-- (msp trio HankScorpio/DeepDive/Mojobisco added to ALIAS_MERGE_GROUPS) takes effect
+-- in the denormalized average_rating / ratings_count columns.
+--
+-- The deploy entrypoint runs scripts/recompute-ratings.ts right after
+-- `prisma migrate deploy`, but that recompute is dirty-gated on
+-- rating_settings.ratings_dirty and a code-only dedup change never flips it. Flip it
+-- here so the very next recompute rebuilds every rateable's canonical average with the
+-- new dedup. The recompute clears the flag when it finishes.
+--
+-- Idempotent: re-running only re-sets true. If no settings row exists, isDirty()
+-- already treats the absent row as dirty, so the recompute still runs.
+UPDATE "rating_settings" SET "ratings_dirty" = true;

--- a/packages/core/src/ratings/rater-aliases.ts
+++ b/packages/core/src/ratings/rater-aliases.ts
@@ -8,9 +8,10 @@
  * Two layers:
  *  - `normalize` folds case/space/underscore, which provably catches login
  *    variants (e.g. "RyKnow" / "RyKnow ", "Digital Buddha" / "DigitalBuddha").
- *  - `ALIAS_MERGE_GROUPS` curates spelling variants that normalization misses
- *    (e.g. "Invisble" vs "Invisible"). Only confirmed-same-person groups go here;
- *    fuzzy matches that might be distinct people are deliberately excluded.
+ *  - `ALIAS_MERGE_GROUPS` curates same-person groups normalization misses (a
+ *    spelling variant like "Invisble" vs "Invisible", or accounts sharing one
+ *    confirmed email namespace). Only infrastructure-backed groups go here; a
+ *    behavioral-only match that might be distinct people is deliberately excluded.
  */
 
 /** Fold a username to its login-variant key: lowercase, no spaces or underscores. */
@@ -19,12 +20,26 @@ export function normalize(username: string): string {
 }
 
 /**
- * Confirmed same-person groups whose normalized keys still differ (spelling
- * variants). Each inner array lists the normalized forms that should merge.
+ * Confirmed same-person groups whose normalized keys still differ. Each inner
+ * array lists the normalized forms that should merge.
+ *
+ * Only same-person links backed by account *infrastructure* — a shared confirmed
+ * email namespace, or near-identical usernames created minutes apart — go here.
+ * Behavioral "switch" evidence (one account re-rating another's batch with matching
+ * scores) is deliberately NOT sufficient: a shared community score source, or a
+ * script, produces that same pattern across genuinely different people. Several
+ * rater accounts here re-rate one identical show-batch in lockstep yet never once
+ * operate concurrently, so batch-mirroring cannot tell one operator from a shared
+ * sheet.
  */
 const ALIAS_MERGE_GROUPS: string[][] = [
-  // "InvisbleBuddha" (misspelled) + "Invisiblebuddha" (correct) + "invisblebuddha".
+  // "InvisbleBuddha" (misspelled) + "Invisiblebuddha" + "invisblebuddha": one-letter
+  // username variants, two of them created 8 minutes apart. One person.
   ["invisblebuddha", "invisiblebuddha"],
+  // HankScorpio, DeepDive, and Mojobisco all authenticate under one personal 33mail
+  // alias namespace (…@msp.33mail.com) and each account is email-confirmed, so all
+  // three verification links landed in one inbox = one person.
+  ["hankscorpio", "deepdive", "mojobisco"],
 ];
 
 /** normalized form → the group's chosen representative key. */


### PR DESCRIPTION
Rating averages and counts on shows and tracks now treat a set of alias accounts as one voter instead of several. The accounts all authenticate under a single confirmed email-alias namespace, so every verification email reached one inbox: one person.

They join the existing `ALIAS_MERGE_GROUPS` dedup, which already folds known spelling-variant logins (and case/space variants via `normalize`). Dedup is aggregate-only: it collapses each person to one most-recent vote in shared averages/counts/histograms and the calibrated score, and never touches a user's own rating history.

Impact: on the local prod restore this collapses ~1,987 duplicate show votes and ~1,598 track votes.

## Deploy note
The denormalized `average_rating`/`ratings_count` columns only reflect a dedup change after a ratings recompute, which is dirty-gated on `rating_settings.ratings_dirty`, and a code-only change never flips it. The included migration flips the flag; the deploy entrypoint runs `migrate deploy` then `recompute-ratings`, so the recompute in that same deploy rebuilds every aggregate and clears the flag. Community averages are read live from the denormalized column, so no cache bust is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
