### PR TITLE
Recompute a track's calibrated rating when it is rated

### DIFF
--- a/packages/core/src/_shared/prisma/migrations/20260722000000_force_ratings_recompute_for_track_calibration/migration.sql
+++ b/packages/core/src/_shared/prisma/migrations/20260722000000_force_ratings_recompute_for_track_calibration/migration.sql
@@ -1,0 +1,13 @@
+-- One-time force of the ratings recompute so every track rated since the last batch
+-- run picks up the Calibrated Track Rating its write path now maintains inline.
+--
+-- The deploy entrypoint runs scripts/recompute-ratings.ts right after
+-- `prisma migrate deploy`, but that recompute is dirty-gated on
+-- rating_settings.ratings_dirty, which may already be clear from the hourly cron.
+-- Flip it here so this deploy rebuilds tracks.discriminating_rating /
+-- discriminating_ratings_count for the tracks whose rating writes never reached them.
+-- The recompute clears the flag when it finishes.
+--
+-- Idempotent: re-running only re-sets true. If no settings row exists, isDirty()
+-- already treats the absent row as dirty, so the recompute still runs.
+UPDATE "rating_settings" SET "ratings_dirty" = true;

--- a/packages/core/src/ratings/rater-weight-service.test.ts
+++ b/packages/core/src/ratings/rater-weight-service.test.ts
@@ -366,9 +366,66 @@ describe("RaterWeightService.recomputeRateable", () => {
     expect(data.weightedRatingsCount).toBe(1);
   });
 
-  test("ignores non-show rateables (no denormalized calibrated column for tracks)", async () => {
-    const { db, showUpdate } = makeDb();
+  // A track rating write must land on tracks.discriminating_rating immediately —
+  // the setlist headline reads that column, so leaving it to the hourly batch
+  // shows the pre-rating score and count on the very next page load.
+  test("writes the calibrated score to tracks.discriminating_rating, dropping the zero-entropy fluffer", async () => {
+    const trackUpdate = vi.fn().mockResolvedValue(undefined);
+    const db = {
+      user: { findMany: vi.fn().mockResolvedValue([]) },
+      rating: {
+        findMany: vi.fn().mockResolvedValue([
+          { userId: "wide", value: 0.5 },
+          { userId: "fluffer", value: 5 },
+        ]),
+        groupBy: vi.fn().mockResolvedValue([]),
+      },
+      show: { findMany: vi.fn(), update: vi.fn() },
+      track: { findMany: vi.fn(), update: trackUpdate },
+      raterStats: {
+        findMany: vi.fn().mockResolvedValue([
+          { userId: "wide", mean: 3, entropy: 2, ratingsCount: 30 },
+          { userId: "fluffer", mean: 4.9, entropy: 0.3, ratingsCount: 20 },
+        ]),
+      },
+      ratingSettings: { findFirst: vi.fn().mockResolvedValue(null) },
+    } as never;
+
     await new RaterWeightService(db).recomputeRateable("Track", "t1");
+
+    const data = (
+      trackUpdate.mock.calls[0][0] as {
+        data: { discriminatingRating: number; discriminatingRatingsCount: number };
+      }
+    ).data;
+    // Raw (un-centered) stars: the fluffer's 5 drops to weight 0, leaving the
+    // wide rater's genuine 0.5 as the whole score.
+    expect(data.discriminatingRating).toBeCloseTo(0.5, 10);
+    expect(data.discriminatingRatingsCount).toBe(1);
+  });
+
+  test("zeroes a track whose last rating was removed", async () => {
+    const trackUpdate = vi.fn().mockResolvedValue(undefined);
+    const db = {
+      user: { findMany: vi.fn().mockResolvedValue([]) },
+      rating: { findMany: vi.fn().mockResolvedValue([]), groupBy: vi.fn().mockResolvedValue([]) },
+      show: { findMany: vi.fn(), update: vi.fn() },
+      track: { findMany: vi.fn(), update: trackUpdate },
+      raterStats: { findMany: vi.fn().mockResolvedValue([]) },
+      ratingSettings: { findFirst: vi.fn().mockResolvedValue(null) },
+    } as never;
+
+    await new RaterWeightService(db).recomputeRateable("Track", "t1");
+
+    expect(trackUpdate.mock.calls[0][0]).toEqual({
+      where: { id: "t1" },
+      data: { discriminatingRating: null, discriminatingRatingsCount: 0 },
+    });
+  });
+
+  test("ignores rateable types with no denormalized calibrated column", async () => {
+    const { db, showUpdate } = makeDb();
+    await new RaterWeightService(db).recomputeRateable("Review", "r1");
     expect(showUpdate).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/ratings/rater-weight-service.ts
+++ b/packages/core/src/ratings/rater-weight-service.ts
@@ -400,19 +400,11 @@ export class RaterWeightService {
   async getCalibratedTrackDistribution(trackId: string): Promise<RatingValueBucket[]> {
     const ratings = await this.loadCanonicalShowRatings("Track", trackId);
     if (ratings.length === 0) return [];
-    const statRows = await this.db.raterStats.findMany({
-      where: { userId: { in: ratings.map((rating) => rating.userId) }, kind: "TRACK", era: "GLOBAL" },
-      select: { userId: true, mean: true, entropy: true, ratingsCount: true },
+    const statByUser = await this.loadTrackStats(ratings.map((rating) => rating.userId));
+    const used = ratings.filter((rating) => {
+      const stats = statByUser(rating.userId);
+      return stats != null && discriminatingRaterWeight(stats, TRACK_DISCRIMINATING_GAMMA) > 0;
     });
-    const contributing = new Set<string>();
-    for (const row of statRows) {
-      const weight = discriminatingRaterWeight(
-        { mean: row.mean, entropy: row.entropy, ratingsCount: row.ratingsCount },
-        TRACK_DISCRIMINATING_GAMMA,
-      );
-      if (weight > 0) contributing.add(row.userId);
-    }
-    const used = ratings.filter((rating) => contributing.has(rating.userId));
     const active = used.length > 0 ? used : ratings;
     return bucketRatingValues(active.map((rating) => rating.value));
   }
@@ -668,9 +660,11 @@ export class RaterWeightService {
   }
 
   /**
-   * Recompute one show's calibrated score (`shows.weighted_rating`) from current
-   * rater_stats. Show-only — tracks have no denormalized calibrated column. The
-   * batch passes `population` + the prebuilt canonical map to skip per-call work.
+   * Recompute one rateable's denormalized calibrated score (`shows.weighted_rating`
+   * or `tracks.discriminating_rating`) from current rater_stats. Both are what the
+   * page reads, so a rating write has to land here too or the score and count stay
+   * at their pre-rating values until the hourly batch. The batch passes `population`
+   * + the prebuilt canonical map to skip per-call work.
    */
   async recomputeRateable(
     rateableType: string,
@@ -678,6 +672,7 @@ export class RaterWeightService {
     population?: PopulationStats,
     canonicalUsers?: Map<string, string>,
   ): Promise<void> {
+    if (rateableType === "Track") return this.recomputeTrack(rateableId, canonicalUsers);
     if (rateableType !== "Show") return;
 
     const ratings = await this.loadCanonicalShowRatings(rateableType, rateableId, canonicalUsers);
@@ -700,6 +695,49 @@ export class RaterWeightService {
       where: { id: rateableId },
       data: { weightedRating, weightedRatingsCount },
     });
+  }
+
+  /**
+   * The track half of {@link recomputeRateable}. Tracks have no era scope and no
+   * population anchor — the score is entropy^gamma-weighted raw stars — so this
+   * needs only the raters' GLOBAL-scope TRACK stats.
+   */
+  private async recomputeTrack(trackId: string, canonicalUsers?: Map<string, string>): Promise<void> {
+    const ratings = await this.loadCanonicalShowRatings("Track", trackId, canonicalUsers);
+    if (ratings.length === 0) {
+      await this.db.track.update({
+        where: { id: trackId },
+        data: { discriminatingRating: null, discriminatingRatingsCount: 0 },
+      });
+      return;
+    }
+
+    const statByUser = await this.loadTrackStats(ratings.map((rating) => rating.userId));
+    const { discriminatingRating, discriminatingRatingsCount } = computeTrackDiscriminating(
+      ratings,
+      statByUser,
+      TRACK_DISCRIMINATING_GAMMA,
+    );
+    await this.db.track.update({
+      where: { id: trackId },
+      data: { discriminatingRating, discriminatingRatingsCount },
+    });
+  }
+
+  /**
+   * The GLOBAL-scope TRACK stats for a set of raters — the discriminating-weight
+   * input. Shared by the track score and its histogram so both draw the
+   * contributing set from the same rows.
+   */
+  private async loadTrackStats(userIds: string[]): Promise<TrackStatByUser> {
+    const statRows = await this.db.raterStats.findMany({
+      where: { userId: { in: userIds }, kind: "TRACK", era: "GLOBAL" },
+      select: { userId: true, mean: true, entropy: true, ratingsCount: true },
+    });
+    const byUser = new Map(
+      statRows.map((row) => [row.userId, { mean: row.mean, entropy: row.entropy, ratingsCount: row.ratingsCount }]),
+    );
+    return (userId) => byUser.get(userId);
   }
 
   /**

--- a/packages/core/src/ratings/rating-service.ts
+++ b/packages/core/src/ratings/rating-service.ts
@@ -215,7 +215,7 @@ export class RatingService {
    * After a rating mutation: mark the calibrated-rating tables dirty (cheap, so the
    * hourly cron rebuilds the actor's stats + the cross-show ripple) and do the
    * one cheap thing inline — recompute the touched rateable's calibrated score from
-   * current stats so the rated show updates immediately. We deliberately do NOT
+   * current stats so the rated show/track updates immediately. We deliberately do NOT
    * recompute the actor's stats here: the old delete-then-recreate-per-write was
    * heavy and could wipe stats on a transient failure. The recompute is
    * best-effort (swallowed) so it never breaks the live rating write.


### PR DESCRIPTION
Rate a track and its score and rating count update on the next page load. Readers opted into calibrated track ratings previously saw their own star appear immediately while the community score and count sat at their pre-rating values for up to an hour, until the next scheduled recompute.

`RaterWeightService.recomputeRateable` early-returned for every rateable type except `Show`, so a track rating write never refreshed `tracks.discriminating_rating` or `discriminating_ratings_count`. Those are exactly the columns the setlist headline reads when a viewer is in calibrated track mode, so the display stayed at whatever the hourly cron last wrote. The plain `average_rating` / `ratings_count` pair was always maintained inline, which is why only calibrated viewers saw stale numbers.

Tracks now recompute on write through the same `computeTrackDiscriminating` the batch recompute uses, so the incremental and batch paths cannot diverge. Clearing a rating zeroes the columns, matching the show branch. The GLOBAL-scope TRACK rater-stat lookup that the score and the histogram each built separately is now one shared helper.

## Deploy

Migration `20260722000000_force_ratings_recompute_for_track_calibration` sets `rating_settings.ratings_dirty = true` so tracks rated before this change are healed on deploy. The entrypoint already runs `scripts/recompute-ratings.ts` after `migrate deploy`, but that recompute is dirty-gated and the hourly cron may have just cleared the flag.

## Notes for the reviewer

Track rating writes now pay `buildCanonicalUserMap`, which aggregates across the whole `ratings` table to resolve alias accounts. Measured at 12 ms against 59k ratings (seq scan, fully cached), against 0.06 ms for the per-track rating fetch. Cost is linear in table size, so at the current rate of roughly 530 ratings/month it grows about 1 ms per year, and organic growth will not make it matter. A bulk rating import that changed the row count by an order of magnitude would. The fix at that point is to resolve alias groups for only the raters on the rateable rather than building the global map, which would speed up the show write path by the same amount.

A track's calibrated score deliberately drops raters with no TRACK `rater_stats` row, unlike the show score, which cold-start-shrinks a statless rater toward the population and gives them full weight. So a track whose only rater is brand new resolves to a null calibrated score and the display falls back to the plain average. That is existing scoring behavior, unchanged here, and the incremental path now matches the batch on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
