### PR TITLE
Cut ~60% of the cached setlist payload

### DIFF
--- a/apps/web/app/lib/seo.test.ts
+++ b/apps/web/app/lib/seo.test.ts
@@ -40,7 +40,8 @@ describe("getVenueMeta", () => {
 describe("getShowMeta", () => {
   it("uses the country when the show's venue has no state", () => {
     const setlist = {
-      show: { slug: "2023-05-22-harpa", date: "2023-05-22", venue: harpa },
+      show: { slug: "2023-05-22-harpa", date: "2023-05-22" },
+      venue: harpa,
       sets: [],
     } as unknown as Setlist;
     const title = titleContent(getShowMeta(setlist));

--- a/apps/web/app/lib/seo.ts
+++ b/apps/web/app/lib/seo.ts
@@ -85,8 +85,8 @@ export function getShowMeta(setlist: Setlist) {
         })()
       : show.date;
 
-  const venue = show.venue?.name || "Unknown Venue";
-  const location = show.venue ? formatVenueLocation(show.venue) : "";
+  const venue = setlist.venue?.name || "Unknown Venue";
+  const location = setlist.venue ? formatVenueLocation(setlist.venue) : "";
 
   const title = `${date} - ${venue} ${location ? `- ${location}` : ""} | ${SEO_CONFIG.siteName}`;
   const description = `View setlist, reviews, and recordings from ${SEO_CONFIG.bandName} show at ${venue}${location ? ` in ${location}` : ""} on ${date}. ${setlist.sets?.length || 0} sets.`;
@@ -97,7 +97,7 @@ export function getShowMeta(setlist: Setlist) {
   const keywords = [
     ...SEO_CONFIG.keywords,
     venue,
-    show.venue?.city || "",
+    setlist.venue?.city || "",
     date,
     ...songNames.slice(0, 10), // Include first 10 songs as keywords
   ].filter(Boolean);
@@ -378,7 +378,7 @@ export function getBlogMeta(blogPost: { title: string; blurb?: string; slug: str
 // Generate JSON-LD structured data for a show
 export function getShowStructuredData(setlist: Setlist) {
   const show = setlist.show;
-  const venue = show.venue;
+  const venue = setlist.venue;
 
   const musicEvent = {
     "@context": "https://schema.org",

--- a/apps/web/app/routes/resources/rock-opera-performances.test.ts
+++ b/apps/web/app/routes/resources/rock-opera-performances.test.ts
@@ -102,10 +102,11 @@ describe("getRockOperaPerformances", () => {
 
     const usedKey = cacheGetOrSet.mock.calls[0][0] as string;
     expect(usedKey).toMatch(/^rock-operas:performances:hot-air-balloon/);
-    // v13 = the Setlist shape with dateFirstPlayed on the lean song.
-    // A payload-shape change without a version bump would serve stale-shape
-    // blobs from deployed instances until TTL (the cache-versioning rule).
-    expect(usedKey).toContain(":v13");
+    // v14 = the Setlist shape whose `show` carries only domain fields (no raw
+    // tracks/showMusicians/venue relations). A payload-shape change without a
+    // version bump would serve stale-shape blobs from deployed instances until
+    // TTL (the cache-versioning rule).
+    expect(usedKey).toContain(":v14");
   });
 
   // Setlists must be loaded by show id in chronological-asc order so the

--- a/packages/core/src/_shared/show-mapper.ts
+++ b/packages/core/src/_shared/show-mapper.ts
@@ -1,0 +1,40 @@
+import type { Show } from "@bip/domain";
+import type { DbShow } from "./database/models";
+
+/**
+ * Build the domain `Show` from a raw Prisma row.
+ *
+ * Every field is listed explicitly rather than spread (`...rest`), because the
+ * rows handed to this mapper are loaded with relation includes (tracks, venue,
+ * showMusicians) and a spread sweeps all of them plus non-domain columns
+ * (searchText, weightedRating) into the returned object. That excess rides
+ * along into every cached setlist payload, and the declared `Show` return type
+ * does not catch it: TypeScript's excess-property check does not apply to a
+ * spread. An explicit list means a new relation on a query's include cannot
+ * silently re-inflate the payload.
+ *
+ * The relation-shaped fields on `Show` (`tracks`, `venue`) are deliberately not
+ * populated here; callers that need them attach mapped copies themselves.
+ */
+export function mapDbShowToDomainEntity(dbShow: DbShow): Show {
+  return {
+    id: dbShow.id,
+    slug: dbShow.slug ?? "",
+    date: String(dbShow.date),
+    venueId: dbShow.venueId ?? "",
+    bandId: dbShow.bandId ?? "",
+    notes: dbShow.notes,
+    createdAt: new Date(dbShow.createdAt),
+    updatedAt: new Date(dbShow.updatedAt),
+    likesCount: dbShow.likesCount,
+    relistenUrl: dbShow.relistenUrl,
+    averageRating: dbShow.averageRating,
+    ratingsCount: dbShow.ratingsCount,
+    showPhotosCount: dbShow.showPhotosCount,
+    showYoutubesCount: dbShow.showYoutubesCount,
+    reviewsCount: dbShow.reviewsCount,
+    countForStats: dbShow.countForStats,
+    dayOrder: dbShow.dayOrder,
+    duration: dbShow.duration,
+  };
+}

--- a/packages/core/src/setlists/setlist-service.test.ts
+++ b/packages/core/src/setlists/setlist-service.test.ts
@@ -941,6 +941,62 @@ describe("SetlistService.findMany", () => {
   });
 });
 
+describe("Setlist.show payload weight", () => {
+  // The mapped `show` is built from an explicit field list, not a spread of the
+  // Prisma row. Every relation the setlist query loads (tracks, showMusicians,
+  // venue) already has a mapped, rendered counterpart on the Setlist itself
+  // (sets[].tracks, lineup, venue), so spreading them onto `show` doubled the
+  // cached payload — ~60% of a 50-show blob — while the declared `Show` return
+  // type hid it (excess-property checks don't apply to spreads).
+  test("omits the raw query relations and search text from the mapped show", async () => {
+    const db = makeMockDb();
+    const service = new SetlistService(db as never, makeRockOperaStub());
+    db.show.findUnique.mockResolvedValue({
+      id: "show-1",
+      slug: "2024-07-26",
+      date: "2024-07-26",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      venueId: "v-1",
+      bandId: "b-1",
+      notes: null,
+      likesCount: 0,
+      relistenUrl: null,
+      averageRating: 4.5,
+      ratingsCount: 12,
+      showPhotosCount: 0,
+      showYoutubesCount: 0,
+      reviewsCount: 0,
+      countForStats: true,
+      dayOrder: null,
+      duration: null,
+      searchText: "2024-07-26 red rocks morrison co",
+      tracks: [],
+      showMusicians: [],
+      venue: {
+        id: "v-1",
+        name: "Red Rocks",
+        slug: "red-rocks",
+        city: "Morrison",
+        country: "US",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    const setlist = await service.findByShowSlug("2024-07-26");
+
+    expect(setlist?.show).not.toHaveProperty("tracks");
+    expect(setlist?.show).not.toHaveProperty("showMusicians");
+    expect(setlist?.show).not.toHaveProperty("venue");
+    expect(setlist?.show).not.toHaveProperty("searchText");
+    // The fields the pages actually render still come through.
+    expect(setlist?.show.averageRating).toBe(4.5);
+    expect(setlist?.show.ratingsCount).toBe(12);
+    expect(setlist?.venue.name).toBe("Red Rocks");
+  });
+});
+
 describe("SetlistService.findMany stub filtering", () => {
   // Stubs must be filtered at the SQL boundary, not in JS after pagination,
   // so a venueless stub landing on a page can't silently shrink it below the

--- a/packages/core/src/setlists/setlist-service.ts
+++ b/packages/core/src/setlists/setlist-service.ts
@@ -33,6 +33,7 @@ import type {
   DbVenue,
 } from "../_shared/database/models";
 import type { PaginationOptions, SortOptions } from "../_shared/database/types";
+import { mapDbShowToDomainEntity } from "../_shared/show-mapper";
 import {
   NON_STUB_SHOWS_WHERE,
   resolveShowOrderBy,
@@ -160,19 +161,6 @@ function previousPerformanceShowFromDb(
 }
 
 // Mapper functions
-function mapShowToDomainEntity(dbShow: DbShow): Show {
-  const { createdAt, updatedAt, slug, venueId, bandId, ...rest } = dbShow;
-  return {
-    ...rest,
-    slug: slug ?? "",
-    venueId: venueId ?? "",
-    bandId: bandId ?? "",
-    date: String(dbShow.date),
-    createdAt: new Date(createdAt),
-    updatedAt: new Date(updatedAt),
-  };
-}
-
 function mapVenueToDomainEntity(dbVenue: DbVenue): Venue {
   const { createdAt, updatedAt, name, slug, city, country, ...rest } = dbVenue;
   return {
@@ -635,7 +623,7 @@ function mapSetlistToDomainEntity(
 
   const eligible = eligibleGapsForAggregation(tracks);
   return {
-    show: mapShowToDomainEntity(show),
+    show: mapDbShowToDomainEntity(show),
     venue: mapVenueToDomainEntity(show.venue),
     sets,
     annotations: tracks.flatMap((t) => t.annotations ?? []).map((a) => mapAnnotationToDomainEntity(a)),

--- a/packages/core/src/shows/show-service.test.ts
+++ b/packages/core/src/shows/show-service.test.ts
@@ -198,6 +198,59 @@ describe("ShowService.search", () => {
   });
 });
 
+describe("ShowService.findMany", () => {
+  // The mapped show is built from an explicit field list, so an included venue
+  // has to be attached deliberately. The MCP `get_shows_by_year` getter asks
+  // for `includes: ["venue"]` and reads venueName/venueCity/venueState off it;
+  // it silently returned empty strings when the relation stopped riding along.
+  // The raw relation itself must not survive — the mapped Venue replaces it.
+  test("attaches the mapped venue when the caller includes it", async () => {
+    const db = makeMockDb();
+    db.show.findMany.mockResolvedValue([
+      {
+        id: "show-1",
+        slug: "2024-07-26-red-rocks",
+        date: "2024-07-26",
+        venueId: "v-1",
+        bandId: "b-1",
+        notes: null,
+        relistenUrl: null,
+        likesCount: 0,
+        averageRating: 0,
+        ratingsCount: 0,
+        showPhotosCount: 0,
+        showYoutubesCount: 0,
+        reviewsCount: 0,
+        countForStats: true,
+        dayOrder: null,
+        duration: null,
+        searchText: "2024-07-26 red rocks",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        venue: {
+          id: "v-1",
+          name: "Red Rocks",
+          slug: "red-rocks",
+          city: "Morrison",
+          state: "CO",
+          country: "US",
+          timesPlayed: 3,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      },
+    ]);
+    const service = new ShowService(db as never, logger, makeCacheInvalidationStub(), makeStatsStub());
+
+    const shows = await service.findMany({ includes: ["venue"] });
+
+    expect(shows[0].venue?.name).toBe("Red Rocks");
+    expect(shows[0].venue?.city).toBe("Morrison");
+    expect(shows[0].venue?.state).toBe("CO");
+    expect(shows[0]).not.toHaveProperty("searchText");
+  });
+});
+
 describe("ShowService.reorderByDate", () => {
   // Admin reorders the same-date shows for 2017-07-22: every show in the
   // supplied id list must have its dayOrder rewritten to its new position

--- a/packages/core/src/shows/show-service.ts
+++ b/packages/core/src/shows/show-service.ts
@@ -4,6 +4,7 @@ import { type CacheInvalidationService, yearFromShowDate } from "../_shared/cach
 import type { DbClient, DbShow, DbVenue } from "../_shared/database/models";
 import { buildIncludeClause, buildWhereClause } from "../_shared/database/query-utils";
 import type { FilterCondition, QueryOptions } from "../_shared/database/types";
+import { mapDbShowToDomainEntity } from "../_shared/show-mapper";
 import {
   DAY_ORDER_NULL_SENTINEL,
   NON_STUB_SHOWS_WHERE,
@@ -56,17 +57,14 @@ export interface LineupEntry {
 }
 
 // Mapper functions
-function mapShowToDomainEntity(show: DbShow): Show {
-  const { venueId, bandId, ...rest } = show;
-  return {
-    ...rest,
-    date: String(show.date),
-    createdAt: new Date(show.createdAt),
-    updatedAt: new Date(show.updatedAt),
-    slug: show.slug ?? "",
-    venueId: venueId ?? "",
-    bandId: bandId ?? "",
-  };
+/**
+ * Map a show row that may carry an included venue, attaching the mapped venue
+ * rather than letting the raw relation ride along on the show.
+ */
+function mapShowWithVenueToDomainEntity(show: DbShow & { venue?: DbVenue | null }): Show {
+  const mapped = mapDbShowToDomainEntity(show);
+  if (show.venue) mapped.venue = mapVenueToDomainEntity(show.venue);
+  return mapped;
 }
 
 function mapVenueToDomainEntity(dbVenue: DbVenue): Venue {
@@ -139,12 +137,12 @@ export class ShowService {
 
   async findById(id: string): Promise<Show | null> {
     const result = await this.db.show.findUnique({ where: { id } });
-    return result ? mapShowToDomainEntity(result) : null;
+    return result ? mapDbShowToDomainEntity(result) : null;
   }
 
   async findBySlug(slug: string): Promise<Show | null> {
     const result = await this.db.show.findUnique({ where: { slug } });
-    return result ? mapShowToDomainEntity(result) : null;
+    return result ? mapDbShowToDomainEntity(result) : null;
   }
 
   async findMany(filterOrOptions: ShowFilter | QueryOptions<Show> = {}): Promise<Show[]> {
@@ -188,7 +186,7 @@ export class ShowService {
       include,
     });
 
-    return results.map((result: DbShow) => mapShowToDomainEntity(result));
+    return results.map((result) => mapShowWithVenueToDomainEntity(result));
   }
 
   async findManyByDates(dates: string[]): Promise<Show[]> {
@@ -207,13 +205,7 @@ export class ShowService {
       orderBy: SHOW_ORDER_ASC,
     });
 
-    return results.map((result) => {
-      const show = mapShowToDomainEntity(result);
-      if (result.venue) {
-        show.venue = mapVenueToDomainEntity(result.venue);
-      }
-      return show;
-    });
+    return results.map((result) => mapShowWithVenueToDomainEntity(result));
   }
 
   async findByDate(date: string): Promise<Show[]> {
@@ -339,7 +331,7 @@ export class ShowService {
       take: options?.pagination?.limit,
     });
 
-    return shows.map((show) => mapShowToDomainEntity(show));
+    return shows.map((show) => mapDbShowToDomainEntity(show));
   }
 
   async create(data: ShowServiceCreateInput): Promise<Show> {
@@ -369,7 +361,7 @@ export class ShowService {
       },
     });
 
-    const show = mapShowToDomainEntity(result);
+    const show = mapDbShowToDomainEntity(result);
 
     // New shows default to the current band makeup. Resolve the seeded
     // musicians lazily so an unseeded environment degrades to an empty lineup
@@ -516,7 +508,7 @@ export class ShowService {
       },
     });
 
-    const show = mapShowToDomainEntity(result);
+    const show = mapDbShowToDomainEntity(result);
 
     // Year-tag purges cover both the old date (so its listing evicts) and
     // the new date (so its listing picks the row up). `||` not `??` so an

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -11,10 +11,11 @@ export const CacheKeys = {
    * Show-related cache keys
    */
   show: {
-    /** Complete show + setlist data for show page. :v15 bump: the payload is
-     *  now Setlist, so track songs carry only the lean fields (id/title/
-     *  slug/kind/authors/dateFirstPlayed), no lyrics/history/notes/tabs text. */
-    data: (slug: string) => `show:${slug}:data:v15`,
+    /** Complete show + setlist data for show page. :v16 bump: `setlist.show`
+     *  no longer carries the raw query relations (tracks, showMusicians,
+     *  venue) or searchText — those duplicated sets[].tracks / lineup / venue
+     *  and made up ~60% of the payload. */
+    data: (slug: string) => `show:${slug}:data:v16`,
 
     // Note: Reviews are loaded fresh from DB, not cached
 
@@ -33,8 +34,9 @@ export const CacheKeys = {
     /** Paginated show listings with filters */
     list: (filters: CacheFilters) => {
       const filterHash = hashFilters(filters);
-      // :v15 bump: SongLight gained dateFirstPlayed (Setlist shape change).
-      return `shows:list:${filterHash}:v15`;
+      // :v16 bump: `setlist.show` no longer carries the raw query relations
+      // (tracks, showMusicians, venue) or searchText.
+      return `shows:list:${filterHash}:v16`;
     },
 
     /** All show listing caches (for pattern deletion) */
@@ -107,9 +109,10 @@ export const CacheKeys = {
    */
   musicians: {
     /** Full musician profile payload (appearances, songs played/written,
-     *  performances). :v5 bump: SongLight gained dateFirstPlayed (Setlist
-     *  shape change; performances embed Setlist). */
-    page: (slug: string) => `musician:${slug}:data:v5`,
+     *  performances). :v6 bump: `setlist.show` no longer carries the raw query
+     *  relations (tracks, showMusicians, venue) or searchText; performances
+     *  embed Setlist. */
+    page: (slug: string) => `musician:${slug}:data:v6`,
     /** Every musician profile cache (for pattern deletion on broad mutations). */
     allPages: () => "musician:*:data:*",
   },
@@ -132,10 +135,11 @@ export const CacheKeys = {
      * Pre-built SetlistList payload (setlists + external sources) for one
      * page of a user's attended shows. Paginated because the heaviest users
      * have 400+ attended shows and the un-paginated payload is large enough
-     * to be slow to deserialize/transport even from Redis. :v15 bump:
-     * SongLight gained dateFirstPlayed (Setlist shape change).
+     * to be slow to deserialize/transport even from Redis. :v16 bump:
+     * `setlist.show` no longer carries the raw query relations (tracks,
+     * showMusicians, venue) or searchText.
      */
-    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}:v15`,
+    attendedSetlists: (userId: string, page: number) => `user:${userId}:attended-setlists:p${page}:v16`,
     /** All pages of a single user's attended-setlists caches (for per-user invalidation). */
     allAttendedSetlistsForUser: (userId: string) => `user:${userId}:attended-setlists:*`,
     /** All per-user attended-setlists caches (for pattern deletion on broad show mutations). */
@@ -160,9 +164,9 @@ export const CacheKeys = {
    */
   rockOperas: {
     /** Resource-page list payload: setlists + external sources for one rock
-     *  opera. :v13 bump: SongLight gained dateFirstPlayed (Setlist
-     *  shape change). */
-    performances: (slug: string) => `rock-operas:performances:${slug}:v13`,
+     *  opera. :v14 bump: `setlist.show` no longer carries the raw query
+     *  relations (tracks, showMusicians, venue) or searchText. */
+    performances: (slug: string) => `rock-operas:performances:${slug}:v14`,
     /** Pattern for invalidating every performances cache (broad mutations). */
     allPerformances: () => "rock-operas:performances:*",
   },
@@ -171,9 +175,10 @@ export const CacheKeys = {
    * Home page cache keys
    */
   home: {
-    /** Recent setlists for home page (limit + sort direction). :v15 bump:
-     *  SongLight gained dateFirstPlayed (Setlist shape change). */
-    recentSetlists: (limit: number) => `home:recent-setlists:${limit}:v15`,
+    /** Recent setlists for home page (limit + sort direction). :v16 bump:
+     *  `setlist.show` no longer carries the raw query relations (tracks,
+     *  showMusicians, venue) or searchText. */
+    recentSetlists: (limit: number) => `home:recent-setlists:${limit}:v16`,
   },
 
   /**


### PR DESCRIPTION
Show pages, year listings, attended-show lists, musician profiles, and rock opera pages all transfer and deserialize ~60% less data. On a real 50-show payload measured against the local prod restore, the setlist blob drops from 1.53 MB to 0.61 MB.

The `show` object inside every `Setlist` was carrying a raw copy of every relation the query loaded. `show.tracks` (41.6% of the payload) duplicated `sets[].tracks`, the mapped and sorted copy that actually renders. `show.showMusicians` (16.4%) duplicated `lineup`. `show.venue` duplicated the top-level `venue`, and `show.searchText` was never rendered anywhere. It now carries only the fields the `Show` domain type declares.

Since one mapper feeds every setlist query, the saving lands in every setlist-holding cache key: `shows:list` (the 2-5 MB year payloads that dominate the prod Redis census), `show:*:data`, `home.recentSetlists`, `users.attendedSetlists`, `rockOperas.performances`, and `musicians.page`. On the 2026-07-21 census of 257.7 MB total, that is on the order of 90-100 MB of Redis, plus the app-heap weight of deserializing it on every request.

## Notes for the reviewer

`mapShowToDomainEntity` built its result by spreading the Prisma row (`const { ...rest } = dbShow; return { ...rest, ... }`), and the runtime argument was never a bare row: it is the whole `SETLIST_INCLUDE` result. TypeScript could not catch it because excess-property checking does not apply to a spread, so the typechecker saw a clean `Show` while the serialized object carried the relations. The replacement `mapDbShowToDomainEntity` lists every field explicitly, so a future addition to `SETLIST_INCLUDE` can't silently re-inflate the payload. `ShowService` had the same spread and is fixed the same way.

`show.venue` was not entirely dead: the show page's `<title>`, meta description, and JSON-LD structured data read it. Those now read `setlist.venue`, which is the mapped copy and non-optional on `Setlist`. `ShowService.findMany` keeps its venue passthrough for the MCP `get_shows_by_year` getter, but now attaches a mapped `Venue` rather than the raw relation.

Cache keys bump for the shape change: `show.data` v16, `shows.list` v16, `musicians.page` v6, `users.attendedSetlists` v16, `rockOperas.performances` v14, `home.recentSetlists` v16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
