### PR TITLE
Add a rating-precision setting and rank shows by the displayed score

### DIFF
--- a/apps/web/app/components/performance/performance-columns.tsx
+++ b/apps/web/app/components/performance/performance-columns.tsx
@@ -1,4 +1,4 @@
-import { compareByShowDate, type SongPagePerformance } from "@bip/domain";
+import { compareByShowDate, RATING_DISPLAY_DECIMALS_DEFAULT, type SongPagePerformance } from "@bip/domain";
 import { type Column, type ColumnDef, createColumnHelper, type Row } from "@tanstack/react-table";
 import { ArrowDownIcon, ArrowUpDown, ArrowUpIcon, Filter, RotateCcw, Star } from "lucide-react";
 import type { ReactNode } from "react";
@@ -10,6 +10,7 @@ import { ShowDateLink } from "~/components/show-date-link";
 import { AllTimerCell, allTimerColumnMeta } from "~/components/track/all-timer-cell";
 import { DurationValue } from "~/components/track/duration-cell";
 import { NumberCell } from "~/components/ui/number-cell";
+import { ratingColumnWidth } from "~/lib/rating-column-width";
 import type { TrackRatingComparison } from "~/server/track-user-ratings";
 import { CombinedNotes } from "./combined-notes";
 import { DateVenueCell } from "./date-venue-cell";
@@ -213,6 +214,8 @@ interface PerformanceColumnOptions {
   displayRatingMap?: Map<string, { average: number; count: number }>;
   /** Plain vs calibrated per track, present only for the author compare overlay. */
   comparisonMap?: Map<string, TrackRatingComparison>;
+  /** Viewer's rating decimal-places setting — sizes the rating column for its score width. */
+  ratingDecimalPlaces?: number;
 }
 
 function SortableHeader({
@@ -255,6 +258,7 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
     isAuthenticated,
     displayRatingMap,
     comparisonMap,
+    ratingDecimalPlaces = RATING_DISPLAY_DECIMALS_DEFAULT,
   } = options;
   const includeGapColumns = showGapColumns !== false;
   const columnHelper = createColumnHelper<SongPagePerformance>();
@@ -548,15 +552,8 @@ export function createPerformanceColumns(options: PerformanceColumnOptions): Col
       // order. Sort defaults to descending ("best first") via sortDescFirst.
       sortingFn: displayRatingSortingFn,
       sortDescFirst: true,
-      // Sized for the busiest badge form: "★ 5.00 · 999 | 4½" — community
-      // average + 3-digit vote count + the viewer's own half-step rating
-      // (4½ is the widest valid user value; ratings cap at 5). Measured at
-      // ~120px on desktop / ~103px on mobile. Desktop 8.25rem (132px)
-      // leaves ~12px slack; mobile 6.75rem (108px) leaves ~5px so typical
-      // rows (no user rating, 1-2 digit count) don't carry obvious empty
-      // space. The 5-star editor pops in a popover that overlays the
-      // badge, so the column doesn't need a wider expanded state.
-      meta: { fixedWidth: "8.25rem", mobileFixedWidth: "6.75rem" },
+      // Width scales with the viewer's chosen decimal places (see ratingColumnWidth).
+      meta: ratingColumnWidth(ratingDecimalPlaces),
       cell: (info) => {
         const row = info.row.original;
         return (

--- a/apps/web/app/components/performance/performance-table.tsx
+++ b/apps/web/app/components/performance/performance-table.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { Card } from "~/components/ui/card";
 import { DataTable } from "~/components/ui/data-table";
 import { useAttendanceRowHighlight } from "~/hooks/use-attendance-row-highlight";
+import { usePreferences } from "~/hooks/use-preferences";
 import { useSession } from "~/hooks/use-session";
 import { useTrackUserRatings } from "~/hooks/use-track-user-ratings";
 import { createPerformanceColumns } from "./performance-columns";
@@ -51,6 +52,7 @@ export function PerformanceTable({
 }: PerformanceTableProps) {
   const { user } = useSession();
   const isAuthenticated = !!user;
+  const { ratingDecimalPlaces } = usePreferences();
 
   const { rowClassName: attendanceRowClassName, isAttended } = useAttendanceRowHighlight(performances, getShowId);
 
@@ -92,6 +94,7 @@ export function PerformanceTable({
         isAuthenticated,
         displayRatingMap,
         comparisonMap,
+        ratingDecimalPlaces,
       }),
     [
       showSongColumn,
@@ -103,6 +106,7 @@ export function PerformanceTable({
       isAuthenticated,
       displayRatingMap,
       comparisonMap,
+      ratingDecimalPlaces,
     ],
   );
 

--- a/apps/web/app/components/performance/track-rating-cell.tsx
+++ b/apps/web/app/components/performance/track-rating-cell.tsx
@@ -1,4 +1,6 @@
+import { formatRatingScore } from "@bip/domain";
 import { RatingBadgeButton } from "~/components/rating/rating-badge-button";
+import { usePreferences } from "~/hooks/use-preferences";
 import type { TrackRatingComparison } from "~/server/track-user-ratings";
 
 /**
@@ -27,6 +29,7 @@ export function TrackRatingCell({
   isAuthenticated: boolean;
   comparison?: TrackRatingComparison;
 }) {
+  const { ratingDecimalPlaces } = usePreferences();
   const badge = (
     <RatingBadgeButton
       rateableId={trackId}
@@ -50,8 +53,9 @@ export function TrackRatingCell({
         className="text-[10px] leading-none text-content-text-tertiary tabular-nums"
         title="community → calibrated (Δ)"
       >
-        {comparison.plain.toFixed(2)}→{comparison.calibrated.toFixed(2)} ({comparison.delta >= 0 ? "+" : ""}
-        {comparison.delta.toFixed(2)})
+        {formatRatingScore(comparison.plain, ratingDecimalPlaces)}→
+        {formatRatingScore(comparison.calibrated, ratingDecimalPlaces)} ({comparison.delta >= 0 ? "+" : ""}
+        {formatRatingScore(comparison.delta, ratingDecimalPlaces)})
       </span>
     </div>
   );

--- a/apps/web/app/components/rating/calibrated-summary.tsx
+++ b/apps/web/app/components/rating/calibrated-summary.tsx
@@ -1,4 +1,6 @@
 import type { RankInField, ShowRankComparison } from "@bip/core";
+import { formatRatingScore, roundRatingForDisplay } from "@bip/domain";
+import { usePreferences } from "~/hooks/use-preferences";
 
 /**
  * The debug rating comparison overlay: a show's simple→calibrated score plus how its
@@ -9,8 +11,8 @@ import type { RankInField, ShowRankComparison } from "@bip/core";
  * behind the `ratings.compare-visible` flag + the user's `showRatingComparisonDebug` pref.
  */
 
-function formatScore(value: number | undefined): string {
-  return value != null && value > 0 ? value.toFixed(2) : "—";
+function formatScore(value: number | undefined, decimals: number): string {
+  return value != null && value > 0 ? formatRatingScore(value, decimals) : "—";
 }
 
 const labelCell = "px-2 py-0.5 text-left font-normal text-content-text-secondary";
@@ -48,19 +50,28 @@ export function CalibratedSummary({
   rank: ShowRankComparison;
   compact?: boolean;
 }) {
+  const { ratingDecimalPlaces } = usePreferences();
   const scoreDiff = canonical != null ? rank.calibrated - canonical : 0;
-  const scoreMoved = Math.abs(scoreDiff) >= 0.005;
+  // "Moved" at the viewer's display precision: a diff that rounds to zero at that
+  // precision reads as no change.
+  const scoreMoved = roundRatingForDisplay(scoreDiff, ratingDecimalPlaces) !== 0;
   return (
     <table className={`border-collapse ${compact ? "text-[10px] leading-tight sm:text-xs" : "text-sm"}`}>
       <tbody>
         <tr>
           <td className={labelCell}>Score</td>
-          <td className={`${numCell} text-content-text-tertiary`}>{formatScore(canonical ?? undefined)}</td>
-          <td className={`${numCell} font-semibold text-content-text-primary`}>{rank.calibrated.toFixed(2)}</td>
+          <td className={`${numCell} text-content-text-tertiary`}>
+            {formatScore(canonical ?? undefined, ratingDecimalPlaces)}
+          </td>
+          <td className={`${numCell} font-semibold text-content-text-primary`}>
+            {formatRatingScore(rank.calibrated, ratingDecimalPlaces)}
+          </td>
           <td
             className={`${numCell} ${scoreDiff > 0 ? "text-green-500" : scoreDiff < 0 ? "text-red-500" : "text-content-text-tertiary"}`}
           >
-            {scoreMoved ? `${scoreDiff > 0 ? "+" : "−"}${Math.abs(scoreDiff).toFixed(2)}` : "—"}
+            {scoreMoved
+              ? `${scoreDiff > 0 ? "+" : "−"}${formatRatingScore(Math.abs(scoreDiff), ratingDecimalPlaces)}`
+              : "—"}
           </td>
         </tr>
         <RankRow label="all" rank={rank.all} />

--- a/apps/web/app/components/rating/rating-charts.tsx
+++ b/apps/web/app/components/rating/rating-charts.tsx
@@ -1,4 +1,5 @@
 import type { RatingYearBucket } from "@bip/core";
+import { formatRatingScore } from "@bip/domain";
 import { useState } from "react";
 import {
   Bar,
@@ -15,6 +16,7 @@ import {
 import { cardVariants } from "~/components/ui/card";
 import { ChartTooltipCard } from "~/components/ui/chart-tooltip";
 import { SegmentButton } from "~/components/ui/segment-button";
+import { usePreferences } from "~/hooks/use-preferences";
 import { CHART_BAR_CURSOR, CHART_COLORS, chartSeriesColor } from "~/lib/chart-colors";
 import {
   availableYears,
@@ -235,13 +237,14 @@ function HistogramTooltip({
 
 /** Trend tooltip: average and median for the hovered concert year. */
 function TrendTooltip({ active, payload, label }: ChartTooltipProps) {
+  const { ratingDecimalPlaces } = usePreferences();
   if (!active || !payload || payload.length === 0) return null;
   return (
     <ChartTooltipCard>
       <div className="font-medium">{label}</div>
       {payload.map((entry) => (
         <div key={entry.dataKey ?? entry.name} style={{ color: entry.color }}>
-          {entry.name}: {(entry.value ?? 0).toFixed(2)}
+          {entry.name}: {formatRatingScore(entry.value ?? 0, ratingDecimalPlaces)}
         </div>
       ))}
     </ChartTooltipCard>

--- a/apps/web/app/components/rating/rating-display-settings.test.tsx
+++ b/apps/web/app/components/rating/rating-display-settings.test.tsx
@@ -18,6 +18,7 @@ const base = {
   trackCalibratedRatings: null,
   trackRatingComparisonDebug: null,
   colorCodeRatings: null,
+  ratingDecimalPlaces: null,
 };
 
 function mockFlags(overrides: Partial<ReturnType<typeof useFeatureFlags>>) {
@@ -84,6 +85,44 @@ describe("RatingDisplaySettings", () => {
     expect(url).toBe("/api/users");
     expect(init.method).toBe("POST");
     expect((init.body as FormData).get("colorCodeRatings")).toBe("true");
+  });
+
+  // The precision dropdown is ungated (available to everyone) and auto-saves the
+  // chosen decimal count to /api/users like the toggles do.
+  test("auto-saves the rating precision choice with no flag enabled", async () => {
+    mockFlags({});
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { user } = await setupWithRouter(<RatingDisplaySettings {...base} />);
+    await user.click(screen.getByLabelText("Rating decimal places"));
+    await user.click(await screen.findByRole("option", { name: "3" }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/users");
+    expect((init.body as FormData).get("ratingDecimalPlaces")).toBe("3");
+  });
+
+  // Holds the save open so the in-flight state is observable on its own: the
+  // dropdown disables while the POST is pending, then re-enables once it settles.
+  test("disables the precision dropdown while its save is in flight", async () => {
+    mockFlags({});
+    let settle: () => void = () => {};
+    const pending = new Promise<{ ok: boolean }>((resolve) => {
+      settle = () => resolve({ ok: true });
+    });
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(pending));
+
+    const { user } = await setupWithRouter(<RatingDisplaySettings {...base} />);
+    const trigger = screen.getByLabelText("Rating decimal places");
+    await user.click(trigger);
+    await user.click(await screen.findByRole("option", { name: "3" }));
+
+    expect(trigger).toBeDisabled();
+
+    settle();
+    await waitFor(() => expect(trigger).not.toBeDisabled());
   });
 
   test("shows only the opt-in toggles when just toggle-visible is on", async () => {

--- a/apps/web/app/components/rating/rating-display-settings.tsx
+++ b/apps/web/app/components/rating/rating-display-settings.tsx
@@ -1,13 +1,24 @@
+import { RATING_DISPLAY_DECIMALS_MAX, RATING_DISPLAY_DECIMALS_MIN } from "@bip/domain";
 import { Fragment } from "react";
 import { Link } from "react-router-dom";
 import { RatingComponent } from "~/components/rating/rating";
 import { ratingBadgeLayoutClass, ratingBadgeStateClass } from "~/components/rating/rating-badge-button";
+import { PreferenceSelect } from "~/components/settings/preference-select";
 import { PreferenceToggle } from "~/components/settings/preference-toggle";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { useFeatureFlags } from "~/hooks/use-feature-flags";
 import { PREFERENCES_DEFAULT } from "~/hooks/use-preferences";
 import { CALIBRATED_RATING_ALGORITHM_PATH } from "~/lib/route-paths";
 import { cn } from "~/lib/utils";
+
+/** Decimal-place choices for the rating precision dropdown (1-4). */
+const RATING_DECIMAL_OPTIONS = Array.from(
+  { length: RATING_DISPLAY_DECIMALS_MAX - RATING_DISPLAY_DECIMALS_MIN + 1 },
+  (_, index) => {
+    const value = String(RATING_DISPLAY_DECIMALS_MIN + index);
+    return { value, label: value };
+  },
+);
 
 /**
  * Live before/after for the color-code toggle: the same three ratings rendered
@@ -77,12 +88,14 @@ export function RatingDisplaySettings({
   trackCalibratedRatings,
   trackRatingComparisonDebug,
   colorCodeRatings,
+  ratingDecimalPlaces,
 }: {
   showCalibratedRatings: boolean | null;
   showRatingComparisonDebug: boolean | null;
   trackCalibratedRatings: boolean | null;
   trackRatingComparisonDebug: boolean | null;
   colorCodeRatings: boolean | null;
+  ratingDecimalPlaces: number | null;
 }) {
   const { toggleVisible, compareVisible, defaultCalibrated } = useFeatureFlags();
 
@@ -150,6 +163,16 @@ export function RatingDisplaySettings({
             initial={trackRatingComparisonDebug ?? false}
           />
         )}
+
+        {/* Available to everyone (ungated), like color coding below. */}
+        <PreferenceSelect
+          field="ratingDecimalPlaces"
+          label="Rating precision"
+          ariaLabel="Rating decimal places"
+          description="How many decimal places rating scores show, from 1 to 4."
+          initial={String(ratingDecimalPlaces ?? PREFERENCES_DEFAULT.ratingDecimalPlaces)}
+          options={RATING_DECIMAL_OPTIONS}
+        />
 
         {/* Available to everyone, so it sits last, after the opt-in calibrated
             settings. Carries a live before/after preview since the tint is

--- a/apps/web/app/components/rating/rating.test.tsx
+++ b/apps/web/app/components/rating/rating.test.tsx
@@ -32,6 +32,25 @@ describe("RatingComponent", () => {
     expect(screen.queryByTestId("user-rating-value")).not.toBeInTheDocument();
   });
 
+  // The community score renders at the viewer's chosen decimal-places setting,
+  // seeded into the preferences context — no per-badge threading.
+  test("renders the community score at the viewer's chosen decimal places", async () => {
+    await setup(
+      <PreferencesProvider colorCodeRatings={null} showSetlistTimes={null} ratingDecimalPlaces={4}>
+        <RatingComponent rating={4.8112} ratingsCount={12} />
+      </PreferencesProvider>,
+    );
+    expect(screen.getByText("4.8112")).toBeInTheDocument();
+    expect(screen.queryByText("4.81")).not.toBeInTheDocument();
+  });
+
+  // With no provider (default context) the score stays at 2 decimals.
+  test("renders the community score at 2 decimals by default", async () => {
+    await setup(<RatingComponent rating={4.811} ratingsCount={12} />);
+    expect(screen.getByText("4.81")).toBeInTheDocument();
+    expect(screen.queryByText("4.811")).not.toBeInTheDocument();
+  });
+
   // Null userRating (e.g. logged-in but hasn't rated yet) renders today's
   // UI unchanged. We never show a placeholder slot — quieter UI for the
   // common "not rated" case.

--- a/apps/web/app/components/rating/rating.tsx
+++ b/apps/web/app/components/rating/rating.tsx
@@ -1,3 +1,4 @@
+import { formatRatingScore } from "@bip/domain";
 import { Star } from "lucide-react";
 import { usePreferences } from "~/hooks/use-preferences";
 import { ratingColor } from "~/lib/rating-colors";
@@ -66,7 +67,7 @@ export function StarValue({ value, label, colorCode }: { value: number; label: s
 }
 
 export const RatingComponent = ({ rating, ratingsCount, userRating, colorCode }: RatingProps) => {
-  const { colorCodeRatings } = usePreferences();
+  const { colorCodeRatings, ratingDecimalPlaces } = usePreferences();
   const colorEnabled = colorCode ?? colorCodeRatings;
 
   if (!rating) return <div className="text-xs sm:text-sm text-content-text-secondary">Rate</div>;
@@ -77,7 +78,7 @@ export const RatingComponent = ({ rating, ratingsCount, userRating, colorCode }:
   const outerGap = hasUserRating ? "gap-1" : "gap-1 sm:gap-1.5";
   return (
     <div className={`flex items-center ${outerGap}`}>
-      <StarValue value={rating} label={rating.toFixed(2)} colorCode={colorCode} />
+      <StarValue value={rating} label={formatRatingScore(rating, ratingDecimalPlaces)} colorCode={colorCode} />
       {ratingsCount &&
         ratingsCount > 0 &&
         (hasUserRating ? (

--- a/apps/web/app/components/setlist/setlist-columns-personal.tsx
+++ b/apps/web/app/components/setlist/setlist-columns-personal.tsx
@@ -1,4 +1,4 @@
-import type { TrackLight } from "@bip/domain";
+import { RATING_DISPLAY_DECIMALS_DEFAULT, type TrackLight } from "@bip/domain";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { PersonalSetlistRow } from "~/lib/personal-setlist-columns";
 import {
@@ -31,6 +31,7 @@ export function createPersonalSetlistColumns(
     userRatingMap: ctx?.userRatingMap ?? new Map(),
     isAuthenticated: ctx?.isAuthenticated ?? false,
     comparisonMap: ctx?.comparisonMap,
+    ratingDecimalPlaces: ctx?.ratingDecimalPlaces ?? RATING_DISPLAY_DECIMALS_DEFAULT,
   };
   return [
     ...createSetlistCommonColumns<PersonalSetlistTableRow>({ songLinkSearchParams: "attended=attended" }),

--- a/apps/web/app/components/setlist/setlist-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-columns.tsx
@@ -1,4 +1,4 @@
-import type { TrackLight } from "@bip/domain";
+import { RATING_DISPLAY_DECIMALS_DEFAULT, type TrackLight } from "@bip/domain";
 import type { ColumnDef } from "@tanstack/react-table";
 import { buildGapCellState, isWithinShowRepeat } from "./gap-cell";
 import {
@@ -34,6 +34,7 @@ export function createSetlistColumns(ctx?: Partial<SetlistRatingContext>): Colum
     userRatingMap: ctx?.userRatingMap ?? new Map(),
     isAuthenticated: ctx?.isAuthenticated ?? false,
     comparisonMap: ctx?.comparisonMap,
+    ratingDecimalPlaces: ctx?.ratingDecimalPlaces ?? RATING_DISPLAY_DECIMALS_DEFAULT,
   };
   return [
     ...createSetlistCommonColumns<SetlistTableRow>(),

--- a/apps/web/app/components/setlist/setlist-common-columns.tsx
+++ b/apps/web/app/components/setlist/setlist-common-columns.tsx
@@ -6,6 +6,7 @@ import { AllTimerCell, allTimerColumnMeta } from "~/components/track/all-timer-c
 import { DurationValue } from "~/components/track/duration-cell";
 import { NumberCell } from "~/components/ui/number-cell";
 import { SortableHeader } from "~/components/ui/sortable-header";
+import { ratingColumnWidth } from "~/lib/rating-column-width";
 import type { TrackRatingComparison } from "~/server/track-user-ratings";
 import { GapCell, type GapCellState } from "./gap-cell";
 import { compareBySetThenPosition, countDistinctEncores, formatSetLabel } from "./set-label";
@@ -41,6 +42,8 @@ export interface SetlistRatingContext {
   userRatingMap: Map<string, number>;
   isAuthenticated: boolean;
   comparisonMap?: Map<string, TrackRatingComparison>;
+  /** Viewer's rating decimal-places setting — sizes the column for its score width. */
+  ratingDecimalPlaces: number;
 }
 
 /**
@@ -58,14 +61,8 @@ export function createRatingColumn<T extends TrackLight>(ctx: SetlistRatingConte
   return columnHelper.accessor((row) => ctx.averageRatingMap.get(row.id)?.average ?? Number.NEGATIVE_INFINITY, {
     id: "rating",
     header: ({ column }) => <SortableHeader column={column} label="Rating" />,
-    // Sized for the busiest badge form: "★ 5.00 · 999 | 4½" — community
-    // average + 3-digit vote count + the viewer's own half-step rating
-    // (4½ is the widest valid user value; ratings cap at 5). Matches the
-    // performance table's rating column width so the column reads
-    // consistently across setlist and song-detail tables. The 5-star
-    // picker pops in a popover overlay, so the column doesn't need a
-    // wider expanded state.
-    meta: { fixedWidth: "8.25rem", mobileFixedWidth: "6.75rem" },
+    // Width scales with the viewer's chosen decimal places (see ratingColumnWidth).
+    meta: ratingColumnWidth(ctx.ratingDecimalPlaces),
     enableSorting: true,
     // Ties resolve first to vote count (more votes = more confidence in the
     // average), then to canonical set+position so "all unrated tracks" still

--- a/apps/web/app/components/setlist/setlist-table-personal.tsx
+++ b/apps/web/app/components/setlist/setlist-table-personal.tsx
@@ -30,7 +30,7 @@ interface SetlistTablePersonalProps {
 export function SetlistTablePersonal({ tracks, showSlug, showDate, onSummaryChange }: SetlistTablePersonalProps) {
   const { data, isLoading } = usePersonalSongHistory();
   const { user } = useSession();
-  const { showSetlistTimes } = usePreferences();
+  const { showSetlistTimes, ratingDecimalPlaces } = usePreferences();
   const isAuthenticated = !!user;
   const trackIds = useMemo(() => tracks.map((t) => t.id), [tracks]);
   const { userRatingMap, displayRatingMap, comparisonMap } = useTrackUserRatings(trackIds);
@@ -62,10 +62,11 @@ export function SetlistTablePersonal({ tracks, showSlug, showDate, onSummaryChan
           userRatingMap,
           isAuthenticated,
           comparisonMap,
+          ratingDecimalPlaces,
         }),
         showSetlistTimes,
       ),
-    [showSlug, displayRatingMap, userRatingMap, isAuthenticated, comparisonMap, showSetlistTimes],
+    [showSlug, displayRatingMap, userRatingMap, isAuthenticated, comparisonMap, showSetlistTimes, ratingDecimalPlaces],
   );
 
   // Hoist the summary up to the parent so it can render alongside the

--- a/apps/web/app/components/setlist/setlist-table.tsx
+++ b/apps/web/app/components/setlist/setlist-table.tsx
@@ -36,7 +36,7 @@ interface SetlistTableProps {
  */
 export function SetlistTable({ tracks, showSlug, showDate }: SetlistTableProps) {
   const { user } = useSession();
-  const { showSetlistTimes } = usePreferences();
+  const { showSetlistTimes, ratingDecimalPlaces } = usePreferences();
   const isAuthenticated = !!user;
   const trackIds = useMemo(() => tracks.map((t) => t.id), [tracks]);
   const { userRatingMap, displayRatingMap, comparisonMap } = useTrackUserRatings(trackIds);
@@ -58,10 +58,11 @@ export function SetlistTable({ tracks, showSlug, showDate }: SetlistTableProps) 
           userRatingMap,
           isAuthenticated,
           comparisonMap,
+          ratingDecimalPlaces,
         }),
         showSetlistTimes,
       ),
-    [showSlug, displayRatingMap, userRatingMap, isAuthenticated, comparisonMap, showSetlistTimes],
+    [showSlug, displayRatingMap, userRatingMap, isAuthenticated, comparisonMap, showSetlistTimes, ratingDecimalPlaces],
   );
   return (
     <DataTable

--- a/apps/web/app/components/settings/preference-select.tsx
+++ b/apps/web/app/components/settings/preference-select.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { Dropdown, type DropdownOption } from "~/components/ui/dropdown";
+import type { PreferenceField } from "./preference-toggle";
+
+/**
+ * A labelled single-select preference that persists itself, the dropdown sibling
+ * of {@link PreferenceToggle}: same optimistic-save-then-revert behavior, same
+ * `POST /api/users` wire, same row layout — for a finite-choice pref (e.g. rating
+ * decimal places) rather than an on/off one. The value is a string to match the
+ * form-encoded payload the action parses; the caller maps to/from its own type.
+ */
+export function PreferenceSelect({
+  field,
+  label,
+  ariaLabel,
+  description,
+  initial,
+  options,
+}: {
+  field: PreferenceField;
+  label: string;
+  /** Accessible name, when the visible label reads as a noun rather than an action. */
+  ariaLabel?: string;
+  description: React.ReactNode;
+  initial: string;
+  options: DropdownOption[];
+}) {
+  const [value, setValue] = useState(initial);
+  const [isSaving, setIsSaving] = useState(false);
+
+  async function save(next: string) {
+    const previous = value;
+    setValue(next); // optimistic
+    setIsSaving(true);
+    try {
+      const body = new FormData();
+      body.set(field, next);
+      const response = await fetch("/api/users", { method: "POST", body });
+      if (!response.ok) throw new Error("save failed");
+      toast.success("Settings saved");
+    } catch {
+      setValue(previous); // revert
+      toast.error("Couldn't save settings");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div className="space-y-1">
+        <div className="text-content-text-primary font-medium">{label}</div>
+        <p className="text-sm text-content-text-tertiary">{description}</p>
+      </div>
+      <Dropdown
+        size="compact"
+        value={value}
+        onValueChange={save}
+        options={options}
+        ariaLabel={ariaLabel ?? label}
+        disabled={isSaving}
+        className="w-20 shrink-0"
+      />
+    </div>
+  );
+}

--- a/apps/web/app/components/settings/preference-toggle.tsx
+++ b/apps/web/app/components/settings/preference-toggle.tsx
@@ -12,7 +12,8 @@ export type PreferenceField =
   | "trackCalibratedRatings"
   | "trackRatingComparisonDebug"
   | "colorCodeRatings"
-  | "showSetlistTimes";
+  | "showSetlistTimes"
+  | "ratingDecimalPlaces";
 
 /**
  * One labelled preference switch that persists itself. Every settings card is

--- a/apps/web/app/components/ui/dropdown.tsx
+++ b/apps/web/app/components/ui/dropdown.tsx
@@ -22,6 +22,8 @@ interface DropdownProps {
   ariaLabel?: string;
   id?: string;
   size?: "default" | "compact";
+  /** Disables the trigger (e.g. while a selection is being saved). */
+  disabled?: boolean;
   className?: string;
 }
 
@@ -40,6 +42,7 @@ const triggerBaseClass = cn(
   "group inline-flex items-center justify-between gap-1 rounded-md border border-[hsl(var(--border))] text-content-text-primary transition-colors",
   dropdownSurface,
   "hover:bg-[hsl(var(--content-bg-tertiary))] focus:outline-none focus-visible:ring-1 data-[placeholder]:text-content-text-tertiary",
+  "disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-[hsl(var(--content-bg-secondary))]",
 );
 const triggerSizeClass = {
   default: "h-11 px-3 text-sm",
@@ -55,6 +58,7 @@ export function Dropdown({
   ariaLabel,
   id,
   size = "default",
+  disabled,
   className,
 }: DropdownProps) {
   // Every label the trigger might display. Rendered invisibly, stacked in one
@@ -66,7 +70,7 @@ export function Dropdown({
     ...(groups ?? []).flatMap((group) => group.options.map((option) => option.label)),
   ];
   return (
-    <Select value={value} onValueChange={onValueChange}>
+    <Select value={value} onValueChange={onValueChange} disabled={disabled}>
       <SelectPrimitive.Trigger
         id={id}
         aria-label={ariaLabel}

--- a/apps/web/app/hooks/use-preferences.tsx
+++ b/apps/web/app/hooks/use-preferences.tsx
@@ -1,8 +1,11 @@
+import { RATING_DISPLAY_DECIMALS_DEFAULT } from "@bip/domain";
 import { createContext, useContext, useMemo } from "react";
 
 export type Preferences = {
   colorCodeRatings: boolean;
   showSetlistTimes: boolean;
+  /** Decimal places rating scores render at (1-4); resolved from the viewer's choice. */
+  ratingDecimalPlaces: number;
 };
 
 /**
@@ -21,6 +24,7 @@ export type Preferences = {
 export const PREFERENCES_DEFAULT: Preferences = {
   colorCodeRatings: false,
   showSetlistTimes: true,
+  ratingDecimalPlaces: RATING_DISPLAY_DECIMALS_DEFAULT,
 };
 
 const PreferencesContext = createContext<Preferences>(PREFERENCES_DEFAULT);
@@ -38,18 +42,23 @@ const PreferencesContext = createContext<Preferences>(PREFERENCES_DEFAULT);
 export function PreferencesProvider({
   colorCodeRatings,
   showSetlistTimes,
+  ratingDecimalPlaces,
   children,
 }: {
   colorCodeRatings: boolean | null | undefined;
   showSetlistTimes: boolean | null | undefined;
+  // Optional so the many test wrappers that don't exercise it can omit it; it
+  // resolves to the default below when absent, like any unset preference.
+  ratingDecimalPlaces?: number | null | undefined;
   children: React.ReactNode;
 }) {
   const value = useMemo<Preferences>(
     () => ({
       colorCodeRatings: colorCodeRatings ?? PREFERENCES_DEFAULT.colorCodeRatings,
       showSetlistTimes: showSetlistTimes ?? PREFERENCES_DEFAULT.showSetlistTimes,
+      ratingDecimalPlaces: ratingDecimalPlaces ?? PREFERENCES_DEFAULT.ratingDecimalPlaces,
     }),
-    [colorCodeRatings, showSetlistTimes],
+    [colorCodeRatings, showSetlistTimes, ratingDecimalPlaces],
   );
   return <PreferencesContext.Provider value={value}>{children}</PreferencesContext.Provider>;
 }

--- a/apps/web/app/lib/rating-column-width.test.ts
+++ b/apps/web/app/lib/rating-column-width.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "vitest";
+import { ratingColumnWidth } from "./rating-column-width";
+
+describe("ratingColumnWidth", () => {
+  // The column widens by ~0.5rem per decimal off the 2-decimal base so the busiest
+  // badge always fits without leaving slack at lower precisions.
+  test("scales the width with the decimal count", () => {
+    expect(ratingColumnWidth(1)).toEqual({ fixedWidth: "7.75rem", mobileFixedWidth: "6.25rem" });
+    expect(ratingColumnWidth(2)).toEqual({ fixedWidth: "8.25rem", mobileFixedWidth: "6.75rem" });
+    expect(ratingColumnWidth(3)).toEqual({ fixedWidth: "8.75rem", mobileFixedWidth: "7.25rem" });
+    expect(ratingColumnWidth(4)).toEqual({ fixedWidth: "9.25rem", mobileFixedWidth: "7.75rem" });
+  });
+
+  // A decimals value outside 1-4 is clamped, not trusted, so a bad stored value
+  // can't produce a zero-width or absurdly wide column.
+  test("clamps out-of-range decimals to the 1-4 bounds", () => {
+    expect(ratingColumnWidth(0)).toEqual(ratingColumnWidth(1));
+    expect(ratingColumnWidth(9)).toEqual(ratingColumnWidth(4));
+  });
+});

--- a/apps/web/app/lib/rating-column-width.ts
+++ b/apps/web/app/lib/rating-column-width.ts
@@ -1,0 +1,20 @@
+import { clampRatingDecimals } from "@bip/domain";
+
+/**
+ * Fixed width for a rating-table column, sized to the busiest badge form at the
+ * viewer's chosen precision: "★ 5.0000 · 999 | 4½" — the score, the 3-digit vote
+ * count, and the viewer's own half-step rating (4½ is the widest valid user
+ * value; ratings cap at 5). Each extra decimal is ~one tabular digit (~0.5rem)
+ * wider, so the width scales off the 2-decimal base (8.25rem desktop / 6.75rem
+ * mobile, measured ~120px / ~103px busiest with ~12px / ~5px slack). The setlist
+ * and performance tables share this so their rating columns read consistently.
+ * The 5-star editor pops in a popover overlaying the badge, so the column never
+ * needs a wider expanded state.
+ *
+ * Lives in `lib` rather than beside the rating cell so the column factories can
+ * import it even in tests that mock the cell component.
+ */
+export function ratingColumnWidth(decimals: number): { fixedWidth: string; mobileFixedWidth: string } {
+  const extra = (clampRatingDecimals(decimals) - 2) * 0.5;
+  return { fixedWidth: `${8.25 + extra}rem`, mobileFixedWidth: `${6.75 + extra}rem` };
+}

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -38,6 +38,11 @@ export type RootPreferences = {
    */
   colorCodeRatings: boolean | null;
   showSetlistTimes: boolean | null;
+  /**
+   * Decimal places the viewer chose for rating scores (1-4), as stored: `null`
+   * means they never chose, which `usePreferences()` resolves to the app default.
+   */
+  ratingDecimalPlaces: number | null;
 };
 
 export type RootData = {
@@ -98,6 +103,7 @@ export async function loader({ request }: Route.LoaderArgs): Promise<RootData> {
     preferences: {
       colorCodeRatings: viewer?.colorCodeRatings ?? null,
       showSetlistTimes: viewer?.showSetlistTimes ?? null,
+      ratingDecimalPlaces: viewer?.ratingDecimalPlaces ?? null,
     },
   };
 }
@@ -131,6 +137,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
               <PreferencesProvider
                 colorCodeRatings={data?.preferences?.colorCodeRatings}
                 showSetlistTimes={data?.preferences?.showSetlistTimes}
+                ratingDecimalPlaces={data?.preferences?.ratingDecimalPlaces}
               >
                 <GlobalSearchProvider>
                   <SearchProvider>

--- a/apps/web/app/routes/api/users.tsx
+++ b/apps/web/app/routes/api/users.tsx
@@ -15,6 +15,8 @@ const updateUserSchema = z.object({
   trackRatingComparisonDebug: z.enum(["true", "false"]).optional(),
   colorCodeRatings: z.enum(["true", "false"]).optional(),
   showSetlistTimes: z.enum(["true", "false"]).optional(),
+  // Rating display precision arrives as the chosen decimal-places string.
+  ratingDecimalPlaces: z.enum(["1", "2", "3", "4"]).optional(),
 });
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -82,6 +84,7 @@ export async function action({ request }: ActionFunctionArgs) {
       trackRatingComparisonDebug?: boolean;
       colorCodeRatings?: boolean;
       showSetlistTimes?: boolean;
+      ratingDecimalPlaces?: number;
     } = {};
     if (validatedData.username) update.username = validatedData.username;
     const flags = await getFeatureFlags({ user: { id: localUser.id, username: localUser.username } });
@@ -104,6 +107,9 @@ export async function action({ request }: ActionFunctionArgs) {
     }
     if (validatedData.showSetlistTimes !== undefined) {
       update.showSetlistTimes = validatedData.showSetlistTimes === "true";
+    }
+    if (validatedData.ratingDecimalPlaces !== undefined) {
+      update.ratingDecimalPlaces = Number(validatedData.ratingDecimalPlaces);
     }
 
     const updatedUser = await services.users.update(localUser.id, update);

--- a/apps/web/app/routes/users/$username.tsx
+++ b/apps/web/app/routes/users/$username.tsx
@@ -484,6 +484,7 @@ export default function UserProfile() {
               trackCalibratedRatings={user.trackCalibratedRatings}
               trackRatingComparisonDebug={user.trackRatingComparisonDebug}
               colorCodeRatings={user.colorCodeRatings}
+              ratingDecimalPlaces={user.ratingDecimalPlaces}
             />
             <SetlistDisplaySettings showSetlistTimes={user.showSetlistTimes} />
           </TabsContent>

--- a/packages/core/src/_shared/prisma/migrations/20260720000000_rating_decimal_places/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260720000000_rating_decimal_places/migration.sql
@@ -1,0 +1,2 @@
+-- Per-user rating display precision (decimal places, 1-4; NULL = app default of 2).
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "rating_decimal_places" INTEGER;

--- a/packages/core/src/_shared/prisma/schema.prisma
+++ b/packages/core/src/_shared/prisma/schema.prisma
@@ -771,6 +771,7 @@ model User {
   trackRatingComparisonDebug Boolean? @map("track_rating_compare")
   colorCodeRatings          Boolean? @map("color_code_ratings")
   showSetlistTimes          Boolean? @map("show_setlist_times")
+  ratingDecimalPlaces       Int?     @map("rating_decimal_places")
   avatarFile          File?        @relation("UserAvatar", fields: [avatarFileId], references: [id], onDelete: SetNull, onUpdate: NoAction)
   attendances         Attendance[]
   blogPosts           BlogPost[]

--- a/packages/core/src/ratings/rater-weight-service.test.ts
+++ b/packages/core/src/ratings/rater-weight-service.test.ts
@@ -41,12 +41,24 @@ describe("rankShowComparisons", () => {
   // The 2001-09-01 overlay scenario: two single-vote 5.0 shows top the raw-average
   // field, but the genuine #1 (highest average among well-rated shows) must own the
   // TOP-LIST rank — thin shows only inflate the `all` field, never the top list.
+  // weightedRatingsCount == ratingsCount here (no bomber exclusion in the fixture);
+  // date/dayOrder feed only the final full-tie tiebreak, which none of these hit.
+  const rankable = (id: string, canonical: number, weighted: number, ratingsCount: number, date: string) => ({
+    id,
+    canonical,
+    weighted,
+    ratingsCount,
+    weightedRatingsCount: ratingsCount,
+    date,
+    dayOrder: null,
+  });
+
   test("thin shows inflate the all-field but never the top list", () => {
     const shows = [
-      { id: "thin-a", canonical: 5.0, weighted: 5.0, ratingsCount: 1 },
-      { id: "thin-b", canonical: 5.0, weighted: 5.0, ratingsCount: 2 },
-      { id: "wetlands", canonical: 4.868, weighted: 4.8, ratingsCount: 34 },
-      { id: "haymaker", canonical: 4.839, weighted: 4.7, ratingsCount: 31 },
+      rankable("thin-a", 5.0, 5.0, 1, "2000-01-01"),
+      rankable("thin-b", 5.0, 5.0, 2, "2000-01-02"),
+      rankable("wetlands", 4.868, 4.8, 34, "2001-09-01"),
+      rankable("haymaker", 4.839, 4.7, 31, "2002-10-05"),
     ];
     const wetlands = rankShowComparisons(shows, ["wetlands"], 3.93, 3).get("wetlands");
     // Over all shows the two thin 5.0s sit above it; on the real top list it's #1.
@@ -58,9 +70,9 @@ describe("rankShowComparisons", () => {
   // the top list. Its raw average can top the all-field while its shrunk score sinks.
   test("a thin show is ranked in the all-field but absent from the top list", () => {
     const shows = [
-      { id: "big1", canonical: 4.8, weighted: 4.8, ratingsCount: 100 },
-      { id: "big2", canonical: 4.6, weighted: 4.6, ratingsCount: 100 },
-      { id: "thin", canonical: 5.0, weighted: 5.0, ratingsCount: 1 },
+      rankable("big1", 4.8, 4.8, 100, "2000-01-01"),
+      rankable("big2", 4.6, 4.6, 100, "2000-01-02"),
+      rankable("thin", 5.0, 5.0, 1, "2000-01-03"),
     ];
     const thin = rankShowComparisons(shows, ["thin"], 4.0, 3).get("thin");
     expect(thin?.top).toBeNull();
@@ -71,14 +83,44 @@ describe("rankShowComparisons", () => {
   // Canonical and calibrated are ranked independently within the top list:
   // count-shrinkage pulls a thinner high-average show below a heavily-rated one.
   test("ranks the calibrated (shrunk) score independently of canonical", () => {
-    const shows = [
-      { id: "a", canonical: 4.9, weighted: 4.9, ratingsCount: 10 },
-      { id: "b", canonical: 4.7, weighted: 4.7, ratingsCount: 500 },
-    ];
+    const shows = [rankable("a", 4.9, 4.9, 10, "2000-01-01"), rankable("b", 4.7, 4.7, 500, "2000-01-02")];
     const ranks = rankShowComparisons(shows, ["a", "b"], 4.0, 3);
     // a canonical 4.9 > b 4.7, but shrink(4.9,4.0,10,3)=4.692 < shrink(4.7,4.0,500,3)=4.696.
     expect(ranks.get("a")?.top).toMatchObject({ canonicalRank: 1, calibratedRank: 2 });
     expect(ranks.get("b")?.top).toMatchObject({ canonicalRank: 2, calibratedRank: 1 });
+  });
+
+  // Two shows whose calibrated scores differ only below the display precision must
+  // TIE on the rounded score and resolve by the displayed count — here the calibrated
+  // count is weighted_ratings_count, so the show with more contributing raters wins.
+  test("a sub-precision calibrated gap ties on the rounded score, count breaks it", () => {
+    const shows = [
+      // Equal weighted (== anchor) makes both shrink to exactly 4.0, so the score
+      // ties precisely and only the count tiebreak decides.
+      {
+        id: "fewer",
+        canonical: 4.8,
+        weighted: 4.8,
+        ratingsCount: 30,
+        weightedRatingsCount: 20,
+        date: "2001-01-01",
+        dayOrder: null,
+      },
+      {
+        id: "more",
+        canonical: 4.8,
+        weighted: 4.8,
+        ratingsCount: 30,
+        weightedRatingsCount: 28,
+        date: "2000-01-01",
+        dayOrder: null,
+      },
+    ];
+    const ranks = rankShowComparisons(shows, ["fewer", "more"], 4.0, 3);
+    // Equal calibrated score → the higher weighted_ratings_count (28) ranks first,
+    // even though "more" is the OLDER show (date tiebreak never reached).
+    expect(ranks.get("more")?.top).toMatchObject({ calibratedRank: 1 });
+    expect(ranks.get("fewer")?.top).toMatchObject({ calibratedRank: 2 });
   });
 });
 
@@ -202,27 +244,72 @@ describe("RaterWeightService recompute settings", () => {
 });
 
 describe("RaterWeightService.rankedShows", () => {
-  // Two shows with the same average_rating render best-first, so the score alone
-  // is a non-unique sort key. The simple path must carry a deterministic tiebreak
-  // into the SQL ORDER BY (ratings_count DESC, then the canonical show ordering).
-  test("simple mode orders by rating then a deterministic tiebreak", async () => {
-    const queryRaw = vi.fn().mockResolvedValue([]);
-    const db = { ratingSettings: { findFirst: vi.fn() }, $queryRaw: queryRaw } as never;
-    await new RaterWeightService(db).rankedShows("simple", 5);
-    const templateStrings: string[] = queryRaw.mock.calls[0][0];
-    expect(templateStrings.join("")).toContain("ORDER BY s.average_rating DESC, s.ratings_count DESC,");
+  // Simple mode ranks by the ROUNDED average users see, so two shows that print the
+  // same score tie on the primary key and the more-rated one wins — even when its
+  // full-precision average is lower. Sorting by the raw float would flip this.
+  test("simple mode ranks by rounded rating, then ratings_count", async () => {
+    const rows = [
+      {
+        id: "many",
+        date: "2002-01-01",
+        dayOrder: null,
+        average: 4.807,
+        weighted: null,
+        ratingsCount: 50,
+        weightedRatingsCount: 0,
+      },
+      {
+        id: "few",
+        date: "2001-01-01",
+        dayOrder: null,
+        average: 4.814,
+        weighted: null,
+        ratingsCount: 40,
+        weightedRatingsCount: 0,
+      },
+    ];
+    const db = { ratingSettings: { findFirst: vi.fn() }, $queryRaw: vi.fn().mockResolvedValue(rows) } as never;
+    const ranked = await new RaterWeightService(db).rankedShows("simple", 5);
+    // Both round to 4.81 → tie → "many" (50 ratings) outranks "few", flipping the
+    // full-precision order where 4.814 would beat 4.807.
+    expect(ranked.map((s) => s.id)).toEqual(["many", "few"]);
   });
 
-  // The calibrated path sorts in JS, so equal shrunk scores must resolve through
-  // an explicit comparator. Feeding the same rows in different input orders must
-  // yield one stable order: more-rated first, then newest-date first.
-  test("calibrated mode breaks equal scores by ratings_count then date (stable across input order)", async () => {
-    // Anchor 4 with raw == anchor makes shrinkToward return exactly 4 for every
+  // The calibrated path sorts in JS, so equal shrunk scores must resolve through the
+  // shared comparator, tiebreaking on the DISPLAYED count (weighted_ratings_count).
+  // Feeding the same rows in different input orders must yield one stable order:
+  // more-contributing-raters first, then newest-date first.
+  test("calibrated mode breaks equal scores by weighted_ratings_count then date (stable across input order)", async () => {
+    // Anchor 4 with weighted == anchor makes shrinkToward return exactly 4 for every
     // count, so all three shows tie on score and only the tiebreak decides order.
     const rows = [
-      { id: "older-30", date: "2008-01-01", dayOrder: null, raw: 4, ratings: 30 },
-      { id: "fewer-20", date: "2005-01-01", dayOrder: null, raw: 4, ratings: 20 },
-      { id: "newer-30", date: "2010-01-01", dayOrder: null, raw: 4, ratings: 30 },
+      {
+        id: "older-30",
+        date: "2008-01-01",
+        dayOrder: null,
+        average: null,
+        weighted: 4,
+        ratingsCount: 40,
+        weightedRatingsCount: 30,
+      },
+      {
+        id: "fewer-20",
+        date: "2005-01-01",
+        dayOrder: null,
+        average: null,
+        weighted: 4,
+        ratingsCount: 40,
+        weightedRatingsCount: 20,
+      },
+      {
+        id: "newer-30",
+        date: "2010-01-01",
+        dayOrder: null,
+        average: null,
+        weighted: 4,
+        ratingsCount: 40,
+        weightedRatingsCount: 30,
+      },
     ];
     const expected = ["newer-30", "older-30", "fewer-20"];
 

--- a/packages/core/src/ratings/rater-weight-service.ts
+++ b/packages/core/src/ratings/rater-weight-service.ts
@@ -1,7 +1,6 @@
-import { compareByShowDate, drummerEraForDate, shrinkToward } from "@bip/domain";
+import { displayedRatingComparator, drummerEraForDate, shrinkToward } from "@bip/domain";
 import { Prisma } from "@prisma/client";
 import type { DbClient } from "../_shared/database/models";
-import { showOrderBySql } from "../_shared/show-ordering";
 import { aliasKey, mostRecentPerKey } from "./rater-aliases";
 import {
   bucketRatingValues,
@@ -65,7 +64,13 @@ interface RankableShow {
   canonical: number;
   /** The raw (un-shrunk) weighted rating. */
   weighted: number;
+  /** Deduped community count — the count shown beside the canonical (simple) score. */
   ratingsCount: number;
+  /** Post-exclusion contributing count — the count shown beside the calibrated score. */
+  weightedRatingsCount: number;
+  /** YYYY-MM-DD, for the show-ordering final tiebreak. */
+  date: string;
+  dayOrder: number | null;
 }
 
 /** A show's position by canonical average vs calibrated score within one field. */
@@ -100,14 +105,39 @@ export function rankShowComparisons(
     id: show.id,
     canonical: show.canonical,
     calibrated: shrinkToward(show.weighted, anchor, show.ratingsCount, k),
+    ratingsCount: show.ratingsCount,
+    weightedRatingsCount: show.weightedRatingsCount,
+    show: { id: show.id, date: show.date, dayOrder: show.dayOrder },
     qualified: show.ratingsCount >= RANKED_SHOW_MIN_RATINGS,
   }));
   const topField = scored.filter((show) => show.qualified);
 
-  // Competition rank within a field: 1 + the number strictly better (ties share a rank).
+  // Competition rank within a field: 1 + the number ranked strictly better under the
+  // displayed-order comparator (rounded score → count → date), so the rank matches the
+  // Top Rated list and a difference no user can see never separates two tied shows.
+  // Canonical ranks by the deduped count, calibrated by the post-exclusion count; both
+  // round at the fixed default precision, since the ranking is one global artifact and
+  // can't depend on any one viewer's per-user decimal setting.
+  const compare = displayedRatingComparator();
   const rankIn = (field: typeof scored, target: (typeof scored)[number]): RankInField => ({
-    canonicalRank: 1 + field.filter((show) => show.canonical > target.canonical).length,
-    calibratedRank: 1 + field.filter((show) => show.calibrated > target.calibrated).length,
+    canonicalRank:
+      1 +
+      field.filter(
+        (show) =>
+          compare(
+            { rating: show.canonical, count: show.ratingsCount, show: show.show },
+            { rating: target.canonical, count: target.ratingsCount, show: target.show },
+          ) < 0,
+      ).length,
+    calibratedRank:
+      1 +
+      field.filter(
+        (show) =>
+          compare(
+            { rating: show.calibrated, count: show.weightedRatingsCount, show: show.show },
+            { rating: target.calibrated, count: target.weightedRatingsCount, show: target.show },
+          ) < 0,
+      ).length,
     total: field.length,
   });
 
@@ -274,7 +304,15 @@ export class RaterWeightService {
     const [shows, anchor] = await Promise.all([
       this.db.show.findMany({
         where: { weightedRating: { not: null } },
-        select: { id: true, averageRating: true, weightedRating: true, ratingsCount: true },
+        select: {
+          id: true,
+          averageRating: true,
+          weightedRating: true,
+          ratingsCount: true,
+          weightedRatingsCount: true,
+          date: true,
+          dayOrder: true,
+        },
       }),
       this.shrinkAnchor(),
     ]);
@@ -286,6 +324,9 @@ export class RaterWeightService {
               canonical: show.averageRating,
               weighted: show.weightedRating,
               ratingsCount: show.ratingsCount,
+              weightedRatingsCount: show.weightedRatingsCount,
+              date: show.date,
+              dayOrder: show.dayOrder,
             },
           ]
         : [],
@@ -409,41 +450,43 @@ export class RaterWeightService {
    * derives the year-picker counts from it, so the counts always match the list.
    */
   async rankedShows(mode: "simple" | "calibrated", minRatings: number): Promise<Array<{ id: string; date: string }>> {
-    // Tied scores must resolve to a stable order (they render best-first and the
-    // score alone is non-unique — e.g. two 85/18 shows both average 4.7222…).
-    // Tiebreak by ratings_count DESC (more-rated ranks higher among equals), then
-    // by the canonical show ordering DESC as a fully deterministic final key.
-    if (mode === "simple") {
-      return this.db.$queryRaw<Array<{ id: string; date: string }>>`
-        SELECT s.id, s.date
-        FROM shows s
-        WHERE s.average_rating IS NOT NULL AND s.ratings_count >= ${minRatings}
-        ORDER BY s.average_rating DESC, s.ratings_count DESC, ${showOrderBySql("s", "DESC")}
-      `;
-    }
-
-    const anchor = await this.shrinkAnchor();
+    // Rank by the rounded display score (at the fixed default precision — this
+    // ordering is one global list, not per-viewer): two shows printing the same
+    // rounded number tie on the primary key and resolve through the shared
+    // display-order comparator (rounded rating DESC → displayed count DESC →
+    // newest-date-first), so the order never flips on precision no one can see and
+    // stays stable across environments (the anchor is per-environment). The
+    // displayed count differs by mode: simple shows the deduped `ratings_count`,
+    // calibrated the post-exclusion `weighted_ratings_count`.
+    const anchor = mode === "calibrated" ? await this.shrinkAnchor() : 0;
+    const scoreNotNull =
+      mode === "calibrated" ? Prisma.sql`s.weighted_rating IS NOT NULL` : Prisma.sql`s.average_rating IS NOT NULL`;
     const rows = await this.db.$queryRaw<
-      Array<{ id: string; date: string; dayOrder: number | null; raw: number; ratings: number }>
+      Array<{
+        id: string;
+        date: string;
+        dayOrder: number | null;
+        average: number;
+        weighted: number;
+        ratingsCount: number;
+        weightedRatingsCount: number;
+      }>
     >`
-      SELECT s.id, s.date, s.day_order AS "dayOrder", s.weighted_rating AS raw, s.ratings_count AS ratings
+      SELECT s.id, s.date, s.day_order AS "dayOrder",
+             s.average_rating AS average, s.weighted_rating AS weighted,
+             s.ratings_count AS "ratingsCount", s.weighted_ratings_count AS "weightedRatingsCount"
       FROM shows s
-      WHERE s.weighted_rating IS NOT NULL AND s.ratings_count >= ${minRatings}
+      WHERE ${scoreNotNull} AND s.ratings_count >= ${minRatings}
     `;
     return rows
       .map((r) => ({
         id: r.id,
         date: r.date,
-        dayOrder: r.dayOrder,
-        ratings: r.ratings,
-        score: shrinkToward(r.raw, anchor, r.ratings, SHRINK_K),
+        rating: mode === "calibrated" ? shrinkToward(r.weighted, anchor, r.ratingsCount, SHRINK_K) : r.average,
+        count: mode === "calibrated" ? r.weightedRatingsCount : r.ratingsCount,
+        show: { id: r.id, date: r.date, dayOrder: r.dayOrder },
       }))
-      .sort((a, b) => {
-        if (b.score !== a.score) return b.score - a.score;
-        if (b.ratings !== a.ratings) return b.ratings - a.ratings;
-        // DESC of the canonical ASC comparator, mirroring showOrderBySql(…, "DESC").
-        return -compareByShowDate({ show: a }, { show: b });
-      })
+      .sort(displayedRatingComparator())
       .map(({ id, date }) => ({ id, date }));
   }
 

--- a/packages/core/src/users/user-service.test.ts
+++ b/packages/core/src/users/user-service.test.ts
@@ -172,6 +172,7 @@ describe("UserService.listForSync", () => {
       trackRatingComparisonDebug: true,
       colorCodeRatings: true,
       showSetlistTimes: true,
+      ratingDecimalPlaces: true,
       createdAt: true,
       updatedAt: true,
     });

--- a/packages/core/src/users/user-service.ts
+++ b/packages/core/src/users/user-service.ts
@@ -62,6 +62,7 @@ function mapUserToDomainEntity(dbUser: DbUser): User {
     trackRatingComparisonDebug: dbUser.trackRatingComparisonDebug ?? null,
     colorCodeRatings: dbUser.colorCodeRatings ?? null,
     showSetlistTimes: dbUser.showSetlistTimes ?? null,
+    ratingDecimalPlaces: dbUser.ratingDecimalPlaces ?? null,
   };
 }
 
@@ -445,6 +446,7 @@ export class UserService {
       trackRatingComparisonDebug: boolean | null;
       colorCodeRatings: boolean | null;
       showSetlistTimes: boolean | null;
+      ratingDecimalPlaces: number | null;
       createdAt: Date;
       updatedAt: Date;
     }>
@@ -473,6 +475,7 @@ export class UserService {
         trackRatingComparisonDebug: true,
         colorCodeRatings: true,
         showSetlistTimes: true,
+        ratingDecimalPlaces: true,
         createdAt: true,
         updatedAt: true,
       },

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -22,6 +22,7 @@ export * from "./models/song";
 export * from "./models/track";
 export * from "./models/user";
 export * from "./models/venue";
+export * from "./rating-display";
 export * from "./recurrence";
 export * from "./search";
 export * from "./segue-run";

--- a/packages/domain/src/models/user.ts
+++ b/packages/domain/src/models/user.ts
@@ -15,6 +15,8 @@ export const userSchema = z.object({
   trackRatingComparisonDebug: z.boolean().nullable(),
   colorCodeRatings: z.boolean().nullable(),
   showSetlistTimes: z.boolean().nullable(),
+  // Rating score decimal places (1-4); null = no explicit choice → app default.
+  ratingDecimalPlaces: z.number().int().min(1).max(4).nullable(),
 });
 
 export const userMinimalSchema = userSchema

--- a/packages/domain/src/rating-display.test.ts
+++ b/packages/domain/src/rating-display.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "vitest";
+import { displayedRatingComparator, formatRatingScore, roundRatingForDisplay } from "./rating-display";
+
+describe("formatRatingScore / roundRatingForDisplay", () => {
+  // The formatter and the sort key MUST agree: the number the sort rounds to is
+  // exactly the number the badge renders, so ranking can't flip on hidden precision.
+  test("formats and rounds at the given precision", () => {
+    expect(formatRatingScore(4.81104404832045, 2)).toBe("4.81");
+    expect(formatRatingScore(4.81104404832045, 3)).toBe("4.811");
+    expect(formatRatingScore(4.81104404832045, 4)).toBe("4.8110");
+    expect(roundRatingForDisplay(4.81104404832045, 3)).toBe(4.811);
+  });
+
+  // Defaults to 2 when no precision is passed (the app default + global-sort precision).
+  test("defaults to 2 decimals", () => {
+    expect(formatRatingScore(4.81104404832045)).toBe("4.81");
+    expect(roundRatingForDisplay(4.81104404832045)).toBe(4.81);
+  });
+
+  // A stored/query value outside 1-4 is clamped rather than trusted.
+  test("clamps precision to the 1-4 range", () => {
+    expect(formatRatingScore(4.8151, 0)).toBe("4.8"); // clamps up to 1
+    expect(formatRatingScore(4.8151, 9)).toBe("4.8151"); // clamps down to 4
+  });
+});
+
+describe("displayedRatingComparator", () => {
+  const show = (id: string, date: string, dayOrder: number | null = null) => ({ id, date, dayOrder });
+
+  // The 10/5/02 Haymaker vs 9/1/01 Wetlands case: both display 4.81 at 2 decimals,
+  // so the rounded score ties them and the count tiebreak decides — Wetlands (33)
+  // over Haymaker (30) — flipping the full-precision order no user could see.
+  test("equal rounded score falls to the count tiebreak (more ratings ranks higher)", () => {
+    const haymaker = { rating: 4.81104404832045, count: 30, show: show("hay", "2002-10-05") };
+    const wetlands = { rating: 4.81102720879324, count: 33, show: show("wet", "2001-09-01") };
+    expect([haymaker, wetlands].sort(displayedRatingComparator(2)).map((s) => s.show.id)).toEqual(["wet", "hay"]);
+    // Full precision alone would rank Haymaker first, so the flip proves the rounding.
+    expect(wetlands.rating).toBeLessThan(haymaker.rating);
+  });
+
+  // At a finer precision the same two scores separate, so the count tiebreak is
+  // never reached and the higher raw score wins.
+  test("a finer precision can separate scores that tie at 2 decimals", () => {
+    const higher = { rating: 4.814, count: 1, show: show("hi", "2000-01-01") };
+    const lower = { rating: 4.811, count: 999, show: show("lo", "2000-01-01") };
+    // Both round to 4.81 at 2 decimals → count wins (lower, 999). At 3 they differ
+    // (4.814 vs 4.811) → the higher score wins.
+    expect([higher, lower].sort(displayedRatingComparator(2)).map((s) => s.show.id)).toEqual(["lo", "hi"]);
+    expect([higher, lower].sort(displayedRatingComparator(3)).map((s) => s.show.id)).toEqual(["hi", "lo"]);
+  });
+
+  // Equal rounded score AND equal count fall to the show-date tiebreak, DESC
+  // (newest-first) to mirror showOrderBySql(..., "DESC").
+  test("equal rounded score and count fall to newest-date-first", () => {
+    const older = { rating: 4.5, count: 10, show: show("older", "2005-01-01") };
+    const newer = { rating: 4.5, count: 10, show: show("newer", "2010-01-01") };
+    expect([older, newer].sort(displayedRatingComparator(2)).map((s) => s.show.id)).toEqual(["newer", "older"]);
+  });
+});

--- a/packages/domain/src/rating-display.ts
+++ b/packages/domain/src/rating-display.ts
@@ -1,0 +1,59 @@
+import { compareByShowDate } from "./show-ordering";
+
+/** Fewest / most decimal places the rating precision setting allows. */
+export const RATING_DISPLAY_DECIMALS_MIN = 1;
+export const RATING_DISPLAY_DECIMALS_MAX = 4;
+/** Decimals shown when the viewer hasn't chosen — and the fixed precision the global sort rounds at. */
+export const RATING_DISPLAY_DECIMALS_DEFAULT = 2;
+
+/** Clamp a decimals value to the allowed 1-4 range (guards against a bad stored/query value). */
+export function clampRatingDecimals(decimals: number): number {
+  return Math.min(RATING_DISPLAY_DECIMALS_MAX, Math.max(RATING_DISPLAY_DECIMALS_MIN, Math.trunc(decimals)));
+}
+
+/** The rating score as the user sees it on a badge, at their chosen decimal precision. */
+export function formatRatingScore(value: number, decimals: number = RATING_DISPLAY_DECIMALS_DEFAULT): string {
+  return value.toFixed(clampRatingDecimals(decimals));
+}
+
+/**
+ * The rating score rounded to exactly the value the badge renders. Derived from
+ * the same `toFixed` as {@link formatRatingScore} so the sort key equals the
+ * displayed number to the bit — two shows that print the same score compare equal.
+ */
+export function roundRatingForDisplay(value: number, decimals: number = RATING_DISPLAY_DECIMALS_DEFAULT): number {
+  return Number(value.toFixed(clampRatingDecimals(decimals)));
+}
+
+/** A show carrying its displayed rating + the count shown beside it, for ranking. */
+export interface DisplayedRatingRankable {
+  /** The score as displayed (already mode-appropriate: canonical or calibrated). */
+  rating: number;
+  /** The rating count shown beside the score (deduped for simple, weighted for calibrated). */
+  count: number;
+  show: Parameters<typeof compareByShowDate>[0]["show"];
+}
+
+/**
+ * Best-first (`.sort`) comparator that ranks shows the way the screen reads them:
+ * by the ROUNDED displayed score DESC (so two shows printing the same number tie
+ * rather than flipping on invisible precision), then by rating count DESC (more
+ * ratings ranks higher), then by the canonical show ordering DESC (newest-first),
+ * mirroring `showOrderBySql(..., "DESC")`, as a fully deterministic final key.
+ *
+ * `decimals` defaults to {@link RATING_DISPLAY_DECIMALS_DEFAULT}: the Top Rated
+ * ranking is one global artifact shared by every viewer, so it rounds at the fixed
+ * default rather than any one viewer's per-user precision setting.
+ */
+export function displayedRatingComparator(
+  decimals: number = RATING_DISPLAY_DECIMALS_DEFAULT,
+): (a: DisplayedRatingRankable, b: DisplayedRatingRankable) => number {
+  return (a, b) => {
+    const ratingA = roundRatingForDisplay(a.rating, decimals);
+    const ratingB = roundRatingForDisplay(b.rating, decimals);
+    if (ratingA !== ratingB) return ratingB - ratingA;
+    if (a.count !== b.count) return b.count - a.count;
+    // DESC of the chronological ASC comparator: newest-first among full ties.
+    return -compareByShowDate(a, b);
+  };
+}


### PR DESCRIPTION
Readers can now choose how many decimal places rating scores show (1 to 4,
default 2) from a new **Rating precision** dropdown in their profile's rating
display settings. The choice applies everywhere a rating number appears: show
and track badges, the setlist and performance tables, the compare overlays,
and the rating trend chart. The dropdown auto-saves and disables itself while
the save is in flight, matching the existing preference toggles.

The **Top Rated** list and the per-show rank comparison now sort by the
rounded score a reader actually sees, tie-broken by number of ratings (more
ratings ranks higher) then show date. Previously two shows that displayed the
identical rounded rating could order differently on sub-millionth precision no
one can see, and that order was unstable across environments; now it matches
the screen. Rating-table columns size themselves to the chosen precision so the
widest badge always fits.

## Technical notes

- Adds a nullable `users.rating_decimal_places` column (migration
  `20260720000000_rating_decimal_places`). `null` = no explicit choice, which
  resolves to the default of 2. Threaded through the Prisma schema, the domain
  `User` model, the read mapper + sync select, and the `/api/users` write path
  (ungated, available to everyone).
- Precision travels as a single resolved value in the preferences context
  (`ratingDecimalPlaces`), seeded once in the root loader and read by
  `RatingComponent`, so no per-badge prop threading. One
  `formatRatingScore(value, decimals)` helper in `@bip/domain` is the single
  source for both display and the sort's rounding.
- The global Top Rated ranking is one artifact shared by every viewer, so its
  tie-break rounding uses the fixed default precision (2) rather than any one
  viewer's per-user setting. The user's setting changes only what is rendered.
- Rating-table column widths scale ~0.5rem per decimal off the 2-decimal base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
