### PR TITLE
Split musician stats into Shows, Songs, and Plays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ apps/web/.react-router/*
 .gitattributes
 .playwright-mcp/*
 backups/
+# Rater duplicate-account investigation: contains real user emails (PII), keep out of git
+rater-investigation/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,14 @@ Any code that orders or filters shows/tracks chronologically MUST use the helper
 
 Use `SHOW_ORDER_ASC` / `SHOW_ORDER_DESC` for Prisma `orderBy`, `showOrderBySql` for raw SQL, `TRACK_BY_SHOW_ORDER_ASC` for ordering tracks by their show, `statsShowsSql` / `STATS_SHOWS_WHERE` for the count_for_stats=true predicate, and `compareByShowDate` for in-memory sorts.
 
+## Every generated statistic is count_for_stats-only, from one shared definition
+
+Any number the site presents as a statistic — counts, averages, totals, first/last dates, "top N" orderings — MUST filter to `count_for_stats = TRUE` via `statsShowsSql` / `STATS_SHOWS_WHERE`. No exceptions for "this set obviously matches". Display-only listings that deliberately show every performance (e.g. the song-detail performances table) are the only queries that skip it, and they aren't statistics.
+
+When the same statistic surfaces in more than one place (an index table and a detail page, say), the *row set* it aggregates over lives in exactly one exported SQL builder that both callers use, not in two hand-written queries that happen to agree today. Two queries drift: the /musicians index and a musician's profile shipped three different definitions of "shows played" (lineup rows vs. shows-with-tracks, one stats-filtered and one not) and disagreed by 96 for Aron Magner. Precedent to copy: [musician-appearances.ts](packages/core/src/musicians/musician-appearances.ts), which exports the appearance-show and song-play row sets plus the shared aggregate SELECT list.
+
+Related: a musician's play count uses distinct `(song_id, show_id)` pairs, matching `Song.timesPlayed`, so a musician's plays can never exceed the per-song totals shown elsewhere.
+
 ## Commit and PR Messages
 
 Describe the final before→after change as the user will see it, not the development process or intermediate iterations. Be pithy. Lead with the user-visible change.

--- a/apps/web/app/routes/api/musicians.test.ts
+++ b/apps/web/app/routes/api/musicians.test.ts
@@ -6,9 +6,9 @@ vi.mock("~/lib/base-loaders", () => ({
 }));
 
 const search = vi.fn();
-const findTopBySongCount = vi.fn();
+const findTopByPlayCount = vi.fn();
 vi.mock("~/server/services", () => ({
-  services: { musicians: { search, findTopBySongCount } },
+  services: { musicians: { search, findTopByPlayCount } },
 }));
 
 vi.mock("~/lib/logger", () => ({
@@ -24,20 +24,20 @@ function makeArgs(url: string): LoaderFunctionArgs & { context: unknown } {
 describe("GET /api/musicians", () => {
   beforeEach(() => {
     search.mockReset();
-    findTopBySongCount.mockReset();
+    findTopByPlayCount.mockReset();
   });
 
-  // The picker's loadOnOpen hits ?top=N for the initial list, ordered by song
+  // The picker's loadOnOpen hits ?top=N for the initial list, ordered by play
   // count (most-played first) rather than alphabetically.
-  test("returns the top musicians by song count for ?top=N, without searching", async () => {
+  test("returns the top musicians by play count for ?top=N, without searching", async () => {
     const top = [{ id: "jg", name: "Jon Gutwillig", slug: "jon-gutwillig" }];
-    findTopBySongCount.mockResolvedValue(top);
+    findTopByPlayCount.mockResolvedValue(top);
 
     const response = (await loader(makeArgs("http://localhost/api/musicians?top=5"))) as Response;
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(top);
-    expect(findTopBySongCount).toHaveBeenCalledWith(5);
+    expect(findTopByPlayCount).toHaveBeenCalledWith(5);
     expect(search).not.toHaveBeenCalled();
   });
 

--- a/apps/web/app/routes/api/musicians.tsx
+++ b/apps/web/app/routes/api/musicians.tsx
@@ -25,12 +25,12 @@ export const loader = publicLoader(async ({ request }) => {
   const topParam = url.searchParams.get("top");
 
   // The picker's loadOnOpen asks for the top list; most-played musicians first
-  // (track count desc, ties alphabetical) so the core lineup and frequent
+  // (play count desc, ties alphabetical) so the core lineup and frequent
   // guests sit at the top rather than being buried in an alphabetical list.
   if (topParam) {
     const topLimit = parseBoundedPositiveInt(topParam, DEFAULT_TOP_LIMIT);
     try {
-      const musicians = await services.musicians.findTopBySongCount(topLimit);
+      const musicians = await services.musicians.findTopByPlayCount(topLimit);
       logger.info(`Fetched top ${musicians.length} musicians`);
       return json(musicians, 200);
     } catch (error) {

--- a/apps/web/app/routes/musicians/$slug.test.tsx
+++ b/apps/web/app/routes/musicians/$slug.test.tsx
@@ -60,7 +60,7 @@ function makeData({ slug = "mike-greenfield", tier = "guest", songs, performance
       updatedAt: new Date(),
     },
     tier,
-    stats: { showCount: 5, songCount: 3 },
+    stats: { showCount: 5, songCount: 2, playCount: 3 },
     firstShow: null,
     lastShow: null,
     shows:
@@ -120,6 +120,20 @@ describe("MusicianPage body", () => {
     expect(screen.getByRole("heading", { name: /Songs played with the band/ })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Shows played with the band/ })).toBeInTheDocument();
     expect(screen.getAllByText("(outside their era)")).toHaveLength(2);
+  });
+
+  // Unique Songs (distinct repertoire) and Song Plays (repeat plays) are two
+  // different numbers over the same appearances, so each headline stat has to
+  // read from its own field rather than both showing the same aggregate.
+  test("the headline stats separate shows, distinct songs, and repeat plays", async () => {
+    loaderData.mockReturnValue(makeData({ slug: "mike-greenfield", tier: "guest" }));
+
+    await setupWithRouter(<MusicianPage />);
+
+    const statValue = (label: string) => screen.getByText(label).closest("div")?.textContent;
+    expect(statValue("Shows Played")).toContain("5");
+    expect(statValue("Unique Songs")).toContain("2");
+    expect(statValue("Song Plays")).toContain("3");
   });
 
   // Core members appear on essentially every show, so the tables are omitted —

--- a/apps/web/app/routes/musicians/$slug.tsx
+++ b/apps/web/app/routes/musicians/$slug.tsx
@@ -58,7 +58,7 @@ interface ShowRow {
 interface MusicianPageData {
   musician: MusicianWithInstrument;
   tier: MusicianTier;
-  stats: { showCount: number; songCount: number };
+  stats: { showCount: number; songCount: number; playCount: number };
   firstShow: MusicianAppearanceShow | null;
   lastShow: MusicianAppearanceShow | null;
   // Empty for core members; for drummers, shows outside their era; else all shows.
@@ -92,7 +92,8 @@ export const loader = publicLoader(async ({ params, context }): Promise<LoaderDa
         ? await services.instruments.findById(musician.defaultInstrumentId)
         : null;
 
-      const { showIds, songCount, firstShow, lastShow } = await services.musicians.findAppearances(musician.id);
+      const { showIds, showCount, songCount, playCount, firstShow, lastShow } =
+        await services.musicians.findAppearances(musician.id);
       const tier = classifyMusician(slug);
       // A drummer's everyday shows are implied by their era; only out-of-era
       // appearances (sit-ins before/after their tenure) are notable, so every
@@ -145,7 +146,7 @@ export const loader = publicLoader(async ({ params, context }): Promise<LoaderDa
       return {
         musician: { ...musician, defaultInstrument },
         tier,
-        stats: { showCount: showIds.length, songCount },
+        stats: { showCount, songCount, playCount },
         firstShow,
         lastShow,
         shows,
@@ -273,9 +274,10 @@ export default function MusicianPage() {
       </div>
 
       <div className="space-y-8">
-        <dl className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <dl className="grid grid-cols-2 lg:grid-cols-5 gap-4">
           <StatBox label="Shows Played" value={stats.showCount} />
-          <StatBox label="Songs Played" value={stats.songCount} />
+          <StatBox label="Unique Songs" value={stats.songCount} />
+          <StatBox label="Song Plays" value={stats.playCount} />
           <PerformanceStatBox label="First Performance" show={firstShow} />
           <PerformanceStatBox label="Last Performance" show={lastShow} />
         </dl>

--- a/apps/web/app/routes/musicians/index.test.tsx
+++ b/apps/web/app/routes/musicians/index.test.tsx
@@ -8,8 +8,9 @@ vi.mock("~/components/admin/admin-only", () => ({
   AdminOnly: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+const loaderData = vi.fn(() => ({ musicians: [] as unknown[] }));
 vi.mock("~/hooks/use-serialized-loader-data", () => ({
-  useSerializedLoaderData: () => ({ musicians: [] }),
+  useSerializedLoaderData: () => loaderData(),
 }));
 
 // The loader pulls in the server services + env modules; stub both so importing
@@ -25,5 +26,40 @@ describe("MusiciansPage admin links", () => {
 
     expect(screen.getByRole("link", { name: /create musician/i })).toHaveAttribute("href", "/admin/musicians/new");
     expect(screen.getByRole("link", { name: /manage instruments/i })).toHaveAttribute("href", "/admin/instruments");
+  });
+});
+
+describe("MusiciansPage count columns", () => {
+  // Songs (distinct repertoire) and Plays (repeat plays) are separate
+  // aggregates over the same appearances; each column has to read its own
+  // field, since swapping them would still render plausible numbers.
+  test("shows, distinct songs, and repeat plays each get their own column", async () => {
+    loaderData.mockReturnValue({
+      musicians: [
+        {
+          id: "am",
+          name: "Aron Magner",
+          slug: "aron-magner",
+          knownFrom: null,
+          defaultInstrumentName: "Keyboards",
+          showCount: 1899,
+          songCount: 550,
+          playCount: 20111,
+          firstShowDate: "1995-04-15",
+          lastShowDate: "2026-01-03",
+        },
+      ],
+    });
+
+    await setupWithRouter(<MusiciansPage />);
+
+    const headers = screen.getAllByRole("columnheader").map((header) => header.textContent ?? "");
+    const row = screen.getByRole("row", { name: /Aron Magner/ });
+    const cells = Array.from(row.querySelectorAll("td")).map((cell) => cell.textContent ?? "");
+    const valueUnder = (label: string) => cells[headers.findIndex((header) => header.includes(label))];
+
+    expect(valueUnder("Shows")).toBe("1899");
+    expect(valueUnder("Songs")).toBe("550");
+    expect(valueUnder("Plays")).toBe("20111");
   });
 });

--- a/apps/web/app/routes/musicians/index.tsx
+++ b/apps/web/app/routes/musicians/index.tsx
@@ -70,6 +70,11 @@ const columns: ColumnDef<MusicianWithStats>[] = [
     header: ({ column }) => <SortableHeader column={column} label="Songs" />,
   },
   {
+    accessorKey: "playCount",
+    meta: { fixedWidth: "5rem", cellClassName: "tabular-nums" },
+    header: ({ column }) => <SortableHeader column={column} label="Plays" />,
+  },
+  {
     accessorKey: "firstShowDate",
     meta: { fixedWidth: "6rem", cellClassName: "tabular-nums", hideOnMobile: true },
     header: ({ column }) => <SortableHeader column={column} label="First" />,

--- a/packages/core/scripts/sync-missing-shows.ts
+++ b/packages/core/scripts/sync-missing-shows.ts
@@ -282,6 +282,8 @@ export interface McpSyncUser {
   // Optional until the setlist-times deploy lands on prod: an older prod omits
   // it, and the sync then leaves the local value alone rather than clearing it.
   showSetlistTimes?: boolean | null;
+  // Same optional-until-deployed guard as showSetlistTimes above.
+  ratingDecimalPlaces?: number | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -1710,6 +1712,7 @@ export async function syncUserActivity(
               trackRatingComparisonDebug: u.trackRatingComparisonDebug,
               colorCodeRatings: u.colorCodeRatings,
               showSetlistTimes: u.showSetlistTimes,
+              ratingDecimalPlaces: u.ratingDecimalPlaces,
               updatedAt: new Date(u.updatedAt),
             },
           });
@@ -1730,6 +1733,7 @@ export async function syncUserActivity(
               trackRatingComparisonDebug: u.trackRatingComparisonDebug,
               colorCodeRatings: u.colorCodeRatings,
               showSetlistTimes: u.showSetlistTimes,
+              ratingDecimalPlaces: u.ratingDecimalPlaces,
               updatedAt: new Date(u.updatedAt),
             },
           });
@@ -1749,6 +1753,7 @@ export async function syncUserActivity(
               trackRatingComparisonDebug: u.trackRatingComparisonDebug,
               colorCodeRatings: u.colorCodeRatings,
               showSetlistTimes: u.showSetlistTimes,
+              ratingDecimalPlaces: u.ratingDecimalPlaces,
               createdAt: new Date(u.createdAt),
               updatedAt: new Date(u.updatedAt),
             },

--- a/packages/core/src/musicians/musician-appearances.test.ts
+++ b/packages/core/src/musicians/musician-appearances.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import { musicianAppearanceShowsSql, musicianSongPlaysSql } from "./musician-appearances";
+
+describe("musicianAppearanceShowsSql", () => {
+  // Every musician statistic counts only stats shows. Both halves of the union
+  // (lineup membership and sit-in deltas) need the filter — a soundcheck
+  // sit-in slipping through one branch would inflate the counts on that page
+  // alone, which is the class of drift this shared builder exists to prevent.
+  test("filters both the lineup and sit-in branches to stats shows", () => {
+    const { sql } = musicianAppearanceShowsSql();
+
+    expect(sql.match(/count_for_stats = TRUE/g)).toHaveLength(2);
+  });
+
+  // Early shows have no setlist entered; a lineup row is still a real
+  // appearance, so the show set must come off `show_musicians` directly rather
+  // than being derived from tracks the way the play counts are.
+  test("counts a lineup show even when it has no tracks", () => {
+    const { sql } = musicianAppearanceShowsSql();
+
+    expect(sql).not.toContain("JOIN tracks t ON t.show_id = sm.show_id");
+  });
+
+  // The profile page scopes to one musician while the index scans everyone;
+  // an unscoped profile query would silently aggregate the whole band.
+  test("scopes both branches to the musician when given an id", () => {
+    expect(musicianAppearanceShowsSql("musician-1").values).toEqual(["musician-1", "musician-1"]);
+    expect(musicianAppearanceShowsSql().values).toEqual([]);
+  });
+});
+
+describe("musicianSongPlaysSql", () => {
+  test("filters both the lineup and sit-in branches to stats shows", () => {
+    const { sql } = musicianSongPlaysSql();
+
+    expect(sql.match(/count_for_stats = TRUE/g)).toHaveLength(2);
+  });
+
+  test("scopes both branches to the musician when given an id", () => {
+    expect(musicianSongPlaysSql("musician-1").values).toEqual(["musician-1", "musician-1"]);
+    expect(musicianSongPlaysSql().values).toEqual([]);
+  });
+});

--- a/packages/core/src/musicians/musician-appearances.ts
+++ b/packages/core/src/musicians/musician-appearances.ts
@@ -1,0 +1,88 @@
+import { Prisma } from "@prisma/client";
+import { statsShowsSql } from "../_shared/show-ordering";
+
+/**
+ * Every show a musician appeared on, shared by the /musicians index and a
+ * musician's profile so the two can never disagree about the same number.
+ *
+ * A musician appears on a show when they are in its lineup or have a
+ * present=true sit-in delta on one of its tracks. Lineup membership alone is
+ * enough on purpose: early shows have no setlist entered, and those are real
+ * appearances even though they contribute no songs or plays.
+ *
+ * Pass a musician id to scope the scan to one musician; omit it for the
+ * all-musicians index, where callers group by `musician_id`.
+ */
+export function musicianAppearanceShowsSql(musicianId?: string): Prisma.Sql {
+  const lineupScope = musicianId ? Prisma.sql`AND sm.musician_id = ${musicianId}::uuid` : Prisma.empty;
+  const sitInScope = musicianId ? Prisma.sql`AND tm.musician_id = ${musicianId}::uuid` : Prisma.empty;
+
+  return Prisma.sql`
+    SELECT sm.musician_id, sm.show_id
+    FROM show_musicians sm
+    JOIN shows s ON s.id = sm.show_id
+    WHERE ${statsShowsSql("s")}
+      ${lineupScope}
+    UNION
+    SELECT tm.musician_id, t.show_id
+    FROM track_musicians tm
+    JOIN tracks t ON t.id = tm.track_id
+    JOIN shows s ON s.id = t.show_id
+    WHERE tm.present = true
+      AND ${statsShowsSql("s")}
+      ${sitInScope}
+  `;
+}
+
+/**
+ * Every song a musician played, one row per (musician, show, song).
+ *
+ * A musician plays a track when they are in that show's lineup and have no
+ * sat-out delta for the track, OR they have a present=true sit-in delta for
+ * it. Scopes exactly like `musicianAppearanceShowsSql`.
+ */
+export function musicianSongPlaysSql(musicianId?: string): Prisma.Sql {
+  const lineupScope = musicianId ? Prisma.sql`AND sm.musician_id = ${musicianId}::uuid` : Prisma.empty;
+  const sitInScope = musicianId ? Prisma.sql`AND tm.musician_id = ${musicianId}::uuid` : Prisma.empty;
+
+  return Prisma.sql`
+    SELECT sm.musician_id, t.show_id, t.song_id
+    FROM show_musicians sm
+    JOIN tracks t ON t.show_id = sm.show_id
+    JOIN shows s ON s.id = t.show_id
+    WHERE ${statsShowsSql("s")}
+      ${lineupScope}
+      AND NOT EXISTS (
+        SELECT 1 FROM track_musicians tm
+        WHERE tm.track_id = t.id AND tm.musician_id = sm.musician_id AND tm.present = false
+      )
+    UNION
+    SELECT tm.musician_id, t.show_id, t.song_id
+    FROM track_musicians tm
+    JOIN tracks t ON t.id = tm.track_id
+    JOIN shows s ON s.id = t.show_id
+    WHERE tm.present = true
+      AND ${statsShowsSql("s")}
+      ${sitInScope}
+  `;
+}
+
+/**
+ * The two play aggregates, defined once so "songs" and "plays" mean the same
+ * thing wherever they surface. `play_count` counts distinct (song, show) pairs
+ * — the same "a song twice in one show counts once" math as Song.timesPlayed,
+ * so a musician's plays never exceed the per-song totals shown elsewhere;
+ * `song_count` collapses those plays to the distinct repertoire behind them.
+ *
+ * Splice into a SELECT over `musicianSongPlaysSql` aliased as `p`.
+ */
+export const MUSICIAN_SONG_PLAY_COUNTS_SQL = Prisma.sql`
+  COUNT(DISTINCT p.song_id) AS song_count,
+  COUNT(DISTINCT (p.song_id, p.show_id)) AS play_count
+`;
+
+/** Raw shape of the columns `MUSICIAN_SONG_PLAY_COUNTS_SQL` projects. */
+export interface MusicianSongPlayCountsRow {
+  song_count: bigint;
+  play_count: bigint;
+}

--- a/packages/core/src/musicians/musician-service.test.ts
+++ b/packages/core/src/musicians/musician-service.test.ts
@@ -58,20 +58,20 @@ describe("MusicianService.create — dedupe by slug", () => {
   });
 });
 
-describe("MusicianService.findTopBySongCount", () => {
+describe("MusicianService.findTopByPlayCount", () => {
   // The picker's default list surfaces the most-played musicians first (the
   // core lineup + frequent guests) so the common picks aren't buried under an
   // alphabetical list. Ties break alphabetically for a stable order.
-  test("orders by song count desc, breaking ties alphabetically, and caps at the limit", async () => {
+  test("orders by play count desc, breaking ties alphabetically, and caps at the limit", async () => {
     const service = new MusicianService({} as never, logger);
     vi.spyOn(service, "findAllWithStats").mockResolvedValue([
-      { id: "1", name: "Allen Aucoin", slug: "allen-aucoin", songCount: 5 },
-      { id: "2", name: "Marc Brownstein", slug: "marc-brownstein", songCount: 40 },
-      { id: "3", name: "Aron Magner", slug: "aron-magner", songCount: 40 },
-      { id: "4", name: "Sam Altman", slug: "sam-altman", songCount: 12 },
+      { id: "1", name: "Allen Aucoin", slug: "allen-aucoin", playCount: 5 },
+      { id: "2", name: "Marc Brownstein", slug: "marc-brownstein", playCount: 40 },
+      { id: "3", name: "Aron Magner", slug: "aron-magner", playCount: 40 },
+      { id: "4", name: "Sam Altman", slug: "sam-altman", playCount: 12 },
     ] as never);
 
-    const result = await service.findTopBySongCount(3);
+    const result = await service.findTopByPlayCount(3);
 
     expect(result.map((m) => m.slug)).toEqual([
       // 40 (Aron < Marc alphabetically), then 40, then 12 — Allen's 5 is cut.
@@ -79,6 +79,40 @@ describe("MusicianService.findTopBySongCount", () => {
       "marc-brownstein",
       "sam-altman",
     ]);
+  });
+});
+
+describe("MusicianService.findAllWithStats", () => {
+  // Shows, songs and plays are three aggregates over the same appearances
+  // (venues turned up at, distinct repertoire, repeat plays); mapping any of
+  // them to the wrong field would silently swap plausible-looking numbers.
+  test("maps the show, song, and play aggregates to their own fields", async () => {
+    const db = {
+      $queryRaw: vi.fn(() =>
+        Promise.resolve([
+          {
+            id: "1",
+            name: "Aron Magner",
+            slug: "aron-magner",
+            known_from: null,
+            default_instrument_id: null,
+            default_instrument_name: "Keyboards",
+            show_count: BigInt(1899),
+            song_count: BigInt(550),
+            play_count: BigInt(20111),
+            first_show_date: "1995-04-15",
+            last_show_date: "2026-01-03",
+          },
+        ]),
+      ),
+    };
+    const service = new MusicianService(db as never, logger);
+
+    const [magner] = await service.findAllWithStats();
+
+    expect(magner.showCount).toBe(1899);
+    expect(magner.songCount).toBe(550);
+    expect(magner.playCount).toBe(20111);
   });
 });
 
@@ -371,64 +405,57 @@ describe("MusicianService.delete guards referenced rows", () => {
 });
 
 describe("MusicianService.findAppearances", () => {
+  // The shows and the counts are two raw queries over two shared builders;
+  // route each by the column the show query projects.
   function makeAppearancesDb(args: {
-    lineupShowIds: string[];
-    presentDeltaShowIds: string[];
-    songCount: number;
+    showIds: string[];
+    songCount?: number;
+    playCount?: number;
     firstShowDate?: string;
     lastShowDate?: string;
   }) {
     return {
-      showMusician: {
-        findMany: vi.fn(() => Promise.resolve(args.lineupShowIds.map((showId) => ({ showId })))),
-      },
-      trackMusician: {
-        findMany: vi.fn(() => Promise.resolve(args.presentDeltaShowIds.map((showId) => ({ track: { showId } })))),
-      },
-      // findAppearances counts distinct (song, show) via a raw query.
-      $queryRaw: vi.fn(() => Promise.resolve([{ song_count: BigInt(args.songCount) }])),
+      $queryRaw: vi.fn((strings: TemplateStringsArray) =>
+        strings.join("").includes("SELECT DISTINCT a.show_id")
+          ? Promise.resolve(args.showIds.map((show_id) => ({ show_id })))
+          : Promise.resolve([{ song_count: BigInt(args.songCount ?? 0), play_count: BigInt(args.playCount ?? 0) }]),
+      ),
       show: {
-        findFirst: vi.fn(({ orderBy }: { orderBy: { date: "asc" | "desc" } }) => {
-          const date = orderBy.date === "asc" ? (args.firstShowDate ?? null) : (args.lastShowDate ?? null);
+        findFirst: vi.fn(({ orderBy }: { orderBy: Array<{ date?: "asc" | "desc" }> }) => {
+          const date = orderBy[0]?.date === "asc" ? (args.firstShowDate ?? null) : (args.lastShowDate ?? null);
           return Promise.resolve(date ? { date, slug: `show-${date}`, venue: null } : null);
         }),
       },
     };
   }
 
-  test("unions lineup shows with sit-in shows and dedupes overlaps", async () => {
-    // The musician is in the lineup for show-1 and show-2, and sat in on a
-    // track of show-2 (overlap) and show-3 (new).
-    const db = makeAppearancesDb({
-      lineupShowIds: ["show-1", "show-2"],
-      presentDeltaShowIds: ["show-2", "show-3"],
-      songCount: 0,
-    });
+  // The shows table and the "Shows Played" figure both read `showIds`, so the
+  // count has to be the length of that same list rather than its own query.
+  test("reports the appearance shows and counts them", async () => {
+    const db = makeAppearancesDb({ showIds: ["show-1", "show-2", "show-3"] });
     const service = new MusicianService(db as never, logger);
 
     const result = await service.findAppearances("musician-1");
 
-    expect([...result.showIds].sort()).toEqual(["show-1", "show-2", "show-3"]);
+    expect(result.showIds).toEqual(["show-1", "show-2", "show-3"]);
+    expect(result.showCount).toBe(3);
   });
 
-  test("song count comes from the distinct (song, show) query", async () => {
-    const db = makeAppearancesDb({
-      lineupShowIds: ["show-1"],
-      presentDeltaShowIds: ["show-9"],
-      songCount: 42,
-    });
+  // The profile header shows repeat plays next to distinct repertoire; both
+  // come from one raw query, so each has to land on its own field.
+  test("song and play counts come from the aggregate query", async () => {
+    const db = makeAppearancesDb({ showIds: ["show-1"], songCount: 17, playCount: 42 });
     const service = new MusicianService(db as never, logger);
 
     const result = await service.findAppearances("musician-1");
 
-    expect(result.songCount).toBe(42);
+    expect(result.songCount).toBe(17);
+    expect(result.playCount).toBe(42);
   });
 
   test("surfaces first and last show dates from the appearance show set", async () => {
     const db = makeAppearancesDb({
-      lineupShowIds: ["show-1"],
-      presentDeltaShowIds: [],
-      songCount: 5,
+      showIds: ["show-1"],
       firstShowDate: "2003-04-12",
       lastShowDate: "2019-09-01",
     });
@@ -438,5 +465,18 @@ describe("MusicianService.findAppearances", () => {
 
     expect(result.firstShow?.date).toBe("2003-04-12");
     expect(result.lastShow?.date).toBe("2019-09-01");
+  });
+
+  // Musicians with no recorded appearances must not fan out into two
+  // first/last lookups over an empty id list.
+  test("skips the first/last lookups when there are no appearance shows", async () => {
+    const db = makeAppearancesDb({ showIds: [] });
+    const service = new MusicianService(db as never, logger);
+
+    const result = await service.findAppearances("musician-1");
+
+    expect(result.showCount).toBe(0);
+    expect(result.firstShow).toBeNull();
+    expect(db.show.findFirst).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/musicians/musician-service.ts
+++ b/packages/core/src/musicians/musician-service.ts
@@ -9,7 +9,14 @@ import type {
 import type { DbClient, DbInstrument, DbMusician } from "../_shared/database/models";
 import { buildOrderByClause, buildWhereClause } from "../_shared/database/query-utils";
 import type { FilterCondition, QueryOptions } from "../_shared/database/types";
+import { SHOW_ORDER_ASC, SHOW_ORDER_DESC } from "../_shared/show-ordering";
 import { slugify } from "../_shared/utils/slugify";
+import {
+  MUSICIAN_SONG_PLAY_COUNTS_SQL,
+  type MusicianSongPlayCountsRow,
+  musicianAppearanceShowsSql,
+  musicianSongPlaysSql,
+} from "./musician-appearances";
 
 export interface CreateInstrumentInput {
   name: string;
@@ -269,58 +276,30 @@ export class MusicianService {
   }
 
   /**
-   * Shows and track count a musician appears on, for their profile page.
-   * Appearances combine lineup membership (every track of a show they were in
-   * the lineup for, minus their per-track sat-outs) with sit-ins (present=true
-   * deltas on shows they were not in the lineup for).
-   *
-   * Known simplification for this preview: a show where the musician is in the
-   * lineup but sat out every track still counts as an appearance. Full
-   * lineup-minus-satouts-plus-sitins show filtering is deferred to the Phase 8
-   * filter work.
+   * Shows, repertoire, and plays for a musician's profile page, off the shared
+   * appearance definitions so every figure here matches the /musicians index.
+   * `showIds` also drives the profile's shows table and first/last cards, so
+   * the listed shows are exactly the ones the count reports.
    */
   async findAppearances(musicianId: string): Promise<MusicianAppearances> {
-    const [lineupRows, presentDeltas, songCountRows] = await Promise.all([
-      this.db.showMusician.findMany({ where: { musicianId }, select: { showId: true } }),
-      this.db.trackMusician.findMany({
-        where: { musicianId, present: true },
-        select: { track: { select: { showId: true } } },
-      }),
-      // Distinct (song, show) the musician played on count_for_stats=true shows —
-      // the same "a song twice in one show counts once" math as Song.timesPlayed
-      // and the /musicians index, so the profile's "Songs Played" stays consistent.
-      this.db.$queryRaw<[{ song_count: bigint }]>`
-        WITH appearances AS (
-          SELECT t.show_id, t.song_id
-          FROM show_musicians sm
-          JOIN tracks t ON t.show_id = sm.show_id
-          WHERE sm.musician_id = ${musicianId}::uuid
-            AND NOT EXISTS (
-              SELECT 1 FROM track_musicians tm
-              WHERE tm.track_id = t.id AND tm.musician_id = ${musicianId}::uuid AND tm.present = false
-            )
-          UNION
-          SELECT t.show_id, t.song_id
-          FROM track_musicians tm
-          JOIN tracks t ON t.id = tm.track_id
-          WHERE tm.musician_id = ${musicianId}::uuid AND tm.present = true
-        )
-        SELECT COUNT(DISTINCT (a.song_id, a.show_id)) FILTER (WHERE s.count_for_stats) AS song_count
-        FROM appearances a
-        JOIN shows s ON s.id = a.show_id
+    const [showRows, countRows] = await Promise.all([
+      this.db.$queryRaw<Array<{ show_id: string }>>`
+        SELECT DISTINCT a.show_id FROM (${musicianAppearanceShowsSql(musicianId)}) a
+      `,
+      this.db.$queryRaw<[MusicianSongPlayCountsRow]>`
+        SELECT ${MUSICIAN_SONG_PLAY_COUNTS_SQL} FROM (${musicianSongPlaysSql(musicianId)}) p
       `,
     ]);
 
-    const lineupShowIds = lineupRows.map((row) => row.showId);
-    const sitInShowIds = presentDeltas.map((delta) => delta.track.showId);
-    const showIds = Array.from(new Set([...lineupShowIds, ...sitInShowIds]));
-    const songCount = Number(songCountRows[0]?.song_count ?? 0);
+    const showIds = showRows.map((row) => row.show_id);
+    const songCount = Number(countRows[0]?.song_count ?? 0);
+    const playCount = Number(countRows[0]?.play_count ?? 0);
 
     const [firstShow, lastShow] = showIds.length
       ? await Promise.all([this.findAppearanceShow(showIds, "asc"), this.findAppearanceShow(showIds, "desc")])
       : [null, null];
 
-    return { showIds, songCount, firstShow, lastShow };
+    return { showIds, showCount: showIds.length, songCount, playCount, firstShow, lastShow };
   }
 
   /** Earliest/latest appearance show (with venue) for the first/last cards. */
@@ -330,7 +309,7 @@ export class MusicianService {
   ): Promise<MusicianAppearanceShow | null> {
     const show = await this.db.show.findFirst({
       where: { id: { in: showIds } },
-      orderBy: { date: direction },
+      orderBy: direction === "asc" ? SHOW_ORDER_ASC : SHOW_ORDER_DESC,
       select: { date: true, slug: true, venue: { select: { name: true, city: true, state: true } } },
     });
     if (!show) return null;
@@ -343,53 +322,41 @@ export class MusicianService {
 
   /**
    * Every musician with their appearance aggregates in one query, for the
-   * /musicians index table. A musician "plays" a track when they are in that
-   * show's lineup and have no sat-out delta for the track, OR they have a
-   * present=true sit-in delta for it. The song count counts distinct
-   * (song, show) pairs on count_for_stats=true shows — the same "a song played
-   * twice in one show counts once" math as Song.timesPlayed — so it never
-   * exceeds the per-song totals. Distinct show count and first/last dates span
-   * all of the musician's appearance shows.
+   * /musicians index table, off the same shared appearance definitions the
+   * profile page uses. Show count and first/last dates span every appearance
+   * show (including early ones with no setlist entered); song and play counts
+   * come from the tracks those shows do have.
    */
   async findAllWithStats(): Promise<MusicianWithStats[]> {
     const rows = await this.db.$queryRaw<
-      Array<{
-        id: string;
-        name: string;
-        slug: string;
-        known_from: string | null;
-        default_instrument_id: string | null;
-        default_instrument_name: string | null;
-        song_count: bigint;
-        show_count: bigint;
-        first_show_date: string | null;
-        last_show_date: string | null;
-      }>
+      Array<
+        MusicianSongPlayCountsRow & {
+          id: string;
+          name: string;
+          slug: string;
+          known_from: string | null;
+          default_instrument_id: string | null;
+          default_instrument_name: string | null;
+          show_count: bigint;
+          first_show_date: string | null;
+          last_show_date: string | null;
+        }
+      >
     >`
-      WITH appearances AS (
-        SELECT t.show_id, t.song_id, sm.musician_id
-        FROM show_musicians sm
-        JOIN tracks t ON t.show_id = sm.show_id
-        WHERE NOT EXISTS (
-          SELECT 1 FROM track_musicians tm
-          WHERE tm.track_id = t.id AND tm.musician_id = sm.musician_id AND tm.present = false
-        )
-        UNION
-        SELECT t.show_id, t.song_id, tm.musician_id
-        FROM track_musicians tm
-        JOIN tracks t ON t.id = tm.track_id
-        WHERE tm.present = true
-      ),
-      stats AS (
+      WITH show_stats AS (
         SELECT
           a.musician_id,
-          COUNT(DISTINCT (a.song_id, a.show_id)) FILTER (WHERE s.count_for_stats) AS song_count,
           COUNT(DISTINCT a.show_id) AS show_count,
           to_char(MIN(s.date::date), 'YYYY-MM-DD') AS first_show_date,
           to_char(MAX(s.date::date), 'YYYY-MM-DD') AS last_show_date
-        FROM appearances a
+        FROM (${musicianAppearanceShowsSql()}) a
         JOIN shows s ON s.id = a.show_id
         GROUP BY a.musician_id
+      ),
+      play_stats AS (
+        SELECT p.musician_id, ${MUSICIAN_SONG_PLAY_COUNTS_SQL}
+        FROM (${musicianSongPlaysSql()}) p
+        GROUP BY p.musician_id
       )
       SELECT
         m.id,
@@ -398,13 +365,15 @@ export class MusicianService {
         m.known_from,
         m.default_instrument_id,
         i.name AS default_instrument_name,
-        COALESCE(stats.song_count, 0) AS song_count,
-        COALESCE(stats.show_count, 0) AS show_count,
-        stats.first_show_date,
-        stats.last_show_date
+        COALESCE(show_stats.show_count, 0) AS show_count,
+        COALESCE(play_stats.song_count, 0) AS song_count,
+        COALESCE(play_stats.play_count, 0) AS play_count,
+        show_stats.first_show_date,
+        show_stats.last_show_date
       FROM musicians m
       LEFT JOIN instruments i ON i.id = m.default_instrument_id
-      LEFT JOIN stats ON stats.musician_id = m.id
+      LEFT JOIN show_stats ON show_stats.musician_id = m.id
+      LEFT JOIN play_stats ON play_stats.musician_id = m.id
       ORDER BY m.name ASC
     `;
 
@@ -414,22 +383,23 @@ export class MusicianService {
       slug: row.slug,
       knownFrom: row.known_from ?? null,
       defaultInstrumentName: row.default_instrument_name ?? null,
-      songCount: Number(row.song_count),
       showCount: Number(row.show_count),
+      songCount: Number(row.song_count),
+      playCount: Number(row.play_count),
       firstShowDate: row.first_show_date,
       lastShowDate: row.last_show_date,
     }));
   }
 
   /**
-   * The most-played musicians first (song count desc, ties alphabetical), for
+   * The most-played musicians first (play count desc, ties alphabetical), for
    * the picker's default list — surfacing the core lineup and frequent guests
-   * ahead of one-off sit-ins. Reuses the findAllWithStats song-count metric so
+   * ahead of one-off sit-ins. Reuses the findAllWithStats play-count metric so
    * "how much a musician played" stays defined in one place.
    */
-  async findTopBySongCount(limit: number): Promise<MusicianWithStats[]> {
+  async findTopByPlayCount(limit: number): Promise<MusicianWithStats[]> {
     const all = await this.findAllWithStats();
-    return all.sort((a, b) => b.songCount - a.songCount || a.name.localeCompare(b.name)).slice(0, limit);
+    return all.sort((a, b) => b.playCount - a.playCount || a.name.localeCompare(b.name)).slice(0, limit);
   }
 
   async create(data: CreateMusicianInput): Promise<Musician> {

--- a/packages/domain/src/cache-keys.ts
+++ b/packages/domain/src/cache-keys.ts
@@ -109,10 +109,10 @@ export const CacheKeys = {
    */
   musicians: {
     /** Full musician profile payload (appearances, songs played/written,
-     *  performances). :v6 bump: `setlist.show` no longer carries the raw query
-     *  relations (tracks, showMusicians, venue) or searchText; performances
-     *  embed Setlist. */
-    page: (slug: string) => `musician:${slug}:data:v6`,
+     *  performances). :v8 bump: `stats` splits the old `songCount` into
+     *  `songCount` (distinct repertoire) and `playCount` (every play), and the
+     *  appearance show set is now stats-shows-only. */
+    page: (slug: string) => `musician:${slug}:data:v8`,
     /** Every musician profile cache (for pattern deletion on broad mutations). */
     allPages: () => "musician:*:data:*",
   },

--- a/packages/domain/src/models/musician.ts
+++ b/packages/domain/src/models/musician.ts
@@ -69,6 +69,9 @@ export type TrackMusicianInstrument = z.infer<typeof trackMusicianInstrumentSche
  * A musician plus their appearance aggregates, for the /musicians index table.
  * Dates are ISO `YYYY-MM-DD` strings (null when the musician has no recorded
  * appearances yet).
+ *
+ * `playCount` counts every play (a song played on ten shows counts ten times);
+ * `songCount` counts the distinct repertoire behind those plays.
  */
 export type MusicianWithStats = {
   id: string;
@@ -76,6 +79,7 @@ export type MusicianWithStats = {
   slug: string;
   knownFrom: string | null;
   defaultInstrumentName: string | null;
+  playCount: number;
   songCount: number;
   showCount: number;
   firstShowDate: string | null;
@@ -92,10 +96,16 @@ export type MusicianAppearanceShow = {
   venue: { name: string | null; city: string | null; state: string | null } | null;
 };
 
-/** A musician's appearance summary for their profile header and tables. */
+/**
+ * A musician's appearance summary for their profile header and tables.
+ * `showIds` are exactly the shows the counts are drawn from, so the profile's
+ * shows table lists the same set its "Shows Played" figure reports.
+ */
 export type MusicianAppearances = {
   showIds: string[];
+  showCount: number;
   songCount: number;
+  playCount: number;
   firstShow: MusicianAppearanceShow | null;
   lastShow: MusicianAppearanceShow | null;
 };


### PR DESCRIPTION
A musician's profile and the `/musicians` table now show three separate figures instead of two: **Shows** they appeared on, the **unique Songs** they played, and their total **song Plays**. A single "Songs" column used to report the play total, so there was no way to see how much of the catalog a musician had actually touched.

The two pages also disagreed about the show count. Aron Magner read 1940 shows on his profile against 1844 in the table, because the profile counted lineup rows while the table counted shows that produced a played track, and neither filtered to stats shows. Both now read 1899.

| | Shows | Songs | Plays |
| --- | --- | --- | --- |
| Aron Magner | 1899 | 550 | 20111 |
| Tom Hamilton | 37 | 107 | 244 |

Profile stat boxes read **Shows Played / Unique Songs / Song Plays**; the index columns are **Shows / Songs / Plays**, matching the vocabulary the songs table already uses.

## Notes for the reviewer

Every musician statistic now derives from two shared SQL builders in `musician-appearances.ts` rather than hand-written queries in each service method:

- `musicianAppearanceShowsSql` — lineup membership ∪ sit-ins. Lineup membership alone counts, so early shows with no setlist entered still count as appearances.
- `musicianSongPlaysSql` — songs played, off tracks, minus per-track sat-outs.

Both filter to `count_for_stats`, and `MUSICIAN_SONG_PLAY_COUNTS_SQL` defines the song and play aggregates once. `findAppearances` returns the same `showIds` that drive the profile's shows table, so the listed shows are exactly the ones the count reports. Play count uses distinct `(song_id, show_id)` pairs, matching `Song.timesPlayed`, so a musician's plays can never exceed the per-song totals shown elsewhere.

Applying the stats filter moves the show count for the five core members only (Aron 1844→1899 net of both changes, Jon, Marc, Allen, Sam); every guest and sit-in musician is unchanged either way.

`findAppearanceShow` was ordering by a bare `date`, which the show-ordering rule forbids; it now uses `SHOW_ORDER_ASC`/`DESC`. The profile cache key is bumped to `:v8`.

**Known follow-up, not in this PR:** `VenueService.getShowAggregates` computes every venue's show count, year list, and first/last show with no `count_for_stats` filter, which drives "Total Shows" on `/venues` and each venue page. It violates the rule this PR documents and should be fixed separately.

## Unrelated changes riding along

- `.gitignore` keeps the `rater-investigation/` directory, which holds real user emails, out of git.
- The MCP user sync carries `ratingDecimalPlaces` through, guarded as optional until that field lands on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
